### PR TITLE
fix(admin): look for project_ids in subqueries

### DIFF
--- a/snuba/admin/production_queries/prod_queries.py
+++ b/snuba/admin/production_queries/prod_queries.py
@@ -39,7 +39,6 @@ def _validate_projects_in_query(body: Dict[str, Any], dataset: Dataset) -> None:
     """
     Validates that the projects accessed by the query are allowed to be accessed.
     """
-
     # In debug, we don't need to validate projects
     if settings.DEBUG and len(settings.ADMIN_ALLOWED_PROD_PROJECTS) == 0:
         return
@@ -47,7 +46,7 @@ def _validate_projects_in_query(body: Dict[str, Any], dataset: Dataset) -> None:
     request_parts = RequestSchema.build(HTTPQuerySettings).validate(body)
     query = parse_snql_query(request_parts.query["query"], dataset)[0]
     project_ids = get_object_ids_in_query_ast(query, "project_id")
-    if project_ids is None:
+    if project_ids == set():
         raise InvalidQueryException("Missing project ID")
 
     disallowed_project_ids = project_ids.difference(

--- a/snuba/clickhouse/query_dsl/accessors.py
+++ b/snuba/clickhouse/query_dsl/accessors.py
@@ -25,58 +25,61 @@ from snuba.query.matchers import (
     String,
 )
 
-# def get_object_ids_in_condition(condition: Expression, object_column: str) -> Set[int]:
-#     """
-#     Extract project ids from an expression. Returns None if no project
-#     if condition is found. It returns an empty set of conflicting project_id
-#     conditions are found.
-#     """
-#     import pdb
-#     pdb.set_trace()
-#     match = FunctionCall(
-#         String(ConditionFunctions.EQ),
-#         (
-#             Column(column_name=String(object_column)),
-#             Literal(value=Param("object_id", Any(int))),
-#         ),
-#     ).match(condition)
-#     if match is not None:
-#         return {match.integer("object_id")}
-#
-#     match = is_in_condition_pattern(
-#         Column(column_name=String(object_column))
-#     ).match(condition)
-#     if match is not None:
-#         objects = match.expression("sequence")
-#         assert isinstance(objects, FunctionCallExpr)
-#         return {
-#             lit.value
-#             for lit in objects.parameters
-#             if isinstance(lit, LiteralExpr) and isinstance(lit.value, int)
-#         }
-#
-#     match = FunctionCall(
-#         Param(
-#             "operator",
-#             Or([String(BooleanFunctions.AND), String(BooleanFunctions.OR)]),
-#         ),
-#         (Param("lhs", AnyExpression()), Param("rhs", AnyExpression())),
-#     ).match(condition)
-#     if match is not None:
-#         lhs_objects = get_object_ids_in_condition(match.expression("lhs"), object_column)
-#         rhs_objects = get_object_ids_in_condition(match.expression("rhs"), object_column)
-#         if lhs_objects is None:
-#             return rhs_objects
-#         elif rhs_objects is None:
-#             return lhs_objects
-#         else:
-#             return (
-#                 lhs_objects & rhs_objects
-#                 if match.string("operator") == BooleanFunctions.AND
-#                 else lhs_objects | rhs_objects
-#             )
-#
-#     return set()
+
+def get_object_ids_in_condition(condition: Expression, object_column: str) -> Set[int]:
+    """
+    Extract project ids from an expression. Returns None if no project
+    if condition is found. It returns an empty set of conflicting project_id
+    conditions are found.
+    """
+    match = FunctionCall(
+        String(ConditionFunctions.EQ),
+        (
+            Column(column_name=String(object_column)),
+            Literal(value=Param("object_id", Any(int))),
+        ),
+    ).match(condition)
+    if match is not None:
+        return {match.integer("object_id")}
+
+    match = is_in_condition_pattern(Column(column_name=String(object_column))).match(
+        condition
+    )
+    if match is not None:
+        objects = match.expression("sequence")
+        assert isinstance(objects, FunctionCallExpr)
+        return {
+            lit.value
+            for lit in objects.parameters
+            if isinstance(lit, LiteralExpr) and isinstance(lit.value, int)
+        }
+
+    match = FunctionCall(
+        Param(
+            "operator",
+            Or([String(BooleanFunctions.AND), String(BooleanFunctions.OR)]),
+        ),
+        (Param("lhs", AnyExpression()), Param("rhs", AnyExpression())),
+    ).match(condition)
+    if match is not None:
+        lhs_objects = get_object_ids_in_condition(
+            match.expression("lhs"), object_column
+        )
+        rhs_objects = get_object_ids_in_condition(
+            match.expression("rhs"), object_column
+        )
+        if lhs_objects is None:
+            return rhs_objects
+        elif rhs_objects is None:
+            return lhs_objects
+        else:
+            return (
+                lhs_objects & rhs_objects
+                if match.string("operator") == BooleanFunctions.AND
+                else lhs_objects | rhs_objects
+            )
+
+    return set()
 
 
 def get_object_ids_in_query_ast(query: AbstractQuery, object_column: str) -> Set[int]:
@@ -88,61 +91,10 @@ def get_object_ids_in_query_ast(query: AbstractQuery, object_column: str) -> Set
     boolean functions are supported here.
     """
 
-    def get_object_ids_in_condition(condition: Expression) -> Set[int]:
-        """
-        Extract project ids from an expression. Returns None if no project
-        if condition is found. It returns an empty set of conflicting project_id
-        conditions are found.
-        """
-        match = FunctionCall(
-            String(ConditionFunctions.EQ),
-            (
-                Column(column_name=String(object_column)),
-                Literal(value=Param("object_id", Any(int))),
-            ),
-        ).match(condition)
-        if match is not None:
-            return {match.integer("object_id")}
-
-        match = is_in_condition_pattern(
-            Column(column_name=String(object_column))
-        ).match(condition)
-        if match is not None:
-            objects = match.expression("sequence")
-            assert isinstance(objects, FunctionCallExpr)
-            return {
-                lit.value
-                for lit in objects.parameters
-                if isinstance(lit, LiteralExpr) and isinstance(lit.value, int)
-            }
-
-        match = FunctionCall(
-            Param(
-                "operator",
-                Or([String(BooleanFunctions.AND), String(BooleanFunctions.OR)]),
-            ),
-            (Param("lhs", AnyExpression()), Param("rhs", AnyExpression())),
-        ).match(condition)
-        if match is not None:
-            lhs_objects = get_object_ids_in_condition(match.expression("lhs"))
-            rhs_objects = get_object_ids_in_condition(match.expression("rhs"))
-            if lhs_objects is None:
-                return rhs_objects
-            elif rhs_objects is None:
-                return lhs_objects
-            else:
-                return (
-                    lhs_objects & rhs_objects
-                    if match.string("operator") == BooleanFunctions.AND
-                    else lhs_objects | rhs_objects
-                )
-
-        return set()
-
     condition = query.get_condition()
     if not condition:
         return set()
-    this_query_object_ids = get_object_ids_in_condition(condition)
+    this_query_object_ids = get_object_ids_in_condition(condition, object_column)
 
     from_clause = query.get_from_clause()
     if isinstance(from_clause, SimpleDataSource):

--- a/snuba/clickhouse/query_dsl/accessors.py
+++ b/snuba/clickhouse/query_dsl/accessors.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional, Sequence, Set, Tuple, Union, cast
 
-from snuba.query import ProcessableQuery
+from snuba.query import FromClauseNotSet, ProcessableQuery
 from snuba.query import Query as AbstractQuery
 from snuba.query.conditions import (
     OPERATOR_TO_FUNCTION,
@@ -95,10 +95,12 @@ def get_object_ids_in_query_ast(query: AbstractQuery, object_column: str) -> Set
         return set()
     this_query_object_ids = get_object_ids_in_condition(condition, object_column)
 
-    from_clause = query.get_from_clause()
+    try:
+        from_clause = query.get_from_clause()
+    except FromClauseNotSet:
+        return this_query_object_ids
     if isinstance(from_clause, SimpleDataSource):
         return this_query_object_ids
-
     elif isinstance(from_clause, AbstractQuery):
         subquery_project_ids = get_object_ids_in_query_ast(from_clause, object_column)
         return subquery_project_ids.union(this_query_object_ids)

--- a/snuba/clickhouse/query_dsl/accessors.py
+++ b/snuba/clickhouse/query_dsl/accessors.py
@@ -68,9 +68,9 @@ def get_object_ids_in_condition(condition: Expression, object_column: str) -> Se
         rhs_objects = get_object_ids_in_condition(
             match.expression("rhs"), object_column
         )
-        if lhs_objects is None:
+        if not lhs_objects:
             return rhs_objects
-        elif rhs_objects is None:
+        elif not rhs_objects:
             return lhs_objects
         else:
             return (
@@ -90,7 +90,6 @@ def get_object_ids_in_query_ast(query: AbstractQuery, object_column: str) -> Set
     It works like get_project_ids_in_query with the exception that
     boolean functions are supported here.
     """
-
     condition = query.get_condition()
     if not condition:
         return set()

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -31,6 +31,10 @@ from snuba.query.expressions import (
 )
 
 
+class FromClauseNotSet(Exception):
+    pass
+
+
 @dataclass(frozen=True)
 class LimitBy:
     limit: int
@@ -523,7 +527,8 @@ class ProcessableQuery(Query, ABC, Generic[TSimpleDataSource]):
         self.__from_clause = from_clause
 
     def get_from_clause(self) -> TSimpleDataSource:
-        assert self.__from_clause is not None, "Data source has not been provided yet."
+        if self.__from_clause is None:
+            raise FromClauseNotSet("Data source has not been provided yet.")
         return self.__from_clause
 
     def set_from_clause(self, from_clause: TSimpleDataSource) -> None:

--- a/tests/admin/test_production_queries.py
+++ b/tests/admin/test_production_queries.py
@@ -2,7 +2,7 @@ from snuba.admin.production_queries import prod_queries
 from snuba.datasets.factory import get_dataset
 
 
-def test_validate_projects():
+def test_validate_projects_with_subquery():
     query = """MATCH {MATCH (events) SELECT time, group_id, count() AS event_count BY time, group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=1 HAVING event_count > 1 ORDER BY time ASC GRANULARITY 3600} SELECT quantiles(90)(event_count) BY group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=1"""
     prod_queries._validate_projects_in_query(
         body={"query": query, "dataset": "events"}, dataset=get_dataset("events")

--- a/tests/admin/test_production_queries.py
+++ b/tests/admin/test_production_queries.py
@@ -1,0 +1,9 @@
+from snuba.admin.production_queries import prod_queries
+from snuba.datasets.factory import get_dataset
+
+
+def test_validate_projects():
+    query = """MATCH {MATCH (events) SELECT time, group_id, count() AS event_count BY time, group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=1 HAVING event_count > 1 ORDER BY time ASC GRANULARITY 3600} SELECT quantiles(90)(event_count) BY group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=1"""
+    prod_queries._validate_projects_in_query(
+        body={"query": query, "dataset": "events"}, dataset=get_dataset("events")
+    )

--- a/tests/admin/test_production_queries.py
+++ b/tests/admin/test_production_queries.py
@@ -1,9 +1,26 @@
+import pytest
+
 from snuba.admin.production_queries import prod_queries
 from snuba.datasets.factory import get_dataset
+from snuba.query.exceptions import InvalidQueryException
 
 
-def test_validate_projects_with_subquery():
-    query = """MATCH {MATCH (events) SELECT time, group_id, count() AS event_count BY time, group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=1 HAVING event_count > 1 ORDER BY time ASC GRANULARITY 3600} SELECT quantiles(90)(event_count) BY group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=1"""
+def test_validate_projects_with_subquery() -> None:
+    # make sure that a subquery does not raise an exception when it specifies project ids
+    # the larger query does not specify the project id and this is still considered valid because the subquery filters
+    # on project_id = 1
+    query = """MATCH {MATCH (events) SELECT time, group_id, count() AS event_count BY time, group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=1 HAVING event_count > 1 ORDER BY time ASC GRANULARITY 3600} SELECT quantiles(90)(event_count) BY group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803')"""
     prod_queries._validate_projects_in_query(
         body={"query": query, "dataset": "events"}, dataset=get_dataset("events")
     )
+
+
+def test_disallowed_project_ids() -> None:
+    # make sure that a subquery does not raise an exception when it specifies project ids
+    # the larger query does not specify the project id and this is still considered valid because the subquery filters
+    # on project_id = 1
+    query = """MATCH (events) SELECT time, group_id, count() AS event_count BY time, group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=42069 HAVING event_count > 1 ORDER BY time ASC GRANULARITY 3600"""
+    with pytest.raises(InvalidQueryException):
+        prod_queries._validate_projects_in_query(
+            body={"query": query, "dataset": "events"}, dataset=get_dataset("events")
+        )

--- a/tests/admin/test_production_queries.py
+++ b/tests/admin/test_production_queries.py
@@ -16,9 +16,7 @@ def test_validate_projects_with_subquery() -> None:
 
 
 def test_disallowed_project_ids() -> None:
-    # make sure that a subquery does not raise an exception when it specifies project ids
-    # the larger query does not specify the project id and this is still considered valid because the subquery filters
-    # on project_id = 1
+    # project_id 42069 is not an allowed project id, make sure we don't allow the query through
     query = """MATCH (events) SELECT time, group_id, count() AS event_count BY time, group_id WHERE timestamp >= toDateTime('2023-11-20T16:02:34.565803') AND timestamp < toDateTime('2023-11-27T16:02:34.565803') AND project_id=42069 HAVING event_count > 1 ORDER BY time ASC GRANULARITY 3600"""
     with pytest.raises(InvalidQueryException):
         prod_queries._validate_projects_in_query(

--- a/tests/clickhouse/query_dsl/test_accessors.py
+++ b/tests/clickhouse/query_dsl/test_accessors.py
@@ -82,3 +82,15 @@ def test_get_object_ids_in_query_ast(obj_condition, expected_project_ids):
     )
     project_ids = get_object_ids_in_query_ast(query, "project_id")
     assert project_ids == expected_project_ids
+
+    # test the case where the from clause is not set
+    query = Query(
+        None,
+        selected_columns=[
+            SelectedExpression("platform", Column("_snuba_platform", None, "platform")),
+        ],
+        groupby=[],
+        condition=where_clause,
+    )
+    project_ids = get_object_ids_in_query_ast(query, "project_id")
+    assert project_ids == expected_project_ids

--- a/tests/clickhouse/query_dsl/test_accessors.py
+++ b/tests/clickhouse/query_dsl/test_accessors.py
@@ -48,7 +48,7 @@ from snuba.query.logical import Query
         ),
     ],
 )
