### PR TITLE
ref(rust): Structured errors & json output

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2391,6 +2391,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,12 +2410,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = { version = "1.0" }
 thiserror = "1.0"
 tokio = { version = "1.19.2", features = ["full"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = "1.5.0"
 
 [dev-dependencies]

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -116,8 +116,8 @@ impl<C: AssignmentCallbacks + Send + Sync> ClientContext for CustomContext<C> {
     }
 
     fn error(&self, error: KafkaError, reason: &str) {
-        let err: &dyn std::error::Error = &error;
-        tracing::error!(err, "librdkafka: {error}: {reason}");
+        let error: &dyn std::error::Error = &error;
+        tracing::error!(error, "librdkafka: {error}: {reason}");
     }
 }
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -92,7 +92,8 @@ impl<TPayload: 'static> AssignmentCallbacks for Callbacks<TPayload> {
                 let res = commit_offsets.commit(commit_request.positions);
 
                 if let Err(err) = res {
-                    tracing::error!("Failed to commit offsets: {:?}", err);
+                    let error: &dyn std::error::Error = &err;
+                    tracing::error!(error, "Failed to commit offsets");
                 }
             }
         }
@@ -188,9 +189,10 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                         self.buffered_messages.append(broker_msg);
                     }
                 }
-                Err(error) => {
-                    tracing::error!(%error, "poll error");
-                    return Err(RunError::Poll(error));
+                Err(err) => {
+                    let error: &dyn std::error::Error = &err;
+                    tracing::error!(error, "poll error");
+                    return Err(RunError::Poll(err));
                 }
             }
         }
@@ -246,9 +248,10 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                         Ok(()) => {
                             consumer_state.is_paused = false;
                         }
-                        Err(error) => {
-                            tracing::error!(%error, "pause error");
-                            return Err(RunError::Pause(error));
+                        Err(err) => {
+                            let error: &dyn std::error::Error = &err;
+                            tracing::error!(error, "pause error");
+                            return Err(RunError::Pause(err));
                         }
                     }
                 }
@@ -285,9 +288,10 @@ impl<TPayload: Clone + 'static> StreamProcessor<TPayload> {
                         Ok(()) => {
                             consumer_state.is_paused = true;
                         }
-                        Err(error) => {
-                            tracing::error!(%error, "pause error");
-                            return Err(RunError::Pause(error));
+                        Err(err) => {
+                            let error: &dyn std::error::Error = &err;
+                            tracing::error!(error, "pause error");
+                            return Err(RunError::Pause(err));
                         }
                     }
                 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -163,7 +163,8 @@ impl<TPayload, TTransformed: Send + Sync + 'static> ProcessingStrategy<TPayload>
                             tracing::error!("retryable error");
                         }
                         Err(error) => {
-                            tracing::error!(%error, "the thread crashed");
+                            let error: &dyn std::error::Error = &error;
+                            tracing::error!(error, "the thread crashed");
                         }
                     }
                 } else {

--- a/rust_snuba/src/logging.rs
+++ b/rust_snuba/src/logging.rs
@@ -18,7 +18,7 @@ pub fn setup_logging() {
         });
 
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::fmt::layer().json())
         .with(filter_layer)
         .with(sentry_layer)
         .init();

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -151,7 +151,8 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ProduceMessage {
                 let payload = commit.try_into().unwrap();
 
                 if let Err(err) = producer.produce(&destination, payload) {
-                    tracing::error!(%err, "Error producing message");
+                    let error: &dyn std::error::Error = &err;
+                    tracing::error!(error, "Error producing message");
                     return Err(RunTaskError::RetryableError);
                 }
             }

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -46,7 +46,8 @@ fn get_schema(schema_name: &str, enforce_schema: bool) -> Option<Arc<Schema>> {
             if enforce_schema {
                 panic!("Schema error: {error}");
             } else {
-                tracing::error!(%error, "Schema error");
+                let error: &dyn std::error::Error = &error;
+                tracing::error!(error, "Schema error");
             }
 
             None


### PR DESCRIPTION
Use the `std::error` trick for errors everywhere and set the log format to JSON.