### PR TITLE
feat(rust): Handle DLQ in callbacks

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -159,7 +159,7 @@ fn create_stream_processor(
     messages: usize,
 ) -> StreamProcessor<KafkaPayload> {
     let factory = create_factory(concurrency, processor, schema);
-    let consumer_state = Arc::new(Mutex::new(ConsumerState::new(factory)));
+    let consumer_state = Arc::new(Mutex::new(ConsumerState::new(factory, None)));
     let topic = Topic::new("test");
     let partition = Partition::new(topic, 0);
 
@@ -182,7 +182,7 @@ fn create_stream_processor(
     );
     let consumer = Box::new(consumer);
 
-    StreamProcessor::new(consumer, consumer_state, None)
+    StreamProcessor::new(consumer, consumer_state)
 }
 
 fn functions_payload() -> KafkaPayload {

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -300,13 +300,15 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
 
         if let Some(dlq_policy) = &self.dlq_policy {
             if self.dlq_limit_state.record_invalid_message(&message) {
+                let (partition, offset) = (message.partition, message.offset);
+
                 let task = dlq_policy.producer.produce(message);
                 let handle = self.runtime.spawn(task);
 
                 self.futures
-                    .entry(message.partition)
+                    .entry(partition)
                     .or_default()
-                    .push_back((message.offset, handle));
+                    .push_back((offset, handle));
             }
         }
     }


### PR DESCRIPTION
Closes SN-2548.

This integrates DLQ handling into the `on_assign` and `on_revoke` callbacks:

* in `on_assign`, call `DlqPolicyWrapper::reset_dlq_limits`,
* in `on_revoke`, call `DlqPolicyWrapper::flush`.

Unfortunately this requires the `DlqPolicyWrapper` to move from the `StreamProcessor` to the `ConsumerState`, so there is some internal reorganization.