### PR TITLE
ci: Reduce Sentry test concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,11 +292,11 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        instance: [0, 1, 2, 3, 4, 5, 6, 7]
+        instance: [0, 1, 2, 3]
     env:
       MIGRATIONS_TEST_MIGRATE: 1
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
-      MATRIX_INSTANCE_TOTAL: 8
+      MATRIX_INSTANCE_TOTAL: 4
       TEST_GROUP_STRATEGY: ROUND_ROBIN
 
     steps:

--- a/gocd/pipelines/snuba-stable.yaml
+++ b/gocd/pipelines/snuba-stable.yaml
@@ -42,11 +42,7 @@ pipelines:
                                     "sentry (0)" \
                                     "sentry (1)" \
                                     "sentry (2)" \
-                                    "sentry (3)" \
-                                    "sentry (4)" \
-                                    "sentry (5)" \
-                                    "sentry (6)" \
-                                    "sentry (7)"
+                                    "sentry (3)"
                               - script: |
                                     /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
                                     ${GO_REVISION_SNUBA_REPO} \

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -10,8 +10,4 @@
   "sentry (0)" \
   "sentry (1)" \
   "sentry (2)" \
-  "sentry (3)" \
-  "sentry (4)" \
-  "sentry (5)" \
-  "sentry (6)" \
-  "sentry (7)"
+  "sentry (3)"

--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -1,5 +1,3 @@
-# TODO: Revert - Testing
-
 import logging
 import uuid
 from datetime import datetime

--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -1,3 +1,5 @@
+# TODO: Revert - Testing
+
 import logging
 import uuid
 from datetime import datetime


### PR DESCRIPTION
This is wasteful since a lot of time is spent just setting up the tests (which has to be done on every shard) and not actually running the test suite.

Sentry org is hitting max concurrency on GitHub so this aims to help in other projects too.
