### PR TITLE
ref(rust): Move broker config validation into deserializer

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -114,25 +114,12 @@ pub fn consumer_impl(
         first_storage.name,
     );
 
-    let broker_config: HashMap<_, _> = consumer_config
-        .raw_topic
-        .broker_config
-        .iter()
-        .filter_map(|(k, v)| {
-            let v = v.as_ref()?;
-            if v.is_empty() {
-                return None;
-            }
-            Some((k.to_owned(), v.to_owned()))
-        })
-        .collect();
-
     let config = KafkaConfig::new_consumer_config(
         vec![],
         consumer_group.to_owned(),
         auto_offset_reset.to_owned(),
         false,
-        Some(broker_config),
+        Some(consumer_config.raw_topic.broker_config),
     );
 
     let consumer = Arc::new(Mutex::new(KafkaConsumer::new(config)));


### PR DESCRIPTION
Ensure broker config is always properly deserialized. Previously this was done in the consumer code, but we should move it to the config, so it will also work in other scenarios where we need broker config - such as the replacements producer and the commit log producer.