### PR TITLE
feat(rust): Port outcomes message processor to Rust

### DIFF
--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -1,11 +1,11 @@
 mod functions;
 mod metrics_summaries;
+mod outcomes;
 mod profiles;
 mod querylog;
 mod replays;
 mod spans;
 mod utils;
-mod outcomes;
 
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -5,6 +5,7 @@ mod querylog;
 mod replays;
 mod spans;
 mod utils;
+mod outcomes;
 
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
@@ -19,6 +20,7 @@ pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
         "ReplaysProcessor" => Some(replays::process_message),
         "SpansMessageProcessor" => Some(spans::process_message),
         "MetricsSummariesMessageProcessor" => Some(metrics_summaries::process_message),
+        "OutcomesProcessor" => Some(outcomes::process_message),
         _ => None,
     }
 }

--- a/rust_snuba/src/processors/outcomes.rs
+++ b/rust_snuba/src/processors/outcomes.rs
@@ -44,15 +44,17 @@ pub fn process_message(
         }
     }
 
-    if msg.outcome != OUTCOME_ABUSE {
-        // we dont care about abuse outcomes for these metrics
-        if msg.category.is_none() {
+    // we dont care about abuse outcomes for these metrics
+    if msg.category.is_none() {
+        msg.category = Some(DEFAULT_CATEGORY);
+        if msg.outcome != OUTCOME_ABUSE {
             get_metrics().increment("missing_category", 1, None);
-            msg.category = Some(DEFAULT_CATEGORY);
         }
-        if msg.quantity.is_none() {
+    }
+    if msg.quantity.is_none() {
+        msg.quantity = Some(1);
+        if msg.outcome != OUTCOME_ABUSE {
             get_metrics().increment("missing_quantity", 1, None);
-            msg.quantity = Some(1);
         }
     }
 
@@ -99,11 +101,11 @@ mod tests {
         };
         let result = process_message(payload, meta).expect("The message should be processed");
 
-        let expected = "{\"timestamp\":1680029444,\"org_id\":1,\"project_id\":1,\"key_id\":null,\"outcome\":4,\"reason\":null,\"event_id\":null,\"quantity\":3,\"category\":1}";
+        let expected = "{\"org_id\":1,\"project_id\":1,\"key_id\":null,\"timestamp\":1680029444,\"outcome\":4,\"category\":1,\"quantity\":3,\"reason\":null,\"event_id\":null}";
 
         assert_eq!(
             result.rows,
-            RowData::from_rows(vec![expected.as_bytes().to_vec()]).unwrap()
+            RowData::from_encoded_rows(vec![expected.as_bytes().to_vec()])
         );
     }
 }

--- a/rust_snuba/src/processors/outcomes.rs
+++ b/rust_snuba/src/processors/outcomes.rs
@@ -1,0 +1,109 @@
+use crate::processors::utils::ensure_valid_datetime;
+use crate::types::{InsertBatch, KafkaMessageMetadata};
+use anyhow::Context;
+use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::utils::metrics::get_metrics;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const OUTCOME_ABUSE: u8 = 4;
+const OUTCOME_CLIENT_DISCARD: u8 = 5;
+// DataCategory 1 is Error
+const DEFAULT_CATEGORY: u8 = 1;
+
+const CLIENT_DISCARD_REASONS: [&str; 11] = [
+    "queue_overflow",
+    "cache_overflow",
+    "ratelimit_backoff",
+    "network_error",
+    "before_send",
+    "event_processor",
+    "sample_rate",
+    "send_error",
+    "internal_sdk_error",
+    "insufficient_data",
+    "backpressure",
+];
+
+pub fn process_message(
+    payload: KafkaPayload,
+    _metadata: KafkaMessageMetadata,
+) -> anyhow::Result<InsertBatch> {
+    let payload_bytes = payload.payload().context("Expected payload")?;
+    let mut msg: Outcome = serde_json::from_slice(payload_bytes)?;
+
+    // relays let arbitrary outcome reasons through do the topic.  We
+    // reject undesired values only in the processor so that we can
+    // add new ones without having to update relays through the entire
+    // chain.
+    if msg.outcome == OUTCOME_CLIENT_DISCARD {
+        if let Some(reason) = &msg.reason {
+            if !CLIENT_DISCARD_REASONS.contains(&reason.as_str()) {
+                msg.reason = None;
+            }
+        }
+    }
+
+    if msg.outcome != OUTCOME_ABUSE {
+        // we dont care about abuse outcomes for these metrics
+        if msg.category.is_none() {
+            get_metrics().increment("missing_category", 1, None);
+            msg.category = Some(DEFAULT_CATEGORY);
+        }
+        if msg.quantity.is_none() {
+            get_metrics().increment("missing_quantity", 1, None);
+            msg.quantity = Some(1);
+        }
+    }
+
+    InsertBatch::from_rows([msg])
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Outcome {
+    #[serde(default)]
+    org_id: u64,
+    #[serde(default)]
+    project_id: Option<u64>,
+    key_id: Option<u64>,
+    #[serde(default, deserialize_with = "ensure_valid_datetime")]
+    timestamp: u32,
+    outcome: u8,
+    category: Option<u8>,
+    quantity: Option<u32>,
+    reason: Option<String>,
+    event_id: Option<Uuid>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::RowData;
+    use chrono::DateTime;
+    use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::time::SystemTime;
+    #[test]
+    fn test_outcome() {
+        let data = r#"{
+            "org_id": 1,
+            "outcome": 4,
+            "project_id": 1,
+            "quantity": 3,
+            "timestamp": "2023-03-28T18:50:44.000011Z"
+          }"#;
+        let payload = KafkaPayload::new(None, None, Some(data.as_bytes().to_vec()));
+        let meta = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: DateTime::from(SystemTime::now()),
+        };
+        let result = process_message(payload, meta).expect("The message should be processed");
+
+        let expected = "{\"timestamp\":1680029444,\"org_id\":1,\"project_id\":1,\"key_id\":null,\"outcome\":4,\"reason\":null,\"event_id\":null,\"quantity\":3,\"category\":1}";
+
+        assert_eq!(
+            result.rows,
+            RowData::from_rows(vec![expected.as_bytes().to_vec()]).unwrap()
+        );
+    }
+}

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -1,6 +1,9 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Deserializer};
 
 pub const DEFAULT_RETENTION_DAYS: u16 = 90;
