### PR TITLE
fix: Remove unnecessary locking in metrics

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
+++ b/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
@@ -2,12 +2,12 @@ use crate::utils::metrics::{get_metrics, Metrics};
 use core::fmt::Debug;
 use std::collections::BTreeMap;
 use std::mem;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 pub struct MetricsBuffer {
-    metrics: Arc<Mutex<Box<dyn Metrics>>>,
+    metrics: Arc<dyn Metrics>,
     timers: BTreeMap<String, Duration>,
     gauges: BTreeMap<String, u64>,
     last_flush: Instant,

--- a/rust_snuba/rust_arroyo/src/utils/metrics.rs
+++ b/rust_snuba/rust_arroyo/src/utils/metrics.rs
@@ -1,8 +1,8 @@
 use core::fmt::Debug;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 
-pub static METRICS: OnceLock<Arc<Mutex<Box<dyn Metrics>>>> = OnceLock::new();
+pub static METRICS: OnceLock<Arc<dyn Metrics>> = OnceLock::new();
 
 pub trait Metrics: Debug + Send + Sync {
     fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>);
@@ -12,15 +12,15 @@ pub trait Metrics: Debug + Send + Sync {
     fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
 }
 
-impl Metrics for Arc<Mutex<Box<dyn Metrics>>> {
+impl Metrics for Arc<dyn Metrics> {
     fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>) {
-        self.as_ref().lock().unwrap().increment(key, value, tags)
+        (**self).increment(key, value, tags)
     }
     fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
-        self.as_ref().lock().unwrap().gauge(key, value, tags)
+        (**self).gauge(key, value, tags)
     }
     fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
-        self.as_ref().lock().unwrap().timing(key, value, tags)
+        (**self).timing(key, value, tags)
     }
 }
 
@@ -35,16 +35,16 @@ impl Metrics for Noop {
     fn timing(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
 }
 
-pub fn configure_metrics(metrics: Box<dyn Metrics>) {
+pub fn configure_metrics<M>(metrics: M)
+where
+    M: Metrics + 'static,
+{
     // Metrics can only be configured once
     METRICS
-        .set(Arc::new(Mutex::new(metrics)))
+        .set(Arc::new(metrics))
         .expect("Metrics already configured");
 }
 
-pub fn get_metrics() -> Arc<Mutex<Box<dyn Metrics>>> {
-    match METRICS.get() {
-        Some(metrics) => metrics.clone(),
-        None => Arc::new(Mutex::new(Box::new(Noop {}))),
-    }
+pub fn get_metrics() -> Arc<dyn Metrics> {
+    METRICS.get().cloned().unwrap_or_else(|| Arc::new(Noop {}))
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -94,12 +94,7 @@ pub fn consumer_impl(
         tags.insert("storage", storage_name.as_str());
         tags.insert("consumer_group", consumer_group);
 
-        configure_metrics(Box::new(StatsDBackend::new(
-            &host,
-            port,
-            "snuba.consumer",
-            tags,
-        )));
+        configure_metrics(StatsDBackend::new(&host, port, "snuba.consumer", tags));
     }
 
     if !use_rust_processor {


### PR DESCRIPTION
at some point `metrics.incr` had `&mut self`, and back then it was necessary