### PR TITLE
ref: Add hybrid querylog consumer back to gocd deployment

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -50,6 +50,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="rust-spans-reference-consumer" \
   --container-name="rust-profiles-consumer" \
   --container-name="rust-profiling-functions-consumer" \
+  --container-name="rust-querylog-consumer" \
   --container-name="spans-exp-static-off" \
   --container-name="dlq-consumer" \
   --container-name="group-attributes-consumer" \


### PR DESCRIPTION
This was removed because it was crashlooping earlier and preventing Snuba deploys from completing successfully. Let's put it back now we have re-implemented the hybrid consumer and fixed the offset reset issues that were previously causing the consumer to crash.


