### PR TITLE
fix: make sure SNUBA_RELEASE is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,16 @@ RUN set -ex; \
     pip install -e .; \
     snuba --help
 
+ARG SOURCE_COMMIT
+ENV SNUBA_RELEASE=$SOURCE_COMMIT \
+    FLASK_DEBUG=0 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UWSGI_ENABLE_METRICS=true \
+    UWSGI_NEED_PLUGIN=/var/lib/uwsgi/dogstatsd \
+    UWSGI_STATS_PUSH=dogstatsd:127.0.0.1:8126 \
+    UWSGI_DOGSTATSD_EXTRA_TAGS=service:snuba
+
 USER snuba
 EXPOSE 1218 1219
 ENTRYPOINT [ "./docker_entrypoint.sh" ]
@@ -127,17 +137,6 @@ RUN set -ex; \
     rm /tmp/build-deps.txt; \
     rm -rf /var/lib/apt/lists/*;
 USER snuba
-
-ARG SOURCE_COMMIT
-ENV SNUBA_RELEASE=$SOURCE_COMMIT \
-    FLASK_DEBUG=0 \
-    PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    UWSGI_ENABLE_METRICS=true \
-    UWSGI_NEED_PLUGIN=/var/lib/uwsgi/dogstatsd \
-    UWSGI_STATS_PUSH=dogstatsd:127.0.0.1:8126 \
-    UWSGI_DOGSTATSD_EXTRA_TAGS=service:snuba
-
 
 FROM application_base AS testing
 


### PR DESCRIPTION
The events in sentry for the snuba project are no longer being tagged with a release, I think that it _might_ have been due to https://github.com/getsentry/snuba/pull/4551/ since changes to the Dockerfile were made.

I'm moving the ENV chunk before running the `api` since I'm assuming that's why the `SNUBA_RELEASE` isn't being picked up. 