### PR TITLE
fix(cardinality): Report cardinality data over some threshold

### DIFF
--- a/snuba/cli/spans_cardinality_analyzer.py
+++ b/snuba/cli/spans_cardinality_analyzer.py
@@ -85,6 +85,17 @@ def spans_cardinality_analyzer(
             span_grouping_cardinality_query(span_group, time_window_hrs=24, limit=1000)
         )
 
+        if len(result.results) == 0:
+            logger.info(
+                f"No data found with cardinality greater than 5000 for span group: {span_group}"
+            )
+            slack_client.post_message(
+                message={
+                    "text": f"No data found with cardinality greater than 5000 for span group: {span_group}"
+                }
+            )
+            continue
+
         write_cardnaltiy_to_csv(result.results, f"/tmp/{span_group}.csv")
         slack_client.post_file(
             file_name=f"{span_group}.csv",

--- a/snuba/clickhouse/span_cardinality_analyzer.py
+++ b/snuba/clickhouse/span_cardinality_analyzer.py
@@ -68,6 +68,7 @@ AND (metric_id IN [{IndexedIDs.SPAN_DURATION_METRIC.value},
 {IndexedIDs.SPAN_EXCLUSIVE_TIME_METRIC.value}])
 AND `span.category` = '{span_category}'
 GROUP BY org_id, project_id, `span.category`
+HAVING count_groups > 5000
 ORDER BY count_groups DESC
 LIMIT {limit}
 """


### PR DESCRIPTION
Cardinality of a module only makes sense when it is above 5000. Modified the clickhouse query to restrict the data on values greater than 5000. If no data is found for a module send a slack message rather than an empty csv.