+// Equivalent to "%Y-%m-%dT%H:%M:%S.%fZ" in python
+pub const PAYLOAD_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S.%6fZ";
 
 pub fn default_retention_days() -> Option<u16> {
     Some(DEFAULT_RETENTION_DAYS)
@@ -12,4 +15,17 @@ where
 {
     let hex = String::deserialize(deserializer)?;
     u64::from_str_radix(&hex, 16).map_err(serde::de::Error::custom)
+}
+
+pub fn ensure_valid_datetime<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    let naive = NaiveDateTime::parse_from_str(&value, PAYLOAD_DATETIME_FORMAT);
+    let seconds_since_epoch = match naive {
+        Ok(naive_dt) => DateTime::from_naive_utc_and_offset(naive_dt, Utc),
+        Err(_) => Utc::now(),
+    };
+    Ok(seconds_since_epoch.timestamp() as u32)
 }

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -181,7 +181,7 @@ impl BytesInsertBatch {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq)]
 pub struct RowData {
     encoded_rows: Vec<u8>,
     num_rows: usize,

--- a/tests/consumers/test_message_processors.py
+++ b/tests/consumers/test_message_processors.py
@@ -15,6 +15,7 @@ from snuba.datasets.processors.functions_processor import FunctionsMessageProces
 from snuba.datasets.processors.metrics_summaries_processor import (
     MetricsSummariesMessageProcessor,
 )
+from snuba.datasets.processors.outcomes_processor import OutcomesProcessor
 from snuba.datasets.processors.profiles_processor import ProfilesMessageProcessor
 from snuba.datasets.processors.querylog_processor import QuerylogProcessor
 from snuba.datasets.processors.replays_processor import ReplaysProcessor
@@ -31,6 +32,7 @@ from snuba.processor import InsertBatch
         ("snuba-queries", QuerylogProcessor),
         ("snuba-spans", MetricsSummariesMessageProcessor),
         ("snuba-spans", SpansMessageProcessor),
+        ("outcomes", OutcomesProcessor),
     ],
 )
 def test_message_processors(


### PR DESCRIPTION
This ports all of the functionality from the Python message processor, including recording metrics (even though they seem like they may be unnecessary?).

It involves a small refactor to the Python message processor to produce unix timestamp instead of Python datetime objects so that the outputs of the 2 message processors are easier to compare in tests.