### PR TITLE
fix(metrics_summaries): Fix sample by expression

### DIFF
--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -45,7 +45,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     order_by="(project_id, metric_mri, end_timestamp, cityHash64(span_id))",
                     version_column="deleted",
                     partition_by="(retention_days, toMonday(end_timestamp))",
-                    sample_by="metric_mri",
+                    sample_by="cityHash64(metric_mri)",
                     settings={"index_granularity": "8192"},
                     storage_set=storage_set_name,
                     ttl="end_timestamp + toIntervalDay(retention_days)",


### PR DESCRIPTION
The `SAMPLE BY` expression needs to be a unsigned integer and `metric_mri` is not, so we need to hash the value.

As far as I know, this migration hasn't been run yet so I think that's OK to modify it.