### PR TITLE
ref(rust): Remove concurrency_override

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence
 
 import click
 
-from snuba import settings, state
+from snuba import settings
 from snuba.consumers.consumer_config import resolve_consumer_config
 from snuba.datasets.storages.factory import get_writable_storage_keys
 
@@ -179,19 +179,13 @@ def rust_consumer(
     # TODO: remove after debugging
     os.environ["RUST_LOG"] = "debug" if not use_rust_processor else log_level.lower()
 
-    # XXX: Temporary way to quickly test different values for concurrency
-    # Should be removed before this is put into  prod
-    concurrency_override = state.get_int_config(
-        f"rust_consumer.{storage_names[0]}.concurrency"
-    )
-
     rust_snuba.consumer(  # type: ignore
         consumer_group,
         auto_offset_reset,
         no_strict_offset_reset,
         consumer_config_raw,
         skip_write,
-        concurrency_override or concurrency or 1,
+        concurrency or 1,
         use_rust_processor,
         max_poll_interval_ms,
         python_max_queue_depth,


### PR DESCRIPTION
We now have a few consumers in prod, and this override makes things more
confusing to review rollouts.
