### PR TITLE
fix(rust): Kafka headers improvements

### DIFF
--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -10,7 +10,7 @@ use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::base_consumer::BaseConsumer;
 use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
 use rdkafka::error::KafkaResult;
-use rdkafka::message::{BorrowedHeaders, BorrowedMessage, Message};
+use rdkafka::message::{BorrowedMessage, Message};
 use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -58,7 +58,7 @@ fn create_kafka_message(msg: BorrowedMessage) -> BrokerMessage<KafkaPayload> {
     BrokerMessage::new(
         KafkaPayload::new(
             msg.key().map(|k| k.to_vec()),
-            msg.headers().map(BorrowedHeaders::detach),
+            msg.headers().map(|h| h.into()),
             msg.payload().map(|p| p.to_vec()),
         ),
         partition,

--- a/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/types.rs
@@ -1,10 +1,53 @@
-use rdkafka::message::OwnedHeaders;
+use crate::types::TopicOrPartition;
+use rdkafka::message::{BorrowedHeaders, Header, OwnedHeaders};
+use rdkafka::producer::BaseRecord;
+
 use std::sync::Arc;
+#[derive(Clone, Debug)]
+pub struct Headers {
+    headers: OwnedHeaders,
+}
+
+impl Headers {
+    pub fn new() -> Self {
+        Self {
+            headers: OwnedHeaders::new(),
+        }
+    }
+
+    pub fn insert(self, key: &str, value: Option<Vec<u8>>) -> Headers {
+        let headers = self.headers.insert(Header {
+            key,
+            value: value.as_ref(),
+        });
+        Self { headers }
+    }
+}
+
+impl Default for Headers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<&BorrowedHeaders> for Headers {
+    fn from(value: &BorrowedHeaders) -> Self {
+        Self {
+            headers: value.detach(),
+        }
+    }
+}
+
+impl From<Headers> for OwnedHeaders {
+    fn from(value: Headers) -> Self {
+        value.headers
+    }
+}
 
 #[derive(Clone, Debug)]
 struct KafkaPayloadInner {
     pub key: Option<Vec<u8>>,
-    pub headers: Option<OwnedHeaders>,
+    pub headers: Option<Headers>,
     pub payload: Option<Vec<u8>>,
 }
 
@@ -13,13 +56,8 @@ pub struct KafkaPayload {
     inner: Arc<KafkaPayloadInner>,
 }
 
-impl KafkaPayload {
-    pub fn new(
-        key: Option<Vec<u8>>,
-        // TODO: OwnedHeaders is an internal rdkafka thing, try to get rid of it here
-        headers: Option<OwnedHeaders>,
-        payload: Option<Vec<u8>>,
-    ) -> Self {
+impl<'a> KafkaPayload {
+    pub fn new(key: Option<Vec<u8>>, headers: Option<Headers>, payload: Option<Vec<u8>>) -> Self {
         Self {
             inner: Arc::new(KafkaPayloadInner {
                 key,
@@ -33,11 +71,76 @@ impl KafkaPayload {
         self.inner.key.as_ref()
     }
 
-    pub fn headers(&self) -> Option<&OwnedHeaders> {
+    pub fn headers(&self) -> Option<&Headers> {
         self.inner.headers.as_ref()
     }
 
     pub fn payload(&self) -> Option<&Vec<u8>> {
         self.inner.payload.as_ref()
+    }
+
+    pub fn to_base_record(
+        &'a self,
+        destination: &'a TopicOrPartition,
+    ) -> BaseRecord<'_, Vec<u8>, Vec<u8>> {
+        let topic = match destination {
+            TopicOrPartition::Topic(topic) => topic.as_str(),
+            TopicOrPartition::Partition(partition) => partition.topic.as_str(),
+        };
+
+        let partition = match destination {
+            TopicOrPartition::Topic(_) => None,
+            TopicOrPartition::Partition(partition) => Some(partition.index),
+        };
+
+        let mut base_record = BaseRecord::to(topic);
+
+        if let Some(msg_key) = self.key() {
+            base_record = base_record.key(msg_key);
+        }
+
+        if let Some(msg_payload) = self.payload() {
+            base_record = base_record.payload(msg_payload);
+        }
+
+        if let Some(headers) = self.headers() {
+            base_record = base_record.headers((*headers).clone().into());
+        }
+
+        if let Some(index) = partition {
+            base_record = base_record.partition(index as i32)
+        }
+
+        base_record
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Topic;
+
+    #[test]
+    fn test_kafka_payload() {
+        let destination = TopicOrPartition::Topic(Topic::new("test"));
+        let p: KafkaPayload = KafkaPayload::new(None, None, None);
+        let base_record = p.to_base_record(&destination);
+        assert_eq!(base_record.topic, "test");
+        assert_eq!(base_record.key, None);
+        assert_eq!(base_record.payload, None);
+        assert_eq!(base_record.partition, None);
+
+        let mut headers = Headers::new();
+        headers = headers.insert("version", Some(b"1".to_vec()));
+        let p2 = KafkaPayload::new(
+            Some(b"key".to_vec()),
+            Some(headers),
+            Some(b"message".to_vec()),
+        );
+
+        let base_record = p2.to_base_record(&destination);
+        assert_eq!(base_record.topic, "test");
+        assert_eq!(base_record.key, Some(&b"key".to_vec()));
+        assert_eq!(base_record.payload, Some(&b"message".to_vec()));
     }
 }


### PR DESCRIPTION
There are 2 fixes in this PR:
1. Fix the producer so it actually produces the correct headers. These were omitted before so it never produced any headers even if they were present on the passed in KafkaPayload
2. Hide the internal rdkakfa BorrowedHeaders/OwnedHeaders types so they are not part of the arroyo API
