### PR TITLE
fix(rust): Add settings to cickhouse writer

### DIFF
--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -152,7 +152,7 @@ impl ClickhouseClient {
             HeaderValue::from_str(database).unwrap(),
         );
 
-        let query_params = format!("load_balancing=in_order&insert_distributed_sync=1");
+        let query_params = "load_balancing=in_order&insert_distributed_sync=1".to_string();
         let url = format!("http://{hostname}:{http_port}?{query_params}");
         let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
 

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -152,7 +152,8 @@ impl ClickhouseClient {
             HeaderValue::from_str(database).unwrap(),
         );
 
-        let url = format!("http://{hostname}:{http_port}");
+        let query_params = format!("load_balancing=in_order&insert_distributed_sync=1");
+        let url = format!("http://{hostname}:{http_port}?{query_params}");
         let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
 
         ClickhouseClient {
@@ -193,6 +194,8 @@ mod tests {
             "default",
         );
 
+        assert!(client.url.contains("load_balancing"));
+        assert!(client.url.contains("insert_distributed_sync"));
         println!("running test");
         let res = client.send(b"[]".to_vec()).await;
         println!("Response status {}", res.unwrap().status());


### PR DESCRIPTION
The rust implementation of writing to clickhouse is missing certain settings we use in the python version. Added those settings as query parameters to the clickhouse writer implementation. The python settings can be found [here](https://github.com/getsentry/snuba/blob/master/snuba/consumers/consumer.py#L400)