### PR TITLE
ref(rust): Remove invalid states from consumers and processors

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -182,9 +182,7 @@ fn create_stream_processor(
     );
     let consumer = Box::new(consumer);
 
-    let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-    processor.subscribe(topic);
-    processor
+    StreamProcessor::new(consumer, consumer_state, None)
 }
 
 fn functions_payload() -> KafkaPayload {

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -104,7 +104,6 @@ fn run_bench(
                     break;
                 }
             }
-            processor.shutdown();
         });
 }
 

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -178,6 +178,7 @@ fn create_stream_processor(
         broker,
         "test_group".to_string(),
         true,
+        &[topic],
         Callbacks(consumer_state.clone()),
     );
     let consumer = Box::new(consumer);

--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -25,10 +25,8 @@ fn main() {
         None,
     );
 
-    let mut consumer = KafkaConsumer::new(config, EmptyCallbacks {}).unwrap();
     let topic = Topic::new("test_static");
-    let res = consumer.subscribe(&[topic]);
-    assert!(res.is_ok());
+    let mut consumer = KafkaConsumer::new(config, &[topic], EmptyCallbacks {}).unwrap();
     println!("Subscribed");
     for _ in 0..20 {
         println!("Polling");

--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -27,7 +27,7 @@ fn main() {
 
     let mut consumer = KafkaConsumer::new(config, EmptyCallbacks {}).unwrap();
     let topic = Topic::new("test_static");
-    let res = consumer.subscribe(&[topic], EmptyCallbacks {});
+    let res = consumer.subscribe(&[topic]);
     assert!(res.is_ok());
     println!("Subscribed");
     for _ in 0..20 {

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -26,12 +26,8 @@ fn main() {
         None,
     );
 
-    let mut processor = StreamProcessor::with_kafka(
-        config,
-        Box::new(TestFactory {}),
-        Topic::new("test_static"),
-        None,
-    );
+    let mut processor =
+        StreamProcessor::with_kafka(config, TestFactory {}, Topic::new("test_static"), None);
 
     for _ in 0..20 {
         processor.run_once().unwrap();

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -2,12 +2,10 @@ extern crate rust_arroyo;
 
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
-use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::processing::strategies::commit_offsets::CommitOffsets;
 use rust_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
-use rust_arroyo::processing::{Callbacks, ConsumerState, StreamProcessor};
+use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::Topic;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 struct TestFactory {}
@@ -28,13 +26,13 @@ fn main() {
         None,
     );
 
-    let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(TestFactory {}))));
+    let mut processor = StreamProcessor::with_kafka(
+        config,
+        Box::new(TestFactory {}),
+        Topic::new("test_static"),
+        None,
+    );
 
-    let topic = Topic::new("test_static");
-    let consumer =
-        Box::new(KafkaConsumer::new(config, &[topic], Callbacks(consumer_state.clone())).unwrap());
-
-    let mut processor = StreamProcessor::new(consumer, consumer_state, None);
     for _ in 0..20 {
         processor.run_once().unwrap();
     }

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -30,11 +30,11 @@ fn main() {
 
     let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(TestFactory {}))));
 
-    let consumer = Box::new(KafkaConsumer::new(config, Callbacks(consumer_state.clone())).unwrap());
     let topic = Topic::new("test_static");
+    let consumer =
+        Box::new(KafkaConsumer::new(config, &[topic], Callbacks(consumer_state.clone())).unwrap());
 
     let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-    processor.subscribe(topic);
     for _ in 0..20 {
         processor.run_once().unwrap();
     }

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -98,7 +98,7 @@ async fn main() {
         .unwrap(),
     );
 
-    let mut processor = StreamProcessor::new(consumer, consumer_state, None);
+    let processor = StreamProcessor::new(consumer, consumer_state, None);
     println!("running processor. transforming from test_in to test_out");
     processor.run().unwrap();
 }

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -80,11 +80,11 @@ async fn main() {
         None,
     );
 
-    let factory = Box::new(ReverseStringAndProduceStrategyFactory {
+    let factory = ReverseStringAndProduceStrategyFactory {
         concurrency: ConcurrencyConfig::new(5),
         config: config.clone(),
         topic: Topic::new("test_out"),
-    });
+    };
 
     let processor = StreamProcessor::with_kafka(config, factory, Topic::new("test_in"), None);
     println!("running processor. transforming from test_in to test_out");

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -89,9 +89,16 @@ async fn main() {
         },
     ))));
 
