### PR TITLE
feat(rust): Buffering messages for DLQ - take 2

### DIFF
--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -28,7 +28,7 @@ fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
     println!("transforming value: {:?} -> {:?}", str_payload, &result_str);
 
     let result = KafkaPayload {
-        payload: Some(result_str.to_bytes().to_vec()),
+        payload: Some(Arc::new(result_str.to_bytes().to_vec())),
         ..value
     };
     Ok(result)

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -57,9 +57,9 @@ fn create_kafka_message(msg: BorrowedMessage) -> BrokerMessage<KafkaPayload> {
 
     BrokerMessage::new(
         KafkaPayload {
-            key: msg.key().map(|k| k.to_vec()),
-            headers: msg.headers().map(BorrowedHeaders::detach),
-            payload: msg.payload().map(|p| p.to_vec()),
+            key: msg.key().map(|k| Arc::new(k.to_vec())),
+            headers: msg.headers().map(|h| Arc::new(BorrowedHeaders::detach(h))),
+            payload: msg.payload().map(|p| Arc::new(p.to_vec())),
         },
         partition,
         msg.offset() as u64,

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -32,10 +32,10 @@ impl ArroyoProducer<KafkaPayload> for KafkaProducer {
             TopicOrPartition::Partition(partition) => partition.topic.as_str(),
         };
 
-        let msg_key = payload.key.unwrap_or_default();
-        let msg_payload = payload.payload.unwrap_or_default();
+        let msg_key = &*payload.key.unwrap_or_default();
+        let msg_payload = &*(payload.payload.unwrap_or_default());
 
-        let mut base_record = BaseRecord::to(topic).payload(&msg_payload).key(&msg_key);
+        let mut base_record = BaseRecord::to(topic).payload(msg_payload).key(msg_key);
 
         let partition = match destination {
             TopicOrPartition::Topic(_) => None,
@@ -61,6 +61,7 @@ mod tests {
     use crate::backends::kafka::types::KafkaPayload;
     use crate::backends::Producer;
     use crate::types::{Topic, TopicOrPartition};
+    use std::sync::Arc;
     #[test]
     fn test_producer() {
         let topic = Topic::new("test");
@@ -73,7 +74,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some("asdf".as_bytes().to_vec()),
+            payload: Some(Arc::new("asdf".as_bytes().to_vec())),
         };
         producer
             .produce(&destination, payload)

--- a/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
@@ -1,8 +1,9 @@
 use rdkafka::message::OwnedHeaders;
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct KafkaPayload {
-    pub key: Option<Vec<u8>>,
-    pub headers: Option<OwnedHeaders>,
-    pub payload: Option<Vec<u8>>,
+    pub key: Option<Arc<Vec<u8>>>,
+    pub headers: Option<Arc<OwnedHeaders>>,
+    pub payload: Option<Arc<Vec<u8>>>,
 }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 use crate::backends::{AssignmentCallbacks, Consumer, ConsumerError};
+use crate::processing::dlq::BufferedMessages;
 use crate::processing::strategies::{MessageRejected, SubmitError};
 use crate::types::{InnerMessage, Message, Partition, Topic};
 use crate::utils::metrics::{get_metrics, Metrics};
@@ -114,7 +115,7 @@ impl<TPayload> Callbacks<TPayload> {
 /// instance and a ``ProcessingStrategy``, ensuring that processing
 /// strategies are instantiated on partition assignment and closed on
 /// partition revocation.
-pub struct StreamProcessor<TPayload> {
+pub struct StreamProcessor<TPayload: Clone> {
     consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
     strategies: Arc<Mutex<Strategies<TPayload>>>,
     message: Option<Message<TPayload>>,
@@ -122,9 +123,10 @@ pub struct StreamProcessor<TPayload> {
     backpressure_timestamp: Option<Instant>,
     is_paused: bool,
     metrics_buffer: metrics_buffer::MetricsBuffer,
+    buffered_messages: BufferedMessages<TPayload>,
 }
 
-impl<TPayload: 'static> StreamProcessor<TPayload> {
+impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
     pub fn new(
         consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
         processing_factory: Box<dyn ProcessingStrategyFactory<TPayload>>,
@@ -144,6 +146,7 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
             backpressure_timestamp: None,
             is_paused: false,
             metrics_buffer: metrics_buffer::MetricsBuffer::new(),
+            buffered_messages: BufferedMessages::new(),
         }
     }
 
@@ -186,11 +189,16 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
                 .poll(Some(Duration::from_secs(1)))
             {
                 Ok(msg) => {
-                    self.message = msg.map(|inner| Message {
-                        inner_message: InnerMessage::BrokerMessage(inner),
-                    });
                     self.metrics_buffer
                         .incr_timing("arroyo.consumer.poll.time", poll_start.elapsed());
+
+                    if let Some(broker_msg) = msg {
+                        self.message = Some(Message {
+                            inner_message: InnerMessage::BrokerMessage(broker_msg.clone()),
+                        });
+
+                        self.buffered_messages.append(broker_msg);
+                    }
                 }
                 Err(error) => {
                     tracing::error!(%error, "poll error");

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -218,6 +218,10 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
         match commit_request {
             Ok(None) => {}
             Ok(Some(request)) => {
+                for (partition, offset) in &request.positions {
+                    self.buffered_messages.pop(partition, offset - 1);
+                }
+
                 let mut consumer = self.consumer.lock().unwrap();
                 consumer.stage_offsets(request.positions).unwrap();
                 consumer.commit_offsets().unwrap();

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -93,6 +93,7 @@ mod tests {
     use crate::processing::strategies::InvalidMessage;
     use crate::types::{BrokerMessage, InnerMessage, Partition, Topic};
     use chrono::Utc;
+    use std::sync::Arc;
 
     #[test]
     fn test_produce() {
@@ -142,7 +143,7 @@ mod tests {
                 payload: KafkaPayload {
                     key: None,
                     headers: None,
-                    payload: Some(payload_str.clone()),
+                    payload: Some(Arc::new(payload_str.clone())),
                 },
                 partition,
                 offset: 0,

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -179,7 +179,7 @@ pub fn process_message(
             let payload = KafkaPayload {
                 key: None,
                 headers: None,
-                payload: Some(value),
+                payload: Some(Arc::new(value)),
             };
 
             let meta = KafkaMessageMetadata {

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -130,6 +130,7 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
@@ -169,7 +170,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.as_bytes().to_vec()),
+            payload: Some(Arc::new(data.as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -65,6 +65,7 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
@@ -96,7 +97,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.as_bytes().to_vec()),
+            payload: Some(Arc::new(data.as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -326,6 +326,7 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
@@ -428,7 +429,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.as_bytes().to_vec()),
+            payload: Some(Arc::new(data.as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -453,7 +453,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,
@@ -491,7 +491,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,
@@ -510,7 +510,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,
@@ -529,7 +529,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -365,6 +365,7 @@ impl SpanStatus {
 mod tests {
     use super::*;
     use chrono::DateTime;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[derive(Debug, Default, Deserialize, Serialize)]
@@ -471,7 +472,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -70,18 +70,18 @@ impl TryFrom<Commit> for KafkaPayload {
     type Error = CommitLogError;
 
     fn try_from(commit: Commit) -> Result<Self, CommitLogError> {
-        let key = Some(
+        let key = Some(Arc::new(
             format!(
                 "{}:{}:{}",
                 commit.topic, commit.partition, commit.consumer_group
             )
             .into_bytes(),
-        );
+        ));
 
-        let payload = Some(serde_json::to_vec(&Payload {
+        let payload = Some(Arc::new(serde_json::to_vec(&Payload {
             offset: commit.offset,
             orig_message_ts: commit.orig_message_ts,
-        })?);
+        })?));
 
         Ok(KafkaPayload {
             key,

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -189,14 +189,16 @@ mod tests {
     use rust_arroyo::backends::ProducerError;
     use rust_arroyo::types::Topic;
     use std::collections::BTreeMap;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn commit() {
         let payload = KafkaPayload {
-            key: Some(b"topic:0:group1".to_vec()),
+            key: Some(Arc::new(b"topic:0:group1".to_vec())),
             headers: None,
-            payload: Some(b"{\"offset\":5,\"orig_message_ts\":1696381946.0}".to_vec()),
+            payload: Some(Arc::new(
+                b"{\"offset\":5,\"orig_message_ts\":1696381946.0}".to_vec(),
+            )),
         };
 
         let payload_clone = payload.clone();
@@ -253,20 +255,20 @@ mod tests {
 
         let payloads = vec![
             KafkaPayload {
-                key: Some(b"topic:0:group1".to_vec()),
+                key: Some(Arc::new(b"topic:0:group1".to_vec())),
                 headers: None,
-                payload: Some(
+                payload: Some(Arc::new(
                     b"{\"offset\":5,\"orig_message_ts\":100000.0,\"received_p99\":100000.0}"
                         .to_vec(),
-                ),
+                )),
             },
             KafkaPayload {
-                key: Some(b"topic:0:group1".to_vec()),
+                key: Some(Arc::new(b"topic:0:group1".to_vec())),
                 headers: None,
-                payload: Some(
+                payload: Some(Arc::new(
                     b"{\"offset\":6,\"orig_message_ts\":100001.0,\"received_p99\":100001.0}"
                         .to_vec(),
-                ),
+                )),
             },
         ];
 

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -155,7 +155,9 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
                 partition,
                 timestamp,
             }) => {
-                let args = (payload.payload, offset, partition.index, timestamp);
+                let payload_bytes = (payload.payload.unwrap_or_default()).as_ref().clone();
+
+                let args = (payload_bytes, offset, partition.index, timestamp);
 
                 let process_message = |args| {
                     tracing::debug!(?args, "processing message in subprocess");

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -235,6 +235,7 @@ mod tests {
     use super::*;
 
     use chrono::Utc;
+    use std::sync::Arc;
 
     use rust_arroyo::{
         testutils::TestStrategy,
@@ -260,7 +261,7 @@ mod tests {
             KafkaPayload {
                 key: None,
                 headers: None,
-                payload: Some(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec()),
+                payload: Some(Arc::new(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec())),
             },
             Partition::new(Topic::new("test"), 1),
             1,

--- a/rust_snuba/src/strategies/validate_schema.rs
+++ b/rust_snuba/src/strategies/validate_schema.rs
@@ -178,7 +178,7 @@ mod tests {
                 payload: KafkaPayload {
                     key: None,
                     headers: None,
-                    payload: Some(payload_str.clone()),
+                    payload: Some(Arc::new(payload_str.clone())),
                 },
                 partition,
                 offset: 0,


### PR DESCRIPTION
Alternate implementation to https://github.com/getsentry/snuba/pull/5044 which uses Arc internally in KafkaPayload rather than forcing the outer strategy to be `Arc<KafkaPayload>`.
