### PR TITLE
fix(joins) Push granularity down to the subqueries

### DIFF
--- a/tests/query/joins/join_structures.py
+++ b/tests/query/joins/join_structures.py
@@ -28,6 +28,7 @@ def build_node(
     from_clause: Entity,
     selected_columns: Sequence[SelectedExpression],
     condition: Optional[Expression],
+    granularity: Optional[int] = None,
 ) -> IndividualNode[Entity]:
     return IndividualNode(
         alias=alias,
@@ -35,6 +36,7 @@ def build_node(
             from_clause=from_clause,
             selected_columns=selected_columns,
             condition=condition,
+            granularity=granularity,
         ),
     )
 
@@ -42,24 +44,28 @@ def build_node(
 def events_node(
     selected_columns: Sequence[SelectedExpression],
     condition: Optional[Expression] = None,
+    granularity: Optional[int] = None,
 ) -> IndividualNode[Entity]:
     return build_node(
         "ev",
         Entity(EntityKey.EVENTS, EntityColumnSet(EVENTS_SCHEMA.columns)),
         selected_columns,
         condition,
+        granularity,
     )
 
 
 def groups_node(
     selected_columns: Sequence[SelectedExpression],
     condition: Optional[Expression] = None,
+    granularity: Optional[int] = None,
 ) -> IndividualNode[Entity]:
     return build_node(
         "gr",
         Entity(EntityKey.GROUPEDMESSAGE, EntityColumnSet(GROUPS_SCHEMA.columns)),
         selected_columns,
         condition,
+        granularity,
     )
 
 

--- a/tests/query/joins/test_subqueries.py
+++ b/tests/query/joins/test_subqueries.py
@@ -363,6 +363,7 @@ TEST_CASES = [
                     Literal(None, "sometime"),
                 ),
             ),
+            granularity=123,
         ),
         CompositeQuery(
             from_clause=events_groups_join(
@@ -387,10 +388,12 @@ TEST_CASES = [
                                 (Column("_snuba_project_id", None, "project_id"),),
                             ),
                         ),
-                    ]
+                    ],
+                    granularity=123,
                 ),
                 groups_node(
                     [SelectedExpression("_snuba_id", Column("_snuba_id", None, "id"))],
+                    granularity=123,
                 ),
             ),
             selected_columns=[
@@ -418,8 +421,9 @@ TEST_CASES = [
                     Literal(None, "sometime"),
                 ),
             ),
+            granularity=123,
         ),
-        id="Query with group by, aggregation and having clause",
+        id="Query with granularity, group by, aggregation and having clause",
     ),
     pytest.param(
         CompositeQuery(


### PR DESCRIPTION
The granularity was not being pushed down to the subqueries created in a
CompositeQuery join. That meant that the TimeSeriesProcessor (an entity level
processor) didn't have access to the granularity and wasn't being executed
correctly.

Push the granularity down to all the subqueries so they can be properly
handled.