-    let consumer = Box::new(KafkaConsumer::new(config, Callbacks(consumer_state.clone())).unwrap());
+    let consumer = Box::new(
+        KafkaConsumer::new(
+            config,
+            &[Topic::new("test_in")],
+            Callbacks(consumer_state.clone()),
+        )
+        .unwrap(),
+    );
+
     let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-    processor.subscribe(Topic::new("test_in"));
     println!("running processor. transforming from test_in to test_out");
     processor.run().unwrap();
 }

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -190,6 +190,8 @@ impl<C: AssignmentCallbacks> KafkaConsumer<C> {
             offsets,
         })
     }
+
+    pub fn shutdown(self) {}
 }
 
 impl<C: AssignmentCallbacks> Drop for KafkaConsumer<C> {
@@ -383,7 +385,7 @@ mod tests {
         let offsets = consumer.tell().unwrap();
         // One partition was assigned
         assert!(offsets.len() == 1);
-        std::mem::drop(consumer);
+        consumer.shutdown();
 
         delete_topic("test").await;
     }
@@ -415,7 +417,8 @@ mod tests {
         }
 
         consumer.commit_offsets(positions.clone()).unwrap();
-        std::mem::drop(consumer);
+        consumer.shutdown();
+
         delete_topic("test2").await;
     }
 

--- a/rust_snuba/rust_arroyo/src/backends/local/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/mod.rs
@@ -87,6 +87,8 @@ impl<TPayload, C: AssignmentCallbacks> LocalConsumer<TPayload, C> {
         let subscribed = &self.subscription_state.offsets;
         partitions.all(|partition| subscribed.contains_key(partition))
     }
+
+    pub fn shutdown(self) {}
 }
 
 impl<TPayload: 'static, C: AssignmentCallbacks> Consumer<TPayload, C>

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -1,4 +1,4 @@
-use super::types::{BrokerMessage, Partition, Topic, TopicOrPartition};
+use super::types::{BrokerMessage, Partition, TopicOrPartition};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
@@ -90,8 +90,6 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
 pub trait Consumer<TPayload, C>: Send {
-    fn subscribe(&mut self, topic: &[Topic]) -> Result<(), ConsumerError>;
-
     fn unsubscribe(&mut self) -> Result<(), ConsumerError>;
 
     /// Fetch a message from the consumer. If no message is available before

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -90,8 +90,6 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
 pub trait Consumer<TPayload, C>: Send {
-    fn unsubscribe(&mut self) -> Result<(), ConsumerError>;
-
     /// Fetch a message from the consumer. If no message is available before
     /// the timeout, ``None`` is returned.
     ///

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -90,7 +90,7 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
 pub trait Consumer<TPayload, C>: Send {
-    fn subscribe(&mut self, topic: &[Topic], callbacks: C) -> Result<(), ConsumerError>;
+    fn subscribe(&mut self, topic: &[Topic]) -> Result<(), ConsumerError>;
 
     fn unsubscribe(&mut self) -> Result<(), ConsumerError>;
 
@@ -152,10 +152,6 @@ pub trait Consumer<TPayload, C>: Send {
 
     /// Commit offsets.
     fn commit_offsets(&mut self, positions: HashMap<Partition, u64>) -> Result<(), ConsumerError>;
-
-    fn close(&mut self);
-
-    fn closed(&self) -> bool;
 }
 
 pub trait Producer<TPayload>: Send + Sync {

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -158,8 +158,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     }
 
     pub fn subscribe(&mut self, topic: Topic) {
-        let callbacks = Callbacks(self.consumer_state.clone());
-        self.consumer.subscribe(&[topic], callbacks).unwrap();
+        self.consumer.subscribe(&[topic]).unwrap();
     }
 
     pub fn run_once(&mut self) -> Result<(), RunError> {
@@ -337,7 +336,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                 }
 
                 drop(trait_callbacks); // unlock mutex so we can close consumer
-                self.consumer.close();
                 return Err(e);
             }
         }
@@ -350,7 +348,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     }
 
     pub fn shutdown(&mut self) {
-        self.consumer.close();
+        // self.consumer.close();
     }
 
     pub fn tell(&self) -> HashMap<Partition, u64> {

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use crate::backends::{AssignmentCallbacks, CommitOffsets, Consumer, ConsumerError};
 use crate::processing::dlq::{BufferedMessages, DlqPolicy, DlqPolicyWrapper};
 use crate::processing::strategies::{MessageRejected, SubmitError};
-use crate::types::{InnerMessage, Message, Partition, Topic};
+use crate::types::{InnerMessage, Message, Partition};
 use crate::utils::metrics::{get_metrics, Metrics};
 use strategies::{ProcessingStrategy, ProcessingStrategyFactory};
 
@@ -155,10 +155,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             buffered_messages: BufferedMessages::new(),
             dlq_policy: DlqPolicyWrapper::new(dlq_policy),
         }
