### PR TITLE
ref(admin): Add AllMigrations role

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -163,6 +163,10 @@ ROLES = {
         name="cardinality-analyzer",
         actions={InteractToolAction([TOOL_RESOURCES["cardinality-analyzer"]])},
     ),
+    "AllMigrationsExecutor": Role(
+        name="AllMigrationsExecutor",
+        actions={ExecuteAllAction(list(MIGRATIONS_RESOURCES.values()))},
+    ),
 }
 
 DEFAULT_ROLES = [

--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -36,6 +36,12 @@
           "group:team-ingestion-pipeline@sentry.io"
       ],
       "role": "roles/CardinalityAnalyzer"
+    },
+    {
+      "members": [
+        "group:team-ops@sentry.io"
+      ],
+      "role": "roles/AllMigrationsExecutor"
     }
   ]
 }


### PR DESCRIPTION
This will allow ops to revert migrations that have been run more than 24hrs ago (which is our limit for the `NonBlockingMigrationsExecutor` role. It makes sense to all folks on ops to have these permissions because they already have access to the machines. 