### PR TITLE
fix(rust): Fix consumer deadlock on strategy panic

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1689,6 +1689,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "once_cell",
+ "parking_lot",
  "rand 0.8.5",
  "rdkafka",
  "sentry",

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1713,6 +1713,7 @@ dependencies = [
  "divan",
  "futures",
  "once_cell",
+ "parking_lot",
  "procspawn",
  "pyo3",
  "reqwest",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -42,6 +42,7 @@ tokio = { version = "1.19.2", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = "1.5.0"
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 divan = "0.1.2"

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -1,5 +1,6 @@
+use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Once};
 use std::time::Duration;
 
 use divan::counter::ItemsCount;

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Once};
+use std::sync::{Arc, Mutex, Once};
 use std::time::Duration;
-use parking_lot::Mutex;
 
 use divan::counter::ItemsCount;
 use once_cell::sync::Lazy;

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Once};
 use std::time::Duration;
+use parking_lot::Mutex;
 
 use divan::counter::ItemsCount;
 use once_cell::sync::Lazy;

--- a/rust_snuba/rust_arroyo/Cargo.toml
+++ b/rust_snuba/rust_arroyo/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1.0"
 tokio = { version = "1.19.2", features = ["full"] }
 tracing = "0.1.40"
 uuid = { version = "1.5.0", features = ["v4"] }
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -6,6 +6,7 @@ use super::ConsumerError;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::types::{BrokerMessage, Partition, Topic};
 use chrono::{DateTime, NaiveDateTime, Utc};
+use parking_lot::Mutex;
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::base_consumer::BaseConsumer;
@@ -19,7 +20,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 pub mod config;
@@ -174,7 +175,7 @@ impl<C: AssignmentCallbacks> ConsumerContext for CustomContext<C> {
                 partitions.push(Partition::new(topic, index));
             }
 
-            let mut offsets = self.consumer_offsets.lock().unwrap();
+            let mut offsets = self.consumer_offsets.lock();
             for partition in partitions.iter() {
                 offsets.remove(partition);
             }
