### PR TITLE
fix(rust): Fix SLO metrics again

### DIFF
--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -39,11 +39,11 @@ impl LatencyRecorder {
 
         let write_time = write_time.timestamp() as u64;
 
-        let latency = self.max_secs.saturating_sub(write_time) * 1000;
-        metrics.timing(&format!("insertions.max_{}_ms", metric_name), latency, None);
+        let max_latency = write_time.saturating_sub(self.max_secs) * 1000;
+        metrics.timing(&format!("insertions.max_{}_ms", metric_name), max_latency * 1000, None);
 
-        let latency = ((self.sum_secs * 1000.0 / self.num_values as f64) as u64)
-            .saturating_sub(write_time * 1000);
+        let latency = write_time as f64 - (self.sum_secs / self.num_values as f64);
+        let latency = (latency * 1000.0) as u64;
         metrics.timing(&format!("insertions.{}_ms", metric_name), latency, None);
     }
 }


### PR DESCRIPTION
This time around, all our SLOs are zero. This is because we subtracted
the larger timestamp from the smaller one instead of the other way
around, always leading to an underflow
