### PR TITLE
feat(rust): Add max-poll-interval-ms CLI parameter

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -21,6 +21,7 @@ fn main() {
         "my_group".to_string(),
         "latest".to_string(),
         false,
+        30_000,
         None,
     );
     let mut consumer = KafkaConsumer::new(config);

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -25,6 +25,7 @@ fn main() {
         "my_group".to_string(),
         "latest".to_string(),
         false,
+        30_000,
         None,
     );
     let consumer = Arc::new(Mutex::new(KafkaConsumer::new(config)));

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -77,6 +77,7 @@ async fn main() {
         "my_group".to_string(),
         "latest".to_string(),
         false,
+        30_000,
         None,
     );
 

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -352,6 +352,7 @@ mod tests {
             "my-group".to_string(),
             "latest".to_string(),
             false,
+            30_000,
             None,
         );
         let mut consumer = KafkaConsumer::new(configuration);
@@ -369,6 +370,7 @@ mod tests {
             "my-group-1".to_string(),
             "latest".to_string(),
             false,
+            30_000,
             None,
         );
         let mut consumer = KafkaConsumer::new(configuration);
@@ -397,6 +399,7 @@ mod tests {
             "my-group-2".to_string(),
             "latest".to_string(),
             false,
+            30_000,
             None,
         );
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -101,6 +101,7 @@ mod tests {
             "my_group".to_string(),
             "latest".to_string(),
             false,
+            30_000,
             None,
         );
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -32,6 +32,7 @@ pub fn consumer(
     skip_write: bool,
     concurrency: usize,
     use_rust_processor: bool,
+    max_poll_interval_ms: usize,
     python_max_queue_depth: Option<usize>,
 ) {
     py.allow_threads(|| {
@@ -42,11 +43,13 @@ pub fn consumer(
             skip_write,
             concurrency,
             use_rust_processor,
+            max_poll_interval_ms,
             python_max_queue_depth,
         )
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn consumer_impl(
     consumer_group: &str,
     auto_offset_reset: &str,
@@ -54,6 +57,7 @@ pub fn consumer_impl(
     skip_write: bool,
     concurrency: usize,
     use_rust_processor: bool,
+    max_poll_interval_ms: usize,
     python_max_queue_depth: Option<usize>,
 ) {
     setup_logging();
@@ -132,6 +136,7 @@ pub fn consumer_impl(
         consumer_group.to_owned(),
         auto_offset_reset.to_owned(),
         false,
+        max_poll_interval_ms,
         Some(broker_config),
     );
 

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -112,6 +112,11 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     default=None,
     help="How many messages should be queued up in the Python message processor before backpressure kicks in. Defaults to the number of processes.",
 )
+@click.option(
+    "--max-interval-poll-ms",
+    type=int,
+    default=30000,
+)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -132,6 +137,7 @@ def rust_consumer(
     use_rust_processor: bool,
     group_instance_id: Optional[str],
     python_max_queue_depth: Optional[int],
+    max_interval_poll_ms: int,
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -173,4 +179,5 @@ def rust_consumer(
         concurrency_override or concurrency or 1,
         use_rust_processor,
         python_max_queue_depth,
+        max_interval_poll_ms,
     )


### PR DESCRIPTION
I'm honestly not loving this API. Adding a parameter to `KafkaConfig::new_consumer_config` that now has to be filled in everywhere feels kind of bad. I think preferably `KafkaConfig` would be a struct with a `Default` impl, maybe that could be done as a follow up.