### PR TITLE
ref(rust): Change order of consumer/processor creation

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -104,7 +104,6 @@ fn run_bench(
                     break;
                 }
             }
-            processor.shutdown();
         });
 }
 
@@ -178,13 +177,12 @@ fn create_stream_processor(
         broker,
         "test_group".to_string(),
         true,
+        &[topic],
         Callbacks(consumer_state.clone()),
     );
     let consumer = Box::new(consumer);
 
-    let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-    processor.subscribe(topic);
-    processor
+    StreamProcessor::new(consumer, consumer_state, None)
 }
 
 fn functions_payload() -> KafkaPayload {

--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -24,7 +24,8 @@ fn main() {
         false,
         None,
     );
-    let mut consumer = KafkaConsumer::new(config);
+
+    let mut consumer = KafkaConsumer::new(config, EmptyCallbacks {}).unwrap();
     let topic = Topic::new("test_static");
     let res = consumer.subscribe(&[topic], EmptyCallbacks {});
     assert!(res.is_ok());

--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -26,10 +26,8 @@ fn main() {
         None,
     );
 
-    let mut consumer = KafkaConsumer::new(config, EmptyCallbacks {}).unwrap();
     let topic = Topic::new("test_static");
-    let res = consumer.subscribe(&[topic], EmptyCallbacks {});
-    assert!(res.is_ok());
+    let mut consumer = KafkaConsumer::new(config, &[topic], EmptyCallbacks {}).unwrap();
     println!("Subscribed");
     for _ in 0..20 {
         println!("Polling");

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -2,12 +2,10 @@ extern crate rust_arroyo;
 
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
-use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::processing::strategies::commit_offsets::CommitOffsets;
 use rust_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
-use rust_arroyo::processing::{Callbacks, ConsumerState, StreamProcessor};
+use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::Topic;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 struct TestFactory {}
@@ -29,13 +27,9 @@ fn main() {
         None,
     );
 
-    let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(TestFactory {}))));
+    let mut processor =
+        StreamProcessor::with_kafka(config, TestFactory {}, Topic::new("test_static"), None);
 
-    let consumer = Box::new(KafkaConsumer::new(config, Callbacks(consumer_state.clone())).unwrap());
-    let topic = Topic::new("test_static");
-
-    let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-    processor.subscribe(topic);
     for _ in 0..20 {
         processor.run_once().unwrap();
     }

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -8,16 +8,15 @@ use rdkafka::message::ToBytes;
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
-use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::processing::strategies::produce::Produce;
 use rust_arroyo::processing::strategies::run_task::RunTask;
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use rust_arroyo::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, ProcessingStrategyFactory, SubmitError,
 };
-use rust_arroyo::processing::{Callbacks, ConsumerState, StreamProcessor};
+use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::{Message, Topic, TopicOrPartition};
-use std::sync::{Arc, Mutex};
+
 use std::time::Duration;
 
 fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
@@ -82,17 +81,13 @@ async fn main() {
         None,
     );
 
-    let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(
-        ReverseStringAndProduceStrategyFactory {
-            concurrency: ConcurrencyConfig::new(5),
-            config: config.clone(),
-            topic: Topic::new("test_out"),
-        },
-    ))));
+    let factory = ReverseStringAndProduceStrategyFactory {
+        concurrency: ConcurrencyConfig::new(5),
+        config: config.clone(),
+        topic: Topic::new("test_out"),
+    };
 
-    let consumer = Box::new(KafkaConsumer::new(config, Callbacks(consumer_state.clone())).unwrap());
-    let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-    processor.subscribe(Topic::new("test_in"));
+    let processor = StreamProcessor::with_kafka(config, factory, Topic::new("test_in"), None);
     println!("running processor. transforming from test_in to test_out");
     processor.run().unwrap();
 }

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -1,4 +1,4 @@
-use super::types::{BrokerMessage, Partition, Topic, TopicOrPartition};
+use super::types::{BrokerMessage, Partition, TopicOrPartition};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
@@ -90,10 +90,6 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
 pub trait Consumer<TPayload, C>: Send {
-    fn subscribe(&mut self, topic: &[Topic], callbacks: C) -> Result<(), ConsumerError>;
-
-    fn unsubscribe(&mut self) -> Result<(), ConsumerError>;
-
     /// Fetch a message from the consumer. If no message is available before
     /// the timeout, ``None`` is returned.
     ///
@@ -152,10 +148,6 @@ pub trait Consumer<TPayload, C>: Send {
 
     /// Commit offsets.
     fn commit_offsets(&mut self, positions: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
-
-    fn close(&mut self);
-
-    fn closed(&self) -> bool;
 }
 
 pub trait Producer<TPayload>: Send + Sync {

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -9,6 +9,9 @@ use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
+use crate::backends::kafka::config::KafkaConfig;
+use crate::backends::kafka::types::KafkaPayload;
+use crate::backends::kafka::KafkaConsumer;
 use crate::backends::{AssignmentCallbacks, CommitOffsets, Consumer, ConsumerError};
 use crate::processing::dlq::{BufferedMessages, DlqPolicy, DlqPolicyWrapper};
 use crate::processing::strategies::{MessageRejected, SubmitError};
@@ -138,6 +141,23 @@ pub struct StreamProcessor<TPayload: Clone> {
     dlq_policy: DlqPolicyWrapper<TPayload>,
 }
 
+impl StreamProcessor<KafkaPayload> {
+    pub fn with_kafka<F: ProcessingStrategyFactory<KafkaPayload> + 'static>(
+        config: KafkaConfig,
+        factory: F,
+        topic: Topic,
+        dlq_policy: Option<DlqPolicy<KafkaPayload>>,
+    ) -> Self {
+        let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(factory))));
+        let callbacks = Callbacks(consumer_state.clone());
+
+        // TODO: Can this fail?
+        let consumer = Box::new(KafkaConsumer::new(config, &[topic], callbacks).unwrap());
+
+        Self::new(consumer, consumer_state, dlq_policy)
+    }
+}
+
 impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     pub fn new(
         consumer: Box<dyn Consumer<TPayload, Callbacks<TPayload>>>,
@@ -155,11 +175,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             buffered_messages: BufferedMessages::new(),
             dlq_policy: DlqPolicyWrapper::new(dlq_policy),
         }
