### PR TITLE
ref(rust): Support --use-python-processor in CLI

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -99,10 +99,10 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     type=int,
 )
 @click.option(
-    "--use-rust-processor",
+    "--use-rust-processor/--use-python-processor",
     "use_rust_processor",
     is_flag=True,
-    help="Use the Rust instead of Python message processor (if available)",
+    help="Use the Rust (if available) or Python message processor",
     default=False,
 )
 @click.option(


### PR DESCRIPTION
The Rust consumer running Python is highly experimental - we should flip the default so pure Rust is default rather than hybrid. This is the first step towards that. We need to ensure the --use-python-processor flag is passed everywhere in prod before actually changing the default in the CLI.
