### PR TITLE
fix(querylog): Add partition and offset columns, migration

### DIFF
--- a/snuba/datasets/configuration/querylog/storages/querylog.yaml
+++ b/snuba/datasets/configuration/querylog/storages/querylog.yaml
@@ -24,6 +24,8 @@ schema:
       { name: timestamp, type: DateTime },
       { name: duration_ms, type: UInt, args: { size: 32 } },
       { name: status, type: String },
+      { name: partition, type: UInt, args: { size: 16 } },
+      { name: offset, type: UInt, args: { size: 64 } },
       # clickhouse_queries Nested columns.
       # This is expanded into arrays instead of being expressed as a
       # Nested column because, when adding new columns to a nested field

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -250,6 +250,7 @@ class QuerylogLoader(DirectoryLoader):
             "0004_add_bytes_scanned",
             "0005_add_codec_update_settings",
             "0006_sorting_key_change",
+            "0007_add_offset_column",
         ]
 
 

--- a/snuba/snuba_migrations/querylog/0007_add_offset_column.py
+++ b/snuba/snuba_migrations/querylog/0007_add_offset_column.py
@@ -1,0 +1,63 @@
+from typing import Generator, Sequence, Tuple
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+TABLE_NAME = "querylog_local"
+columns: Sequence[Tuple[Column[Modifiers], str]] = [
+    (Column("partition", UInt(16)), "status"),
+    (Column("offset", UInt(64)), "partition"),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Add partition and offset columns to querylog, so a row in clickhouse can be
+    correlated with a kafka message
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(_forward())
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(_backward())
+
+
+def _forward() -> Generator[operations.SqlOperation, None, None]:
+    for column, after in columns:
+        yield operations.AddColumn(
+            StorageSetKey.QUERYLOG,
+            TABLE_NAME,
+            column=column,
+            after=after,
+            target=operations.OperationTarget.LOCAL,
+        )
+
+        yield operations.AddColumn(
+            StorageSetKey.QUERYLOG,
+            TABLE_NAME,
+            column=column,
+            after=after,
+            target=operations.OperationTarget.DISTRIBUTED,
+        )
+
+
+def _backward() -> Generator[operations.SqlOperation, None, None]:
+    for column, after in columns:
+        yield operations.DropColumn(
+            storage_set=StorageSetKey.QUERYLOG,
+            table_name=TABLE_NAME,
+            target=operations.OperationTarget.DISTRIBUTED,
+            column_name=column.name,
+        )
+
+        yield operations.DropColumn(
+            storage_set=StorageSetKey.QUERYLOG,
+            table_name=TABLE_NAME,
+            target=operations.OperationTarget.LOCAL,
+            column_name=column.name,
+        )

--- a/snuba/snuba_migrations/querylog/0007_add_offset_column.py
+++ b/snuba/snuba_migrations/querylog/0007_add_offset_column.py
@@ -5,7 +5,6 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
-TABLE_NAME = "querylog_local"
 columns: Sequence[Tuple[Column[Modifiers], str]] = [
     (Column("partition", UInt(16)), "status"),
     (Column("offset", UInt(64)), "partition"),
@@ -31,7 +30,7 @@ def _forward() -> Generator[operations.SqlOperation, None, None]:
     for column, after in columns:
         yield operations.AddColumn(
             StorageSetKey.QUERYLOG,
-            TABLE_NAME,
+            table_name="querylog_local",
             column=column,
             after=after,
             target=operations.OperationTarget.LOCAL,
@@ -39,7 +38,7 @@ def _forward() -> Generator[operations.SqlOperation, None, None]:
 
         yield operations.AddColumn(
             StorageSetKey.QUERYLOG,
-            TABLE_NAME,
+            table_name="querylog_dist",
             column=column,
             after=after,
             target=operations.OperationTarget.DISTRIBUTED,
@@ -50,14 +49,14 @@ def _backward() -> Generator[operations.SqlOperation, None, None]:
     for column, after in columns:
         yield operations.DropColumn(
             storage_set=StorageSetKey.QUERYLOG,
-            table_name=TABLE_NAME,
+            table_name="querylog_dist",
             target=operations.OperationTarget.DISTRIBUTED,
             column_name=column.name,
         )
 
         yield operations.DropColumn(
             storage_set=StorageSetKey.QUERYLOG,
-            table_name=TABLE_NAME,
+            table_name="querylog_local",
             target=operations.OperationTarget.LOCAL,
             column_name=column.name,
         )


### PR DESCRIPTION
add partition and offset columns to querylog like most other datasets have it. we recently deployed rust consumers to querylog in saas, and this will allow us to check whether we are dropping any messages between kafka and clickhouse