### PR TITLE
bug(mql): Support resolve release-health tag filters in MQL

### DIFF
--- a/snuba/query/indexer/resolver.py
+++ b/snuba/query/indexer/resolver.py
@@ -27,7 +27,6 @@ def resolve_tag_key_mappings(
 ) -> None:
     def resolve_tag_column(exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in indexer_mapping:
-            print(get_dataset_name(dataset))
             if get_dataset_name(dataset) == "metrics":
                 column_name = f"tags[{resolve(exp.column_name, indexer_mapping)}]"
             else:

--- a/snuba/query/indexer/resolver.py
+++ b/snuba/query/indexer/resolver.py
@@ -27,6 +27,7 @@ def resolve_tag_key_mappings(
 ) -> None:
     def resolve_tag_column(exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in indexer_mapping:
+            print(get_dataset_name(dataset))
             if get_dataset_name(dataset) == "metrics":
                 column_name = f"tags[{resolve(exp.column_name, indexer_mapping)}]"
             else:

--- a/snuba/query/indexer/resolver.py
+++ b/snuba/query/indexer/resolver.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.factory import get_dataset_name
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.exceptions import InvalidQueryException
@@ -18,50 +20,65 @@ def resolve(value: str, mapping: dict[str, str | int]) -> str | int:
     raise InvalidQueryException(f"Could not resolve {value}")
 
 
-def resolve_tag_mappings(
+def resolve_tag_key_mappings(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
     indexer_mapping: dict[str, str | int],
+    dataset: Dataset,
 ) -> None:
     def resolve_tag_column(exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in indexer_mapping:
+            if get_dataset_name(dataset) == "metrics":
+                column_name = f"tags[{resolve(exp.column_name, indexer_mapping)}]"
+            else:
+                column_name = f"tags_raw[{resolve(exp.column_name, indexer_mapping)}]"
             return Column(
                 alias=exp.alias,
                 table_name=exp.table_name,
-                # TODO: Metrics (non-generic metrics) queries use `tags` instead of `tags_raw`
-                column_name=f"tags_raw[{resolve(exp.column_name, indexer_mapping)}]",
+                column_name=column_name,
             )
         return exp
 
     query.transform_expressions(resolve_tag_column)
 
 
-def resolve_metric_id(
+def resolve_tag_value_mappings(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
     indexer_mappings: dict[str, str | int],
 ) -> None:
-    def resolve_metric_id_column(exp: Expression) -> Expression:
-        # Metric IDs are built into the queries as conditions, e.g. metric_id = X
-        # However X could be a public name ("transaction.duration") or an MRI ("d:transactions/duration@millisecond")
-        # Resolve those strings down to the integer metric ID.
+    """
+    This function is responsible for resolving all tag values of a query.
 
+    Metric IDs are built into the queries as conditions, e.g. metric_id = X.
+    Additionally, the metrics (release-health) dataset indexes both tag keys
+    and tag values. Therefore, we can resolve both the metric_id (which is just a tag value)
+    and the filter tag values together since they are both RHS literals.
+    """
+
+    def resolve_tag_value(exp: Expression) -> Expression:
         if isinstance(exp, Literal) and exp.value in indexer_mappings:
-            # This could be a public_name or an mri. public_name -> mri -> metric_id
-            # So we need to resolve the MRI potentially as well.
             mapping = resolve(str(exp.value), indexer_mappings)
             if isinstance(mapping, int):
-                metric_id = mapping
+                value = mapping
             else:
-                metric_id = int(resolve(mapping, indexer_mappings))
+                # We support passing in either public_name or mri in MQL.
+                # The indexer_mapping follows the order: public_name -> mri -> metric_id
+                # For exmaple: {
+                #     "transaction.duration": "d:transactions/duration@millisecond",
+                #     "d:transactions/duration@millisecond": 100001,
+                # }
+                # Therefore, we need to resolve the string down to the integer metric_id
+                value = int(resolve(mapping, indexer_mappings))
 
-            return Literal(None, metric_id)
+            return Literal(None, value)
         return exp
 
-    query.transform_expressions(resolve_metric_id_column)
+    query.transform_expressions(resolve_tag_value)
 
 
 def resolve_mappings(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
     mappings: dict[str, str | int],
+    dataset: Dataset,
 ) -> None:
     """
     At the time of writting (Nov 30, 2023), the indexer is called within sentry.
@@ -69,5 +86,5 @@ def resolve_mappings(
     mimics the behavior of the indexer to resolve the metric_id and tag filters
     by using the indexer_mapping provided by the client.
     """
-    resolve_metric_id(query, mappings)
-    resolve_tag_mappings(query, mappings)
+    resolve_tag_key_mappings(query, mappings, dataset)
+    resolve_tag_value_mappings(query, mappings)

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -674,7 +674,7 @@ def parse_mql_query(
     ):
         query, mql_context = populate_query_from_mql_context(query, mql_context_dict)
     with sentry_sdk.start_span(op="processor", description="resolve_indexer_mappings"):
-        resolve_mappings(query, mql_context.indexer_mappings)
+        resolve_mappings(query, mql_context.indexer_mappings, dataset)
 
     if settings and settings.get_dry_run():
         explain_meta.set_original_ast(str(query))

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -708,4 +708,5 @@ def parse_mql_query(
     # Validating
     with sentry_sdk.start_span(op="validate", description="expression_validators"):
         _post_process(query, VALIDATORS)
+    print(query)
     return query, snql_anonymized

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -708,5 +708,5 @@ def parse_mql_query(
     # Validating
     with sentry_sdk.start_span(op="validate", description="expression_validators"):
         _post_process(query, VALIDATORS)
-    print(query)
+
     return query, snql_anonymized

--- a/tests/query/indexer/test_resolver.py
+++ b/tests/query/indexer/test_resolver.py
@@ -9,7 +9,10 @@ from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, CurriedFunctionCall, FunctionCall, Literal
-from snuba.query.indexer.resolver import resolve_metric_id, resolve_tag_mappings
+from snuba.query.indexer.resolver import (
+    resolve_tag_key_mappings,
+    resolve_tag_value_mappings,
+)
 from snuba.query.logical import Query as LogicalQuery
 
 metric_id_test_cases = [
@@ -125,12 +128,12 @@ metric_id_test_cases = [
 
 @pytest.mark.skip(reason="resolver is not being used yet")
 @pytest.mark.parametrize("query, mappings, expected_query", metric_id_test_cases)
-def test_resolve_metric_id_processor(
+def test_resolve_tag_value_mappings_processor(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
     mappings: dict[str, str | int],
     expected_query: CompositeQuery[QueryEntity] | LogicalQuery,
 ) -> None:
-    resolve_metric_id(query, mappings)
+    resolve_tag_value_mappings(query, mappings)
     assert query == expected_query
 
 
@@ -393,10 +396,10 @@ tag_test_cases = [
 
 @pytest.mark.skip(reason="resolver is not being used yet")
 @pytest.mark.parametrize("query, mappings, expected_query", tag_test_cases)
-def test_resolve_tag_filters_processor(
+def test_resolve_tag_key_mappings_processor(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
     mappings: dict[str, str | int],
     expected_query: CompositeQuery[QueryEntity] | LogicalQuery,
 ) -> None:
-    resolve_tag_mappings(query, mappings)
+    resolve_tag_key_mappings(query, mappings)
     assert query == expected_query

--- a/tests/query/parser/test_mql_query.py
+++ b/tests/query/parser/test_mql_query.py
@@ -304,6 +304,7 @@ mql_test_cases = [
             limit=1000,
             offset=0,
         ),
+        "generic_metrics",
         id="test of resolved query",
     ),
     pytest.param(
@@ -549,6 +550,7 @@ mql_test_cases = [
             ],
             limit=1000,
         ),
+        "generic_metrics",
         id="Select metric with filter",
     ),
     pytest.param(
@@ -829,6 +831,7 @@ mql_test_cases = [
             limit=100,
             offset=3,
         ),
+        "generic_metrics",
         id="Select metric with filter and groupby",
     ),
     pytest.param(
@@ -1098,16 +1101,289 @@ mql_test_cases = [
             limit=1000,
             offset=0,
         ),
+        "generic_metrics",
         id="curried function",
+    ),
+    pytest.param(
+        'sum(`d:sessions/duration@second`){release:["foo", "bar"]} by release',
+        {
+            "entity": "metrics_distributions",
+            "start": "2021-01-01T00:00:00",
+            "end": "2021-01-02T00:00:00",
+            "rollup": {
+                "orderby": "ASC",
+                "granularity": 60,
+                "interval": None,
+                "with_totals": None,
+            },
+            "scope": {
+                "org_ids": [1],
+                "project_ids": [1],
+                "use_case_id": "sessions",
+            },
+            "limit": None,
+            "offset": None,
+            "indexer_mappings": {
+                "d:sessions/duration@second": 123456,
+                "release": 111,
+                "foo": 222,
+                "bar": 333,
+            },
+        },
+        Query(
+            QueryEntity(
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "aggregate_value",
+                    FunctionCall(
+                        "_snuba_aggregate_value",
+                        "sum",
+                        (Column("_snuba_value", None, "value"),),
+                    ),
+                ),
+                SelectedExpression(
+                    "release",
+                    SubscriptableReference(
+                        "_snuba_tags[111]",
+                        Column(
+                            "_snuba_tags",
+                            None,
+                            "tags",
+                        ),
+                        Literal(None, "111"),
+                    ),
+                ),
+            ],
+            condition=FunctionCall(
+                None,
+                "and",
+                (
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            Column(
+                                "_snuba_granularity",
+                                None,
+                                "granularity",
+                            ),
+                            Literal(None, 60),
+                        ),
+                    ),
+                    FunctionCall(
+                        None,
+                        "and",
+                        (
+                            FunctionCall(
+                                None,
+                                "in",
+                                (
+                                    Column(
+                                        "_snuba_project_id",
+                                        None,
+                                        "project_id",
+                                    ),
+                                    FunctionCall(
+                                        None,
+                                        "tuple",
+                                        (Literal(None, 1),),
+                                    ),
+                                ),
+                            ),
+                            FunctionCall(
+                                None,
+                                "and",
+                                (
+                                    FunctionCall(
+                                        None,
+                                        "in",
+                                        (
+                                            Column(
+                                                "_snuba_org_id",
+                                                None,
+                                                "org_id",
+                                            ),
+                                            FunctionCall(
+                                                None,
+                                                "tuple",
+                                                (Literal(None, 1),),
+                                            ),
+                                        ),
+                                    ),
+                                    FunctionCall(
+                                        None,
+                                        "and",
+                                        (
+                                            FunctionCall(
+                                                None,
+                                                "equals",
+                                                (
+                                                    Column(
+                                                        "_snuba_use_case_id",
+                                                        None,
+                                                        "use_case_id",
+                                                    ),
+                                                    Literal(None, "sessions"),
+                                                ),
+                                            ),
+                                            FunctionCall(
+                                                None,
+                                                "and",
+                                                (
+                                                    FunctionCall(
+                                                        None,
+                                                        "greaterOrEquals",
+                                                        (
+                                                            Column(
+                                                                "_snuba_timestamp",
+                                                                None,
+                                                                "timestamp",
+                                                            ),
+                                                            Literal(
+                                                                None,
+                                                                datetime(
+                                                                    2021, 1, 1, 0, 0
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    FunctionCall(
+                                                        None,
+                                                        "and",
+                                                        (
+                                                            FunctionCall(
+                                                                None,
+                                                                "less",
+                                                                (
+                                                                    Column(
+                                                                        "_snuba_timestamp",
+                                                                        None,
+                                                                        "timestamp",
+                                                                    ),
+                                                                    Literal(
+                                                                        None,
+                                                                        datetime(
+                                                                            2021,
+                                                                            1,
+                                                                            2,
+                                                                            0,
+                                                                            0,
+                                                                        ),
+                                                                    ),
+                                                                ),
+                                                            ),
+                                                            FunctionCall(
+                                                                None,
+                                                                "and",
+                                                                (
+                                                                    FunctionCall(
+                                                                        None,
+                                                                        "equals",
+                                                                        (
+                                                                            Column(
+                                                                                "_snuba_metric_id",
+                                                                                None,
+                                                                                "metric_id",
+                                                                            ),
+                                                                            Literal(
+                                                                                None,
+                                                                                123456,
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                    FunctionCall(
+                                                                        None,
+                                                                        "in",
+                                                                        (
+                                                                            SubscriptableReference(
+                                                                                "_snuba_tags[111]",
+                                                                                column=Column(
+                                                                                    "_snuba_tags",
+                                                                                    None,
+                                                                                    "tags",
+                                                                                ),
+                                                                                key=Literal(
+                                                                                    None,
+                                                                                    "111",
+                                                                                ),
+                                                                            ),
+                                                                            FunctionCall(
+                                                                                None,
+                                                                                "tuple",
+                                                                                (
+                                                                                    Literal(
+                                                                                        None,
+                                                                                        222,
+                                                                                    ),
+                                                                                    Literal(
+                                                                                        None,
+                                                                                        333,
+                                                                                    ),
+                                                                                ),
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            groupby=[
+                SubscriptableReference(
+                    "_snuba_tags[111]",
+                    Column(
+                        "_snuba_tags",
+                        None,
+                        "tags",
+                    ),
+                    Literal(None, "111"),
+                )
+            ],
+            order_by=[
+                OrderBy(
+                    OrderByDirection.ASC,
+                    FunctionCall(
+                        alias="_snuba_aggregate_value",
+                        function_name="sum",
+                        parameters=(
+                            (
+                                Column(
+                                    alias="_snuba_value",
+                                    table_name=None,
+                                    column_name="value",
+                                ),
+                            )
+                        ),
+                    ),
+                ),
+            ],
+            limit=1000,
+        ),
+        "metrics",
+        id="Select metric with filter for metrics dataset",
     ),
 ]
 
 
-@pytest.mark.parametrize("query_body, mql_context, expected_query", mql_test_cases)
+@pytest.mark.parametrize(
+    "query_body, mql_context, expected_query, dataset", mql_test_cases
+)
 def test_format_expressions_from_mql(
-    query_body: str, mql_context: Dict[str, Any], expected_query: Query
+    query_body: str, mql_context: Dict[str, Any], expected_query: Query, dataset: str
 ) -> None:
-    generic_metrics = get_dataset("generic_metrics")
+    generic_metrics = get_dataset(dataset)
     query, _ = parse_mql_query(str(query_body), mql_context, generic_metrics)
     eq, reason = query.equals(expected_query)
     assert eq, reason


### PR DESCRIPTION
This PR is responsible for correctly resolving tag filters in order to support release-health MQL queries. Firstly, we need to correctly assign `tags` and `tags_raw` columns for metrics and generic-metrics datasets respectively. Secondly, since both tag keys and tag values are indexed in release-health, we need to resolve the tag values of filters.

It is important to note that the call to the indexer happens in sentry. The mappings are passed as a dict to the request object and sent to the snuba API. Then, snuba query pipeline executes a "resolve" step which transforms the tags into the mapped integers. Therefore, this code simply ensures that the resolutions are execute, but it still the job of the metrics layer (sentry) to perform the indexer lookups and pass the correct mappings.