### PR TITLE
fix(ci): Run sentry under its preferred Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,6 @@ jobs:
         with:
           workdir: sentry
           cache-files-hash: ${{ hashFiles('sentry/requirements**.txt') }}
-          python-version: 3.8
           snuba: false
           kafka: true
           clickhouse: true


### PR DESCRIPTION
sentry no longer supports 3.8 and as a result, integration tests broke