-    }
-
-    pub fn subscribe(&mut self, _topic: Topic) {
-        // self.consumer.subscribe(&[topic]).unwrap();
     }
 
     pub fn run_once(&mut self) -> Result<(), RunError> {
@@ -322,7 +318,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     }
 
     /// The main run loop, see class docstring for more information.
-    pub fn run(&mut self) -> Result<(), RunError> {
+    pub fn run(mut self) -> Result<(), RunError> {
         while !self
             .processor_handle
             .shutdown_requested
@@ -339,16 +335,11 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                 return Err(e);
             }
         }
-        self.shutdown();
         Ok(())
     }
 
     pub fn get_handle(&self) -> ProcessorHandle {
         self.processor_handle.clone()
-    }
-
-    pub fn shutdown(&mut self) {
-        // self.consumer.close();
     }
 
     pub fn tell(&self) -> HashMap<Partition, u64> {

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -365,6 +365,8 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     pub fn tell(&self) -> HashMap<Partition, u64> {
         self.consumer.tell().unwrap()
     }
+
+    pub fn shutdown(self) {}
 }
 
 #[cfg(test)]

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -157,8 +157,8 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
         }
     }
 
-    pub fn subscribe(&mut self, topic: Topic) {
-        self.consumer.subscribe(&[topic]).unwrap();
+    pub fn subscribe(&mut self, _topic: Topic) {
+        // self.consumer.subscribe(&[topic]).unwrap();
     }
 
     pub fn run_once(&mut self) -> Result<(), RunError> {
@@ -425,11 +425,11 @@ mod tests {
             broker,
             "test_group".to_string(),
             false,
+            &[Topic::new("test1")],
             Callbacks(consumer_state.clone()),
         ));
 
         let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-        processor.subscribe(Topic::new("test1"));
         let res = processor.run_once();
         assert!(res.is_ok())
     }
@@ -449,11 +449,11 @@ mod tests {
             broker,
             "test_group".to_string(),
             false,
+            &[Topic::new("test1")],
             Callbacks(consumer_state.clone()),
         ));
 
         let mut processor = StreamProcessor::new(consumer, consumer_state, None);
-        processor.subscribe(Topic::new("test1"));
         let res = processor.run_once();
         assert!(res.is_ok());
         let res = processor.run_once();

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -142,13 +142,13 @@ pub struct StreamProcessor<TPayload: Clone> {
 }
 
 impl StreamProcessor<KafkaPayload> {
-    pub fn with_kafka(
+    pub fn with_kafka<F: ProcessingStrategyFactory<KafkaPayload> + 'static>(
         config: KafkaConfig,
-        factory: Box<dyn ProcessingStrategyFactory<KafkaPayload>>,
+        factory: F,
         topic: Topic,
         dlq_policy: Option<DlqPolicy<KafkaPayload>>,
     ) -> Self {
-        let consumer_state = Arc::new(Mutex::new(ConsumerState::new(factory)));
+        let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(factory))));
         let callbacks = Callbacks(consumer_state.clone());
 
         // TODO: Can this fail?

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -160,7 +160,7 @@ pub fn consumer_impl(
     );
 
     let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);
-    let processor = StreamProcessor::with_kafka(config, Box::new(factory), topic, dlq_policy);
+    let processor = StreamProcessor::with_kafka(config, factory, topic, dlq_policy);
 
     let mut handle = processor.get_handle();
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -139,7 +139,10 @@ pub fn consumer_impl(
         ),
     ))));
 
