### PR TITLE
fix(rust): Fix the ProduceCommitLog strategy

### DIFF
--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -6,12 +6,12 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::processors::spans::SpanStatus;
-use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{KafkaMessageMetadata, RowData};
 
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
-) -> anyhow::Result<BytesInsertBatch> {
+) -> anyhow::Result<RowData> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: FromFunctionsMessage = serde_json::from_slice(payload_bytes)?;
 
@@ -54,7 +54,7 @@ pub fn process_message(
         rows.push(serialized);
     }
 
-    Ok(BytesInsertBatch { rows })
+    Ok(RowData { rows })
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -4,11 +4,10 @@ mod querylog;
 mod spans;
 mod utils;
 
-use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{KafkaMessageMetadata, RowData};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 
-type ProcessingFunction =
-    fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<BytesInsertBatch>;
+type ProcessingFunction = fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<RowData>;
 
 pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
     match name {

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -3,12 +3,12 @@ use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{KafkaMessageMetadata, RowData};
 
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-) -> anyhow::Result<BytesInsertBatch> {
+) -> anyhow::Result<RowData> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let mut msg: ProfileMessage = serde_json::from_slice(payload_bytes)?;
 
@@ -19,7 +19,7 @@ pub fn process_message(
 
     let serialized = serde_json::to_vec(&msg)?;
 
-    Ok(BytesInsertBatch {
+    Ok(RowData {
         rows: vec![serialized],
     })
 }

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -7,12 +7,12 @@ use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{KafkaMessageMetadata, RowData};
 
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
-) -> anyhow::Result<BytesInsertBatch> {
+) -> anyhow::Result<RowData> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: FromQuerylogMessage = serde_json::from_slice(payload_bytes)?;
 
@@ -20,7 +20,7 @@ pub fn process_message(
 
     let serialized = serde_json::to_vec(&querylog_msg)?;
 
-    Ok(BytesInsertBatch {
+    Ok(RowData {
         rows: vec![serialized],
     })
 }

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::processors::utils::{default_retention_days, hex_to_u64, DEFAULT_RETENTION_DAYS};
-use crate::types::{RowData, KafkaMessageMetadata};
+use crate::types::{KafkaMessageMetadata, RowData};
 
 pub fn process_message(
     payload: KafkaPayload,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -6,12 +6,12 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::processors::utils::{default_retention_days, hex_to_u64, DEFAULT_RETENTION_DAYS};
-use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{RowData, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-) -> anyhow::Result<BytesInsertBatch> {
+) -> anyhow::Result<RowData> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
 
@@ -22,7 +22,7 @@ pub fn process_message(
 
     let serialized = serde_json::to_vec(&span)?;
 
-    Ok(BytesInsertBatch {
+    Ok(RowData {
         rows: vec![serialized],
     })
 }

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -1,3 +1,5 @@
+use crate::types::BytesInsertBatch;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::Producer;
 use rust_arroyo::processing::strategies::run_task_in_threads::{
@@ -6,7 +8,7 @@ use rust_arroyo::processing::strategies::run_task_in_threads::{
 use rust_arroyo::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
 };
-use rust_arroyo::types::{Message, TopicOrPartition};
+use rust_arroyo::types::{Message, Topic, TopicOrPartition};
 use serde::{Deserialize, Serialize};
 use std::str;
 use std::sync::Arc;
@@ -18,7 +20,7 @@ struct Commit {
     topic: String,
     partition: u16,
     consumer_group: String,
-    orig_message_ts: f64,
+    orig_message_ts: DateTime<Utc>,
     offset: u64,
 }
 
@@ -36,6 +38,8 @@ enum CommitLogError {
     InvalidKey,
     #[error("invalid message payload")]
     InvalidPayload,
+    #[error("invalid timestamp")]
+    InvalidTimestamp,
 }
 
 impl TryFrom<KafkaPayload> for Commit {
@@ -56,11 +60,18 @@ impl TryFrom<KafkaPayload> for Commit {
         let d: Payload =
             serde_json::from_slice(payload.payload().ok_or(CommitLogError::InvalidPayload)?)?;
 
+        let time_millis = (d.orig_message_ts * 1000.0) as i64;
+
+        let orig_message_ts = DateTime::from_naive_utc_and_offset(
+            NaiveDateTime::from_timestamp_millis(time_millis).unwrap_or(NaiveDateTime::MIN),
+            Utc,
+        );
+
         Ok(Commit {
             topic,
             partition,
             consumer_group,
-            orig_message_ts: d.orig_message_ts,
+            orig_message_ts,
             offset: d.offset,
         })
     }
@@ -78,9 +89,11 @@ impl TryFrom<Commit> for KafkaPayload {
             .into_bytes(),
         );
 
+        let orig_message_ts = commit.orig_message_ts.timestamp_millis() as f64 / 1000.0;
+
         let payload = Some(serde_json::to_vec(&Payload {
             offset: commit.offset,
-            orig_message_ts: commit.orig_message_ts,
+            orig_message_ts,
         })?);
 
         Ok(KafkaPayload::new(key, None, payload))
@@ -89,7 +102,9 @@ impl TryFrom<Commit> for KafkaPayload {
 
 struct ProduceMessage {
     producer: Arc<dyn Producer<KafkaPayload>>,
-    topic: Arc<TopicOrPartition>,
+    topic: Topic,
+    destination: Arc<TopicOrPartition>,
+    consumer_group: String,
     skip_produce: bool,
 }
 
@@ -97,41 +112,57 @@ impl ProduceMessage {
     #[allow(dead_code)]
     pub fn new(
         producer: impl Producer<KafkaPayload> + 'static,
-        topic: TopicOrPartition,
+        topic: Topic,
+        consumer_group: String,
         skip_produce: bool,
     ) -> Self {
         ProduceMessage {
             producer: Arc::new(producer),
-            topic: Arc::new(topic),
+            topic,
+            destination: Arc::new(TopicOrPartition::Topic(topic)),
+            consumer_group,
             skip_produce,
         }
     }
 }
 
-impl TaskRunner<KafkaPayload, KafkaPayload> for ProduceMessage {
-    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<KafkaPayload> {
+impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ProduceMessage {
+    fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch> {
         let producer = self.producer.clone();
-        let topic = self.topic.clone();
+        let destination = self.destination.clone();
+        let topic = self.topic.as_str();
         let skip_produce = self.skip_produce;
+        let consumer_group = &self.consumer_group;
 
         Box::pin(async move {
             if skip_produce {
                 return Ok(message);
             }
 
-            match producer.produce(&topic, message.payload().clone()) {
-                Ok(_) => Ok(message),
-                Err(error) => {
-                    tracing::error!(%error, "Error producing message");
-                    Err(RunTaskError::RetryableError)
+            for (partition, (offset, orig_message_ts)) in message.payload().commit_log_offsets {
+                let commit = Commit {
+                    topic: topic.to_string(),
+                    partition: partition,
+                    consumer_group: consumer_group.to_string(),
+                    orig_message_ts,
+                    offset,
+                };
+
+                let payload = commit.try_into().unwrap();
+
+                if let Err(err) = producer.produce(&destination, payload) {
+                    tracing::error!(%err, "Error producing message");
+                    return Err(RunTaskError::RetryableError);
                 }
             }
+
+            Ok(message)
         })
     }
 }
 
 pub struct ProduceCommitLog {
-    inner: RunTaskInThreads<KafkaPayload, KafkaPayload>,
+    inner: RunTaskInThreads<BytesInsertBatch, BytesInsertBatch>,
 }
 
 impl ProduceCommitLog {
@@ -140,15 +171,21 @@ impl ProduceCommitLog {
         next_step: N,
         producer: impl Producer<KafkaPayload> + 'static,
         concurrency: &ConcurrencyConfig,
-        topic: TopicOrPartition,
+        topic: Topic,
+        consumer_group: String,
         skip_produce: bool,
     ) -> Self
     where
-        N: ProcessingStrategy<KafkaPayload> + 'static,
+        N: ProcessingStrategy<BytesInsertBatch> + 'static,
     {
         let inner = RunTaskInThreads::new(
             next_step,
-            Box::new(ProduceMessage::new(producer, topic, skip_produce)),
+            Box::new(ProduceMessage::new(
+                producer,
+                topic,
+                consumer_group,
+                skip_produce,
+            )),
             concurrency,
             Some("produce_commit_log"),
         );
@@ -157,12 +194,15 @@ impl ProduceCommitLog {
     }
 }
 
-impl ProcessingStrategy<KafkaPayload> for ProduceCommitLog {
+impl ProcessingStrategy<BytesInsertBatch> for ProduceCommitLog {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         self.inner.poll()
     }
 
-    fn submit(&mut self, message: Message<KafkaPayload>) -> Result<(), SubmitError<KafkaPayload>> {
+    fn submit(
+        &mut self,
+        message: Message<BytesInsertBatch>,
+    ) -> Result<(), SubmitError<BytesInsertBatch>> {
         self.inner.submit(message)
     }
 
@@ -279,7 +319,8 @@ mod tests {
             next_step,
             producer,
             &concurrency,
-            TopicOrPartition::Topic(Topic::new("test")),
+            Topic::new("test"),
+            "group1".to_string(),
             false,
         );
 

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -256,7 +256,7 @@ mod tests {
             fn submit(
                 &mut self,
                 message: Message<BytesInsertBatch>,
-            ) -> Result<(), SubmitError<KafkaPayload>> {
+            ) -> Result<(), SubmitError<BytesInsertBatch>> {
                 self.payloads.push(message.payload().clone());
                 Ok(())
             }

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -13,7 +13,7 @@ use anyhow::Error;
 
 use pyo3::prelude::*;
 
-use crate::types::RowData;
+use crate::types::{BytesInsertBatch, RowData};
 
 use crate::config::MessageProcessorConfig;
 
@@ -29,9 +29,9 @@ enum TaskHandle {
 }
 
 pub struct PythonTransformStep {
-    next_step: Box<dyn ProcessingStrategy<RowData>>,
+    next_step: Box<dyn ProcessingStrategy<BytesInsertBatch>>,
     handles: VecDeque<TaskHandle>,
-    message_carried_over: Option<Message<RowData>>,
+    message_carried_over: Option<Message<BytesInsertBatch>>,
     processing_pool: Option<procspawn::Pool>,
     max_queue_depth: usize,
 }
@@ -44,7 +44,7 @@ impl PythonTransformStep {
         next_step: N,
     ) -> Result<Self, Error>
     where
-        N: ProcessingStrategy<RowData> + 'static,
+        N: ProcessingStrategy<BytesInsertBatch> + 'static,
     {
         let next_step = Box::new(next_step);
         let python_module = &processor_config.python_module;

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -4,6 +4,7 @@ use rust_arroyo::processing::strategies::{
 };
 use rust_arroyo::types::{BrokerMessage, InnerMessage, Message};
 
+use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::thread::sleep;
@@ -112,9 +113,17 @@ impl PythonTransformStep {
             };
             match message_result {
                 Ok(data) => {
+                    let replacement = BytesInsertBatch {
+                        rows: data.rows,
+                        // TODO: Actually implement this
+                        commit_log_offsets: BTreeMap::from([]),
+                    };
+
                     if let Err(SubmitError::MessageRejected(MessageRejected {
                         message: transformed_message,
-                    })) = self.next_step.submit(original_message_meta.replace(data))
+                    })) = self
+                        .next_step
+                        .submit(original_message_meta.replace(replacement))
                     {
                         self.message_carried_over = Some(transformed_message);
                     }

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -1,9 +1,17 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RowData {
+    pub rows: Vec<Vec<u8>>,
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BytesInsertBatch {
     pub rows: Vec<Vec<u8>>,
+    // For each partition we store the offset and timestamp to be produced to the commit log
+    pub commit_log_offsets: BTreeMap<u16, (u64, DateTime<Utc>)>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
The ProduceCommitLog should get a message with type `BytesInsertBatch` from the prior processing step, and produces one message for each partition contained within that batch. The prior version where it got a `KafkaPayload` and produced a single message was wrong.

In order to achieve this, this splits the `BytesInsertBatch` into two separate structs. Now we have `RowData` which we require the message processors to return, as well as `BytesInsertBatch` which is now internal to Snuba and contains other metadata that we will add for producing to the commit log.
