### PR TITLE
fix(rust): Actually produce to DLQ

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -272,9 +272,8 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             }
             Err(e) => match self.buffered_messages.pop(&e.partition, e.offset) {
                 Some(msg) => {
-                    self.message = Some(Message {
-                        inner_message: InnerMessage::BrokerMessage(msg),
-                    });
+                    tracing::error!(?e, "Invalid message");
+                    consumer_state.dlq_policy.produce(msg);
                 }
                 None => {
                     tracing::error!("Could not find invalid message in buffer");


### PR DESCRIPTION
If InvalidMessage was raised in strategy.poll(), we were not previously submitting the message to the DLQ, but putting it back so it would be constantly resubmitted (i.e. handling it like backpressure, which is wrong).


