### PR TITLE
Optimize ConsumerState

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
+++ b/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
@@ -1,14 +1,13 @@
-use crate::utils::metrics::{get_metrics, Metrics};
+use crate::utils::metrics::{get_metrics, BoxMetrics};
 use crate::utils::timing::Deadline;
 use core::fmt::Debug;
 use std::collections::BTreeMap;
 use std::mem;
-use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(Debug)]
 pub struct MetricsBuffer {
-    metrics: Arc<dyn Metrics>,
+    metrics: BoxMetrics,
     timers: BTreeMap<String, Duration>,
     gauges: BTreeMap<String, u64>,
     flush_deadline: Deadline,

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -35,7 +35,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ClickhouseWriter {
     fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch> {
         let skip_write = self.skip_write;
         let client = self.client.clone();
-        let metrics = self.metrics.clone();
+        let metrics = self.metrics;
 
         Box::pin(async move {
             let insert_batch = message.payload();

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 
 use chrono::{DateTime, Utc};
-use rust_arroyo::utils::metrics::{BoxMetrics, Metrics};
+use rust_arroyo::utils::metrics::BoxMetrics;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
This has a bunch of micro-optimizations:

- Moves the `Arc<Mutex>` into `ConsumerState`.
- Avoids two locking operations per `run_once` by moving the `is_paused` flag to an `AtomicBool`. Though this is pretty much academic since we never have contention on this lock anyway, as it is purely single-threaded.
- Optimizes global metrics a bit by avoiding the `Arc` completely, and instead just use a `&'static dyn Metrics`.