### PR TITLE
fix(rust): Separate clickhouse concurrency from processing

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -136,14 +136,18 @@ fn create_factory(
         },
     };
 
-    let concurrency = ConcurrencyConfig::with_runtime(concurrency, RUNTIME.handle().to_owned());
+    let processing_concurrency =
+        ConcurrencyConfig::with_runtime(concurrency, RUNTIME.handle().to_owned());
+    let clickhouse_concurrency =
+        ConcurrencyConfig::with_runtime(concurrency, RUNTIME.handle().to_owned());
     let factory = ConsumerStrategyFactory::new(
         storage,
         schema.into(),
         1_000,
         Duration::from_millis(10),
         true,
-        concurrency,
+        processing_concurrency,
+        clickhouse_concurrency,
         None,
         true,
         None,

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -163,6 +163,7 @@ pub fn consumer_impl(
         max_batch_time,
         skip_write,
         ConcurrencyConfig::new(concurrency),
+        ConcurrencyConfig::new(2),
         python_max_queue_depth,
         use_rust_processor,
         health_check_file.map(ToOwned::to_owned),

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -91,7 +91,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             _ => Box::new(
                 PythonTransformStep::new(
                     self.storage_config.message_processor.clone(),
-                    self.concurrency.concurrency,
+                    self.processing_concurrency.concurrency,
                     self.python_max_queue_depth,
                     next_step,
                 )

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -21,7 +21,8 @@ pub struct ConsumerStrategyFactory {
     max_batch_size: usize,
     max_batch_time: Duration,
     skip_write: bool,
-    concurrency: ConcurrencyConfig,
+    processing_concurrency: ConcurrencyConfig,
+    clickhouse_concurrency: ConcurrencyConfig,
     python_max_queue_depth: Option<usize>,
     use_rust_processor: bool,
     health_check_file: Option<String>,
@@ -35,7 +36,8 @@ impl ConsumerStrategyFactory {
         max_batch_size: usize,
         max_batch_time: Duration,
         skip_write: bool,
-        concurrency: ConcurrencyConfig,
+        processing_concurrency: ConcurrencyConfig,
+        clickhouse_concurrency: ConcurrencyConfig,
         python_max_queue_depth: Option<usize>,
         use_rust_processor: bool,
         health_check_file: Option<String>,
@@ -46,7 +48,8 @@ impl ConsumerStrategyFactory {
             max_batch_size,
             max_batch_time,
             skip_write,
-            concurrency,
+            processing_concurrency,
+            clickhouse_concurrency,
             python_max_queue_depth,
             use_rust_processor,
             health_check_file,
@@ -58,17 +61,13 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
     fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
         let accumulator = Arc::new(BytesInsertBatch::merge);
 
-        let clickhouse_concurrency = ConcurrencyConfig::with_runtime(
-            self.concurrency.concurrency,
-            self.concurrency.handle(),
-        );
         let next_step = Reduce::new(
             Box::new(ClickhouseWriterStep::new(
                 CommitOffsets::new(Duration::from_secs(1)),
                 self.storage_config.clickhouse_cluster.clone(),
                 self.storage_config.clickhouse_table_name.clone(),
                 self.skip_write,
-                &clickhouse_concurrency,
+                &self.clickhouse_concurrency,
             )),
             accumulator,
             BytesInsertBatch::default(),
@@ -87,7 +86,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
                 func,
                 &self.logical_topic_name,
                 false,
-                &self.concurrency,
+                &self.processing_concurrency,
             ),
             _ => Box::new(
                 PythonTransformStep::new(


### PR DESCRIPTION
This is a partial reversal of https://github.com/getsentry/snuba/pull/5039

We want to scale processing speed separately from the concurrency of
INSERTs we hit clickhouse with. This does not necessarily mean a
separate threadpool, it's just the easiest way to ensure that.

This is equivalent to what we do in Python (again): https://github.com/getsentry/snuba/blob/59732199ceded1dfd239389b0b10b3a48152da8c/snuba/consumers/strategy_factory.py#L139-L140
