### PR TITLE
fix(rust-python): Join handles less frequently, fix backpressure bug

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -54,3 +54,9 @@ pyo3 = { version = "*", features = ["auto-initialize"] }
 [[bench]]
 name = "processors"
 harness = false
+
+[[bin]]
+# this is not a proper benchmark since it runs forever.
+name = "python-processor-infinite"
+path = "bin/python_processor_infinite.rs"
+required-features = ["pyo3/auto-initialize"]

--- a/rust_snuba/bin/python_processor_infinite.rs
+++ b/rust_snuba/bin/python_processor_infinite.rs
@@ -1,0 +1,98 @@
+//! Launch the Python message processor and send messages into it, forever. The purpose is to find
+//! memory leaks and to see how well it utilizes CPU, not to measure throughput.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::processing::strategies::run_task::RunTask;
+use rust_arroyo::processing::strategies::ProcessingStrategy;
+use rust_arroyo::types::{Message, Partition, Topic};
+use rust_snuba::{MessageProcessorConfig, Noop, PythonTransformStep};
+use serde_json::json;
+
+fn main() {
+    procspawn::init();
+
+    let step = Noop;
+
+    let output = Arc::new(AtomicUsize::new(0));
+    let output2 = output.clone();
+
+    let step = RunTask::new(
+        move |_| {
+            output2.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        },
+        step,
+    );
+
+    let mut step = PythonTransformStep::new(
+        MessageProcessorConfig {
+            python_class_name: "SpansMessageProcessor".into(),
+            python_module: "snuba.datasets.processors.spans_processor".into(),
+        },
+        8,
+        Some(256),
+        step,
+    )
+    .unwrap();
+
+    for _ in 0..2000000 {
+        step.poll().unwrap();
+        let message = Message::new_broker_message(
+            spans_payload(),
+            Partition::new(Topic::new("test"), 1),
+            1,
+            Utc::now(),
+        );
+        step.submit(message).unwrap();
+    }
+
+    println!("join");
+
+    step.close();
+    step.join(None).unwrap();
+
+    println!("{}", output.load(Ordering::Relaxed))
+}
+
+fn spans_payload() -> KafkaPayload {
+    let now = Utc::now();
+    let data = json!({
+        "description": "GET /blah",
+        "duration_ms": 1000,
+        "event_id": "f7d00ab7-ebb8-433b-ba8b-719028bc2f40",
+        "exclusive_time_ms": 1000.0,
+        "group_raw": "deadbeefdeadbeef",
+        "is_segment": false,
+        "parent_span_id": "deadbeefdeadbeef",
+        "profile_id": "facb4816-3f0f-4b71-9306-c77b5109e7b4",
+        "project_id": 1,
+        "retention_days": 90,
+        "segment_id": "deadbeefdeadbeef",
+        "sentry_tags": {
+            "action": "GET",
+            "domain": "targetdomain.tld:targetport",
+            "group": "deadbeefdeadbeef",
+            "http.method": "GET",
+            "module": "http",
+            "op": "http.client",
+            "status": "ok",
+            "status_code": "200",
+            "system": "python",
+            "transaction": "/organizations/:orgId/issues/",
+            "transaction.method": "GET",
+            "transaction.op": "navigation"
+        },
+        "span_id": "deadbeefdeadbeef",
+        "start_timestamp_ms": now.timestamp() * 1000,
+        "tags": { "tag1": "value1", "tag2": "123", "tag3": "true" },
+        "trace_id": "6f2a27f7-942d-4db1-b406-93524ed7da54"
+    });
+
+    let data_bytes = serde_json::to_vec(&data).unwrap();
+    KafkaPayload::new(None, None, Some(data_bytes))
+}

--- a/rust_snuba/rust_arroyo/src/types/mod.rs
+++ b/rust_snuba/rust_arroyo/src/types/mod.rs
@@ -252,7 +252,7 @@ impl<T> Message<T> {
     }
 
     /// Map a fallible function over this messages's payload.
-    pub fn try_map<TReplaced, E, F: FnOnce(T) -> Result<TReplaced, E>>(
+    pub fn try_map<TReplaced, E, F: Fn(T) -> Result<TReplaced, E>>(
         self,
         f: F,
     ) -> Result<Message<TReplaced>, E> {

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -23,3 +23,5 @@ fn rust_snuba(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 // plus a pyo3 specific crate as `cdylib`.
 pub use config::{ClickhouseConfig, MessageProcessorConfig, StorageConfig};
 pub use factory::ConsumerStrategyFactory;
+pub use strategies::noop::Noop;
+pub use strategies::python::PythonTransformStep;

--- a/rust_snuba/src/strategies/mod.rs
+++ b/rust_snuba/src/strategies/mod.rs
@@ -1,4 +1,5 @@
 pub mod clickhouse;
 pub mod commit_log;
+pub mod noop;
 pub mod python;
 pub mod validate_schema;

--- a/rust_snuba/src/strategies/noop.rs
+++ b/rust_snuba/src/strategies/noop.rs
@@ -1,0 +1,29 @@
+use std::time::Duration;
+
+use rust_arroyo::processing::strategies::{
+    CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
+};
+use rust_arroyo::types::Message;
+
+pub struct Noop;
+
+impl<T> ProcessingStrategy<T> for Noop {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+        Ok(None)
+    }
+
+    fn submit(&mut self, _message: Message<T>) -> Result<(), SubmitError<T>> {
+        Ok(())
+    }
+
+    fn close(&mut self) {}
+
+    fn terminate(&mut self) {}
+
+    fn join(
+        &mut self,
+        _timeout: Option<Duration>,
+    ) -> Result<Option<CommitRequest>, InvalidMessage> {
+        Ok(None)
+    }
+}

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -39,8 +39,12 @@ enum TaskHandle {
 impl TaskHandle {
     fn submit_timestamp(&self) -> SystemTime {
         match self {
-            TaskHandle::Procspawn { submit_timestamp, .. } => *submit_timestamp,
-            TaskHandle::Immediate { submit_timestamp, .. } => *submit_timestamp,
+            TaskHandle::Procspawn {
+                submit_timestamp, ..
+            } => *submit_timestamp,
+            TaskHandle::Immediate {
+                submit_timestamp, ..
+            } => *submit_timestamp,
         }
     }
 }

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -174,7 +174,7 @@ impl PythonTransformStep {
 
 impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
-        if self.queue_needs_drain() {
+        while self.queue_needs_drain() {
             self.check_for_results();
         }
 


### PR DESCRIPTION
max_queue_depth does not work as it is implemented right now, but now
that we expose it as a parameter, we might as well use it to determine
how many handles are supposed to be in-flight.

The original theory was correct though: We are blocking too much in
check_for_results, and that's the culprit for our performance problems.

Now the next performance problem is the serialization overhead for
individual messages between processes, and we might have to implement
batching to fix that. But at the very least the processor can now
saturate 5 cores on my machine.
