### PR TITLE
chore(dep): Bump sentry-relay from 0.8.27 to 0.8.39

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ redis==4.3.4
 sentry-arroyo==2.14.25
 sentry-kafka-schemas==0.1.37
 sentry-redis-tools==0.1.7
-sentry-relay==0.8.27
+sentry-relay==0.8.39
 sentry-sdk==1.28.0
 simplejson==3.17.6
 structlog==22.3.0

--- a/snuba/datasets/processors/outcomes_processor.py
+++ b/snuba/datasets/processors/outcomes_processor.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Optional
 
 from sentry_kafka_schemas.schema_types.outcomes_v1 import Outcome
-from sentry_relay import DataCategory
+from sentry_relay.consts import DataCategory
 
 from snuba import environment, settings
 from snuba.consumers.types import KafkaMessageMetadata

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Optional, Tuple, Union
 
 import pytest
 import simplejson as json
-from sentry_relay import DataCategory
+from sentry_relay.consts import DataCategory
 
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.storages.factory import get_writable_storage


### PR DESCRIPTION
bumping snuba because we introduce new datacategory in https://github.com/getsentry/relay/pull/2824