### PR TITLE
Serialize Rows directly

### DIFF
--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::processors::spans::SpanStatus;
-use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
+use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
@@ -21,9 +21,8 @@ pub fn process_message(
     };
     let device_classification = msg.device_class.unwrap_or_default();
 
-    let mut rows = Vec::with_capacity(msg.functions.len());
-    for from in msg.functions {
-        let function = Function {
+    let functions = msg.functions.into_iter().map(|from| {
+        Function {
             profile_id: msg.profile_id,
             project_id: msg.project_id,
             // Profile metadata
@@ -49,16 +48,9 @@ pub fn process_message(
             is_application: from.in_app as u8,
 
             ..Default::default()
-        };
-        let serialized = serde_json::to_vec(&function)?;
-        rows.push(serialized);
-    }
-
-    Ok(InsertBatch {
-        rows: RowData::from_rows(rows),
-        origin_timestamp: None,
-        sentry_received_timestamp: None,
-    })
+        }
+    });
+    InsertBatch::from_rows(functions)
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -3,7 +3,7 @@ use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
+use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
@@ -17,13 +17,7 @@ pub fn process_message(
     msg.offset = metadata.offset;
     msg.partition = metadata.partition;
 
-    let serialized = serde_json::to_vec(&msg)?;
-
-    Ok(InsertBatch {
-        rows: RowData::from_rows(vec![serialized]),
-        origin_timestamp: None,
-        sentry_received_timestamp: None,
-    })
+    InsertBatch::from_rows([msg])
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use uuid::Uuid;
 
-use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
+use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
@@ -15,36 +15,32 @@ pub fn process_message(
     let replay_message: ReplayMessage = serde_json::from_slice(payload_bytes)?;
     let replay_payload = serde_json::from_slice(&replay_message.payload)?;
 
-    let output = match replay_payload {
-        ReplayPayload::ClickEvent(event) => event
-            .clicks
-            .into_iter()
-            .map(|click| {
-                serde_json::to_vec(&ReplayRow {
-                    click_alt: click.alt,
-                    click_aria_label: click.aria_label,
-                    click_class: click.class,
-                    click_id: click.id,
-                    click_is_dead: click.is_dead,
-                    click_is_rage: click.is_rage,
-                    click_node_id: click.node_id,
-                    click_component_name: click.component_name,
-                    click_role: click.role,
-                    click_tag: click.tag,
-                    click_testid: click.testid,
-                    click_text: click.text,
-                    click_title: click.title,
-                    event_hash: click.event_hash,
-                    offset: metadata.offset,
-                    partition: metadata.partition,
-                    project_id: replay_message.project_id,
-                    replay_id: replay_message.replay_id,
-                    retention_days: replay_message.retention_days,
-                    timestamp: click.timestamp as u32,
-                    ..Default::default()
-                })
-            })
-            .collect::<Result<_, _>>()?,
+    match replay_payload {
+        ReplayPayload::ClickEvent(event) => {
+            InsertBatch::from_rows(event.clicks.into_iter().map(|click| ReplayRow {
+                click_alt: click.alt,
+                click_aria_label: click.aria_label,
+                click_class: click.class,
+                click_id: click.id,
+                click_is_dead: click.is_dead,
+                click_is_rage: click.is_rage,
+                click_node_id: click.node_id,
+                click_component_name: click.component_name,
+                click_role: click.role,
+                click_tag: click.tag,
+                click_testid: click.testid,
+                click_text: click.text,
+                click_title: click.title,
+                event_hash: click.event_hash,
+                offset: metadata.offset,
+                partition: metadata.partition,
+                project_id: replay_message.project_id,
+                replay_id: replay_message.replay_id,
+                retention_days: replay_message.retention_days,
+                timestamp: click.timestamp as u32,
+                ..Default::default()
+            }))
+        }
         ReplayPayload::Event(event) => {
             let event_hash = match (event.event_hash, event.segment_id) {
                 (None, None) => Uuid::new_v4(),
@@ -133,7 +129,7 @@ pub fn process_message(
                 ..Default::default()
             };
 
-            vec![serde_json::to_vec(&replay_row)?]
+            InsertBatch::from_rows([replay_row])
         }
         ReplayPayload::EventLinkEvent(event) => {
             let replay_row = ReplayRow {
@@ -152,15 +148,9 @@ pub fn process_message(
                 ..Default::default()
             };
 
-            vec![serde_json::to_vec(&replay_row)?]
+            InsertBatch::from_rows([replay_row])
         }
-    };
-
-    Ok(InsertBatch {
-        rows: RowData::from_rows(output),
-        origin_timestamp: None,
-        sentry_received_timestamp: None,
-    })
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::processors::utils::{default_retention_days, hex_to_u64, DEFAULT_RETENTION_DAYS};
-use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
+use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
@@ -21,13 +21,7 @@ pub fn process_message(
     span.offset = metadata.offset;
     span.partition = metadata.partition;
 
-    let serialized = serde_json::to_vec(&span)?;
-
-    Ok(InsertBatch {
-        rows: RowData::from_rows(vec![serialized]),
-        origin_timestamp: None,
-        sentry_received_timestamp: None,
-    })
+    InsertBatch::from_rows([span])
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -292,14 +292,14 @@ mod tests {
 
         let payloads = vec![
             BytesInsertBatch::new(
-                RowData::from_rows(vec![]),
+                RowData::default(),
                 Utc::now(),
                 None,
                 None,
                 BTreeMap::from([(0, (500, Utc::now()))]),
             ),
             BytesInsertBatch::new(
-                RowData::from_rows(vec![]),
+                RowData::default(),
                 Utc::now(),
                 None,
                 None,

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -183,7 +183,7 @@ mod tests {
     use rust_arroyo::backends::kafka::types::KafkaPayload;
     use rust_arroyo::types::{Message, Partition, Topic};
 
-    use crate::types::{InsertBatch, RowData};
+    use crate::types::InsertBatch;
     use crate::Noop;
 
     #[test]
@@ -195,11 +195,7 @@ mod tests {
             _payload: KafkaPayload,
             _metadata: KafkaMessageMetadata,
         ) -> anyhow::Result<InsertBatch> {
-            Ok(InsertBatch {
-                rows: RowData::from_rows([]),
-                origin_timestamp: None,
-                sentry_received_timestamp: None,
-            })
+            Ok(InsertBatch::default())
         }
 
         let mut strategy =

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -267,7 +267,7 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
                             _,
                         ) = result.extract(py)?;
                         Ok(InsertBatch {
-                            rows: RowData::from_rows(result_decoded),
+                            rows: RowData::from_encoded_rows(result_decoded),
                             origin_timestamp,
                             sentry_received_timestamp,
                         })


### PR DESCRIPTION
This directly serializes an `Iterator<impl Serialize>` into the output rows. Doing so, it can avoid a bunch of intermediate allocations, as well as simplify its usage.