### PR TITLE
feat(metrics): Create new DataSource for running multiple metrics queries

### DIFF
--- a/snuba/pipeline/composite.py
+++ b/snuba/pipeline/composite.py
@@ -522,6 +522,7 @@ class CompositeExecutionPipeline(QueryExecutionPipeline):
     def execute(self) -> QueryResult:
         plan = CompositeQueryPlanner(self.__query, self.__settings).build_best_plan()
         root_processors, aliased_processors = plan.get_plan_processors()
+        # TODO: This is also run in the `CompositeExecutionStrategy`, do we need it twice?
         ProcessorsExecutor(
             root_processors,
             aliased_processors,

--- a/snuba/query/composite.py
+++ b/snuba/query/composite.py
@@ -11,6 +11,7 @@ from snuba.query import (
     TSimpleDataSource,
 )
 from snuba.query.data_source.join import JoinClause
+from snuba.query.data_source.multi import MultiQuery
 from snuba.query.data_source.simple import SimpleDataSource
 from snuba.query.expressions import Expression, ExpressionVisitor
 
@@ -31,6 +32,7 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
                 ProcessableQuery[TSimpleDataSource],
                 CompositeQuery[TSimpleDataSource],
                 JoinClause[TSimpleDataSource],
+                MultiQuery[TSimpleDataSource],
             ]
         ],
         # TODO: Consider if to remove the defaults and make some of
@@ -92,6 +94,7 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
         ProcessableQuery[TSimpleDataSource],
         CompositeQuery[TSimpleDataSource],
         JoinClause[TSimpleDataSource],
+        MultiQuery[TSimpleDataSource],
     ]:
         assert self.__from_clause is not None, "Data source has not been provided yet."
         return self.__from_clause
@@ -102,6 +105,7 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
             ProcessableQuery[TSimpleDataSource],
             CompositeQuery[TSimpleDataSource],
             JoinClause[TSimpleDataSource],
+            MultiQuery[TSimpleDataSource],
         ],
     ) -> None:
         self.__from_clause = from_clause

--- a/snuba/query/data_source/multi.py
+++ b/snuba/query/data_source/multi.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, Sequence
+
+from snuba.query import ProcessableQuery, TSimpleDataSource
+from snuba.query.data_source import DataSource
+from snuba.utils.schemas import ColumnSet
+
+
+@dataclass(frozen=True)
+class MultiQuery(DataSource, Generic[TSimpleDataSource]):
+    queries: Sequence[ProcessableQuery[TSimpleDataSource]]
+    result_function: Callable[..., Any]
+
+    def get_columns(self) -> ColumnSet:
+        return self.queries[0].get_from_clause().get_columns()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MultiQuery):
+            return False
+        return self.queries == other.queries

--- a/snuba/query/data_source/visitor.py
+++ b/snuba/query/data_source/visitor.py
@@ -4,6 +4,7 @@ from typing import Generic, TypeVar, Union
 from snuba.query import ProcessableQuery, TSimpleDataSource
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.join import JoinClause
+from snuba.query.data_source.multi import MultiQuery
 
 TReturn = TypeVar("TReturn")
 
@@ -26,6 +27,7 @@ class DataSourceVisitor(ABC, Generic[TReturn, TSimpleDataSource]):
             JoinClause[TSimpleDataSource],
             ProcessableQuery[TSimpleDataSource],
             CompositeQuery[TSimpleDataSource],
+            MultiQuery[TSimpleDataSource],
         ],
     ) -> TReturn:
         if isinstance(data_source, JoinClause):
@@ -34,6 +36,8 @@ class DataSourceVisitor(ABC, Generic[TReturn, TSimpleDataSource]):
             return self._visit_simple_query(data_source)
         elif isinstance(data_source, CompositeQuery):
             return self._visit_composite_query(data_source)
+        elif isinstance(data_source, MultiQuery):
+            return self._visit_multi_query(data_source)
         else:
             # It must be a simple data source according to the type
             # signature, we cannot do that via the isinstance call
