### PR TITLE
fix(rust): Suppress error when manually resetting offsets

### DIFF
--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -99,22 +99,33 @@ fn create_kafka_message(msg: BorrowedMessage) -> BrokerMessage<KafkaPayload> {
     )
 }
 
-struct OffsetCommitter<'a, C: AssignmentCallbacks>(&'a BaseConsumer<CustomContext<C>>);
+fn commit_impl<C: AssignmentCallbacks>(
+    consumer: &BaseConsumer<CustomContext<C>>,
+    consumer_offsets: &Arc<Mutex<HashMap<Partition, u64>>>,
+    offsets: HashMap<Partition, u64>
+) -> Result<(), ConsumerError> {
+    let mut partitions = TopicPartitionList::with_capacity(offsets.len());
+    for (partition, offset) in &offsets {
+        partitions.add_partition_offset(
+            partition.topic.as_str(),
+            partition.index as i32,
+            Offset::from_raw(*offset as i64),
+        )?;
+    }
+
+    consumer.commit(&partitions, CommitMode::Sync).unwrap();
+    consumer_offsets.lock().unwrap().extend(&offsets);
+    Ok(())
+}
+
+struct OffsetCommitter<'a, C: AssignmentCallbacks> {
+    consumer: &'a BaseConsumer<CustomContext<C>>,
+    consumer_offsets: Arc<Mutex<HashMap<Partition, u64>>>,
+}
 
 impl<'a, C: AssignmentCallbacks> CommitOffsets for OffsetCommitter<'a, C> {
     fn commit(self, offsets: HashMap<Partition, u64>) -> Result<(), ConsumerError> {
-        let mut partitions = TopicPartitionList::with_capacity(offsets.len());
-        for (partition, offset) in offsets {
-            partitions.add_partition_offset(
-                partition.topic.as_str(),
-                partition.index as i32,
-                Offset::from_raw(offset as i64),
-            )?;
-        }
-
-        self.0.commit(&partitions, CommitMode::Sync).unwrap();
-
-        Ok(())
+        commit_impl(self.consumer, &self.consumer_offsets, offsets)
     }
 }
 
@@ -169,8 +180,13 @@ impl<C: AssignmentCallbacks> ConsumerContext for CustomContext<C> {
                 offsets.remove(partition);
             }
 
+            let committer = OffsetCommitter {
+                consumer: base_consumer,
+                consumer_offsets: self.consumer_offsets.clone()
+            };
+
             self.callbacks
-                .on_revoke(OffsetCommitter(base_consumer), partitions);
+                .on_revoke(committer, partitions);
         }
     }
 
@@ -220,6 +236,18 @@ impl<C: AssignmentCallbacks> ConsumerContext for CustomContext<C> {
                     Offset::from_raw(*offset as i64),
                 )
                 .unwrap();
+            }
+
+            // specifically in rust-rdkafka (not in python confluent-kafka) we are observing a
+            // weird bug where assigning an offset after rebalancing does not work until the
+            // consumer is being polled.
+            //
+            // the poll() may return an offset-related error or advance the internal rdkafka
+            // buffer. but it shouldn't matter which case we hit, because even if poll() returns a
+            // message here, we are resetting offsets to something else, and (hopefully) not commit
+            // anything before that
+            if let Some(Err(_)) = base_consumer.poll(Some(Duration::from_millis(10))) {
+                tracing::info!("polling failed during rebalancing, resetting offsets manually");
             }
 
             base_consumer
@@ -371,19 +399,7 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
 
     fn commit_offsets(&mut self, offsets: HashMap<Partition, u64>) -> Result<(), ConsumerError> {
         self.state.assert_consuming_state()?;
-
-        let mut partitions = TopicPartitionList::with_capacity(offsets.len());
-        for (partition, offset) in &offsets {
-            partitions.add_partition_offset(
-                partition.topic.as_str(),
-                partition.index as i32,
-                Offset::from_raw(*offset as i64),
-            )?;
-        }
-
-        self.consumer.commit(&partitions, CommitMode::Sync).unwrap();
-
-        Ok(())
+        commit_impl(&self.consumer, &self.offsets, offsets)
     }
 }
 
