### PR TITLE
oncall(validation): Turn on query column validator for more entities

### DIFF
--- a/snuba/datasets/configuration/functions/entities/functions.yaml
+++ b/snuba/datasets/configuration/functions/entities/functions.yaml
@@ -91,6 +91,7 @@ query_processors:
     args:
       project_field: project_id
 
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/groupassignee/entities/groupassignee.yaml
+++ b/snuba/datasets/configuration/groupassignee/entities/groupassignee.yaml
@@ -24,6 +24,7 @@ query_processors:
   - processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
+validate_data_model: error
 validators: []
 required_time_column: null
 join_relationships:

--- a/snuba/datasets/configuration/groupedmessage/entities/groupedmessage.yaml
+++ b/snuba/datasets/configuration/groupedmessage/entities/groupedmessage.yaml
@@ -26,6 +26,7 @@ query_processors:
   - processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
+validate_data_model: error
 validators: []
 required_time_column: null
 join_relationships:

--- a/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
+++ b/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
@@ -37,6 +37,7 @@ query_processors:
   - processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/outcomes_raw/entities/outcomes_raw.yaml
+++ b/snuba/datasets/configuration/outcomes_raw/entities/outcomes_raw.yaml
@@ -43,6 +43,7 @@ query_processors:
   - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/profiles/entities/profiles.yaml
+++ b/snuba/datasets/configuration/profiles/entities/profiles.yaml
@@ -64,6 +64,7 @@ query_processors:
       time_parse_columns:
         - received
 
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/sessions/entities/org.yaml
+++ b/snuba/datasets/configuration/sessions/entities/org.yaml
@@ -39,4 +39,5 @@ query_processors:
   - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
+validate_data_model: error
 validators: []

--- a/snuba/datasets/configuration/sessions/entities/sessions.yaml
+++ b/snuba/datasets/configuration/sessions/entities/sessions.yaml
@@ -248,6 +248,7 @@ query_processors:
   - processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -371,6 +371,7 @@ query_processors:
     { processor: ResourceQuotaProcessor, args: { project_field: project_id } },
   ]
 
+validate_data_model: error
 validators:
   [
     {

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -370,7 +370,6 @@ query_processors:
     },
     { processor: ResourceQuotaProcessor, args: { project_field: project_id } },
   ]
-
 validate_data_model: error
 validators:
   [


### PR DESCRIPTION
In the past week, there were no missing query column warnings for these entities in sentry. 

See: https://sentry.sentry.io/issues/?groupStatsPeriod=auto&page=0&project=300688&query=is%3Aunresolved+Query+column&referrer=issue-list&statsPeriod=7d

We can safely turn this on for these entities.