### PR TITLE
feat(spans): Add a metrics summaries dataset

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -78,11 +78,7 @@ def register_storage_set_key(key: str) -> StorageSetKey:
 
 
 # Storage sets enabled only when development features are enabled.
-DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset(
-    [
-        StorageSetKey.METRICS_SUMMARIES,
-    ]
-)
+DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset()
 
 # Storage sets in a group share the same query and distributed nodes but
 # do not have the same local node cluster configuration.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -18,6 +18,7 @@ _HARDCODED_STORAGE_SET_KEYS = {
     "SEARCH_ISSUES": "search_issues",
     "SPANS": "spans",
     "GROUP_ATTRIBUTES": "group_attributes",
+    "METRICS_SUMMARIES": "metrics_summaries",
 }
 
 
@@ -77,7 +78,7 @@ def register_storage_set_key(key: str) -> StorageSetKey:
 
 
 # Storage sets enabled only when development features are enabled.
-DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset()
+DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset(StorageSetKey.METRICS_SUMMARIES)
 
 # Storage sets in a group share the same query and distributed nodes but
 # do not have the same local node cluster configuration.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -78,7 +78,11 @@ def register_storage_set_key(key: str) -> StorageSetKey:
 
 
 # Storage sets enabled only when development features are enabled.
-DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset(StorageSetKey.METRICS_SUMMARIES)
+DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset(
+    [
+        StorageSetKey.METRICS_SUMMARIES,
+    ]
+)
 
 # Storage sets in a group share the same query and distributed nodes but
 # do not have the same local node cluster configuration.

--- a/snuba/datasets/processors/metrics_summaries.py
+++ b/snuba/datasets/processors/metrics_summaries.py
@@ -1,0 +1,115 @@
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Mapping, MutableMapping, MutableSequence, Optional, Tuple
+
+import structlog
+
+from snuba import environment
+from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.events_format import (
+    EventTooOld,
+    _as_dict_safe,
+    enforce_retention,
+    extract_extra_tags,
+)
+from snuba.datasets.processors import DatasetMessageProcessor
+from snuba.processor import InsertBatch, ProcessedMessage, _ensure_valid_date
+from snuba.utils.metrics.wrapper import MetricsWrapper
+
+logger = structlog.get_logger(__name__)
+
+metrics = MetricsWrapper(environment.metrics, "metrics_summaries.processor")
+
+MetricsSummaryEvent = MutableMapping[str, Any]
+RetentionDays = int
+
+
+class SpansMessageProcessor(DatasetMessageProcessor):
+    """
+    Message processor for writing spans data to the spans table.
+    The implementation has taken inspiration from the transactions processor.
+    The initial version of this processor is able to read existing data
+    from the transactions topic and de-normalize it into the spans table.
+    """
+
+    def __extract_timestamp(self, timestamp_ms: int) -> Tuple[int, int]:
+        # We are purposely using a naive datetime here to work with the rest of the codebase.
+        # We can be confident that clients are only sending UTC dates.
+        timestamp_sec = timestamp_ms / 1000
+        if _ensure_valid_date(datetime.utcfromtimestamp(timestamp_sec)) is None:
+            timestamp_sec = int(time.time())
+        return int(timestamp_sec), int(timestamp_ms % 1000)
+
+    @staticmethod
+    def _structure_and_validate_message(
+        message: MetricsSummaryEvent,
+    ) -> Optional[Tuple[MetricsSummaryEvent, RetentionDays]]:
+        if not message.get("trace_id"):
+            return None
+        try:
+            # We are purposely using a naive datetime here to work with the
+            # rest of the codebase. We can be confident that clients are only
+            # sending UTC dates.
+            retention_days = enforce_retention(
+                message.get("retention_days"),
+                datetime.utcfromtimestamp(message["start_timestamp_ms"] / 1000),
+            )
+        except EventTooOld:
+            return None
+
+        return message, retention_days
+
+    def _process_metrics_summary_event(
+        self,
+        processed: MutableMapping[str, Any],
+        metrics_summary_event: MetricsSummaryEvent,
+    ) -> None:
+        processed["trace_id"] = str(uuid.UUID(metrics_summary_event["trace_id"]))
+        processed["span_id"] = int(metrics_summary_event["span_id"], 16)
+        processed["segment_id"] = processed["span_id"]
+        processed["start_timestamp"], processed["start_ms"] = self.__extract_timestamp(
+            metrics_summary_event["start_timestamp_ms"],
+        )
+        processed["duration"] = max(metrics_summary_event["duration_ms"], 0)
+        processed["exclusive_time"] = float(metrics_summary_event["exclusive_time_ms"])
+        tags: Mapping[str, Any] = _as_dict_safe(metrics_summary_event.get("tags", None))
+        processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
+
+    def process_message(
+        self,
+        message: MetricsSummaryEvent,
+        metadata: KafkaMessageMetadata,
+    ) -> Optional[ProcessedMessage]:
+        metrics_summary_event, retention_days = self._structure_and_validate_message(
+            message
+        ) or (
+            None,
+            None,
+        )
+        if not metrics_summary_event:
+            return None
+
+        processed_rows: MutableSequence[MutableMapping[str, Any]] = []
+        processed: MutableMapping[str, Any] = {
+            "deleted": 0,
+            "retention_days": retention_days,
+            "partition": metadata.partition,
+            "offset": metadata.offset,
+        }
+
+        processed["project_id"] = metrics_summary_event["project_id"]
+
+        try:
+            self._process_metrics_summary_event(processed, metrics_summary_event)
+            processed_rows.append(processed)
+        except Exception:
+            metrics.increment("message_processing_error")
+            return None
+
+        received = (
+            datetime.fromtimestamp(metrics_summary_event["received"], tz=timezone.utc)
+            if "received" in metrics_summary_event
+            else None
+        )
+        return InsertBatch(rows=processed_rows, origin_timestamp=received)