-    let consumer = Box::new(KafkaConsumer::new(config, Callbacks(consumer_state.clone())).unwrap());
+    let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);
+
+    let consumer =
+        Box::new(KafkaConsumer::new(config, &[topic], Callbacks(consumer_state.clone())).unwrap());
 
     // DLQ policy applies only if we are not skipping writes, otherwise we don't want to be
     // writing to the DLQ topics in prod.
@@ -166,8 +169,6 @@ pub fn consumer_impl(
     };
 
     let mut processor = StreamProcessor::new(consumer, consumer_state, dlq_policy);
-
-    processor.subscribe(Topic::new(&consumer_config.raw_topic.physical_topic_name));
 
     let mut handle = processor.get_handle();
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -7,11 +6,10 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
-use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::processing::dlq::{DlqLimit, DlqPolicy, KafkaDlqProducer};
 
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
-use rust_arroyo::processing::{Callbacks, ConsumerState, StreamProcessor};
+use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::Topic;
 use rust_arroyo::utils::metrics::configure_metrics;
 
@@ -125,25 +123,6 @@ pub fn consumer_impl(
 
     let logical_topic_name = consumer_config.raw_topic.logical_topic_name;
 
-    let consumer_state = Arc::new(Mutex::new(ConsumerState::new(Box::new(
-        ConsumerStrategyFactory::new(
-            first_storage,
-            logical_topic_name,
-            max_batch_size,
-            max_batch_time,
-            skip_write,
-            ConcurrencyConfig::new(concurrency),
-            python_max_queue_depth,
-            use_rust_processor,
-            health_check_file.map(ToOwned::to_owned),
-        ),
-    ))));
-
-    let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);
-
-    let consumer =
-        Box::new(KafkaConsumer::new(config, &[topic], Callbacks(consumer_state.clone())).unwrap());
-
     // DLQ policy applies only if we are not skipping writes, otherwise we don't want to be
     // writing to the DLQ topics in prod.
     let dlq_policy = match skip_write {
@@ -168,7 +147,20 @@ pub fn consumer_impl(
         }),
     };
 
-    let processor = StreamProcessor::new(consumer, consumer_state, dlq_policy);
+    let factory = ConsumerStrategyFactory::new(
+        first_storage,
+        logical_topic_name,
+        max_batch_size,
+        max_batch_time,
+        skip_write,
+        ConcurrencyConfig::new(concurrency),
+        python_max_queue_depth,
+        use_rust_processor,
+        health_check_file.map(ToOwned::to_owned),
+    );
+
+    let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);
+    let processor = StreamProcessor::with_kafka(config, Box::new(factory), topic, dlq_policy);
 
     let mut handle = processor.get_handle();
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -168,7 +168,7 @@ pub fn consumer_impl(
         }),
     };
 
-    let mut processor = StreamProcessor::new(consumer, consumer_state, dlq_policy);
+    let processor = StreamProcessor::new(consumer, consumer_state, dlq_policy);
 
     let mut handle = processor.get_handle();
 


### PR DESCRIPTION
This is the first part of an effort to make sure consumers and processors are never in invalid states. The first part is https://github.com/getsentry/snuba/pull/5123.

It removes the methods `subscribe`, `unsubscribe`, `close`, and `shutdown` from `Consumer` and `StreamProcessor`. What was `subscribe` now happens at construction time, while the other functions are moved to `Drop` implementations where necessary.

In other words, no consumer or processor is ever in an unsubscribed state. This removes a lot of checks for whether a consumer is still being polled after it has been closed, &c.

It also adds a constructor `with_kafka` to `StreamProcessor` that removes a lot of the complication from building a `StreamProcessor` in the Kafka case:
```rust
impl StreamProcessor<KafkaPayload> {
    pub fn with_kafka(
        config: KafkaConfig,
        factory: Box<dyn ProcessingStrategyFactory<KafkaPayload>>,
        topic: Topic,
        dlq_policy: Option<DlqPolicy<KafkaPayload>>,
    ) -> Self {
        let consumer_state = Arc::new(Mutex::new(ConsumerState::new(factory)));
        let callbacks = Callbacks(consumer_state.clone());

        // TODO: Can this fail?
        let consumer = Box::new(KafkaConsumer::new(config, &[topic], callbacks).unwrap());

        Self::new(consumer, consumer_state, dlq_policy)
    }
}
```

I haven't implemented a corresponding constructor for the `LocalConsumer` case under the assumption that that is only for testing and not necessarily part of the public API anyway.