@@ -391,11 +407,14 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
 mod tests {
     use super::{AssignmentCallbacks, InitialOffset, KafkaConsumer};
     use crate::backends::kafka::config::KafkaConfig;
-    use crate::backends::Consumer;
+    use crate::backends::kafka::producer::KafkaProducer;
+    use crate::backends::kafka::KafkaPayload;
+    use crate::backends::{Producer, Consumer};
     use crate::types::{Partition, Topic};
     use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
     use rdkafka::client::DefaultClientContext;
     use rdkafka::config::ClientConfig;
+    use tokio::runtime::Runtime;
     use std::collections::HashMap;
     use std::thread::sleep;
     use std::time::Duration;
@@ -428,12 +447,38 @@ mod tests {
             .await
             .unwrap();
     }
+
     async fn delete_topic(topic_name: &str) {
         let client = get_admin_client();
         client
             .delete_topics(&[topic_name], &AdminOptions::new())
             .await
             .unwrap();
+    }
+
+    struct TestTopic {
+        runtime: Runtime,
+        topic: Topic,
+    }
+
+    impl TestTopic {
+        fn create(name: &str) -> Self {
+            let runtime = Runtime::new().unwrap();
+            let name = format!("rust-arroyo-{}-{}", name, uuid::Uuid::new_v4());
+            runtime.block_on(create_topic(&name, 1));
+            Self {
+                runtime,
+                topic: Topic::new(&name),
+            }
+        }
+    }
+
+    impl Drop for TestTopic {
+        fn drop(&mut self) {
+            let name = self.topic.as_str();
+            // i really wish i had async drop now
+            self.runtime.block_on(delete_topic(name));
+        }
     }
 
     #[test]
@@ -450,9 +495,9 @@ mod tests {
         KafkaConsumer::new(configuration, &[topic], EmptyCallbacks {}).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_tell() {
-        create_topic("test", 1).await;
+    #[test]
+    fn test_tell() {
+        let topic = TestTopic::create("test-tell");
         let configuration = KafkaConfig::new_consumer_config(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
             "my-group-1".to_string(),
@@ -461,8 +506,7 @@ mod tests {
             30_000,
             None,
         );
-        let topic = Topic::new("test");
-        let mut consumer = KafkaConsumer::new(configuration, &[topic], EmptyCallbacks {}).unwrap();
+        let mut consumer = KafkaConsumer::new(configuration, &[topic.topic], EmptyCallbacks {}).unwrap();
         assert_eq!(consumer.tell().unwrap(), HashMap::new());
 
         // Getting the assignment may take a while
@@ -479,13 +523,65 @@ mod tests {
         // One partition was assigned
         assert_eq!(offsets.len(), 1);
         consumer.shutdown();
-
-        delete_topic("test").await;
     }
 
-    #[tokio::test]
-    async fn test_commit() {
-        create_topic("test2", 1).await;
+    /// check that consumer does not crash with strict_offset_reset if the offset does not exist
+    /// yet.
+    #[test]
+    fn test_offset_reset_strict() {
+        let topic = TestTopic::create("test-offset-reset-strict");
+        let configuration = KafkaConfig::new_consumer_config(
+            vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
+            "my-group-1".to_string(),
+            InitialOffset::Earliest,
+            true,
+            30_000,
+            None,
+        );
+
+        let producer_configuration = KafkaConfig::new_producer_config(
+            vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())], None
+        );
+
+        let producer = KafkaProducer::new(producer_configuration);
+        let payload = KafkaPayload::new(None, None, Some("asdf".as_bytes().to_vec()));
+
+        producer
+            .produce(&crate::types::TopicOrPartition::Topic(topic.topic), payload)
+            .expect("Message produced");
+
+        let mut consumer = KafkaConsumer::new(configuration, &[topic.topic], EmptyCallbacks {}).unwrap();
+        assert_eq!(consumer.tell().unwrap(), HashMap::new());
+
+        let consumer_message = consumer.poll(Some(Duration::from_millis(25_000))).unwrap().unwrap();
+        assert_eq!(consumer_message.offset, 0);
+        let consumer_payload = consumer_message.payload.payload().unwrap();
+        // ensure that our weird workarounds in consumer callbacks (polling the consumer and
+        // discarding the result) do not read past the message we produced into the new topic
+        assert_eq!(consumer_payload, b"asdf");
+
+        assert!(consumer.poll(Some(Duration::from_millis(10))).unwrap().is_none());
+
+        let offsets = consumer.tell().unwrap();
+        assert_eq!(offsets, HashMap::from([
+            (Partition::new(topic.topic, 0), 0)
+        ]));
+
+        consumer.commit_offsets(HashMap::from([
+                (consumer_message.partition, consumer_message.offset + 1)
+        ])).unwrap();
+
+        let offsets = consumer.tell().unwrap();
+        assert_eq!(offsets, HashMap::from([
+            (Partition::new(topic.topic, 0), 1)
+        ]));
+
+        consumer.shutdown();
+    }
+
+    #[test]
+    fn test_commit() {
+        let topic = TestTopic::create("test-commit");
         let configuration = KafkaConfig::new_consumer_config(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
             "my-group-2".to_string(),
@@ -495,10 +591,9 @@ mod tests {
             None,
         );
 
-        let topic = Topic::new("test2");
-        let mut consumer = KafkaConsumer::new(configuration, &[topic], EmptyCallbacks {}).unwrap();
+        let mut consumer = KafkaConsumer::new(configuration, &[topic.topic], EmptyCallbacks {}).unwrap();
 
-        let positions = HashMap::from([(Partition { topic, index: 0 }, 100)]);
+        let positions = HashMap::from([(Partition { topic: topic.topic, index: 0 }, 100)]);
 
         // Wait until the consumer got an assignment
         for _ in 0..10 {
@@ -512,8 +607,6 @@ mod tests {
 
         consumer.commit_offsets(positions.clone()).unwrap();
         consumer.shutdown();
-
-        delete_topic("test2").await;
     }
 
     #[test]

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -566,9 +566,7 @@ mod tests {
         let mut consumer_message = None;
 
         for _ in 0..10 {
-            consumer_message = consumer
-                .poll(Some(Duration::from_millis(5_000)))
-                .unwrap();
+            consumer_message = consumer.poll(Some(Duration::from_millis(5_000))).unwrap();
 
             if consumer_message.is_some() {
                 break;

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -247,7 +247,10 @@ impl<C: AssignmentCallbacks> ConsumerContext for CustomContext<C> {
             // message here, we are resetting offsets to something else, and (hopefully) not commit
             // anything before that
             if let Some(Err(err)) = base_consumer.poll(Some(Duration::from_millis(10))) {
-                if matches!(err.rdkafka_error_code(), Some(RDKafkaErrorCode::AutoOffsetReset)) {
+                if matches!(
+                    err.rdkafka_error_code(),
+                    Some(RDKafkaErrorCode::AutoOffsetReset)
+                ) {
                     tracing::info!("polling failed during rebalancing, resetting offsets manually");
                 } else {
                     panic!("consumer poll failed in callback: {}", err);

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -563,10 +563,20 @@ mod tests {
             KafkaConsumer::new(configuration, &[topic.topic], EmptyCallbacks {}).unwrap();
         assert_eq!(consumer.tell().unwrap(), HashMap::new());
 
-        let consumer_message = consumer
-            .poll(Some(Duration::from_millis(25_000)))
-            .unwrap()
-            .unwrap();
+        let mut consumer_message = None;
+
+        for _ in 0..10 {
+            consumer_message = consumer
+                .poll(Some(Duration::from_millis(5_000)))
+                .unwrap();
+
+            if consumer_message.is_some() {
+                break;
+            }
+        }
+
+        let consumer_message = consumer_message.unwrap();
+
         assert_eq!(consumer_message.offset, 0);
         let consumer_payload = consumer_message.payload.payload().unwrap();
         // ensure that our weird workarounds in consumer callbacks (polling the consumer and


### PR DESCRIPTION
This fixes the same bug as https://github.com/getsentry/snuba/pull/5181,
but with a test and without the potential to suppress all kinds of
poll() errors mid-operation. Still a gross hack though.

Also fix a bug where consumer.tell() would be out of date once
consumer.commit_offsets was used. ~We don't really use tell() in prod so
it didn't come up.~

**We do use consumer.tell() extensively in prod.** I don't know why we didn't notice this bug sooner. Potentially affected areas:

* paused consumer -- unclear why we didn't hit it. do our strategies just never backpressure?
* dlq -- maybe it works now?