### PR TITLE
fix(spans): Add profile_id to spans query columns

### DIFF
--- a/snuba/datasets/configuration/spans/entities/spans.yaml
+++ b/snuba/datasets/configuration/spans/entities/spans.yaml
@@ -17,6 +17,7 @@ schema:
     },
     { name: trace_id, type: UUID },
     { name: span_id, type: UInt, args: { size: 64 } },
+    { name: profile_id, type: UUID, args: { schema_modifiers: [nullable] } },
     {
       name: parent_span_id,
       type: UInt,

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -16,6 +16,7 @@ schema:
       { name: transaction_op, type: String, args: { schema_modifiers: [nullable] } },
       { name: trace_id, type: UUID},
       { name: span_id, type: UInt, args: { size: 64 } },
+      { name: profile_id, type: UUID, args: { schema_modifiers: [nullable] } },
       { name: parent_span_id, type: UInt, args: { size: 64, schema_modifiers: [nullable] } },
       { name: segment_id, type: UInt, args: { size: 64 } },
       { name: is_segment, type: UInt, args: { size: 8 } },


### PR DESCRIPTION
The `profile_id` column was added to spans: https://github.com/getsentry/snuba/blob/master/snuba/snuba_migrations/spans/0006_spans_add_profile_id.py. However, it wasn't added to the storage and entity yet. As a result, a few users are experiencing snuba errors when querying for this column.