### PR TITLE
fix: Skip warnings in gocd error checks

### DIFF
--- a/gocd/templates/bash/saas-sentry-error-check.sh
+++ b/gocd/templates/bash/saas-sentry-error-check.sh
@@ -6,6 +6,7 @@
   --release="${GO_REVISION_SNUBA_REPO}" \
   --duration=5 \
   --error-events-limit=500 \
+  --skip-warnings=true \
 
 
 # --skip-check=${SKIP_CANARY_CHECKS}


### PR DESCRIPTION
The rate limit warnings that go to Sentry was causing this check to trip up and
prevent the deploy pipeline from working. Skip warning error events when
running this check.

Depends on https://github.com/getsentry/devinfra-deployment-service/pull/503