### PR TITLE
feat(rust): Implement DlqLimitState

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -442,10 +442,10 @@ mod tests {
 
             fn build_initial_state(
                 &self,
-                _limit: DlqLimit,
-                _assignment: &HashMap<Partition, u64>,
+                limit: DlqLimit,
+                assignment: &HashMap<Partition, u64>,
             ) -> DlqLimitState {
-                DlqLimitState::default()
+                DlqLimitState::new(limit, assignment)
             }
         }
 
@@ -458,11 +458,10 @@ mod tests {
 
         let mut wrapper = DlqPolicyWrapper::new(Some(DlqPolicy::new(
             Box::new(producer.clone()),
-            DlqLimit {
-                max_invalid_ratio: None,
-                max_consecutive_count: Some(1),
-            },
+            DlqLimit::default(),
         )));
+
+        wrapper.reset_dlq_limit(&[(partition, 0)].into_iter().collect());
 
         for i in 0..10 {
             wrapper.produce(BrokerMessage {

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -136,6 +136,11 @@ struct InvalidMessageStats {
     last_invalid_offset: u64,
 }
 
+/// Struct that keeps a record of how many valid and invalid messages have been received
+/// per partition and decides whether to produce a message to the DLQ according to a configured limit.
+///
+/// Note that `DlqLimitState` keeps a fixed list of partitions for which it records messages.
+/// Messages on any other partitions will be automatically rejected.
 #[derive(Debug, Clone, Default)]
 pub struct DlqLimitState {
     limit: DlqLimit,

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -167,6 +167,7 @@ impl DlqLimitState {
     fn record_invalid_message<T>(&mut self, message: &BrokerMessage<T>) -> bool {
         let Some(record) = self.records.get_mut(&message.partition) else {
             // If we don't know about this message's partition, we reject it out of hand.
+            // TODO: Add some logging here?
             return false;
         };
 

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -193,11 +193,8 @@ impl DlqLimitState {
 
         if let Some(last_invalid) = record.last_invalid_offset {
             match message.offset {
-                o if o < last_invalid => {
+                o if o <= last_invalid => {
                     tracing::error!("Invalid message raised out of order")
-                }
-                o if o == last_invalid => {
-                    tracing::error!("Duplicate invalid message raised")
                 }
                 o if o == last_invalid + 1 => record.consecutive_invalid += 1,
                 o => {

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -140,7 +140,7 @@ pub struct InvalidMessageStats {
     pub invalid: u64,
     /// The length of the current run of received invalid messages.
     pub consecutive_invalid: u64,
-    /// The offset of the last received invalid message, if any.
+    /// The offset of the last received invalid message.
     pub last_invalid_offset: u64,
 }
 

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -178,7 +178,7 @@ impl DlqLimitState {
 
         if record.last_invalid_offset > message.offset {
             tracing::error!("Invalid message raised out of order");
-        } else if record.last_invalid_offset == message.offset - 1 {
+        } else if record.last_invalid_offset + 1 == message.offset {
             record.consecutive_invalid += 1;
         } else {
             let valid_count = message.offset - record.last_invalid_offset + 1;

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -184,6 +184,8 @@ impl DlqLimitState {
             .and_modify(|record| {
                 if record.last_invalid_offset > message.offset {
                     tracing::error!("Invalid message raised out of order");
+                } else if record.last_invalid_offset == message.offset {
+                    tracing::error!("Duplicate invalid message raised")
                 } else if record.last_invalid_offset + 1 == message.offset {
                     record.consecutive_invalid += 1;
                 } else {

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -123,9 +123,9 @@ pub struct DlqLimit {
     pub max_consecutive_count: Option<u64>,
 }
 
-/// A record of valid and invalid messages that have been received on a topic.
+/// A record of valid and invalid messages that have been received on a partition.
 #[derive(Debug, Clone, Copy, Default)]
-struct InvalidMessageRecord {
+struct InvalidMessageStats {
     /// The number of valid messages that have been received.
     valid: u64,
     /// The number of invalid messages that have been received.
@@ -139,7 +139,7 @@ struct InvalidMessageRecord {
 #[derive(Debug, Clone, Default)]
 pub struct DlqLimitState {
     limit: DlqLimit,
-    records: HashMap<Partition, InvalidMessageRecord>,
+    records: HashMap<Partition, InvalidMessageStats>,
 }
 
 impl DlqLimitState {
@@ -149,7 +149,7 @@ impl DlqLimitState {
             .map(|(&p, &o)| {
                 (
                     p,
-                    InvalidMessageRecord {
+                    InvalidMessageStats {
                         last_invalid_offset: o - 1,
                         ..Default::default()
                     },

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -273,7 +273,7 @@ impl<TPayload: Clone + Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
 
     /// Clears the DLQ limits.
     #[allow(dead_code)]
-    pub fn reset_dlq_limit(&mut self, assignment: &HashMap<Partition, u64>) {
+    pub fn reset_dlq_limits(&mut self, assignment: &HashMap<Partition, u64>) {
         let Some(policy) = self.dlq_policy.as_ref() else {
             return;
         };


### PR DESCRIPTION
Closes SNS-2550.

This implements the `DlqLimitState` struct in a way that's similar, but not identical to the Python version.

Differences:
* internally it keeps a single map collecting the numbers of valid messages, invalid messages, consecutive invalid messages, and the offset of the last invalid message per partition, instead of four separate maps.
* the `update_invalid_value` and `should_accept` methods have been combined into `record_invalid_message`, since they are never called separately in the Python implementation.

This implementations also makes the following property explicit that AFAICT is intended in the Python version: the `DlqLimitState` is instantiated with a list of partitions that is never mutated later and any message outside of these partitions is rejected.