### PR TITLE
fix(arroyo): Tag all consumer metrics by the smallest partition index

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -261,6 +261,7 @@ def consumer(
         max_insert_batch_size=max_insert_batch_size,
         max_insert_batch_time_ms=max_insert_batch_time_ms,
         metrics=metrics,
+        metrics_tags=metrics_tags,
         profile_path=profile_path,
         slice_id=slice_id,
         join_timeout=join_timeout,

--- a/snuba/cli/dlq_consumer.py
+++ b/snuba/cli/dlq_consumer.py
@@ -186,6 +186,7 @@ def dlq_consumer(
             slice_id=instruction.slice_id,
             join_timeout=None,
             enforce_schema=False,
+            metrics_tags=metrics_tags,
         )
 
         consumer = consumer_builder.build_dlq_consumer(instruction)

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import MutableMapping, Optional
 
 from arroyo.backends.kafka import (
     KafkaConsumer,
@@ -71,6 +71,7 @@ class ConsumerBuilder:
         max_insert_batch_size: Optional[int],
         max_insert_batch_time_ms: Optional[int],
         metrics: MetricsBackend,
+        metrics_tags: MutableMapping[str, str],
         slice_id: Optional[int],
         join_timeout: Optional[float],
         enforce_schema: bool,
@@ -136,6 +137,7 @@ class ConsumerBuilder:
             self.commit_log_producer = None
 
         self.metrics = metrics
+        self.metrics_tags = metrics_tags
         self.max_batch_size = max_batch_size
         self.max_batch_time_ms = max_batch_time_ms
         self.max_insert_batch_size = max_insert_batch_size
@@ -253,6 +255,7 @@ class ConsumerBuilder:
             initialize_parallel_transform=setup_sentry,
             health_check_file=self.health_check_file,
             skip_write=self.__skip_write,
+            metrics_tags=self.metrics_tags,
         )
 
         if self.__profile_path is not None:
@@ -310,6 +313,7 @@ class ConsumerBuilder:
             output_block_size=self.output_block_size,
             max_messages_to_process=instruction.max_messages_to_process,
             initialize_parallel_transform=setup_sentry,
+            metrics_tags=self.metrics_tags,
         )
 
         return strategy_factory

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -709,6 +709,7 @@ if application.debug or application.testing:
                     output_block_size=None,
                     max_insert_batch_size=None,
                     max_insert_batch_time=None,
+                    metrics_tags={},
                 ).create_with_partitions(commit, {})
                 strategy.submit(message)
                 strategy.close()

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -164,9 +164,8 @@ def test_run_processing_strategy() -> None:
     assert get_row_count(get_writable_storage(StorageKey.ERRORS)) == 0
 
     commit = Mock()
-    partitions = {}
     strategy_factory = consumer_builder.build_streaming_strategy_factory()
-    strategy = strategy_factory.create_with_partitions(commit, partitions)
+    strategy = strategy_factory.create_with_partitions(commit, {})
 
     json_string = json.dumps(get_raw_error_message())
 

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -64,6 +64,7 @@ consumer_builder = ConsumerBuilder(
     slice_id=None,
     join_timeout=5,
     enforce_schema=True,
+    metrics_tags={},
 )
 
 optional_consumer_config = resolve_consumer_config(
@@ -110,6 +111,7 @@ consumer_builder_with_opt = ConsumerBuilder(
     slice_id=None,
     join_timeout=5,
     enforce_schema=True,
+    metrics_tags={},
 )
 
 

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -164,7 +164,7 @@ def test_run_processing_strategy() -> None:
     assert get_row_count(get_writable_storage(StorageKey.ERRORS)) == 0
 
     commit = Mock()
-    partitions = Mock()
+    partitions = {}
     strategy_factory = consumer_builder.build_streaming_strategy_factory()
     strategy = strategy_factory.create_with_partitions(commit, partitions)
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -88,6 +88,7 @@ def test_streaming_consumer_strategy(tmpdir: LocalPath) -> None:
         input_block_size=None,
         output_block_size=None,
         health_check_file=health_check_file.strpath,
+        metrics_tags={},
     )
 
     commit_function = Mock()

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -92,7 +92,7 @@ def test_streaming_consumer_strategy(tmpdir: LocalPath) -> None:
     )
 
     commit_function = Mock()
-    partitions = Mock()
+    partitions = {}
     strategy = factory.create_with_partitions(commit_function, partitions)
 
     for i in range(3):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -92,8 +92,7 @@ def test_streaming_consumer_strategy(tmpdir: LocalPath) -> None:
     )
 
     commit_function = Mock()
-    partitions = {}
-    strategy = factory.create_with_partitions(commit_function, partitions)
+    strategy = factory.create_with_partitions(commit_function, {})
 
     for i in range(3):
         strategy.poll()


### PR DESCRIPTION
INC-588 INC-581

This should help us identify pod-specific problems, such as one
partition lagging behind another.

Ideally arroyo should do this, but it's easier here because arroyo has
no concept of global tags.
