### PR TITLE
Run rdkafka logging with an explicit Sentry Hub

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1712,6 +1712,7 @@ dependencies = [
  "filetime",
  "once_cell",
  "rdkafka",
+ "sentry",
  "serde",
  "serde_json",
  "thiserror",

--- a/rust_snuba/rust_arroyo/Cargo.toml
+++ b/rust_snuba/rust_arroyo/Cargo.toml
@@ -10,6 +10,7 @@ chrono = "0.4.26"
 filetime = "0.2.22"
 once_cell = "1.18.0"
 rdkafka = { git = "https://github.com/getsentry/rust-rdkafka", branch = "base-consumer", features = ["cmake-build", "tracing"] }
+sentry = { version = "0.32.0" }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0"


### PR DESCRIPTION
This explicitly uses `Hub::run` to trigger logging within a Sentry Hub. The hunch here would be that these logs are running on a background thread that was initialized before Sentry, and so has not inherited a properly configured Hub.

This would be a fix for SNS-2546 if indeed this is the problem.