-def test_get_object_ids_in_query_ast(obj_condition, expected_project_ids):
+def test_get_object_ids_in_query_ast(obj_condition, expected_project_ids) -> None:
     where_clause = binary_condition(
         BooleanFunctions.AND,
         FunctionCall(

--- a/tests/clickhouse/query_dsl/test_accessors.py
+++ b/tests/clickhouse/query_dsl/test_accessors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 import pytest
@@ -8,7 +10,7 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.query import SelectedExpression
 from snuba.query.conditions import BooleanFunctions, binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
-from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
 
 
@@ -48,7 +50,9 @@ from snuba.query.logical import Query
         ),
     ],
 )
-def test_get_object_ids_in_query_ast(obj_condition, expected_project_ids) -> None:
+def test_get_object_ids_in_query_ast(
+    obj_condition: Expression, expected_project_ids: set[int]
+) -> None:
     where_clause = binary_condition(
         BooleanFunctions.AND,
         FunctionCall(

--- a/tests/clickhouse/query_dsl/test_accessors.py
+++ b/tests/clickhouse/query_dsl/test_accessors.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+import pytest
+
+from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query import SelectedExpression
+from snuba.query.conditions import BooleanFunctions, binary_condition
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.logical import Query
+
+
+@pytest.mark.parametrize(
+    ["obj_condition", "expected_project_ids"],
+    [
+        pytest.param(
+            FunctionCall(
+                None,
+                "equals",
+                (
+                    Column("_snuba_project_id", None, "project_id"),
+                    Literal(None, 1),
+                ),
+            ),
+            set([1]),
+            id="equals_case",
+        ),
+        pytest.param(
+            FunctionCall(
+                None,
+                "in",
+                (
+                    Column("_snuba_project_id", None, "project_id"),
+                    FunctionCall(
+                        None, "array", tuple([Literal(None, i) for i in range(1, 5)])
+                    ),
+                ),
+            ),
+            set([1, 2, 3, 4]),
+            id="in_case",
+        ),
+        pytest.param(
+            Literal(None, 1),
+            set([]),
+            id="empty_case",
+        ),
+    ],
+)
+def test_get_object_ids_in_query_ast(obj_condition, expected_project_ids):
+    where_clause = binary_condition(
+        BooleanFunctions.AND,
+        FunctionCall(
+            None,
+            "greaterOrEquals",
+            (
+                Column("_snuba_timestamp", None, "timestamp"),
+                Literal(None, datetime(2021, 1, 1, 0, 0)),
+            ),
+        ),
+        binary_condition(
+            BooleanFunctions.AND,
+            FunctionCall(
+                None,
+                "less",
+                (
+                    Column("_snuba_timestamp", None, "timestamp"),
+                    Literal(None, datetime(2021, 1, 2, 0, 0)),
+                ),
+            ),
+            obj_condition,
+        ),
+    )
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()),
+        selected_columns=[
+            SelectedExpression("platform", Column("_snuba_platform", None, "platform")),
+        ],
+        groupby=[],
+        condition=where_clause,
+    )
+    project_ids = get_object_ids_in_query_ast(query, "project_id")
+    assert project_ids == expected_project_ids


### PR DESCRIPTION
Fixes: https://getsentry.atlassian.net/jira/software/c/projects/SNS/issues/SNS-2537

When project ids are specified in subqueries, the production queries tool breaks because we don't look in subqueries for the project ids. make the function doing this recursive so we do look for it