### PR TITLE
fix(rust): Fix deadlock on backpressure

### DIFF
--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -434,6 +434,8 @@ mod tests {
         assert_eq!(backpressure.0.load(Ordering::Relaxed), 0);
 
         step.poll().unwrap();
+
+        // assert that after backpressure.0 has hit zero, we are able to submit messages again
         step.submit(Message::new_broker_message(
             KafkaPayload::new(
                 None,

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -300,8 +300,8 @@ procspawn::enable_test_support!();
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     use super::*;
 


### PR DESCRIPTION
in https://github.com/getsentry/snuba/pull/5088 i introduced a bug that would
make the python processor permanently backpressure if there was ever
backpressure from the next_step at any point

we currently experience deadlocks in hybrid consumer, but this bugfix _should_
be unrelated, as the clickhouse writer step _should_ never apply backpressure
and we'd never run into this scenario
