### PR TITLE
fix(cache): Slightly clean up cache set errors

### DIFF
--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -59,6 +59,8 @@ class RequestStatus(Enum):
     CACHE_SET_TIMEOUT = "cache-set-timeout"
     # The thread waiting for a cache result to be written times out
     CACHE_WAIT_TIMEOUT = "cache-wait-timeout"
+    # If the query takes longer than 30 seconds to run, and the thread is killed by the cache
+    QUERY_TIMEOUT = "query-timeout"
     # Clickhouse predicted the query would time out. TOO_SLOW
     PREDICTED_TIMEOUT = "predicted-timeout"
     # Clickhouse timeout, TIMEOUT_EXCEEDED
@@ -91,6 +93,7 @@ SLO_FOR = {
     RequestStatus.INVALID_REQUEST,
     RequestStatus.INVALID_TYPING,
     RequestStatus.RATE_LIMITED,
+    RequestStatus.QUERY_TIMEOUT,
     RequestStatus.PREDICTED_TIMEOUT,
     RequestStatus.MEMORY_EXCEEDED,
 }
@@ -122,7 +125,7 @@ def get_request_status(cause: Exception | None = None) -> Status:
     elif isinstance(cause, ClickhouseError):
         slo_status = ERROR_CODE_MAPPINGS.get(cause.code, RequestStatus.ERROR)
     elif isinstance(cause, TimeoutError):
-        slo_status = RequestStatus.CACHE_SET_TIMEOUT
+        slo_status = RequestStatus.QUERY_TIMEOUT
     elif isinstance(cause, ExecutionTimeoutError):
         slo_status = RequestStatus.CACHE_WAIT_TIMEOUT
     elif isinstance(

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -150,7 +150,6 @@ class RedisCache(Cache[TValue]):
             logger.debug("Immediately returning result from cache hit.")
             return self.__codec.decode(result[1])
         elif result[0] == RESULT_EXECUTE:
-
             # If we were the first in line, we need to execute the function.
             # We'll also get back the task identity to use for sending
             # notifications and approximately how long we have to run the
@@ -175,7 +174,7 @@ class RedisCache(Cache[TValue]):
                 )
             except concurrent.futures.TimeoutError as error:
                 metrics.increment("execute_timeout", tags=metric_tags)
-                raise TimeoutError("timed out waiting for value") from error
+                raise TimeoutError("timed out while running query") from error
             except Exception as e:
                 metrics.increment("execute_error", tags=metric_tags)
                 error_value = SerializableException.from_standard_exception_instance(e)

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -102,7 +102,7 @@ class TestApiCodes(BaseApiTest):
                 "memory-exceeded",
                 "for",
             ),
-            (TimeoutError("test"), "cache-set-timeout", "against"),
+            (TimeoutError("test"), "query-timeout", "for"),
             (ExecutionTimeoutError("test"), "cache-wait-timeout", "against"),
             (
                 ClickhouseError(


### PR DESCRIPTION
When the query takes longer than the cache thread timeout, the executor raises
a concurrent.futures.TimeoutError. This was mislabelled as a cache set error,
which it is not. The cache set happens further down in the execution, and a
warning is logged for that. This is a query simply taking too long to run.

As such, reword the error to be slightly more informative and create a new
status to track the difference between a query taking to long to run and a
query that fails to set the cache.