### PR TITLE
fix(rust): Rename run_once metric

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -161,7 +161,7 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
 
     pub fn run_once(&mut self) -> Result<(), RunError> {
         let metrics = get_metrics();
-        metrics.increment("arroyo.consumer.run_once", 1, None);
+        metrics.increment("arroyo.consumer.run.count", 1, None);
 
         if self.is_paused {
             // If the consumer waas paused, it should not be returning any messages


### PR DESCRIPTION
This metric is not named the way I remember! I want it to overlap with: https://github.com/getsentry/arroyo/blob/ba85564a91f95b0188d626dd3c03bb855f15726c/arroyo/processing/processor.py#L336
