### PR TITLE
perf: replace serde_json with simd_json

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -470,6 +470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +670,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5681137554ddff44396e5f149892c769d45301dd9aa19c51602a89ee214cb0ec"
+dependencies = [
+ "hashbrown 0.13.2",
+ "serde",
 ]
 
 [[package]]
@@ -930,6 +949,70 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1604,6 +1687,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53313ec9f12686aeeffb43462c3ac77aa25f590a5f630eb2cde0de59417b29c7"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2566c4bf6845f2c2e83b27043c3f5dfcd5ba8f2937d6c00dc009bfb51a079dc4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1845,7 @@ dependencies = [
  "sentry-kafka-schemas",
  "serde",
  "serde_json",
+ "simd-json",
  "thiserror",
  "tokio",
  "tracing",
@@ -2086,6 +2190,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-json"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a3720326b20bf5b95b72dbbd133caae7e0dcf71eae8f6e6656e71a7e5c9aaa"
+dependencies = [
+ "getrandom 0.2.11",
+ "halfbrown",
+ "lexical-core",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2245,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2561,6 +2693,18 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-trait"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea87257cfcbedcb9444eda79c59fdfea71217e6305afee8ee33f500375c2ac97"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vcpkg"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -44,6 +44,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = "1.5.0"
 parking_lot = "0.12.1"
+simd-json = "0.13.4"
 
 [dev-dependencies]
 divan = "0.1.2"

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -13,7 +13,7 @@ pub fn process_message(
     _metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let msg: FromFunctionsMessage = serde_json::from_slice(payload_bytes)?;
+    let msg: FromFunctionsMessage = simd_json::from_slice(payload_bytes.clone().as_mut_slice())?;
 
     let timestamp = match msg.timestamp {
         Some(timestamp) => timestamp,

--- a/rust_snuba/src/processors/metrics_summaries.rs
+++ b/rust_snuba/src/processors/metrics_summaries.rs
@@ -12,9 +12,9 @@ pub fn process_message(
     _: KafkaMessageMetadata,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let from: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
-
-    let mut metrics_summaries: Vec<MetricsSummary> = Vec::new();
+    let from: FromSpanMessage = simd_json::serde::from_slice(payload_bytes.clone().as_mut_slice())?;
+    let mut metrics_summaries: Vec<MetricsSummary> =
+        Vec::with_capacity(from._metrics_summary.len());
 
     let end_timestamp_ms = from.start_timestamp_ms + from.duration_ms as u64;
     for (metric_mri, summaries) in from._metrics_summary {

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -10,7 +10,7 @@ pub fn process_message(
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let mut msg: ProfileMessage = serde_json::from_slice(payload_bytes)?;
+    let mut msg: ProfileMessage = simd_json::from_slice(payload_bytes.clone().as_mut_slice())?;
 
     // we always want an empty string at least
     msg.device_classification = Some(msg.device_classification.unwrap_or_default());

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -14,7 +14,7 @@ pub fn process_message(
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let from: FromQuerylogMessage = serde_json::from_slice(payload_bytes)?;
+    let from: FromQuerylogMessage = simd_json::from_slice(payload_bytes.clone().as_mut_slice())?;
 
     let querylog_msg = QuerylogMessage {
         request: from.request,

--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -11,9 +11,9 @@ pub fn process_message(
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-
-    let replay_message: ReplayMessage = serde_json::from_slice(payload_bytes)?;
-    let replay_payload = serde_json::from_slice(&replay_message.payload)?;
+    let replay_message: ReplayMessage =
+        simd_json::from_slice(payload_bytes.clone().as_mut_slice())?;
+    let replay_payload = simd_json::from_slice(replay_message.payload.clone().as_mut_slice())?;
 
     match replay_payload {
         ReplayPayload::ClickEvent(event) => {

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -14,7 +14,7 @@ pub fn process_message(
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
+    let msg: FromSpanMessage = simd_json::from_slice(payload_bytes.clone().as_mut_slice())?;
 
     let mut span: Span = msg.try_into()?;
 


### PR DESCRIPTION
Small experiment. Please run the benchmarks locally to validate.

### Before

```
Timer precision: 41 ns
processors    fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ functions                │               │               │               │         │
│  ├─ 1       26.23 ms      │ 53.19 ms      │ 27.16 ms      │ 27.68 ms      │ 100     │ 100
│  │          190.5 Kitem/s │ 94 Kitem/s    │ 184 Kitem/s   │ 180.6 Kitem/s │         │
│  ├─ 4       17.92 ms      │ 21.88 ms      │ 18.82 ms      │ 19.02 ms      │ 100     │ 100
│  │          278.9 Kitem/s │ 228.5 Kitem/s │ 265.6 Kitem/s │ 262.8 Kitem/s │         │
│  ╰─ 16      13.14 ms      │ 35.18 ms      │ 14 ms         │ 14.35 ms      │ 100     │ 100
│             380.2 Kitem/s │ 142.1 Kitem/s │ 357 Kitem/s   │ 348.3 Kitem/s │         │
├─ profiles                 │               │               │               │         │
│  ├─ 1       21.15 ms      │ 28.93 ms      │ 22.49 ms      │ 22.65 ms      │ 100     │ 100
│  │          236.3 Kitem/s │ 172.7 Kitem/s │ 222.2 Kitem/s │ 220.6 Kitem/s │         │
│  ├─ 4       15.41 ms      │ 19.49 ms      │ 16.25 ms      │ 16.57 ms      │ 100     │ 100
│  │          324.3 Kitem/s │ 256.4 Kitem/s │ 307.6 Kitem/s │ 301.7 Kitem/s │         │
│  ╰─ 16      12.16 ms      │ 14.51 ms      │ 13.23 ms      │ 13.27 ms      │ 100     │ 100
│             411.1 Kitem/s │ 344.3 Kitem/s │ 377.8 Kitem/s │ 376.5 Kitem/s │         │
├─ querylog                 │               │               │               │         │
│  ├─ 1       66.67 ms      │ 105.3 ms      │ 69.26 ms      │ 70.73 ms      │ 100     │ 100
│  │          74.98 Kitem/s │ 47.47 Kitem/s │ 72.18 Kitem/s │ 70.68 Kitem/s │         │
│  ├─ 4       38.92 ms      │ 48.5 ms       │ 43.86 ms      │ 43.7 ms       │ 100     │ 100
│  │          128.4 Kitem/s │ 103 Kitem/s   │ 113.9 Kitem/s │ 114.4 Kitem/s │         │
│  ╰─ 16      28.76 ms      │ 32.72 ms      │ 30.17 ms      │ 30.17 ms      │ 100     │ 100
│             173.8 Kitem/s │ 152.7 Kitem/s │ 165.7 Kitem/s │ 165.7 Kitem/s │         │
╰─ spans                    │               │               │               │         │
   ├─ 1       33.43 ms      │ 45.9 ms       │ 34.77 ms      │ 35.24 ms      │ 100     │ 100
   │          149.5 Kitem/s │ 108.9 Kitem/s │ 143.7 Kitem/s │ 141.8 Kitem/s │         │
   ├─ 4       23.51 ms      │ 29.26 ms      │ 26.88 ms      │ 26.73 ms      │ 100     │ 100
   │          212.5 Kitem/s │ 170.8 Kitem/s │ 185.9 Kitem/s │ 187 Kitem/s   │         │
   ╰─ 16      16.27 ms      │ 18.79 ms      │ 17.12 ms      │ 17.18 ms      │ 100     │ 100
              307.2 Kitem/s │ 266 Kitem/s   │ 291.9 Kitem/s │ 290.9 Kitem/s │         │
```

### After

```
Timer precision: 41 ns
processors    fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ functions                │               │               │               │         │
│  ├─ 1       26.83 ms      │ 50.89 ms      │ 27.5 ms       │ 28.05 ms      │ 100     │ 100
│  │          186.3 Kitem/s │ 98.24 Kitem/s │ 181.7 Kitem/s │ 178.1 Kitem/s │         │
│  ├─ 4       17.73 ms      │ 21.64 ms      │ 18.66 ms      │ 18.94 ms      │ 100     │ 100
│  │          282 Kitem/s   │ 231 Kitem/s   │ 267.9 Kitem/s │ 263.9 Kitem/s │         │
│  ╰─ 16      13.6 ms       │ 15.3 ms       │ 14.46 ms      │ 14.45 ms      │ 100     │ 100
│             367.4 Kitem/s │ 326.7 Kitem/s │ 345.6 Kitem/s │ 346 Kitem/s   │         │
├─ profiles                 │               │               │               │         │
│  ├─ 1       22.11 ms      │ 29.48 ms      │ 22.75 ms      │ 23.14 ms      │ 100     │ 100
│  │          226.1 Kitem/s │ 169.5 Kitem/s │ 219.6 Kitem/s │ 216 Kitem/s   │         │
│  ├─ 4       15.2 ms       │ 22.29 ms      │ 16.25 ms      │ 16.66 ms      │ 100     │ 100
│  │          328.7 Kitem/s │ 224.2 Kitem/s │ 307.5 Kitem/s │ 300 Kitem/s   │         │
│  ╰─ 16      12.36 ms      │ 32.82 ms      │ 13.63 ms      │ 14.08 ms      │ 100     │ 100
│             404.2 Kitem/s │ 152.3 Kitem/s │ 366.7 Kitem/s │ 354.8 Kitem/s │         │
├─ querylog                 │               │               │               │         │
│  ├─ 1       62.84 ms      │ 250.7 ms      │ 65.44 ms      │ 69.13 ms      │ 100     │ 100
│  │          79.55 Kitem/s │ 19.94 Kitem/s │ 76.4 Kitem/s  │ 72.32 Kitem/s │         │
│  ├─ 4       35.66 ms      │ 42.15 ms      │ 39.02 ms      │ 39.12 ms      │ 100     │ 100
│  │          140.2 Kitem/s │ 118.5 Kitem/s │ 128.1 Kitem/s │ 127.7 Kitem/s │         │
│  ╰─ 16      26.69 ms      │ 31.51 ms      │ 28.11 ms      │ 28.17 ms      │ 100     │ 100
│             187.3 Kitem/s │ 158.6 Kitem/s │ 177.8 Kitem/s │ 177.4 Kitem/s │         │
╰─ spans                    │               │               │               │         │
   ├─ 1       33.78 ms      │ 43.79 ms      │ 34.81 ms      │ 35.35 ms      │ 100     │ 100
   │          147.9 Kitem/s │ 114.1 Kitem/s │ 143.6 Kitem/s │ 141.4 Kitem/s │         │
   ├─ 4       22.27 ms      │ 27.68 ms      │ 23.88 ms      │ 24 ms         │ 100     │ 100
   │          224.4 Kitem/s │ 180.5 Kitem/s │ 209.3 Kitem/s │ 208.2 Kitem/s │         │
   ╰─ 16      15.33 ms      │ 19.23 ms      │ 16.2 ms       │ 16.18 ms      │ 100     │ 100
              325.9 Kitem/s │ 259.9 Kitem/s │ 308.5 Kitem/s │ 308.8 Kitem/s │         │
```