### PR TITLE
Initialize metrics in benchmarks

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::sync::Once;
 use std::time::Duration;
 
 use divan::counter::ItemsCount;
@@ -12,6 +14,7 @@ use rust_arroyo::processing::strategies::ProcessingStrategyFactory;
 use rust_arroyo::processing::{Callbacks, RunError, StreamProcessor};
 use rust_arroyo::types::{Partition, Topic};
 use rust_arroyo::utils::clock::SystemClock;
+use rust_arroyo::utils::metrics::{configure_metrics, Metrics};
 use rust_snuba::{
     ClickhouseConfig, ConsumerStrategyFactory, MessageProcessorConfig, StorageConfig,
 };
@@ -22,6 +25,7 @@ fn main() {
 }
 
 const MSG_COUNT: usize = 5_000;
+static METRICS_INIT: Once = Once::new();
 
 #[divan::bench(consts = [1, 4, 16])]
 fn functions<const N: usize>(bencher: divan::Bencher) {
@@ -74,6 +78,17 @@ fn run_bench(
     processor: &str,
     schema: &str,
 ) {
+    METRICS_INIT.call_once(|| {
+        #[derive(Debug)]
+        struct Noop;
+        impl Metrics for Noop {
+            fn increment(&self, _key: &str, _value: i64, _tags: Option<HashMap<&str, &str>>) {}
+            fn gauge(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+            fn timing(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+        }
+
+        configure_metrics(Noop)
+    });
     bencher
         .counter(ItemsCount::new(MSG_COUNT))
         .with_inputs(|| {


### PR DESCRIPTION
It turns out that `get_metrics` and the associated `Arc::drop` is hot enough in benchmarks that it makes a difference.