### PR TITLE
perf: use `phf` for more efficient lookup tables

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1349,6 +1349,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1776,7 @@ dependencies = [
  "md5",
  "once_cell",
  "parking_lot",
+ "phf",
  "procspawn",
  "pyo3",
  "reqwest",
@@ -2084,6 +2127,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -44,6 +44,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = "1.5.0"
 parking_lot = "0.12.1"
+phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 divan = "0.1.2"

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -193,7 +193,7 @@ pub fn process_message(
 ) -> Option<Vec<u8>> {
     // XXX: Currently only takes the message payload and metadata. This assumes
     // key and headers are not used for message processing
-    processors::get_processing_function(name).map(|func| {
+    processors::PROCESSING_FUNCTIONS.get(name).map(|func| {
         let payload = KafkaPayload::new(None, None, Some(value));
 
         let timestamp = DateTime::from_naive_utc_and_offset(

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -77,13 +77,12 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
 
         let processor = match (
             self.use_rust_processor,
-            processors::get_processing_function(
-                &self.storage_config.message_processor.python_class_name,
-            ),
+            processors::PROCESSING_FUNCTIONS
+                .get(&self.storage_config.message_processor.python_class_name),
         ) {
             (true, Some(func)) => make_rust_processor(
                 next_step,
-                func,
+                *func,
                 &self.logical_topic_name,
                 false,
                 &self.processing_concurrency,

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -11,14 +11,11 @@ use rust_arroyo::backends::kafka::types::KafkaPayload;
 
 pub type ProcessingFunction = fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<InsertBatch>;
 
-pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
-    match name {
-        "FunctionsMessageProcessor" => Some(functions::process_message),
-        "ProfilesMessageProcessor" => Some(profiles::process_message),
-        "QuerylogProcessor" => Some(querylog::process_message),
-        "ReplaysProcessor" => Some(replays::process_message),
-        "SpansMessageProcessor" => Some(spans::process_message),
-        "MetricsSummariesMessageProcessor" => Some(metrics_summaries::process_message),
-        _ => None,
-    }
-}
+pub static PROCESSING_FUNCTIONS: phf::Map<&'static str, ProcessingFunction> = phf::phf_map! {
+    "FunctionsMessageProcessor" => functions::process_message,
+    "ProfilesMessageProcessor" => profiles::process_message,
+    "QuerylogProcessor" => querylog::process_message,
+    "ReplaysProcessor" => replays::process_message,
+    "SpansMessageProcessor" => spans::process_message,
+    "MetricsSummariesMessageProcessor" => metrics_summaries::process_message,
+};


### PR DESCRIPTION
Replaces function with a lookup table generated at compile time.

### Before

```
Timer precision: 41 ns
processors    fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ functions                │               │               │               │         │
│  ├─ 1       26.1 ms       │ 47.4 ms       │ 28.17 ms      │ 31.87 ms      │ 100     │ 100
│  │          191.5 Kitem/s │ 105.4 Kitem/s │ 177.4 Kitem/s │ 156.8 Kitem/s │         │
│  ├─ 4       17.88 ms      │ 22.11 ms      │ 18.63 ms      │ 18.9 ms       │ 100     │ 100
│  │          279.5 Kitem/s │ 226.1 Kitem/s │ 268.2 Kitem/s │ 264.4 Kitem/s │         │
│  ╰─ 16      13.11 ms      │ 14.72 ms      │ 14.03 ms      │ 14.02 ms      │ 100     │ 100
│             381.1 Kitem/s │ 339.5 Kitem/s │ 356.2 Kitem/s │ 356.5 Kitem/s │         │
├─ profiles                 │               │               │               │         │
│  ├─ 1       21.13 ms      │ 30.97 ms      │ 22.06 ms      │ 22.42 ms      │ 100     │ 100
│  │          236.5 Kitem/s │ 161.4 Kitem/s │ 226.6 Kitem/s │ 222.9 Kitem/s │         │
│  ├─ 4       14.79 ms      │ 21.33 ms      │ 15.52 ms      │ 16.15 ms      │ 100     │ 100
│  │          337.8 Kitem/s │ 234.3 Kitem/s │ 322 Kitem/s   │ 309.5 Kitem/s │         │
│  ╰─ 16      12.07 ms      │ 14.06 ms      │ 13.18 ms      │ 13.14 ms      │ 100     │ 100
│             414 Kitem/s   │ 355.4 Kitem/s │ 379.2 Kitem/s │ 380.4 Kitem/s │         │
├─ querylog                 │               │               │               │         │
│  ├─ 1       66.27 ms      │ 79.11 ms      │ 69.65 ms      │ 70.07 ms      │ 100     │ 100
│  │          75.44 Kitem/s │ 63.19 Kitem/s │ 71.77 Kitem/s │ 71.34 Kitem/s │         │
│  ├─ 4       39.23 ms      │ 48.8 ms       │ 43.72 ms      │ 43.94 ms      │ 100     │ 100
│  │          127.4 Kitem/s │ 102.4 Kitem/s │ 114.3 Kitem/s │ 113.7 Kitem/s │         │
│  ╰─ 16      28.36 ms      │ 31.16 ms      │ 29.94 ms      │ 29.94 ms      │ 100     │ 100
│             176.2 Kitem/s │ 160.4 Kitem/s │ 166.9 Kitem/s │ 166.9 Kitem/s │         │
╰─ spans                    │               │               │               │         │
   ├─ 1       32.38 ms      │ 47.77 ms      │ 34.71 ms      │ 35.29 ms      │ 100     │ 100
   │          154.4 Kitem/s │ 104.6 Kitem/s │ 144 Kitem/s   │ 141.6 Kitem/s │         │
   ├─ 4       22.14 ms      │ 26.16 ms      │ 23.71 ms      │ 23.8 ms       │ 100     │ 100
   │          225.7 Kitem/s │ 191 Kitem/s   │ 210.8 Kitem/s │ 210 Kitem/s   │         │
   ╰─ 16      15.23 ms      │ 18.39 ms      │ 16.27 ms      │ 16.29 ms      │ 100     │ 100
              328 Kitem/s   │ 271.7 Kitem/s │ 307.2 Kitem/s │ 306.8 Kitem/s │         
```


### After

```
Timer precision: 41 ns
processors    fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ functions                │               │               │               │         │
│  ├─ 1       25.99 ms      │ 45.83 ms      │ 27.21 ms      │ 28.95 ms      │ 100     │ 100
│  │          192.3 Kitem/s │ 109 Kitem/s   │ 183.7 Kitem/s │ 172.7 Kitem/s │         │
│  ├─ 4       17.62 ms      │ 22.63 ms      │ 19.69 ms      │ 20.03 ms      │ 100     │ 100
│  │          283.7 Kitem/s │ 220.8 Kitem/s │ 253.8 Kitem/s │ 249.6 Kitem/s │         │
│  ╰─ 16      13.23 ms      │ 17.97 ms      │ 14.11 ms      │ 14.21 ms      │ 100     │ 100
│             377.7 Kitem/s │ 278.1 Kitem/s │ 354.3 Kitem/s │ 351.7 Kitem/s │         │
├─ profiles                 │               │               │               │         │
│  ├─ 1       21.3 ms       │ 33.45 ms      │ 22.27 ms      │ 22.62 ms      │ 100     │ 100
│  │          234.6 Kitem/s │ 149.4 Kitem/s │ 224.4 Kitem/s │ 220.9 Kitem/s │         │
│  ├─ 4       14.86 ms      │ 19.7 ms       │ 16.16 ms      │ 16.33 ms      │ 100     │ 100
│  │          336.4 Kitem/s │ 253.7 Kitem/s │ 309.2 Kitem/s │ 306.1 Kitem/s │         │
│  ╰─ 16      12.04 ms      │ 14.5 ms       │ 13.12 ms      │ 13.13 ms      │ 100     │ 100
│             415.1 Kitem/s │ 344.6 Kitem/s │ 380.8 Kitem/s │ 380.5 Kitem/s │         │
├─ querylog                 │               │               │               │         │
│  ├─ 1       67.32 ms      │ 75.44 ms      │ 69.05 ms      │ 69.68 ms      │ 100     │ 100
│  │          74.26 Kitem/s │ 66.27 Kitem/s │ 72.4 Kitem/s  │ 71.75 Kitem/s │         │
│  ├─ 4       40.22 ms      │ 46.62 ms      │ 43.94 ms      │ 43.78 ms      │ 100     │ 100
│  │          124.3 Kitem/s │ 107.2 Kitem/s │ 113.7 Kitem/s │ 114.1 Kitem/s │         │
│  ╰─ 16      28.49 ms      │ 33.41 ms      │ 30.37 ms      │ 30.37 ms      │ 100     │ 100
│             175.4 Kitem/s │ 149.6 Kitem/s │ 164.5 Kitem/s │ 164.5 Kitem/s │         │
╰─ spans                    │               │               │               │         │
   ├─ 1       32.41 ms      │ 42.28 ms      │ 34.64 ms      │ 35.28 ms      │ 100     │ 100
   │          154.2 Kitem/s │ 118.2 Kitem/s │ 144.3 Kitem/s │ 141.6 Kitem/s │         │
   ├─ 4       23.53 ms      │ 28.37 ms      │ 25.72 ms      │ 25.91 ms      │ 100     │ 100
   │          212.4 Kitem/s │ 176.2 Kitem/s │ 194.3 Kitem/s │ 192.9 Kitem/s │         │
   ╰─ 16      15.68 ms      │ 17.93 ms      │ 16.59 ms      │ 16.62 ms      │ 100     │ 100
              318.8 Kitem/s │ 278.7 Kitem/s │ 301.2 Kitem/s │ 300.8 Kitem/s │         │
```