@@ -257,7 +258,7 @@ impl<C: AssignmentCallbacks> ConsumerContext for CustomContext<C> {
             base_consumer
                 .assign(&tpl)
                 .expect("failed to assign partitions");
-            self.consumer_offsets.lock().unwrap().extend(&offset_map);
+            self.consumer_offsets.lock().extend(&offset_map);
 
             // Ensure that all partitions are resumed on assignment to avoid
             // carrying over state from a previous assignment.
@@ -337,10 +338,7 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
             None => Ok(None),
             Some(res) => {
                 let msg = create_kafka_message(res?);
-                self.offsets
-                    .lock()
-                    .unwrap()
-                    .insert(msg.partition, msg.offset);
+                self.offsets.lock().insert(msg.partition, msg.offset);
 
                 Ok(Some(msg))
             }
@@ -352,7 +350,7 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
 
         let mut topic_partition_list = TopicPartitionList::with_capacity(partitions.len());
         {
-            let offsets = self.offsets.lock().unwrap();
+            let offsets = self.offsets.lock();
             for partition in partitions {
                 let offset = offsets
                     .get(&partition)
@@ -375,7 +373,7 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
 
         let mut topic_partition_list = TopicPartitionList::new();
         for partition in partitions {
-            if !self.offsets.lock().unwrap().contains_key(&partition) {
+            if !self.offsets.lock().contains_key(&partition) {
                 return Err(ConsumerError::UnassignedPartition);
             }
             topic_partition_list.add_partition(partition.topic.as_str(), partition.index as i32);
@@ -393,7 +391,7 @@ impl<C: AssignmentCallbacks> ArroyoConsumer<KafkaPayload, C> for KafkaConsumer<C
 
     fn tell(&self) -> Result<HashMap<Partition, u64>, ConsumerError> {
         self.state.assert_consuming_state()?;
-        Ok(self.offsets.lock().unwrap().clone())
+        Ok(self.offsets.lock().clone())
     }
 
     fn seek(&self, _: HashMap<Partition, u64>) -> Result<(), ConsumerError> {

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -401,12 +401,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             .shutdown_requested
             .load(Ordering::Relaxed)
         {
-            // In case the strategy panics, we attempt to catch it and return an error.
-            // This enables the consumer to crash rather than hang indedinitely.
-            let result = panic::catch_unwind(AssertUnwindSafe(|| self.run_once()))
-                .unwrap_or(Err(RunError::StrategyPanic));
-
-            if let Err(e) = result {
+            if let Err(e) = self.run_once() {
                 let mut trait_callbacks = self.consumer_state.lock();
 
                 if let Some(strategy) = trait_callbacks.strategy.as_mut() {

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -632,7 +632,13 @@ mod tests {
             let mut processor = build_processor(broker, test_case);
 
             let res = processor.run_once();
-            assert!(res.is_err());
+
+            if test_case == "join" || test_case == "close" {
+                assert!(res.is_ok());
+            } else {
+                assert!(res.is_err());
+            }
+
             processor.shutdown();
         }
     }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -2,10 +2,11 @@ pub mod dlq;
 mod metrics_buffer;
 pub mod strategies;
 
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use thiserror::Error;
@@ -106,7 +107,7 @@ impl<TPayload: Send + Sync + 'static> AssignmentCallbacks for Callbacks<TPayload
 
         let start = Instant::now();
 
-        let mut state = self.0.lock().unwrap();
+        let mut state = self.0.lock();
         state.strategy = Some(state.processing_factory.create());
         state.dlq_policy.reset_dlq_limits(&partitions);
 
@@ -128,7 +129,7 @@ impl<TPayload: Send + Sync + 'static> AssignmentCallbacks for Callbacks<TPayload
 
         let start = Instant::now();
 
-        let mut state = self.0.lock().unwrap();
+        let mut state = self.0.lock();
         if let Some(s) = state.strategy.as_mut() {
             s.close();
             if let Ok(Some(commit_request)) = s.join(None) {
@@ -198,7 +199,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     ) -> Self {
         let max_buffered_messages_per_partition = consumer_state
             .lock()
-            .unwrap()
             .dlq_policy
             .max_buffered_messages_per_partition();
 
@@ -215,10 +215,17 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
     }
 
     pub fn run_once(&mut self) -> Result<(), RunError> {
+        // In case the strategy panics, we attempt to catch it and return an error.
+        // This enables the consumer to crash rather than hang indedinitely.
+        panic::catch_unwind(AssertUnwindSafe(|| self._run_once()))
+            .unwrap_or(Err(RunError::StrategyPanic))
+    }
+
+    fn _run_once(&mut self) -> Result<(), RunError> {
         let metrics = get_metrics();
         metrics.increment("arroyo.consumer.run.count", 1, None);
 
-        if self.consumer_state.lock().unwrap().is_paused {
+        if self.consumer_state.lock().is_paused {
             // If the consumer was paused, it should not be returning any messages
             // on `poll`.
             let res = self.consumer.poll(Some(Duration::ZERO)).unwrap();
@@ -254,7 +261,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
         // since we do not drive the kafka consumer at this point, it is safe to acquire the state
         // lock, as we can be sure that for the rest of this function, no assignment callback will
         // run.
-        let mut consumer_state = self.consumer_state.lock().unwrap();
+        let mut consumer_state = self.consumer_state.lock();
         let consumer_state: &mut ConsumerState<_> = &mut consumer_state;
 
         let Some(strategy) = consumer_state.strategy.as_mut() else {
@@ -265,11 +272,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
         };
         let poll_start = Instant::now();
 
-        // In case the strategy panics, we attempt to catch it and return an error.
-        // This enables the consumer to crash rather than hang indedinitely.
-        let result = panic::catch_unwind(AssertUnwindSafe(|| strategy.poll()));
-
-        let commit_request = result.map_err(|_| RunError::StrategyPanic)?;
+        let commit_request = strategy.poll();
 
         self.metrics_buffer
             .incr_timing("arroyo.consumer.processing.time", poll_start.elapsed());
@@ -386,8 +389,13 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             .shutdown_requested
             .load(Ordering::Relaxed)
         {
-            if let Err(e) = self.run_once() {
-                let mut trait_callbacks = self.consumer_state.lock().unwrap();
+            // In case the strategy panics, we attempt to catch it and return an error.
+            // This enables the consumer to crash rather than hang indedinitely.
+            let result = panic::catch_unwind(AssertUnwindSafe(|| self.run_once()))
+                .unwrap_or(Err(RunError::StrategyPanic));
+
+            if let Err(e) = result {
+                let mut trait_callbacks = self.consumer_state.lock();
 
                 if let Some(strategy) = trait_callbacks.strategy.as_mut() {
                     strategy.terminate();
@@ -530,7 +538,7 @@ mod tests {
         // Tests that a panic in any of the poll, submit, join, or close methods will crash the consumer
         // and not deadlock
         struct TestStrategy {
-            panic_on: String, // poll, submit, join, close
+            panic_on: &'static str, // poll, submit, join, close
         }
         impl ProcessingStrategy<String> for TestStrategy {
             fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
@@ -540,7 +548,7 @@ mod tests {
                 Ok(None)
             }
 
-            fn submit(&mut self, message: Message<String>) -> Result<(), SubmitError<String>> {
+            fn submit(&mut self, _message: Message<String>) -> Result<(), SubmitError<String>> {
                 if self.panic_on == "submit" {
                     panic!("panic in submit");
                 }
@@ -568,26 +576,52 @@ mod tests {
             }
         }
 
-        let mut broker = build_broker();
+        struct TestFactory {
+            panic_on: &'static str,
+        }
+        impl ProcessingStrategyFactory<String> for TestFactory {
+            fn create(&self) -> Box<dyn ProcessingStrategy<String>> {
+                Box::new(TestStrategy {
+                    panic_on: self.panic_on,
+                })
+            }
+        }
+
+        fn build_processor(
+            broker: LocalBroker<String>,
+            panic_on: &'static str,
+        ) -> StreamProcessor<String> {
+            let consumer_state = Arc::new(Mutex::new(ConsumerState::new(
+                Box::new(TestFactory { panic_on }),
+                None,
+            )));
+
+            let consumer = Box::new(LocalConsumer::new(
+                Uuid::nil(),
+                Arc::new(Mutex::new(broker)),
+                "test_group".to_string(),
+                false,
+                &[Topic::new("test1")],
+                Callbacks(consumer_state.clone()),
+            ));
+
+            StreamProcessor::new(consumer, consumer_state)
+        }
+
         let topic1 = Topic::new("test1");
         let partition = Partition::new(topic1, 0);
-        let _ = broker.produce(&partition, "message1".to_string());
-        let _ = broker.produce(&partition, "message2".to_string());
 
-        let consumer_state = Arc::new(Mutex::new(ConsumerState::new(
-            Box::new(TestFactory {}),
-            None,
-        )));
+        let test_cases = ["poll", "submit", "join"];
 
-        let consumer = Box::new(LocalConsumer::new(
-            Uuid::nil(),
-            Arc::new(Mutex::new(broker)),
-            "test_group".to_string(),
-            false,
-            &[Topic::new("test1")],
-            Callbacks(consumer_state.clone()),
-        ));
+        for test_case in test_cases {
+            let mut broker = build_broker();
+            let _ = broker.produce(&partition, "message1".to_string());
+            let _ = broker.produce(&partition, "message2".to_string());
+            let mut processor = build_processor(broker, test_case);
 
-        let mut processor = StreamProcessor::new(consumer, consumer_state);
+            let res = processor.run_once();
+            assert!(res.is_err());
+            processor.shutdown();
+        }
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -265,6 +265,8 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
         };
         let poll_start = Instant::now();
 
+        // In case the strategy panics, we attempt to catch it and return an error.
+        // This enables the consumer to crash rather than hang indedinitely.
         let result = panic::catch_unwind(AssertUnwindSafe(|| strategy.poll()));
 
         let commit_request = result.map_err(|_| RunError::StrategyPanic)?;

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -165,6 +165,7 @@ impl<TPayload, TTransformed: Send + Sync + 'static> ProcessingStrategy<TPayload>
                         Err(error) => {
                             let error: &dyn std::error::Error = &error;
                             tracing::error!(error, "the thread crashed");
+                            panic!("the thread crashed");
                         }
                     }
                 } else {


### PR DESCRIPTION
If strategy panics in poll, submit, join or close, we terminate the consumer now

We swap out std::sync::Mutex for parking_lot::Mutex everywhere to avoid lock poisioning.


fixes SNS-2539

<details>

<summary>contents of jira ticket</summary>

EIther induce a panic in a strategy, or segfault in a message processor in python like so (put this in def process_message):

import ctypes; ctypes.string_at(0)

then, start the consumer.

you will observe the main thread panicking, but at the same time the program won’t stop and also no longer reacts to Ctrl-C (SIGTERM still works). i profiled this with samply to get a stacktrace at the time of the deadlock, and we are locking up in the Drop impl of rdkafka’s NativeClient.

There are a few tickets in rust-rdkafka that hint at this being a potential problem: https://github.com/fede1024/rust-rdkafka/issues/453 https://github.com/fede1024/rust-rdkafka/pull/517 

but i was not able to figure out a patch where we’d drop some resources earlier and as a result fix this deadlock. also it is fairly weird that we’d have incorrectly cleaned-up resources on panic but not when just hitting Ctrl-C

Note the problem can be reproduced if any strategy panics too



```__psynch_cvwait [libsystem_kernel.dylib]
_pthread_cond_wait [libsystem_pthread.dylib]
cnd_wait [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/rdkafka-sys/librdkafka/src/tinycthread.c]
cnd_timedwait_abs [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/rdkafka-sys/librdkafka/src/tinycthread_extra.c]
rd_kafka_q_pop_serve [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/rdkafka-sys/librdkafka/src/rdkafka_queue.c]
rd_kafka_q_pop [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/rdkafka-sys/librdkafka/src/rdkafka_queue.c]
rd_kafka_consumer_close [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/rdkafka-sys/librdkafka/src/rdkafka.c]
rd_kafka_destroy_app [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/rdkafka-sys/librdkafka/src/rdkafka.c]
rd_kafka_destroy [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/rdkafka-sys/librdkafka/src/rdkafka.c]
<rdkafka::util::NativePtr<T> as core::ops::drop::Drop>::drop [/Users/untitaker/.cargo/git/checkouts/rust-rdkafka-3aecfeeb0cead927/c811175/src/util.rs]
core::ptr::drop_in_place<rdkafka::util::NativePtr<rdkafka_sys::bindings::rd_kafka_s>> [library/core/src/ptr/mod.rs]
core::ptr::drop_in_place<rdkafka::client::NativeClient> [library/core/src/ptr/mod.rs]
core::ptr::drop_in_place<rdkafka::client::Client<rust_arroyo::backends::kafka::CustomContext<rust_arroyo::processing::Callbacks<rust_arroyo::backends::kafka::types::KafkaPayload>>>> [library/core/src/ptr/mod.rs]
core::ptr::drop_in_place<rdkafka::consumer::base_consumer::BaseConsumer<rust_arroyo::backends::kafka::CustomContext<rust_arroyo::processing::Callbacks<rust_arroyo::backends::kafka::types::KafkaPayload>>>> [library/core/src/ptr/mod.rs]
core::ptr::drop_in_place<core::option::Option<rdkafka::consumer::base_consumer::BaseConsumer<rust_arroyo::backends::kafka::CustomContext<rust_arroyo::processing::Callbacks<rust_arroyo::backends::kafka::types::KafkaPayload>>>>> [library/core/src/ptr/mod.rs]
core::ptr::drop_in_place<rust_arroyo::backends::kafka::KafkaConsumer<rust_arroyo::processing::Callbacks<rust_arroyo::backends::kafka::types::KafkaPayload>>> [library/core/src/ptr/mod.rs]
core::ptr::drop_in_place<alloc::boxed::Box<dyn rust_arroyo::backends::Consumer<rust_arroyo::backends::kafka::types::KafkaPayload,rust_arroyo::processing::Callbacks<rust_arroyo::backends::kafka::types::KafkaPayload>>>> [library/core/src/ptr/mod.rs]
core::ptr::drop_in_place<rust_arroyo::processing::StreamProcessor<rust_arroyo::backends::kafka::types::KafkaPayload>> [library/core/src/ptr/mod.rs]
rust_snuba::consumer::consumer_impl [/Users/untitaker/projects/snuba/rust_snuba/src/consumer.rs]
rust_snuba::consumer::consumer::{{closure}} [/Users/untitaker/projects/snuba/rust_snuba/src/consumer.rs]
pyo3::marker::Python::allow_threads [pyo3-0.20.0/src/marker.rs]
rust_snuba::consumer::consumer [/Users/untitaker/projects/snuba/rust_snuba/src/consumer.rs]
rust_snuba::consumer::_::__pyfunction_consumer [/Users/untitaker/projects/snuba/rust_snuba/src/consumer.rs]
pyo3::impl_::trampoline::fastcall_with_keywords::{{closure}} [pyo3-0.20.0/src/impl_/trampoline.rs]
pyo3::impl_::trampoline::trampoline::{{closure}} [pyo3-0.20.0/src/impl_/trampoline.rs]
std::panicking::try::do_call [library/std/src/panicking.rs]
__rust_try [rust_snuba.cpython-38-darwin.so]
std::panicking::try [library/std/src/panicking.rs]
std::panic::catch_unwind [library/std/src/panic.rs]
pyo3::impl_::trampoline::trampoline [pyo3-0.20.0/src/impl_/trampoline.rs]
pyo3::impl_::trampoline::fastcall_with_keywords [pyo3-0.20.0/src/impl_/trampoline.rs]
rust_snuba::consumer::_::<impl rust_snuba::consumer::consumer::MakeDef>::DEF::trampoline [/Users/untitaker/projects/snuba/rust_snuba/src/consumer.rs]
cfunction_vectorcall_FASTCALL_KEYWORDS [libpython3.8.dylib]
call_function [libpython3.8.dylib]
_PyEval_EvalFrameDefault [libpython3.8.dylib]
_PyEval_EvalCodeWithName [libpython3.8.dylib]
_PyFunction_Vectorcall [libpython3.8.dylib]
PyVectorcall_Call [libpython3.8.dylib]
_PyEval_EvalFrameDefault [libpython3.8.dylib]
_PyEval_EvalCodeWithName [libpython3.8.dylib]
_PyFunction_Vectorcall [libpython3.8.dylib]
method_vectorcall [libpython3.8.dylib]
PyVectorcall_Call [libpython3.8.dylib]
_PyEval_EvalFrameDefault [libpython3.8.dylib]
function_code_fastcall [libpython3.8.dylib]
call_function [libpython3.8.dylib]
_PyEval_EvalFrameDefault [libpython3.8.dylib]
_PyEval_EvalCodeWithName [libpython3.8.dylib]
_PyFunction_Vectorcall [libpython3.8.dylib]
call_function [libpython3.8.dylib]
_PyEval_EvalFrameDefault [libpython3.8.dylib]
_PyEval_EvalCodeWithName [libpython3.8.dylib]
_PyFunction_Vectorcall [libpython3.8.dylib]
method_vectorcall [libpython3.8.dylib]
PyVectorcall_Call [libpython3.8.dylib]
_PyEval_EvalFrameDefault [libpython3.8.dylib]
_PyEval_EvalCodeWithName [libpython3.8.dylib]
_PyFunction_Vectorcall [libpython3.8.dylib]
_PyObject_FastCallDict [libpython3.8.dylib]
_PyObject_Call_Prepend [libpython3.8.dylib]
slot_tp_call [libpython3.8.dylib]
_PyObject_MakeTpCall [libpython3.8.dylib]
call_function [libpython3.8.dylib]
_PyEval_EvalFrameDefault [libpython3.8.dylib]
_PyEval_EvalCodeWithName [libpython3.8.dylib]
PyEval_EvalCode [libpython3.8.dylib]
run_mod [libpython3.8.dylib]
PyRun_SimpleFileExFlags [libpython3.8.dylib]
Py_RunMain [libpython3.8.dylib]
pymain_main [libpython3.8.dylib]
Py_BytesMain [libpython3.8.dylib]
start [dyld]```

</details>