### PR TITLE
feat(rust): Pass the DLQ policy to stream processor

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -84,7 +84,7 @@ fn run_bench(
             )
         })
         .bench_local_values(|((topic, consumer), factory)| {
-            let mut processor = StreamProcessor::new(consumer, factory);
+            let mut processor = StreamProcessor::new(consumer, factory, None);
             processor.subscribe(topic);
 
             loop {

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -30,7 +30,7 @@ fn main() {
     let consumer = Arc::new(Mutex::new(KafkaConsumer::new(config)));
     let topic = Topic::new("test_static");
 
-    let mut processor = StreamProcessor::new(consumer, Box::new(TestFactory {}));
+    let mut processor = StreamProcessor::new(consumer, Box::new(TestFactory {}), None);
     processor.subscribe(topic);
     for _ in 0..20 {
         processor.run_once().unwrap();

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -89,6 +89,7 @@ async fn main() {
             config,
             topic: Topic::new("test_out"),
         }),
+        None,
     );
     processor.subscribe(Topic::new("test_in"));
     println!("running processor. transforming from test_in to test_out");

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-trait DlqProducer<TPayload> {
+pub trait DlqProducer<TPayload> {
     // Send a message to the DLQ.
     fn produce(
         &self,
@@ -40,13 +40,13 @@ impl<TPayload: 'static> DlqProducer<TPayload> for NoopDlqProducer {
 // Two additional fields are added to the headers of the Kafka message
 // "original_partition": The partition of the original message
 // "original_offset": The offset of the original message
-struct KafkaDlqProducer {
+pub struct KafkaDlqProducer {
     producer: Arc<KafkaProducer>,
     topic: TopicOrPartition,
 }
 
 impl KafkaDlqProducer {
-    fn new(producer: KafkaProducer, topic: Topic) -> Self {
+    pub fn new(producer: KafkaProducer, topic: Topic) -> Self {
         Self {
             producer: Arc::new(producer),
             topic: TopicOrPartition::Topic(topic),
@@ -100,17 +100,17 @@ impl DlqProducer<KafkaPayload> for KafkaDlqProducer {
 // rather than rerouting every message to the DLQ.
 
 // The ratio and max_consecutive_count are counted on a per-partition basis.
-struct DlqLimit {
-    max_invalid_ratio: Option<f64>,
-    max_consecutive_count: Option<u64>,
+pub struct DlqLimit {
+    pub max_invalid_ratio: Option<f64>,
+    pub max_consecutive_count: Option<u64>,
 }
 
-struct DlqLimitState {}
+pub struct DlqLimitState {}
 
 // DLQ policy defines the DLQ configuration, and is passed to the stream processor
 // upon creation of the consumer. It consists of the DLQ producer implementation and
 // any limits that should be applied.
-struct DlqPolicy<TPayload> {
+pub struct DlqPolicy<TPayload> {
     producer: Box<dyn DlqProducer<TPayload>>,
     limit: DlqLimit,
 }

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -127,6 +127,12 @@ pub struct BufferedMessages<TPayload> {
     buffered_messages: BTreeMap<Partition, VecDeque<BrokerMessage<TPayload>>>,
 }
 
+impl<TPayload> Default for BufferedMessages<TPayload> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<TPayload> BufferedMessages<TPayload> {
     pub fn new() -> Self {
         BufferedMessages {

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -379,7 +379,6 @@ mod tests {
     use crate::backends::local::broker::LocalBroker;
     use crate::backends::local::LocalConsumer;
     use crate::backends::storages::memory::MemoryMessageStorage;
-    use crate::processing::dlq::DlqLimit;
     use crate::types::{Message, Partition, Topic};
     use crate::utils::clock::SystemClock;
     use std::collections::HashMap;

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -5,8 +5,10 @@ use std::time::Duration;
 use chrono::{DateTime, NaiveDateTime, Utc};
 
 use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::kafka::KafkaConsumer;
+use rust_arroyo::processing::dlq::{DlqLimit, DlqPolicy, KafkaDlqProducer};
 
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use rust_arroyo::processing::StreamProcessor;
@@ -119,6 +121,30 @@ pub fn consumer_impl(
 
     let consumer = Arc::new(Mutex::new(KafkaConsumer::new(config)));
     let logical_topic_name = consumer_config.raw_topic.logical_topic_name;
+
+    // TODO: Create the policy
+    let dlq_policy = match consumer_config.dlq_topic {
+        None => None,
+        Some(dlq_topic_config) => {
+            let producer_config =
+                KafkaConfig::new_producer_config(vec![], Some(dlq_topic_config.broker_config));
+            let producer = KafkaProducer::new(producer_config);
+
+            let kafka_dlq_producer = Box::new(KafkaDlqProducer::new(
+                producer,
+                Topic::new(&dlq_topic_config.physical_topic_name),
+            ));
+
+            Some(DlqPolicy::new(
+                kafka_dlq_producer,
+                DlqLimit {
+                    max_invalid_ratio: Some(0.01),
+                    max_consecutive_count: Some(1000),
+                },
+            ))
+        }
+    };
+
     let mut processor = StreamProcessor::new(
         consumer,
         Box::new(ConsumerStrategyFactory::new(
@@ -131,6 +157,7 @@ pub fn consumer_impl(
             python_max_queue_depth,
             use_rust_processor,
         )),
+        dlq_policy,
     );
 
     processor.subscribe(Topic::new(&consumer_config.raw_topic.physical_topic_name));

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -122,7 +122,6 @@ pub fn consumer_impl(
     let consumer = Arc::new(Mutex::new(KafkaConsumer::new(config)));
     let logical_topic_name = consumer_config.raw_topic.logical_topic_name;
 
-    // TODO: Create the policy
     let dlq_policy = match consumer_config.dlq_topic {
         None => None,
         Some(dlq_topic_config) => {


### PR DESCRIPTION
This change starts wiring up the DLQ policy and producer.

- The StreamProcessor now takes an optional dlq_policy parameter, which defines the policy to be applied to invalid messages.

- The dlq_policy is applied for consumers/topics where a value for `dlq_topic` is defined (this comes from storage .yaml files), otherwise it is None and no messages will be DLQ'ed.

- The policy is not being used by the StreamProcessor yet
