### PR TITLE
feat(rust): Add --no-strict-offset-reset to the Rust CLI

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -28,6 +28,7 @@ pub fn consumer(
     py: Python<'_>,
     consumer_group: &str,
     auto_offset_reset: &str,
+    no_strict_offset_reset: bool,
     consumer_config_raw: &str,
     skip_write: bool,
     concurrency: usize,
@@ -40,6 +41,7 @@ pub fn consumer(
         consumer_impl(
             consumer_group,
             auto_offset_reset,
+            no_strict_offset_reset,
             consumer_config_raw,
             skip_write,
             concurrency,
@@ -55,6 +57,7 @@ pub fn consumer(
 pub fn consumer_impl(
     consumer_group: &str,
     auto_offset_reset: &str,
+    no_strict_offset_reset: bool,
     consumer_config_raw: &str,
     skip_write: bool,
     concurrency: usize,
@@ -120,7 +123,7 @@ pub fn consumer_impl(
         vec![],
         consumer_group.to_owned(),
         auto_offset_reset.to_owned(),
-        false,
+        !no_strict_offset_reset,
         max_poll_interval_ms,
         Some(consumer_config.raw_topic.broker_config),
     );

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -31,6 +31,11 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     type=click.Choice(["error", "earliest", "latest"]),
     help="Kafka consumer auto offset reset.",
 )
+@click.option(
+    "--no-strict-offset-reset",
+    is_flag=True,
+    help="Forces the kafka consumer auto offset reset.",
+)
 @click.option("--raw-events-topic", help="Topic to consume raw events from.")
 @click.option(
     "--commit-log-topic",
@@ -128,6 +133,7 @@ def rust_consumer(
     storage_names: Sequence[str],
     consumer_group: str,
     auto_offset_reset: str,
+    no_strict_offset_reset: bool,
     raw_events_topic: Optional[str],
     commit_log_topic: Optional[str],
     replacements_topic: Optional[str],
@@ -182,6 +188,7 @@ def rust_consumer(
     rust_snuba.consumer(  # type: ignore
         consumer_group,
         auto_offset_reset,
+        no_strict_offset_reset,
         consumer_config_raw,
         skip_write,
         concurrency_override or concurrency or 1,


### PR DESCRIPTION
This doesn't do anything yet, just adding the flag first and passing it through to the Rust Kafka config. 
Merging this first allows us to start passing this flag in some of our test consumers that are already running before we flip the actual behavior over to strict mode with the rest of the implementation.

