### PR TITLE
fix(rust): Fix processing time metric

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -191,6 +191,9 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                     return Err(RunError::Poll(error));
                 }
             }
+
+            self.metrics_buffer
+                .incr_timing("arroyo.consumer.processing.time", poll_start.elapsed());
         }
 
         // since we do not drive the kafka consumer at this point, it is safe to acquire the state
@@ -204,6 +207,8 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                 Some(_) => return Err(RunError::InvalidState),
             }
         };
+
+        let poll_start = Instant::now();
         let commit_request = strategy.poll();
         match commit_request {
             Ok(None) => {}

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -191,9 +191,6 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                     return Err(RunError::Poll(error));
                 }
             }
-
-            self.metrics_buffer
-                .incr_timing("arroyo.consumer.processing.time", poll_start.elapsed());
         }
 
         // since we do not drive the kafka consumer at this point, it is safe to acquire the state
@@ -207,9 +204,12 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                 Some(_) => return Err(RunError::InvalidState),
             }
         };
-
         let poll_start = Instant::now();
         let commit_request = strategy.poll();
+
+        self.metrics_buffer
+            .incr_timing("arroyo.consumer.processing.time", poll_start.elapsed());
+
         match commit_request {
             Ok(None) => {}
             Ok(Some(request)) => {


### PR DESCRIPTION
Processing time was understated since we were not counting the time spent in strategy.poll() which is where a lot of consumers do processing work. This is now aligned with the Python Arroyo implementation.
