### PR TITLE
ref: Add experimental readiness state

### DIFF
--- a/snuba/datasets/readiness_state.py
+++ b/snuba/datasets/readiness_state.py
@@ -8,9 +8,16 @@ class ReadinessState(Enum):
     DEPRECATE = "deprecate"
     PARTIAL = "partial"
     COMPLETE = "complete"
+    EXPERIMENTAL = "experimental"
 
     def __init__(self, _: str) -> None:
-        self.order = {"limited": 1, "deprecate": 2, "partial": 3, "complete": 4}
+        self.order = {
+            "limited": 1,
+            "deprecate": 2,
+            "experimental": 3,
+            "partial": 4,
+            "complete": 5,
+        }
 
     def __gt__(self, other_rs: ReadinessState) -> bool:
         return self.order[self.value] > self.order[other_rs.value]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -292,7 +292,13 @@ COLUMN_SPLIT_MAX_RESULTS = 5000
 SKIPPED_MIGRATION_GROUPS: Set[str] = set()
 
 # Dataset readiness states supported in this environment
-SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
+SUPPORTED_STATES: Set[str] = {
+    "deprecate",
+    "limited",
+    "experimental",
+    "partial",
+    "complete",
+}
 # [04-18-2023] These two readiness state settings are temporary and used to facilitate the rollout of readiness states.
 # We expect to remove them after all storages and migration groups have been migrated.
 READINESS_STATE_FAIL_QUERIES: bool = True


### PR DESCRIPTION
This state is meant for experimental features that should only be used locally
or in S4S.
