### PR TITLE
feat(rust): Buffered messages option 3

### DIFF
--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -28,8 +28,8 @@ fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
     println!("transforming value: {:?} -> {:?}", str_payload, &result_str);
 
     let result = KafkaPayload::new(
-        value.key().map(|k| k.clone()),
-        value.headers().map(|h| h.clone()),
+        value.key().cloned(),
+        value.headers().cloned(),
         Some(result_str.to_bytes().to_vec()),
     );
     Ok(result)

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -21,16 +21,17 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
-    let payload = value.payload.unwrap();
+    let payload = value.payload().unwrap();
     let str_payload = std::str::from_utf8(&payload).unwrap();
     let result_str = str_payload.chars().rev().collect::<String>();
 
     println!("transforming value: {:?} -> {:?}", str_payload, &result_str);
 
-    let result = KafkaPayload {
-        payload: Some(Arc::new(result_str.to_bytes().to_vec())),
-        ..value
-    };
+    let result = KafkaPayload::new(
+        value.key().map(|k| k.clone()),
+        value.headers().map(|h| h.clone()),
+        Some(result_str.to_bytes().to_vec()),
+    );
     Ok(result)
 }
 struct Noop {}

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
     let payload = value.payload().unwrap();
-    let str_payload = std::str::from_utf8(&payload).unwrap();
+    let str_payload = std::str::from_utf8(payload).unwrap();
     let result_str = str_payload.chars().rev().collect::<String>();
 
     println!("transforming value: {:?} -> {:?}", str_payload, &result_str);

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -28,7 +28,7 @@ fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
     println!("transforming value: {:?} -> {:?}", str_payload, &result_str);
 
     let result = KafkaPayload {
-        payload: Some(result_str.to_bytes().to_vec()),
+        payload: Some(Arc::new(result_str.to_bytes().to_vec())),
         ..value
     };
     Ok(result)

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -57,9 +57,9 @@ fn create_kafka_message(msg: BorrowedMessage) -> BrokerMessage<KafkaPayload> {
 
     BrokerMessage::new(
         KafkaPayload {
-            key: msg.key().map(|k| k.to_vec()),
-            headers: msg.headers().map(BorrowedHeaders::detach),
-            payload: msg.payload().map(|p| p.to_vec()),
+            key: msg.key().map(|k| Arc::new(k.to_vec())),
+            headers: msg.headers().map(|h| Arc::new(BorrowedHeaders::detach(h))),
+            payload: msg.payload().map(|p| Arc::new(p.to_vec())),
         },
         partition,
         msg.offset() as u64,

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -56,11 +56,11 @@ fn create_kafka_message(msg: BorrowedMessage) -> BrokerMessage<KafkaPayload> {
     let time_millis = msg.timestamp().to_millis().unwrap_or(0);
 
     BrokerMessage::new(
-        KafkaPayload {
-            key: msg.key().map(|k| Arc::new(k.to_vec())),
-            headers: msg.headers().map(|h| Arc::new(BorrowedHeaders::detach(h))),
-            payload: msg.payload().map(|p| Arc::new(p.to_vec())),
-        },
+        KafkaPayload::new(
+            msg.key().map(|k| k.to_vec()),
+            msg.headers().map(BorrowedHeaders::detach),
+            msg.payload().map(|p| p.to_vec()),
+        ),
         partition,
         msg.offset() as u64,
         DateTime::from_naive_utc_and_offset(

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -32,10 +32,15 @@ impl ArroyoProducer<KafkaPayload> for KafkaProducer {
             TopicOrPartition::Partition(partition) => partition.topic.as_str(),
         };
 
-        let msg_key = payload.key().unwrap();
-        let msg_payload = payload.payload().unwrap();
+        let mut base_record = BaseRecord::to(topic);
 
-        let mut base_record = BaseRecord::to(topic).payload(msg_payload).key(msg_key);
+        if let Some(msg_key) = payload.key() {
+            base_record = base_record.key(msg_key);
+        }
+
+        if let Some(msg_payload) = payload.payload() {
+            base_record = base_record.payload(msg_payload);
+        }
 
         let partition = match destination {
             TopicOrPartition::Topic(_) => None,

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -32,8 +32,8 @@ impl ArroyoProducer<KafkaPayload> for KafkaProducer {
             TopicOrPartition::Partition(partition) => partition.topic.as_str(),
         };
 
-        let msg_key = &*payload.key.unwrap_or_default();
-        let msg_payload = &*(payload.payload.unwrap_or_default());
+        let msg_key = payload.key().unwrap();
+        let msg_payload = payload.payload().unwrap();
 
         let mut base_record = BaseRecord::to(topic).payload(msg_payload).key(msg_key);
 
@@ -61,7 +61,6 @@ mod tests {
     use crate::backends::kafka::types::KafkaPayload;
     use crate::backends::Producer;
     use crate::types::{Topic, TopicOrPartition};
-    use std::sync::Arc;
     #[test]
     fn test_producer() {
         let topic = Topic::new("test");
@@ -71,11 +70,7 @@ mod tests {
 
         let producer = KafkaProducer::new(configuration);
 
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new("asdf".as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some("asdf".as_bytes().to_vec()));
         producer
             .produce(&destination, payload)
             .expect("Message produced")

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -32,10 +32,10 @@ impl ArroyoProducer<KafkaPayload> for KafkaProducer {
             TopicOrPartition::Partition(partition) => partition.topic.as_str(),
         };
 
-        let msg_key = payload.key.unwrap_or_default();
-        let msg_payload = payload.payload.unwrap_or_default();
+        let msg_key = &*payload.key.unwrap_or_default();
+        let msg_payload = &*(payload.payload.unwrap_or_default());
 
-        let mut base_record = BaseRecord::to(topic).payload(&msg_payload).key(&msg_key);
+        let mut base_record = BaseRecord::to(topic).payload(msg_payload).key(msg_key);
 
         let partition = match destination {
             TopicOrPartition::Topic(_) => None,
@@ -61,6 +61,7 @@ mod tests {
     use crate::backends::kafka::types::KafkaPayload;
     use crate::backends::Producer;
     use crate::types::{Topic, TopicOrPartition};
+    use std::sync::Arc;
     #[test]
     fn test_producer() {
         let topic = Topic::new("test");
@@ -73,7 +74,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some("asdf".as_bytes().to_vec()),
+            payload: Some(Arc::new("asdf".as_bytes().to_vec())),
         };
         producer
             .produce(&destination, payload)

--- a/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
@@ -1,8 +1,9 @@
 use rdkafka::message::OwnedHeaders;
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct KafkaPayload {
-    pub key: Option<Vec<u8>>,
-    pub headers: Option<OwnedHeaders>,
-    pub payload: Option<Vec<u8>>,
+    pub key: Option<Arc<Vec<u8>>>,
+    pub headers: Option<Arc<OwnedHeaders>>,
+    pub payload: Option<Arc<Vec<u8>>>,
 }

--- a/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
@@ -2,8 +2,42 @@ use rdkafka::message::OwnedHeaders;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
+struct KafkaPayloadInner {
+    pub key: Option<Vec<u8>>,
+    pub headers: Option<OwnedHeaders>,
+    pub payload: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug)]
 pub struct KafkaPayload {
-    pub key: Option<Arc<Vec<u8>>>,
-    pub headers: Option<Arc<OwnedHeaders>>,
-    pub payload: Option<Arc<Vec<u8>>>,
+    inner: Arc<KafkaPayloadInner>,
+}
+
+impl KafkaPayload {
+    pub fn new(
+        key: Option<Vec<u8>>,
+        // TODO: OwnedHeaders is an internal rdkafka thing, try to get rid of it here
+        headers: Option<OwnedHeaders>,
+        payload: Option<Vec<u8>>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(KafkaPayloadInner {
+                key,
+                headers,
+                payload,
+            }),
+        }
+    }
+
+    pub fn key(&self) -> Option<&Vec<u8>> {
+        self.inner.key.as_ref()
+    }
+
+    pub fn headers(&self) -> Option<&OwnedHeaders> {
+        self.inner.headers.as_ref()
+    }
+
+    pub fn payload(&self) -> Option<&Vec<u8>> {
+        self.inner.payload.as_ref()
+    }
 }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 use crate::backends::{AssignmentCallbacks, Consumer, ConsumerError};
+use crate::processing::dlq::BufferedMessages;
 use crate::processing::strategies::{MessageRejected, SubmitError};
 use crate::types::{InnerMessage, Message, Partition, Topic};
 use crate::utils::metrics::{get_metrics, Metrics};
@@ -114,7 +115,7 @@ impl<TPayload> Callbacks<TPayload> {
 /// instance and a ``ProcessingStrategy``, ensuring that processing
 /// strategies are instantiated on partition assignment and closed on
 /// partition revocation.
-pub struct StreamProcessor<TPayload> {
+pub struct StreamProcessor<TPayload: Clone> {
     consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
     strategies: Arc<Mutex<Strategies<TPayload>>>,
     message: Option<Message<TPayload>>,
@@ -122,9 +123,10 @@ pub struct StreamProcessor<TPayload> {
     backpressure_timestamp: Option<Instant>,
     is_paused: bool,
     metrics_buffer: metrics_buffer::MetricsBuffer,
+    buffered_messages: BufferedMessages<TPayload>,
 }
 
-impl<TPayload: 'static> StreamProcessor<TPayload> {
+impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
     pub fn new(
         consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
         processing_factory: Box<dyn ProcessingStrategyFactory<TPayload>>,
@@ -144,6 +146,7 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
             backpressure_timestamp: None,
             is_paused: false,
             metrics_buffer: metrics_buffer::MetricsBuffer::new(),
+            buffered_messages: BufferedMessages::new(),
         }
     }
 
@@ -186,11 +189,16 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
                 .poll(Some(Duration::from_secs(1)))
             {
                 Ok(msg) => {
-                    self.message = msg.map(|inner| Message {
-                        inner_message: InnerMessage::BrokerMessage(inner),
-                    });
                     self.metrics_buffer
                         .incr_timing("arroyo.consumer.poll.time", poll_start.elapsed());
+
+                    if let Some(broker_msg) = msg {
+                        self.message = Some(Message {
+                            inner_message: InnerMessage::BrokerMessage(broker_msg.clone()),
+                        });
+
+                        self.buffered_messages.append(broker_msg);
+                    }
                 }
                 Err(error) => {
                     tracing::error!(%error, "poll error");

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -218,6 +218,10 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
         match commit_request {
             Ok(None) => {}
             Ok(Some(request)) => {
+                for (partition, offset) in &request.positions {
+                    self.buffered_messages.pop(partition, offset - 1);
+                }
+
                 let mut consumer = self.consumer.lock().unwrap();
                 consumer.stage_offsets(request.positions).unwrap();
                 consumer.commit_offsets().unwrap();

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -80,11 +80,7 @@ mod tests {
             inner_message: InnerMessage::BrokerMessage(BrokerMessage {
                 partition: partition1,
                 offset: 1000,
-                payload: KafkaPayload {
-                    key: None,
-                    headers: None,
-                    payload: None,
-                },
+                payload: KafkaPayload::new(None, None, None),
                 timestamp,
             }),
         };
@@ -93,11 +89,7 @@ mod tests {
             inner_message: InnerMessage::BrokerMessage(BrokerMessage {
                 partition: partition2,
                 offset: 2000,
-                payload: KafkaPayload {
-                    key: None,
-                    headers: None,
-                    payload: None,
-                },
+                payload: KafkaPayload::new(None, None, None),
                 timestamp,
             }),
         };

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -93,6 +93,7 @@ mod tests {
     use crate::processing::strategies::InvalidMessage;
     use crate::types::{BrokerMessage, InnerMessage, Partition, Topic};
     use chrono::Utc;
+    use std::sync::Arc;
 
     #[test]
     fn test_produce() {
@@ -142,7 +143,7 @@ mod tests {
                 payload: KafkaPayload {
                     key: None,
                     headers: None,
-                    payload: Some(payload_str.clone()),
+                    payload: Some(Arc::new(payload_str.clone())),
                 },
                 partition,
                 offset: 0,

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -93,7 +93,6 @@ mod tests {
     use crate::processing::strategies::InvalidMessage;
     use crate::types::{BrokerMessage, InnerMessage, Partition, Topic};
     use chrono::Utc;
-    use std::sync::Arc;
 
     #[test]
     fn test_produce() {
@@ -140,11 +139,7 @@ mod tests {
         let payload_str = "hello world".to_string().as_bytes().to_vec();
         let message = Message {
             inner_message: InnerMessage::BrokerMessage(BrokerMessage {
-                payload: KafkaPayload {
-                    key: None,
-                    headers: None,
-                    payload: Some(Arc::new(payload_str.clone())),
-                },
+                payload: KafkaPayload::new(None, None, Some(payload_str.clone())),
                 partition,
                 offset: 0,
                 timestamp: Utc::now(),

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -179,7 +179,7 @@ pub fn process_message(
             let payload = KafkaPayload {
                 key: None,
                 headers: None,
-                payload: Some(value),
+                payload: Some(Arc::new(value)),
             };
 
             let meta = KafkaMessageMetadata {

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -176,11 +176,7 @@ pub fn process_message(
     match processors::get_processing_function(name) {
         None => None,
         Some(func) => {
-            let payload = KafkaPayload {
-                key: None,
-                headers: None,
-                payload: Some(Arc::new(value)),
-            };
+            let payload = KafkaPayload::new(None, None, Some(value));
 
             let meta = KafkaMessageMetadata {
                 partition,

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -130,7 +130,6 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
-    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -130,6 +130,7 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
@@ -169,7 +170,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.as_bytes().to_vec()),
+            payload: Some(Arc::new(data.as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -12,8 +12,8 @@ pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let msg: FromFunctionsMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload().context("Expected payload")?;
+    let msg: FromFunctionsMessage = serde_json::from_slice(payload_bytes)?;
 
     let timestamp = match msg.timestamp {
         Some(timestamp) => timestamp,
@@ -167,11 +167,7 @@ mod tests {
             "device_class": 2,
             "retention_days": 30
         }"#;
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -9,8 +9,8 @@ pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let mut msg: ProfileMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload().context("Expected payload")?;
+    let mut msg: ProfileMessage = serde_json::from_slice(payload_bytes)?;
 
     // we always want an empty string at least
     msg.device_classification = Some(msg.device_classification.unwrap_or_default());
@@ -65,7 +65,6 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
-    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
@@ -94,11 +93,7 @@ mod tests {
             "version_code": "1337",
             "version_name": "v42.0.0"
         }"#;
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -65,6 +65,7 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
@@ -96,7 +97,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.as_bytes().to_vec()),
+            payload: Some(Arc::new(data.as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -13,8 +13,8 @@ pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let msg: FromQuerylogMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload().context("Expected payload")?;
+    let msg: FromQuerylogMessage = serde_json::from_slice(payload_bytes)?;
 
     let querylog_msg: QuerylogMessage = msg.try_into()?;
 
@@ -426,11 +426,7 @@ mod tests {
             "snql_anonymized": "MATCH Entity(events) SELECT tags_key, tags_value, (count() AS count), (min(timestamp) AS first_seen), (max(timestamp) AS last_seen) GROUP BY tags_key, tags_value WHERE greaterOrEquals(timestamp, toDateTime('$S')) AND less(timestamp, toDateTime('$S')) AND in(project_id, tuple(-1337)) AND in(project_id, tuple(-1337)) AND in(group_id, tuple(-1337)) ORDER BY count DESC LIMIT 4 BY tags_key LIMIT 1000 OFFSET 0"
           }"#;
 
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -326,7 +326,6 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
-    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -326,6 +326,7 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[test]
@@ -428,7 +429,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.as_bytes().to_vec()),
+            payload: Some(Arc::new(data.as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -453,7 +453,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,
@@ -491,7 +491,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,
@@ -510,7 +510,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,
@@ -529,7 +529,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -12,8 +12,8 @@ pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let msg: FromSpanMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload().context("Expected payload")?;
+    let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
 
     let mut span: Span = msg.try_into()?;
 
@@ -365,7 +365,6 @@ impl SpanStatus {
 mod tests {
     use super::*;
     use chrono::DateTime;
-    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[derive(Debug, Default, Deserialize, Serialize)]
@@ -450,11 +449,7 @@ mod tests {
         let span = valid_span();
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.unwrap().as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -469,11 +464,7 @@ mod tests {
         span.sentry_tags.status = Option::None;
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.unwrap().as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -488,11 +479,7 @@ mod tests {
         span.sentry_tags.status = Some("".into());
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.unwrap().as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -507,11 +494,7 @@ mod tests {
         span.retention_days = default_retention_days();
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.unwrap().as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -526,11 +509,7 @@ mod tests {
         span.tags = Option::None;
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
-            key: None,
-            headers: None,
-            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
-        };
+        let payload = KafkaPayload::new(None, None, Some(data.unwrap().as_bytes().to_vec()));
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -365,6 +365,7 @@ impl SpanStatus {
 mod tests {
     use super::*;
     use chrono::DateTime;
+    use std::sync::Arc;
     use std::time::SystemTime;
 
     #[derive(Debug, Default, Deserialize, Serialize)]
@@ -471,7 +472,7 @@ mod tests {
         let payload = KafkaPayload {
             key: None,
             headers: None,
-            payload: Some(data.unwrap().as_bytes().to_vec()),
+            payload: Some(Arc::new(data.unwrap().as_bytes().to_vec())),
         };
         let meta = KafkaMessageMetadata {
             partition: 0,

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -44,7 +44,7 @@ impl TryFrom<KafkaPayload> for Commit {
     fn try_from(payload: KafkaPayload) -> Result<Self, CommitLogError> {
         let key = payload.key().unwrap();
 
-        let data: Vec<&str> = str::from_utf8(&key).unwrap().split(':').collect();
+        let data: Vec<&str> = str::from_utf8(key).unwrap().split(':').collect();
         if data.len() != 3 {
             return Err(CommitLogError::InvalidKey);
         }
@@ -54,7 +54,7 @@ impl TryFrom<KafkaPayload> for Commit {
         let consumer_group = data[2].to_string();
 
         let d: Payload =
-            serde_json::from_slice(&payload.payload().ok_or(CommitLogError::InvalidPayload)?)?;
+            serde_json::from_slice(payload.payload().ok_or(CommitLogError::InvalidPayload)?)?;
 
         Ok(Commit {
             topic,

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -70,18 +70,18 @@ impl TryFrom<Commit> for KafkaPayload {
     type Error = CommitLogError;
 
     fn try_from(commit: Commit) -> Result<Self, CommitLogError> {
-        let key = Some(
+        let key = Some(Arc::new(
             format!(
                 "{}:{}:{}",
                 commit.topic, commit.partition, commit.consumer_group
             )
             .into_bytes(),
-        );
+        ));
 
-        let payload = Some(serde_json::to_vec(&Payload {
+        let payload = Some(Arc::new(serde_json::to_vec(&Payload {
             offset: commit.offset,
             orig_message_ts: commit.orig_message_ts,
-        })?);
+        })?));
 
         Ok(KafkaPayload {
             key,

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -200,8 +200,8 @@ mod tests {
         let commit: Commit = payload.try_into().unwrap();
         assert_eq!(commit.partition, 0);
         let transformed: KafkaPayload = commit.try_into().unwrap();
-        assert_eq!(transformed.key, payload_clone.key);
-        assert_eq!(transformed.payload, payload_clone.payload);
+        assert_eq!(transformed.key(), payload_clone.key());
+        assert_eq!(transformed.payload(), payload_clone.payload());
     }
 
     #[test]

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -189,14 +189,16 @@ mod tests {
     use rust_arroyo::backends::ProducerError;
     use rust_arroyo::types::Topic;
     use std::collections::BTreeMap;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn commit() {
         let payload = KafkaPayload {
-            key: Some(b"topic:0:group1".to_vec()),
+            key: Some(Arc::new(b"topic:0:group1".to_vec())),
             headers: None,
-            payload: Some(b"{\"offset\":5,\"orig_message_ts\":1696381946.0}".to_vec()),
+            payload: Some(Arc::new(
+                b"{\"offset\":5,\"orig_message_ts\":1696381946.0}".to_vec(),
+            )),
         };
 
         let payload_clone = payload.clone();
@@ -253,20 +255,20 @@ mod tests {
 
         let payloads = vec![
             KafkaPayload {
-                key: Some(b"topic:0:group1".to_vec()),
+                key: Some(Arc::new(b"topic:0:group1".to_vec())),
                 headers: None,
-                payload: Some(
+                payload: Some(Arc::new(
                     b"{\"offset\":5,\"orig_message_ts\":100000.0,\"received_p99\":100000.0}"
                         .to_vec(),
-                ),
+                )),
             },
             KafkaPayload {
-                key: Some(b"topic:0:group1".to_vec()),
+                key: Some(Arc::new(b"topic:0:group1".to_vec())),
                 headers: None,
-                payload: Some(
+                payload: Some(Arc::new(
                     b"{\"offset\":6,\"orig_message_ts\":100001.0,\"received_p99\":100001.0}"
                         .to_vec(),
-                ),
+                )),
             },
         ];
 

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -155,7 +155,8 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
                 partition,
                 timestamp,
             }) => {
-                let payload_bytes = (payload.payload.unwrap_or_default()).as_ref().clone();
+                // TODO: Handle None payload
+                let payload_bytes = (payload.payload().unwrap()).clone();
 
                 let args = (payload_bytes, offset, partition.index, timestamp);
 
@@ -235,7 +236,6 @@ mod tests {
     use super::*;
 
     use chrono::Utc;
-    use std::sync::Arc;
 
     use rust_arroyo::{
         testutils::TestStrategy,
@@ -258,11 +258,11 @@ mod tests {
 
         let _ = step.poll();
         step.submit(Message::new_broker_message(
-            KafkaPayload {
-                key: None,
-                headers: None,
-                payload: Some(Arc::new(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec())),
-            },
+            KafkaPayload::new(
+                None,
+                None,
+                Some(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec()),
+            ),
             Partition::new(Topic::new("test"), 1),
             1,
             Utc::now(),

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -155,7 +155,9 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
                 partition,
                 timestamp,
             }) => {
-                let args = (payload.payload, offset, partition.index, timestamp);
+                let payload_bytes = (payload.payload.unwrap_or_default()).as_ref().clone();
+
+                let args = (payload_bytes, offset, partition.index, timestamp);
 
                 let process_message = |args| {
                     tracing::debug!(?args, "processing message in subprocess");

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -235,6 +235,7 @@ mod tests {
     use super::*;
 
     use chrono::Utc;
+    use std::sync::Arc;
 
     use rust_arroyo::{
         testutils::TestStrategy,
@@ -260,7 +261,7 @@ mod tests {
             KafkaPayload {
                 key: None,
                 headers: None,
-                payload: Some(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec()),
+                payload: Some(Arc::new(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec())),
             },
             Partition::new(Topic::new("test"), 1),
             1,

--- a/rust_snuba/src/strategies/validate_schema.rs
+++ b/rust_snuba/src/strategies/validate_schema.rs
@@ -175,11 +175,7 @@ mod tests {
         let payload_str = example.to_string().as_bytes().to_vec();
         let message = Message {
             inner_message: InnerMessage::BrokerMessage(BrokerMessage {
-                payload: KafkaPayload::new(
-                    None,
-                    None,
-                    Some(payload_str.clone()),
-                ),
+                payload: KafkaPayload::new(None, None, Some(payload_str.clone())),
                 partition,
                 offset: 0,
                 timestamp: Utc::now(),

--- a/rust_snuba/src/strategies/validate_schema.rs
+++ b/rust_snuba/src/strategies/validate_schema.rs
@@ -178,7 +178,7 @@ mod tests {
                 payload: KafkaPayload {
                     key: None,
                     headers: None,
-                    payload: Some(payload_str.clone()),
+                    payload: Some(Arc::new(payload_str.clone())),
                 },
                 partition,
                 offset: 0,

--- a/rust_snuba/src/strategies/validate_schema.rs
+++ b/rust_snuba/src/strategies/validate_schema.rs
@@ -47,7 +47,7 @@ impl TaskRunner<KafkaPayload, KafkaPayload> for SchemaValidator {
 
         Box::pin(async move {
             // FIXME: this will panic when the payload is empty
-            let payload = message.payload().payload.as_ref().unwrap();
+            let payload = message.payload().payload().unwrap();
 
             let Err(error) = schema.validate_json(payload) else {
                 return Ok(message);
@@ -175,11 +175,11 @@ mod tests {
         let payload_str = example.to_string().as_bytes().to_vec();
         let message = Message {
             inner_message: InnerMessage::BrokerMessage(BrokerMessage {
-                payload: KafkaPayload {
-                    key: None,
-                    headers: None,
-                    payload: Some(Arc::new(payload_str.clone())),
-                },
+                payload: KafkaPayload::new(
+                    None,
+                    None,
+                    Some(payload_str.clone()),
+                ),
                 partition,
                 offset: 0,
                 timestamp: Utc::now(),


### PR DESCRIPTION
Another take on https://github.com/getsentry/snuba/pull/5044
This one uses a single Arc inside KafkaPayload instead of one for
each of the key, headers and payload. Goal was to make it even
cheaper to clone than v2.