### PR TITLE
fix(metrics_summary): fix sample by clause maybe

### DIFF
--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -45,7 +45,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     order_by="(project_id, cityHash64(metric_mri), end_timestamp, cityHash64(span_id))",
                     version_column="deleted",
                     partition_by="(retention_days, toMonday(end_timestamp))",
-                    sample_by="toUint64(cityHash64(metric_mri))",
+                    sample_by="toUInt64(cityHash64(metric_mri))",
                     settings={"index_granularity": "8192"},
                     storage_set=storage_set_name,
                     ttl="end_timestamp + toIntervalDay(retention_days)",

--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -42,7 +42,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=local_table_name,
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    order_by="(project_id, cityHash64(metric_mri), end_timestamp, cityHash64(span_id))",
+                    order_by="(project_id, toUInt64(cityHash64(metric_mri)), end_timestamp, cityHash64(span_id))",
                     version_column="deleted",
                     partition_by="(retention_days, toMonday(end_timestamp))",
                     sample_by="toUInt64(cityHash64(metric_mri))",

--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -45,7 +45,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     order_by="(project_id, cityHash64(metric_mri), end_timestamp, cityHash64(span_id))",
                     version_column="deleted",
                     partition_by="(retention_days, toMonday(end_timestamp))",
-                    sample_by="cityHash64(metric_mri)",
+                    sample_by="toUint64(cityHash64(metric_mri))",
                     settings={"index_granularity": "8192"},
                     storage_set=storage_set_name,
                     ttl="end_timestamp + toIntervalDay(retention_days)",


### PR DESCRIPTION
Don't see why we can't use a LowCardinality(Uint64) as a sampling key. We shall see