### PR TITLE
fix(rust): pause/resume bugfixes

### DIFF
--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -1,20 +1,20 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use rdkafka::admin::{NewTopic, AdminClient, TopicReplication, AdminOptions};
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::ClientConfig;
 use tokio::runtime::Runtime;
 
-use crate::types::Topic;
-use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::kafka::config::KafkaConfig;
 use crate::backends::kafka::producer::KafkaProducer;
+use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
 use crate::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
 };
 use crate::types::Message;
+use crate::types::Topic;
 
 #[derive(Clone)]
 pub struct TestStrategy<T> {
@@ -61,10 +61,7 @@ pub fn get_default_broker() -> String {
 
 fn get_admin_client() -> AdminClient<DefaultClientContext> {
     let mut config = ClientConfig::new();
-    config.set(
-        "bootstrap.servers".to_string(),
-        get_default_broker(),
-    );
+    config.set("bootstrap.servers".to_string(), get_default_broker());
 
     config.create().unwrap()
 }
@@ -107,10 +104,8 @@ impl TestTopic {
     }
 
     pub fn produce(&self, payload: KafkaPayload) {
-        let producer_configuration = KafkaConfig::new_producer_config(
-            vec![get_default_broker()],
-            None,
-        );
+        let producer_configuration =
+            KafkaConfig::new_producer_config(vec![get_default_broker()], None);
 
         let producer = KafkaProducer::new(producer_configuration);
 

--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -1,6 +1,16 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use rdkafka::admin::{NewTopic, AdminClient, TopicReplication, AdminOptions};
+use rdkafka::client::DefaultClientContext;
+use rdkafka::ClientConfig;
+use tokio::runtime::Runtime;
+
+use crate::types::Topic;
+use crate::backends::kafka::types::KafkaPayload;
+use crate::backends::kafka::config::KafkaConfig;
+use crate::backends::kafka::producer::KafkaProducer;
+use crate::backends::Producer;
 use crate::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
 };
@@ -42,5 +52,78 @@ impl<T: Send> ProcessingStrategy<T> for TestStrategy<T> {
         _timeout: Option<Duration>,
     ) -> Result<Option<CommitRequest>, InvalidMessage> {
         Ok(None)
+    }
+}
+
+pub fn get_default_broker() -> String {
+    std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())
+}
+
+fn get_admin_client() -> AdminClient<DefaultClientContext> {
+    let mut config = ClientConfig::new();
+    config.set(
+        "bootstrap.servers".to_string(),
+        get_default_broker(),
+    );
+
+    config.create().unwrap()
+}
+
+async fn create_topic(topic_name: &str, partition_count: i32) {
+    let client = get_admin_client();
+    let topics = [NewTopic::new(
+        topic_name,
+        partition_count,
+        TopicReplication::Fixed(1),
+    )];
+    client
+        .create_topics(&topics, &AdminOptions::new())
+        .await
+        .unwrap();
+}
+
+async fn delete_topic(topic_name: &str) {
+    let client = get_admin_client();
+    client
+        .delete_topics(&[topic_name], &AdminOptions::new())
+        .await
+        .unwrap();
+}
+
+pub struct TestTopic {
+    runtime: Runtime,
+    pub topic: Topic,
+}
+
+impl TestTopic {
+    pub fn create(name: &str) -> Self {
+        let runtime = Runtime::new().unwrap();
+        let name = format!("rust-arroyo-{}-{}", name, uuid::Uuid::new_v4());
+        runtime.block_on(create_topic(&name, 1));
+        Self {
+            runtime,
+            topic: Topic::new(&name),
+        }
+    }
+
+    pub fn produce(&self, payload: KafkaPayload) {
+        let producer_configuration = KafkaConfig::new_producer_config(
+            vec![get_default_broker()],
+            None,
+        );
+
+        let producer = KafkaProducer::new(producer_configuration);
+
+        producer
+            .produce(&crate::types::TopicOrPartition::Topic(self.topic), payload)
+            .expect("Message produced");
+    }
+}
+
+impl Drop for TestTopic {
+    fn drop(&mut self) {
+        let name = self.topic.as_str();
+        // i really wish i had async drop now
+        self.runtime.block_on(delete_topic(name));
     }
 }


### PR DESCRIPTION
Implement pause/seek/resume/tell properly, and attempt to reproduce a rdkafka bug mentioned in python-arroyo where seek + pause would ignore the seek, + write testcase

SNS-2556