### PR TITLE
fix(metrics) Add _indexed_tags_hash column to distributions

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -314,6 +314,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0025_counters_add_raw_tags_hash_column",
             "0026_gauges_add_raw_tags_hash_column",
             "0027_sets_add_raw_tags_column",
+            "0028_distributions_add_indexed_tags_column",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0028_distributions_add_indexed_tags_column.py
+++ b/snuba/snuba_migrations/generic_metrics/0028_distributions_add_indexed_tags_column.py
@@ -1,0 +1,43 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Array, Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import hash_map_int_column_definition
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    dist_table_name = "generic_metric_distributions_aggregated_dist"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                column=Column(
+                    "_indexed_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_column_definition(
+                                "tags.key", "tags.indexed_value"
+                            )
+                        ),
+                    ),
+                ),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                column_name="_indexed_tags_hash",
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]


### PR DESCRIPTION
The distributions table already has the _raw_tags_hash column, but it is
missing the _indexed_tags_hash column to make it consistent with the other
metric types.

![Screenshot 2023-11-21 at 3 31 17 PM](https://github.com/getsentry/snuba/assets/2727124/dfa055ba-cfd2-4d23-bc14-183bf833764c)
