### PR TITLE
perf: Increase consumer join timeout

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -136,7 +136,7 @@ logger = logging.getLogger(__name__)
     "--output-block-size",
     type=int,
 )
-@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=5)
+@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=10)
 @click.option(
     "--enforce-schema",
     type=bool,
@@ -201,7 +201,6 @@ def consumer(
     group_instance_id: Optional[str],
     skip_write: bool,
 ) -> None:
-
     setup_logging(log_level)
     setup_sentry()
 


### PR DESCRIPTION
A few consumers (spans, generic metrics distributions) regularly exceed the 5 second timeout currently configured, and cannot finish processing pending work in time. When this is the case, the multiprocessing pool cannot be reused since there is state in the pool that cannot be carried over to the next assignment. This aims to avoid that scenario.

