### PR TITLE
fix(generic_metrics): Expose tags.raw_value in the generic_metrics entities

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
@@ -24,6 +24,15 @@ schema:
         },
     },
     {
+      name: tags.raw_value,
+      type: Array,
+      args:
+        {
+          schema_modifiers: [readonly],
+          inner_type: { type: String },
+        },
+    },
+    {
       name: value,
       type: AggregateFunction,
       args: { func: sum, arg_types: [{ type: Float, args: { size: 64 } }] },

--- a/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
@@ -24,6 +24,15 @@ schema:
         },
     },
     {
+      name: tags.raw_value,
+      type: Array,
+      args:
+        {
+          schema_modifiers: [readonly],
+          inner_type: { type: String },
+        },
+    },
+    {
       name: percentiles,
       type: AggregateFunction,
       args:

--- a/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
@@ -24,6 +24,15 @@ schema:
         },
     },
     {
+      name: tags.raw_value,
+      type: Array,
+      args:
+        {
+          schema_modifiers: [readonly],
+          inner_type: { type: String },
+        },
+    },
+    {
       name: min,
       type: AggregateFunction,
       args: { func: min, arg_types: [{ type: Float, args: { size: 64 } }] },

--- a/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
@@ -24,6 +24,15 @@ schema:
         },
     },
     {
+      name: tags.raw_value,
+      type: Array,
+      args:
+        {
+          schema_modifiers: [readonly],
+          inner_type: { type: String },
+        },
+    },
+    {
       name: value,
       type: AggregateFunction,
       args:


### PR DESCRIPTION
This column needs to be queried in order to get proper meta information about
the tags and their values in the tables. Ensure that it can be queried with
SnQL.