### PR TITLE
fix(replacegroup): Catch bad datetime formats in ReplaceGroup

### DIFF
--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -195,7 +195,6 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
         ):
             return None
         elif type_ in _REPLACEMENT_BY_TYPE:
-
             processed = _REPLACEMENT_BY_TYPE[type_].parse_message(
                 message,
                 self.__replacement_context,
@@ -262,6 +261,10 @@ def _build_event_set_filter(
     def get_timestamp_condition(msg_value: Optional[str], operator: str) -> str:
         if not msg_value:
             return ""
+
+        if "+" in msg_value:  # e.g. "2023-08-28T03:05:38+00:00"
+            msg_value, _ = msg_value.rsplit("+", 1)
+            msg_value += ".000Z"
 
         timestamp = datetime.strptime(msg_value, settings.PAYLOAD_DATETIME_FORMAT)
         return (
@@ -392,7 +395,6 @@ class DeleteGroupsReplacement(Replacement):
         message: ReplacementMessage[EndDeleteGroupsMessageBody],
         context: ReplacementContext,
     ) -> Optional[DeleteGroupsReplacement]:
-
         group_ids = message.data["group_ids"]
         if not group_ids:
             return None

--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -262,11 +262,11 @@ def _build_event_set_filter(
         if not msg_value:
             return ""
 
-        if "+" in msg_value:  # e.g. "2023-08-28T03:05:38+00:00"
-            msg_value, _ = msg_value.rsplit("+", 1)
-            msg_value += ".000Z"
+        try:
+            timestamp = datetime.strptime(msg_value, settings.PAYLOAD_DATETIME_FORMAT)
+        except ValueError:  # e.g. "2023-08-28T03:05:38+00:00"
+            timestamp = datetime.fromisoformat(msg_value)
 
-        timestamp = datetime.strptime(msg_value, settings.PAYLOAD_DATETIME_FORMAT)
         return (
             f"timestamp {operator} toDateTime('{timestamp.strftime(DATETIME_FORMAT)}')"
         )

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -727,6 +727,45 @@ class TestReplacerProcess(BaseTest):
         )
         assert replacement.get_query_time_flags() is None
 
+    def test_replace_group_process_alternate_date(self) -> None:
+        timestamp = datetime.now()
+        message = (
+            2,
+            ReplacementType.REPLACE_GROUP,
+            {
+                "project_id": self.project_id,
+                "event_ids": ["00e24a150d7f4ee4b142b61b4d893b6d"],
+                "new_group_id": 2,
+                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+            },
+        )
+
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
+        assert replacement is not None
+
+        query_args = {
+            "event_ids": "'00e24a15-0d7f-4ee4-b142-b61b4d893b6d'",
+            "project_id": self.project_id,
+            "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, hierarchical_hashes, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, exception_main_thread, sdk_integrations, modules.name, modules.version, trace_sampled, num_processing_errors, replay_id",
+            "select_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, 2, primary_hash, hierarchical_hashes, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, exception_main_thread, sdk_integrations, modules.name, modules.version, trace_sampled, num_processing_errors, replay_id",
+            "table_name": "foo",
+        }
+
+        assert (
+            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            == "SELECT count() FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            % query_args
+        )
+
+        assert (
+            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            == "INSERT INTO %(table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            % query_args
+        )
+        assert replacement.get_query_time_flags() is None
+
     def test_merge_process(self) -> None:
         timestamp = datetime.now()
         message = (


### PR DESCRIPTION
A bad message was sent to ReplaceGroup that used the `+00:00` format instead of
`.000Z` format. In order to continue processing, handle that edge case just for
the ReplaceGroup class. As a follow up the emitter of the bad message will be
fixed.