### PR TITLE
ref(rust): Use enum pervasively

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -1,6 +1,7 @@
 extern crate rust_arroyo;
 
 use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::InitialOffset;
 use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::backends::AssignmentCallbacks;
 use rust_arroyo::backends::CommitOffsets;
@@ -20,7 +21,7 @@ fn main() {
     let config = KafkaConfig::new_consumer_config(
         vec!["127.0.0.1:9092".to_string()],
         "my_group".to_string(),
-        "latest".to_string(),
+        InitialOffset::Latest,
         false,
         30_000,
         None,

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -2,6 +2,7 @@ extern crate rust_arroyo;
 
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::backends::kafka::InitialOffset;
 use rust_arroyo::processing::strategies::commit_offsets::CommitOffsets;
 use rust_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
 use rust_arroyo::processing::StreamProcessor;
@@ -21,7 +22,7 @@ fn main() {
     let config = KafkaConfig::new_consumer_config(
         vec!["127.0.0.1:9092".to_string()],
         "my_group".to_string(),
-        "latest".to_string(),
+        InitialOffset::Latest,
         false,
         30_000,
         None,

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -8,6 +8,7 @@ use rdkafka::message::ToBytes;
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::backends::kafka::InitialOffset;
 use rust_arroyo::processing::strategies::produce::Produce;
 use rust_arroyo::processing::strategies::run_task::RunTask;
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
@@ -75,7 +76,7 @@ async fn main() {
     let config = KafkaConfig::new_consumer_config(
         vec!["0.0.0.0:9092".to_string()],
         "my_group".to_string(),
-        "latest".to_string(),
+        InitialOffset::Latest,
         false,
         30_000,
         None,

--- a/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
@@ -1,10 +1,22 @@
 use rdkafka::config::ClientConfig as RdKafkaConfig;
 use std::collections::HashMap;
 
+use super::InitialOffset;
+
 #[derive(Debug, Clone)]
 pub struct OffsetResetConfig {
-    pub auto_offset_reset: String,
+    pub auto_offset_reset: InitialOffset,
     pub strict_offset_reset: bool,
+}
+
+impl OffsetResetConfig {
+    fn for_rdkafka(&self) -> InitialOffset {
+        if self.strict_offset_reset {
+            InitialOffset::Error
+        } else {
+            self.auto_offset_reset
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -32,7 +44,7 @@ impl KafkaConfig {
     pub fn new_consumer_config(
         bootstrap_servers: Vec<String>,
         group_id: String,
-        auto_offset_reset: String,
+        auto_offset_reset: InitialOffset,
         strict_offset_reset: bool,
         max_poll_interval_ms: usize,
         override_params: Option<HashMap<String, String>>,
@@ -79,24 +91,18 @@ impl KafkaConfig {
 }
 
 impl From<KafkaConfig> for RdKafkaConfig {
-    fn from(item: KafkaConfig) -> Self {
+    fn from(cfg: KafkaConfig) -> Self {
         let mut config_obj = RdKafkaConfig::new();
-        for (key, val) in item.config_map.iter() {
+        for (key, val) in cfg.config_map.iter() {
             config_obj.set(key, val);
         }
 
         // NOTE: Offsets are explicitly managed as part of the assignment
         // callback, so preemptively resetting offsets is not enabled when
         // strict_offset_reset is enabled.
-        if let Some(config) = item.offset_reset_config {
-            let auto_offset_reset = match config.strict_offset_reset {
-                true => "error",
-                false => &config.auto_offset_reset,
-            };
-
-            config_obj.set("auto.offset.reset", auto_offset_reset);
+        if let Some(config) = cfg.offset_reset_config {
+            config_obj.set("auto.offset.reset", config.for_rdkafka().to_string());
         }
-
         config_obj
     }
 }
@@ -115,6 +121,8 @@ fn apply_override_params(
 
 #[cfg(test)]
 mod tests {
+    use crate::backends::kafka::InitialOffset;
+
     use super::KafkaConfig;
     use rdkafka::config::ClientConfig as RdKafkaConfig;
     use std::collections::HashMap;
@@ -124,7 +132,7 @@ mod tests {
         let config = KafkaConfig::new_consumer_config(
             vec!["127.0.0.1:9092".to_string()],
             "my-group".to_string(),
-            "error".to_string(),
+            InitialOffset::Error,
             false,
             30_000,
             Some(HashMap::from([(

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -90,6 +90,7 @@ mod tests {
     use super::*;
     use crate::backends::kafka::config::KafkaConfig;
     use crate::backends::kafka::producer::KafkaProducer;
+    use crate::backends::kafka::InitialOffset;
     use crate::processing::strategies::InvalidMessage;
     use crate::types::{BrokerMessage, InnerMessage, Partition, Topic};
     use chrono::Utc;
@@ -99,7 +100,7 @@ mod tests {
         let config = KafkaConfig::new_consumer_config(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
             "my_group".to_string(),
-            "latest".to_string(),
+            InitialOffset::Latest,
             false,
             30_000,
             None,

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -122,7 +122,9 @@ pub fn consumer_impl(
     let config = KafkaConfig::new_consumer_config(
         vec![],
         consumer_group.to_owned(),
-        auto_offset_reset.to_owned(),
+        auto_offset_reset.parse().expect(
+            "Invalid value for `auto_offset_reset`. Valid values: `error`, `earliest`, `latest`",
+        ),
         !no_strict_offset_reset,
         max_poll_interval_ms,
         Some(consumer_config.raw_topic.broker_config),


### PR DESCRIPTION
This uses the `InitialCommit` enum instead of a `String` everywhere. It's only parsed once (in `consumer_impl`) and serialized once (when serializing to the `rdkafka` configuration).