--- a/snuba/datasets/processors/metrics_summaries_processor.py
+++ b/snuba/datasets/processors/metrics_summaries_processor.py
@@ -68,6 +68,7 @@ class MetricsSummariesMessageProcessor(DatasetMessageProcessor):
         processed["span_id"] = int(metrics_summary_event["span_id"], 16)
         processed["segment_id"] = int(metrics_summary_event["segment_id"], 16)
         processed["project_id"] = metrics_summary_event["project_id"]
+        processed["metric_id"] = metrics_summary_event["metric_id"]
 
         processed["start_timestamp"], processed["start_ms"] = self.__extract_timestamp(
             metrics_summary_event["start_timestamp_ms"],

--- a/snuba/datasets/processors/metrics_summaries_processor.py
+++ b/snuba/datasets/processors/metrics_summaries_processor.py
@@ -25,7 +25,7 @@ MetricsSummaryEvent = MutableMapping[str, Any]
 RetentionDays = int
 
 
-class SpansMessageProcessor(DatasetMessageProcessor):
+class MetricsSummariesMessageProcessor(DatasetMessageProcessor):
     """
     Message processor for writing spans data to the spans table.
     The implementation has taken inspiration from the transactions processor.

--- a/snuba/datasets/processors/metrics_summaries_processor.py
+++ b/snuba/datasets/processors/metrics_summaries_processor.py
@@ -9,12 +9,16 @@ from snuba import environment
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.events_format import (
     EventTooOld,
-    _as_dict_safe,
     enforce_retention,
     extract_extra_tags,
 )
 from snuba.datasets.processors import DatasetMessageProcessor
-from snuba.processor import InsertBatch, ProcessedMessage, _ensure_valid_date
+from snuba.processor import (
+    InsertBatch,
+    ProcessedMessage,
+    _as_dict_safe,
+    _ensure_valid_date,
+)
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = structlog.get_logger(__name__)

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -348,6 +348,7 @@ class SpansLoader(DirectoryLoader):
             "0004_spans_group_raw_col",
             "0005_spans_add_sentry_tags",
             "0006_spans_add_profile_id",
+            "0007_spans_add_metrics_summary",
         ]
 
 

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -363,7 +363,7 @@ class GroupAttributesLoader(DirectoryLoader):
 
 class MetricsSummariesLoader(DirectoryLoader):
     def __init__(self) -> None:
-        super().__init__("snuba.snuba_migrations.group_attributes")
+        super().__init__("snuba.snuba_migrations.metrics_summaries")
 
     def get_migrations(self) -> Sequence[str]:
         return [

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -359,3 +359,13 @@ class GroupAttributesLoader(DirectoryLoader):
         return [
             "0001_group_attributes",
         ]
+
+
+class MetricsSummariesLoader(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("snuba.snuba_migrations.group_attributes")
+
+    def get_migrations(self) -> Sequence[str]:
+        return [
+            "0001_metrics_summaries_create_table",
+        ]

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -11,6 +11,7 @@ from snuba.migrations.group_loader import (
     GroupAttributesLoader,
     GroupLoader,
     MetricsLoader,
+    MetricsSummariesLoader,
     OutcomesLoader,
     ProfilesLoader,
     QuerylogLoader,
@@ -41,6 +42,7 @@ class MigrationGroup(Enum):
     SEARCH_ISSUES = "search_issues"
     SPANS = "spans"
     GROUP_ATTRIBUTES = "group_attributes"
+    METRICS_SUMMARIES = "metrics_summaries"
 
 
 # Migration groups are mandatory by default. Specific groups can
@@ -57,6 +59,7 @@ OPTIONAL_GROUPS = {
     MigrationGroup.SEARCH_ISSUES,
     MigrationGroup.SPANS,
     MigrationGroup.GROUP_ATTRIBUTES,
+    MigrationGroup.METRICS_SUMMARIES,
 }
 
 
@@ -160,6 +163,11 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.GROUP_ATTRIBUTES: _MigrationGroup(
         loader=GroupAttributesLoader(),
         storage_sets_keys={StorageSetKey.GROUP_ATTRIBUTES},
+        readiness_state=ReadinessState.PARTIAL,
+    ),
+    MigrationGroup.METRICS_SUMMARIES: _MigrationGroup(
+        loader=MetricsSummariesLoader(),
+        storage_sets_keys={StorageSetKey.METRICS_SUMMARIES},
         readiness_state=ReadinessState.PARTIAL,
     ),
 }

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -107,6 +107,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "spans",
             "group_attributes",
             "generic_metrics_gauges",
+            "metrics_summaries",
         },
         "single_node": True,
     },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -29,6 +29,7 @@ CLUSTERS = [
             "spans",
             "group_attributes",
             "generic_metrics_gauges",
+            "metrics_summaries",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -57,6 +57,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "spans",
             "group_attributes",
             "generic_metrics_gauges",
+            "metrics_summaries",
         },
         "single_node": False,
         "cluster_name": "storage_cluster",

--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -7,9 +7,9 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.migrations.operations import OperationTarget, SqlOperation
 from snuba.utils.schemas import Float
 
-storage_set_name = StorageSetKey.SPANS
-local_table_name = "spans_local"
-dist_table_name = "spans_dist"
+storage_set_name = StorageSetKey.METRICS_SUMMARIES
+local_table_name = "metrics_summaries_local"
+dist_table_name = "metrics_summaries_dist"
 
 UNKNOWN_SPAN_STATUS = 2
 

--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -14,23 +14,28 @@ dist_table_name = "spans_dist"
 UNKNOWN_SPAN_STATUS = 2
 
 columns: List[Column[Modifiers]] = [
+    # ids
     Column("project_id", UInt(64)),
     Column("trace_id", UUID()),
     Column("span_id", UInt(64)),
     Column("segment_id", UInt(64)),
-    Column("start_timestamp", DateTime()),
-    Column("exclusive_time", Float(64)),
-    Column("op", String(Modifiers(low_cardinality=True))),
-    Column("group", UInt(64)),
-    Column("tags", Nested([("key", String()), ("value", String())])),
-    Column("partition", UInt(16)),
-    Column("offset", UInt(64)),
-    Column("retention_days", UInt(16)),
-    Column("deleted", UInt(8)),
+    # metrics summary
     Column("min", Float(64)),
     Column("max", Float(64)),
     Column("sum", Float(64)),
     Column("count", Float(64)),
+    # metrics metadata
+    Column("tags", Nested([("key", String()), ("value", String())])),
+    # span metadata
+    Column("start_timestamp", DateTime()),
+    Column("exclusive_time", Float(64)),
+    Column("op", String(Modifiers(low_cardinality=True))),
+    Column("group", UInt(64)),
+    # snuba internals
+    Column("partition", UInt(16)),
+    Column("offset", UInt(64)),
+    Column("retention_days", UInt(16)),
+    Column("deleted", UInt(8)),
 ]
 
 

--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -16,9 +16,10 @@ UNKNOWN_SPAN_STATUS = 2
 columns: List[Column[Modifiers]] = [
     # ids
     Column("project_id", UInt(64)),
-    Column("trace_id", UUID()),
-    Column("span_id", UInt(64)),
+    Column("metric_id", UInt(64)),
     Column("segment_id", UInt(64)),
+    Column("span_id", UInt(64)),
+    Column("trace_id", UUID()),
     # metrics summary
     Column("min", Float(64)),
     Column("max", Float(64)),
@@ -49,10 +50,10 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=local_table_name,
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    order_by="(project_id, group, cityHash64(span_id))",
+                    order_by="(project_id, metric_id, start_timestamp)",
                     version_column="deleted",
                     partition_by="(retention_days, toMonday(start_timestamp))",
-                    sample_by="cityHash64(span_id)",
+                    sample_by="cityHash64(metric_id)",
                     settings={"index_granularity": "8192"},
                     storage_set=storage_set_name,
                     ttl="start_timestamp + toIntervalDay(retention_days)",

--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -1,0 +1,81 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import UUID, Column, DateTime, Nested, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import Float
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+UNKNOWN_SPAN_STATUS = 2
+
+columns: List[Column[Modifiers]] = [
+    Column("project_id", UInt(64)),
+    Column("trace_id", UUID()),
+    Column("span_id", UInt(64)),
+    Column("segment_id", UInt(64)),
+    Column("start_timestamp", DateTime()),
+    Column("exclusive_time", Float(64)),
+    Column("op", String(Modifiers(low_cardinality=True))),
+    Column("group", UInt(64)),
+    Column("tags", Nested([("key", String()), ("value", String())])),
+    Column("partition", UInt(16)),
+    Column("offset", UInt(64)),
+    Column("retention_days", UInt(16)),
+    Column("deleted", UInt(8)),
+    Column("min", Float(64)),
+    Column("max", Float(64)),
+    Column("sum", Float(64)),
+    Column("count", Float(64)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                columns=columns,
+                engine=table_engines.ReplacingMergeTree(
+                    order_by="(project_id, group, cityHash64(span_id))",
+                    version_column="deleted",
+                    partition_by="(retention_days, toMonday(start_timestamp))",
+                    sample_by="cityHash64(span_id)",
+                    settings={"index_granularity": "8192"},
+                    storage_set=storage_set_name,
+                    ttl="start_timestamp + toIntervalDay(retention_days)",
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name=local_table_name,
+                    sharding_key="cityHash64(trace_id)",
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]

--- a/snuba/snuba_migrations/spans/0007_spans_add_metrics_summary.py
+++ b/snuba/snuba_migrations/spans/0007_spans_add_metrics_summary.py
@@ -1,0 +1,52 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Add metrics_summary column.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column("metrics_summary", String()),
+                target=OperationTarget.LOCAL,
+                after="span_id",
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column("metrics_summary", String()),
+                target=OperationTarget.DISTRIBUTED,
+                after="span_id",
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="metrics_summary",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="metrics_summary",
+                target=OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/spans/0007_spans_add_metrics_summary.py
+++ b/snuba/snuba_migrations/spans/0007_spans_add_metrics_summary.py
@@ -3,6 +3,7 @@ from typing import Sequence
 from snuba.clickhouse.columns import Column, String
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.migrations.operations import OperationTarget, SqlOperation
 
 storage_set_name = StorageSetKey.SPANS
@@ -22,16 +23,32 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.AddColumn(
                 storage_set=storage_set_name,
                 table_name=local_table_name,
-                column=Column("metrics_summary", String()),
+                column=Column(
+                    "metrics_summary",
+                    String(
+                        Modifiers(
+                            default="''",
+                            codecs=["ZSTD(1)"],
+                        )
+                    ),
+                ),
                 target=OperationTarget.LOCAL,
-                after="span_id",
+                after="measurements",
             ),
             operations.AddColumn(
                 storage_set=storage_set_name,
                 table_name=dist_table_name,
-                column=Column("metrics_summary", String()),
+                column=Column(
+                    "metrics_summary",
+                    String(
+                        Modifiers(
+                            default="''",
+                            codecs=["ZSTD(1)"],
+                        )
+                    ),
+                ),
                 target=OperationTarget.DISTRIBUTED,
-                after="span_id",
+                after="measurements",
             ),
         ]
 


### PR DESCRIPTION
For DDM, we'd like to add a way to provide examples of spans which generated some metrics. The idea is, when we're visualizing a DDM metric, the user would be able to select a square on the chart and we'd show them a list of spans associated with those values. This would add a new dataset called `metrics_summaries` in order to correlate DDM metrics with spans.

In order to correlate DDM metrics and spans, [RFC 123](https://github.com/getsentry/rfcs/blob/main/text/0123-metrics-correlation.md) adds a metrics summary to spans. The relationship between spans and summaries is like this:
```
1 span -> M metrics -> S metrics summaries -> T tags
```

To display metrics information when querying spans, we'd like to add a column called `metrics_summary` to the `spans` dataset to purely **store** the needed information. When rendering those spans, we'd be able to show information about the metrics and the different values.

In order to do the reverse, showing spans related to some specific metrics, we'd need a way to filter through these spans' metrics summaries. Given the multi-dimensional nature of metrics summaries (we could have many summaries attached to 1 metric attached to 1 span), using the same way we do to filter on `tags` is not possible without flattening the tags as well and it's less efficient to fully filter that way.
One efficient way to do this is have a separate dataset. We'd store enough information about the spans so we don't have to join (in ClickHouse or in the app). We could keep tags as an array column or even insert 1 row per tag value. This way, selecting a list of spans corresponding to certain values for given metric would be a simple `SELECT` query away.