### PR TITLE
fix(discover): Enable column validator on discover entities

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -458,6 +458,8 @@ query_processors:
   - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
+
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/discover/entities/discover_events.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_events.yaml
@@ -521,6 +521,8 @@ query_processors:
   - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
+
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
@@ -337,6 +337,8 @@ query_processors:
   - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
+
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:


### PR DESCRIPTION
Change the discover entities to reject queries with invalid columns.

This has been tested in production, by logging warnings instead of errors. All
the instances of invalid columns being logged were from queries with invalid
columns.