-    }
-
-    pub fn subscribe(&mut self, topic: Topic) {
-        let callbacks = Callbacks(self.consumer_state.clone());
-        self.consumer.subscribe(&[topic], callbacks).unwrap();
     }
 
     pub fn run_once(&mut self) -> Result<(), RunError> {
@@ -323,7 +338,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     }
 
     /// The main run loop, see class docstring for more information.
-    pub fn run(&mut self) -> Result<(), RunError> {
+    pub fn run(mut self) -> Result<(), RunError> {
         while !self
             .processor_handle
             .shutdown_requested
@@ -337,11 +352,9 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                 }
 
                 drop(trait_callbacks); // unlock mutex so we can close consumer
-                self.consumer.close();
                 return Err(e);
             }
         }
-        self.shutdown();
         Ok(())
     }
 
@@ -349,13 +362,11 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
         self.processor_handle.clone()
     }
 
-    pub fn shutdown(&mut self) {
-        self.consumer.close();
-    }
-
     pub fn tell(&self) -> HashMap<Partition, u64> {
         self.consumer.tell().unwrap()
     }
+
+    pub fn shutdown(self) {}
 }
 
 #[cfg(test)]
@@ -427,11 +438,11 @@ mod tests {
             broker,
             "test_group".to_string(),
             false,
+            &[Topic::new("test1")],
             Callbacks(consumer_state.clone()),
         ));
 
         let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-        processor.subscribe(Topic::new("test1"));
         let res = processor.run_once();
         assert!(res.is_ok())
     }
@@ -451,11 +462,11 @@ mod tests {
             broker,
             "test_group".to_string(),
             false,
+            &[Topic::new("test1")],
             Callbacks(consumer_state.clone()),
         ));
 
         let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-        processor.subscribe(Topic::new("test1"));
         let res = processor.run_once();
         assert!(res.is_ok());
         let res = processor.run_once();

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -7,11 +6,10 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
-use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::processing::dlq::{DlqLimit, DlqPolicy, KafkaDlqProducer};
 
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
-use rust_arroyo::processing::{Callbacks, ConsumerState, StreamProcessor};
+use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::Topic;
 use rust_arroyo::utils::metrics::configure_metrics;
 
@@ -129,22 +127,6 @@ pub fn consumer_impl(
 
     let logical_topic_name = consumer_config.raw_topic.logical_topic_name;
 
-    let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(
-        ConsumerStrategyFactory::new(
-            first_storage,
-            logical_topic_name,
-            max_batch_size,
-            max_batch_time,
-            skip_write,
-            ConcurrencyConfig::new(concurrency),
-            python_max_queue_depth,
-            use_rust_processor,
-            health_check_file.map(ToOwned::to_owned),
-        ),
-    ))));
-
-    let consumer = Box::new(KafkaConsumer::new(config, Callbacks(consumer_state.clone())).unwrap());
-
     // DLQ policy applies only if we are not skipping writes, otherwise we don't want to be
     // writing to the DLQ topics in prod.
     let dlq_policy = match skip_write {
@@ -169,9 +151,20 @@ pub fn consumer_impl(
         }),
     };
 
-    let mut processor = StreamProcessor::new(consumer, consumer_state, dlq_policy);
+    let factory = ConsumerStrategyFactory::new(
+        first_storage,
+        logical_topic_name,
+        max_batch_size,
+        max_batch_time,
+        skip_write,
+        ConcurrencyConfig::new(concurrency),
+        python_max_queue_depth,
+        use_rust_processor,
+        health_check_file.map(ToOwned::to_owned),
+    );
 
-    processor.subscribe(Topic::new(&consumer_config.raw_topic.physical_topic_name));
+    let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);
+    let processor = StreamProcessor::with_kafka(config, factory, topic, dlq_policy);
 
     let mut handle = processor.get_handle();
 


### PR DESCRIPTION
This is the first part of an effort to make sure consumers and processors are never in invalid states.

It changes the order in which the parts of `Consumers`/`StreamProcessors` are created so that all the parts must always be there before the whole object. This makes a bunch of `Option` unwrapping unnecessary.

Concretely, it now works like this:
1. Construct a `ConsumerState` from a `StrategyFactory`
2. Construct a `Consumer` from (an `Arc` copy of) the `ConsumerState`
3. Construct a `StreamProcessor` from the `Consumer` and another `Arc` copy of the `ConsumerState`.

Having to manually create the `ConsumerState` (which is really an implementation detail) makes this really cumbersome. This is addressed in TBA.