### PR TITLE
fix(rust/dlq): Do not drop runtime and accidentally cancel tasks

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -8,7 +8,6 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
 pub trait DlqProducer<TPayload>: Send + Sync {
@@ -248,7 +247,8 @@ type Futures<TPayload> = VecDeque<(u64, JoinHandle<BrokerMessage<TPayload>>)>;
 pub(crate) struct DlqPolicyWrapper<TPayload> {
     dlq_policy: Option<DlqPolicy<TPayload>>,
     dlq_limit_state: DlqLimitState,
-    runtime: Handle,
+    // need to keep concurrency config around in order to not drop runtime
+    concurrency_config: ConcurrencyConfig,
     // This is a per-partition max
     max_pending_futures: usize,
     futures: BTreeMap<Partition, Futures<TPayload>>,
@@ -260,7 +260,7 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
         DlqPolicyWrapper {
             dlq_policy,
             dlq_limit_state: DlqLimitState::default(),
-            runtime: concurrency_config.handle(),
+            concurrency_config,
             max_pending_futures: 1000,
             futures: BTreeMap::new(),
         }
@@ -284,10 +284,8 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
             while !values.is_empty() {
                 let len = values.len();
                 let (_, future) = &mut values[0];
-                if future.is_finished() {
-                    values.pop_front();
-                } else if len >= self.max_pending_futures {
-                    let res = self.runtime.block_on(future);
+                if future.is_finished() || len >= self.max_pending_futures {
+                    let res = self.concurrency_config.handle().block_on(future);
                     if let Err(err) = res {
                         tracing::error!("Error producing to DLQ: {}", err);
                     }
@@ -300,16 +298,21 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
 
         if let Some(dlq_policy) = &self.dlq_policy {
             if self.dlq_limit_state.record_invalid_message(&message) {
+                tracing::info!("producing message to dlq");
                 let (partition, offset) = (message.partition, message.offset);
 
                 let task = dlq_policy.producer.produce(message);
-                let handle = self.runtime.spawn(task);
+                let handle = self.concurrency_config.handle().spawn(task);
 
                 self.futures
                     .entry(partition)
                     .or_default()
                     .push_back((offset, handle));
+            } else {
+                tracing::info!("dlq limit reached, dropping message");
             }
+        } else {
+            tracing::info!("dlq policy missing, dropping message");
         }
     }
 
@@ -321,7 +324,7 @@ impl<TPayload: Send + Sync + 'static> DlqPolicyWrapper<TPayload> {
                 while let Some((offset, future)) = values.front_mut() {
                     // The committable offset is message's offset + 1
                     if committable_offset > *offset {
-                        if let Err(error) = self.runtime.block_on(future) {
+                        if let Err(error) = self.concurrency_config.handle().block_on(future) {
                             let error: &dyn std::error::Error = &error;
                             tracing::error!(error, "Error producing to DLQ");
                         }
@@ -446,8 +449,11 @@ mod tests {
                 &self,
                 message: BrokerMessage<TPayload>,
             ) -> Pin<Box<dyn Future<Output = BrokerMessage<TPayload>> + Send + Sync>> {
-                *self.call_count.lock().unwrap() += 1;
-                Box::pin(async move { message })
+                let call_count = self.call_count.clone();
+                Box::pin(async move {
+                    *call_count.lock().unwrap() += 1;
+                    message
+                })
             }
 
             fn build_initial_state(


### PR DESCRIPTION
We were not producing anything to the DLQ because after calling the
async fn, we scheduled the future onto a runtime that we already dropped
in the constructor of DlqProducer. Holding onto the Handle is not
enough, we need the entire Runtime.

Also adjust tests so the error becomes apparent: now the counter is not
incremented if the future isn't polled at least once.
