### PR TITLE
feat(spans): Enable spans consumer by default

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -83,6 +83,16 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--storage=errors",
             ],
         ),
+        (
+            "spans-consumer",
+            [
+                "snuba",
+                "consumer",
+                "--storage=spans",
+                "--consumer-group=spans_group",
+                *COMMON_CONSUMER_DEV_OPTIONS,
+            ],
+        ),
     ]
 
     if settings.SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV:
@@ -371,20 +381,6 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                     "consumer",
                     "--storage=search_issues",
                     "--consumer-group=generic_events_group",
-                    *COMMON_CONSUMER_DEV_OPTIONS,
-                ],
-            ),
-        ]
-
-    if settings.ENABLE_SPANS_CONSUMER:
-        daemons += [
-            (
-                "spans-consumer",
-                [
-                    "snuba",
-                    "consumer",
-                    "--storage=spans",
-                    "--consumer-group=spans_group",
                     *COMMON_CONSUMER_DEV_OPTIONS,
                 ],
             ),

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -344,9 +344,6 @@ ENABLE_ISSUE_OCCURRENCE_CONSUMER = os.environ.get(
     "ENABLE_ISSUE_OCCURRENCE_CONSUMER", False
 )
 
-# Enable spans ingestion
-ENABLE_SPANS_CONSUMER = os.environ.get("ENABLE_SPANS_CONSUMER", False)
-
 # Enable group attributes consumer
 ENABLE_GROUP_ATTRIBUTES_CONSUMER = os.environ.get(
     "ENABLE_GROUP_ATTRIBUTES_CONSUMER", False


### PR DESCRIPTION
In order for Sentry to run tests against the spans dataset, enable the spans consumer by default. Tests are going to be written in Sentry using the kafka interface rather than the HTTP interface which were used before.