### PR TITLE
feat(rust): Produce invalid messages to DLQ

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -184,8 +184,7 @@ impl<TPayload: Clone + Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
     // they are safe to commit.
     pub fn flush(&mut self, committable: HashMap<Partition, u64>) {
         for (p, values) in self.futures.iter_mut() {
-            while !values.is_empty() {
-                let (offset, future) = &mut values[0];
+            while let Some((offset, future)) = values.front_mut() {
                 if let Some(committable_offset) = committable.get(p) {
                     // The committable offset is message's offset + 1
                     if *committable_offset > *offset {

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -1,20 +1,22 @@
-#![allow(dead_code)]
 use crate::backends::kafka::producer::KafkaProducer;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
+use crate::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use crate::types::{BrokerMessage, Partition, Topic, TopicOrPartition};
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
 
 pub trait DlqProducer<TPayload> {
     // Send a message to the DLQ.
     fn produce(
         &self,
         message: BrokerMessage<TPayload>,
-    ) -> Pin<Box<dyn Future<Output = BrokerMessage<TPayload>>>>;
+    ) -> Pin<Box<dyn Future<Output = BrokerMessage<TPayload>> + Send + Sync>>;
 
     fn build_initial_state(&self) -> DlqLimitState;
 }
@@ -22,11 +24,11 @@ pub trait DlqProducer<TPayload> {
 // Drops all invalid messages. Produce returns an immediately resolved future.
 struct NoopDlqProducer {}
 
-impl<TPayload: 'static> DlqProducer<TPayload> for NoopDlqProducer {
+impl<TPayload: Send + Sync + 'static> DlqProducer<TPayload> for NoopDlqProducer {
     fn produce(
         &self,
         message: BrokerMessage<TPayload>,
-    ) -> Pin<Box<dyn Future<Output = BrokerMessage<TPayload>>>> {
+    ) -> Pin<Box<dyn Future<Output = BrokerMessage<TPayload>> + Send + Sync>> {
         Box::pin(async move { message })
     }
 
@@ -58,7 +60,7 @@ impl DlqProducer<KafkaPayload> for KafkaDlqProducer {
     fn produce(
         &self,
         message: BrokerMessage<KafkaPayload>,
-    ) -> Pin<Box<dyn Future<Output = BrokerMessage<KafkaPayload>>>> {
+    ) -> Pin<Box<dyn Future<Output = BrokerMessage<KafkaPayload>> + Send + Sync>> {
         let producer = self.producer.clone();
         let topic = self.topic;
 
@@ -110,14 +112,95 @@ pub struct DlqLimitState {}
 // DLQ policy defines the DLQ configuration, and is passed to the stream processor
 // upon creation of the consumer. It consists of the DLQ producer implementation and
 // any limits that should be applied.
+//
+// TODO: Respect DLQ limits
 pub struct DlqPolicy<TPayload> {
     producer: Box<dyn DlqProducer<TPayload>>,
+    #[allow(dead_code)]
     limit: DlqLimit,
 }
 
 impl<TPayload> DlqPolicy<TPayload> {
     pub fn new(producer: Box<dyn DlqProducer<TPayload>>, limit: DlqLimit) -> Self {
         DlqPolicy { producer, limit }
+    }
+}
+
+// Wraps the DLQ policy and keeps track of messages pending produce/commit.
+type Futures<TPayload> = VecDeque<(u64, JoinHandle<BrokerMessage<TPayload>>)>;
+
+pub(crate) struct DlqPolicyWrapper<TPayload> {
+    dlq_policy: Option<DlqPolicy<TPayload>>,
+    runtime: Handle,
+    // This is a per-partition max
+    max_pending_futures: usize,
+    futures: BTreeMap<Partition, Futures<TPayload>>,
+}
+
+impl<TPayload: Clone + Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
+    pub fn new(dlq_policy: Option<DlqPolicy<TPayload>>) -> Self {
+        let concurrency_config = ConcurrencyConfig::new(10);
+        DlqPolicyWrapper {
+            dlq_policy,
+            runtime: concurrency_config.handle(),
+            max_pending_futures: 1000,
+            futures: BTreeMap::new(),
+        }
+    }
+
+    // Removes all completed futures, then appends a future with message to be produced
+    // to the queue. Blocks if there are too many pending futures until some are done.
+    pub fn produce(&mut self, message: BrokerMessage<TPayload>) {
+        for (_p, values) in self.futures.iter_mut() {
+            while !values.is_empty() {
+                let len = values.len();
+                let (_, future) = &mut values[0];
+                if future.is_finished() {
+                    values.pop_front();
+                } else if len >= self.max_pending_futures {
+                    let res = self.runtime.block_on(future);
+                    if let Err(err) = res {
+                        tracing::error!("Error producing to DLQ: {}", err);
+                    }
+                    values.pop_front();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        if let Some(dlq_policy) = &self.dlq_policy {
+            let task = dlq_policy.producer.produce(message.clone());
+            let handle = self.runtime.spawn(task);
+
+            self.futures
+                .entry(message.partition)
+                .or_default()
+                .push_back((message.offset, handle));
+        }
+    }
+
+    // Blocks until all messages up to the committable have been produced so
+    // they are safe to commit.
+    pub fn flush(&mut self, committable: HashMap<Partition, u64>) {
+        for (p, values) in self.futures.iter_mut() {
+            while !values.is_empty() {
+                let (offset, future) = &mut values[0];
+                if let Some(committable_offset) = committable.get(p) {
+                    // The committable offset is message's offset + 1
+                    if *committable_offset > *offset {
+                        let res: Result<BrokerMessage<TPayload>, tokio::task::JoinError> =
+                            self.runtime.block_on(future);
+
+                        if let Err(err) = res {
+                            tracing::error!("Error producing to DLQ: {}", err);
+                        } else {
+                            values.pop_front();
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -183,6 +266,7 @@ impl<TPayload> BufferedMessages<TPayload> {
 mod tests {
     use crate::types::Topic;
     use chrono::Utc;
+    use std::sync::Mutex;
 
     use super::*;
 
@@ -208,5 +292,63 @@ mod tests {
         assert_eq!(buffer.pop(&partition, 1), None); // Removed when we popped offset 8
         assert_eq!(buffer.pop(&partition, 9).unwrap().offset, 9);
         assert_eq!(buffer.pop(&partition, 10), None); // Doesn't exist
+    }
+
+    #[test]
+    fn test_dlq_policy_wrapper() {
+        #[derive(Clone)]
+        struct TestDlqProducer {
+            pub call_count: Arc<Mutex<usize>>,
+        }
+
+        impl TestDlqProducer {
+            fn new() -> Self {
+                TestDlqProducer {
+                    call_count: Arc::new(Mutex::new(0)),
+                }
+            }
+        }
+
+        impl<TPayload: Send + Sync + 'static> DlqProducer<TPayload> for TestDlqProducer {
+            fn produce(
+                &self,
+                message: BrokerMessage<TPayload>,
+            ) -> Pin<Box<dyn Future<Output = BrokerMessage<TPayload>> + Send + Sync>> {
+                *self.call_count.lock().unwrap() += 1;
+                Box::pin(async move { message })
+            }
+
+            fn build_initial_state(&self) -> DlqLimitState {
+                DlqLimitState {}
+            }
+        }
+
+        let partition = Partition {
+            topic: Topic::new("test"),
+            index: 1,
+        };
+
+        let producer = TestDlqProducer::new();
+
+        let mut wrapper = DlqPolicyWrapper::new(Some(DlqPolicy::new(
+            Box::new(producer.clone()),
+            DlqLimit {
+                max_invalid_ratio: None,
+                max_consecutive_count: Some(1),
+            },
+        )));
+
+        for i in 0..10 {
+            wrapper.produce(BrokerMessage {
+                partition,
+                offset: i,
+                payload: i,
+                timestamp: Utc::now(),
+            });
+        }
+
+        wrapper.flush(HashMap::from([(partition, 11)]));
+
+        assert_eq!(*producer.call_count.lock().unwrap(), 10);
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 use crate::backends::{AssignmentCallbacks, CommitOffsets, Consumer, ConsumerError};
-use crate::processing::dlq::{BufferedMessages, DlqPolicy};
+use crate::processing::dlq::{BufferedMessages, DlqPolicy, DlqPolicyWrapper};
 use crate::processing::strategies::{MessageRejected, SubmitError};
 use crate::types::{InnerMessage, Message, Partition, Topic};
 use crate::utils::metrics::{get_metrics, Metrics};
@@ -88,6 +88,7 @@ impl<TPayload: 'static> AssignmentCallbacks for Callbacks<TPayload> {
         if let Some(s) = state.strategy.as_mut() {
             s.close();
             if let Ok(Some(commit_request)) = s.join(None) {
+                // TODO: DLQ should be flushed here as well
                 tracing::info!("Committing offsets");
                 let res = commit_offsets.commit(commit_request.positions);
 
@@ -123,11 +124,10 @@ pub struct StreamProcessor<TPayload: Clone> {
     processor_handle: ProcessorHandle,
     metrics_buffer: metrics_buffer::MetricsBuffer,
     buffered_messages: BufferedMessages<TPayload>,
-    #[allow(dead_code)]
-    dlq_policy: Option<DlqPolicy<TPayload>>,
+    dlq_policy: DlqPolicyWrapper<TPayload>,
 }
 
-impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
+impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     pub fn new(
         consumer: Box<dyn Consumer<TPayload, Callbacks<TPayload>>>,
         processing_factory: Box<dyn ProcessingStrategyFactory<TPayload>>,
@@ -150,7 +150,7 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
             },
             metrics_buffer: metrics_buffer::MetricsBuffer::new(),
             buffered_messages: BufferedMessages::new(),
-            dlq_policy,
+            dlq_policy: DlqPolicyWrapper::new(dlq_policy),
         }
     }
 
@@ -219,11 +219,19 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                     self.buffered_messages.pop(partition, offset - 1);
                 }
 
+                self.dlq_policy.flush(request.positions.clone());
                 self.consumer.commit_offsets(request.positions).unwrap();
             }
-            Err(e) => {
-                println!("TODOO: Handle invalid message {:?}", e);
-            }
+            Err(e) => match self.buffered_messages.pop(&e.partition, e.offset) {
+                Some(msg) => {
+                    self.message = Some(Message {
+                        inner_message: InnerMessage::BrokerMessage(msg),
+                    });
+                }
+                None => {
+                    tracing::error!("Could not find invalid message in buffer");
+                }
+            },
         };
 
         let Some(msg_s) = self.message.take() else {
@@ -293,8 +301,16 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                 }
             }
             Err(SubmitError::InvalidMessage(message)) => {
-                // TODO: Put this into the DLQ once we have one
-                tracing::error!(?message, "Invalid message");
+                let invalid_message = self
+                    .buffered_messages
+                    .pop(&message.partition, message.offset);
+
+                if let Some(msg) = invalid_message {
+                    tracing::error!(?message, "Invalid message");
+                    self.dlq_policy.produce(msg);
+                } else {
+                    tracing::error!(?message, "Could not retrieve invalid message from buffer");
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
This adds the basic DLQ implementation. Invalid messages are automatically produced to the DLQ if a topic is defined for the storage.

The feature is not enabled unless `skip_write` is set to False, as we should not be producing any data to actual topics in prod otherwise.

There are a couple of features that are not yet implemented yet and will need to be done as a followup:
- DLQ limits are currently ignored and still need to be wired up
- The DLQ producer should be flushed prior to committing offsets in the revocation callback
