### PR TITLE
perm(cardinality-analyzer): Replace team-ingestion-pipeline with team-ingest

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -33,7 +33,7 @@
     {
       "members": [
           "group:team-starfish@sentry.io",
-          "group:team-ingestion-pipeline@sentry.io"
+          "group:team-ingest@sentry.io"
       ],
       "role": "roles/CardinalityAnalyzer"
     },


### PR DESCRIPTION
`team-ingestion-pipeline` was added in #4458 and since then removed (see https://github.com/getsentry/security-as-code/pull/515/) and unified under `team-ingest`


