### PR TITLE
ref(metrics-summaries): Skip all the work if the field needed is not there

### DIFF
--- a/snuba/datasets/processors/metrics_summaries_processor.py
+++ b/snuba/datasets/processors/metrics_summaries_processor.py
@@ -48,7 +48,7 @@ class MetricsSummariesMessageProcessor(DatasetMessageProcessor):
     def _structure_and_validate_message(
         message: SpanEvent,
     ) -> Optional[Tuple[SpanEvent, RetentionDays]]:
-        if not message.get("trace_id"):
+        if not message.get("_metrics_summary"):
             return None
         try:
             # We are purposely using a naive datetime here to work with the


### PR DESCRIPTION
There's not point of calling more functions if the field we're interested in is not there.