### PR TITLE
ref(rust): Remove offset staging

### DIFF
--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -153,14 +153,8 @@ pub trait Consumer<TPayload, C>: Send {
     /// exception will be raised and no offsets will be modified.
     fn seek(&self, offsets: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
 
-    /// Stage offsets to be committed. If an offset has already been staged
-    /// for a given partition, that offset is overwritten (even if the offset
-    /// moves in reverse.)
-    fn stage_offsets(&mut self, positions: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
-
-    /// Commit staged offsets. The return value of this method is a mapping
-    /// of streams with their committed offsets as values.
-    fn commit_offsets(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError>;
+    /// Commit offsets.
+    fn commit_offsets(&mut self, positions: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
 
     fn close(&mut self);
 

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -45,10 +45,7 @@ pub trait CommitOffsets {
     ///
     /// Returns a map of all offsets that were committed. This combines [`Consumer::stage_offsets`] and
     /// [`Consumer::commit_offsets`].
-    fn commit(
-        self,
-        offsets: HashMap<Partition, u64>,
-    ) -> Result<HashMap<Partition, u64>, ConsumerError>;
+    fn commit(self, offsets: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
 }
 
 /// This is basically an observer pattern to receive the callbacks from

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -217,8 +217,7 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                     self.buffered_messages.pop(partition, offset - 1);
                 }
 
-                self.consumer.stage_offsets(request.positions).unwrap();
-                self.consumer.commit_offsets().unwrap();
+                self.consumer.commit_offsets(request.positions).unwrap();
             }
             Err(e) => {
                 println!("TODOO: Handle invalid message {:?}", e);


### PR DESCRIPTION
Offsets are never actually staged without immediately committing them, so we might as well roll the two functions into one.

The `Consumer::commit_offsets` method gains an `offsets` parameter (that was previously on `stage_offsets`) and now only returns `()` in the `Ok` case.

~In the Kafka backend, the `Mutex` around the base consumer is replaced with an `RwLock`, since all calls to the base consumer only require a shared reference. The only times we need a `write` lock are in `subscribe` and `close`, where the base consumer is created and destroyed, respectively.~