@@ -58,4 +62,8 @@ class DataSourceVisitor(ABC, Generic[TReturn, TSimpleDataSource]):
     def _visit_composite_query(
         self, data_source: CompositeQuery[TSimpleDataSource]
     ) -> TReturn:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _visit_multi_query(self, data_source: MultiQuery[TSimpleDataSource]) -> TReturn:
         raise NotImplementedError

--- a/snuba/query/formatters/tracing.py
+++ b/snuba/query/formatters/tracing.py
@@ -3,6 +3,7 @@ from typing import Any, List, Mapping, Sequence, Union
 from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
+from snuba.query.data_source.multi import MultiQuery
 from snuba.query.data_source.simple import SimpleDataSource
 from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.expressions import StringifyVisitor
@@ -154,3 +155,11 @@ class TracingQueryFormatter(
                 1,
             ),
         ]
+
+    def _visit_multi_query(
+        self, data_source: MultiQuery[SimpleDataSource]
+    ) -> List[str]:
+        formatted_queries = []
+        for q in data_source.queries:
+            formatted_queries.extend(_indent_str_list(format_query(q), 1))
+        return formatted_queries

--- a/snuba/query/joins/equivalence_adder.py
+++ b/snuba/query/joins/equivalence_adder.py
@@ -9,6 +9,7 @@ from snuba.query.conditions import (
     get_first_level_and_conditions,
 )
 from snuba.query.data_source.join import entity_from_node
+from snuba.query.data_source.multi import MultiQuery
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, Expression
 from snuba.query.joins.pre_processor import QualifiedCol, get_equivalent_columns
@@ -43,6 +44,8 @@ def add_equivalent_conditions(query: CompositeQuery[Entity]) -> None:
         add_equivalent_conditions(from_clause)
         return
     elif isinstance(from_clause, ProcessableQuery):
+        return
+    elif isinstance(from_clause, MultiQuery):
         return
 
     # Now this has to be a join, so we can work with it.

--- a/snuba/query/joins/semi_joins.py
+++ b/snuba/query/joins/semi_joins.py
@@ -1,6 +1,5 @@
 from typing import Set
 
-from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.join import (
     IndividualNode,
@@ -43,10 +42,7 @@ class SemiJoinOptimizer(CompositeQueryProcessor):
         self, query: CompositeQuery[Table], query_settings: QuerySettings
     ) -> None:
         from_clause = query.get_from_clause()
-        if isinstance(from_clause, CompositeQuery):
-            self.process_query(from_clause, query_settings)
-            return
-        elif isinstance(from_clause, ProcessableQuery):
+        if not isinstance(from_clause, JoinClause):
             return
 
         # Now this has to be a join, so we can work with it.

--- a/snuba/query/joins/subquery_generator.py
+++ b/snuba/query/joins/subquery_generator.py
@@ -17,6 +17,7 @@ from snuba.query.data_source.join import (
     JoinNode,
     JoinVisitor,
 )
+from snuba.query.data_source.multi import MultiQuery
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, Expression
 from snuba.query.joins.classifier import (
@@ -234,6 +235,8 @@ def generate_subqueries(query: CompositeQuery[Entity]) -> None:
         generate_subqueries(from_clause)
         return
     elif isinstance(from_clause, ProcessableQuery):
+        return
+    elif isinstance(from_clause, MultiQuery):
         return
 
     # Now this has to be a join, so we can work with it.


### PR DESCRIPTION
Effectively, the idea of how to run metrics queries with formulas would be to
run a separate subquery for each timeseries requested, and then combine the
results back together from each of these queries.

The `CompositeQuery` class already has a lot of utlities in place for handling
subqueries, so this PR attempts to leverage those existing utilities. This
means modifying the composite pipeline to create a query plan for each of the
subqueries in a CompositeQuery, run each of them, and then use the result
function to rebuild the results.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
