### PR TITLE
fix(rust): Use jemalloc even on ARM image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,9 @@ FROM base AS application_base
 COPY . ./
 COPY --from=build_rust_snuba /usr/src/snuba/rust_snuba/target/wheels/ /tmp/rust_wheels/
 COPY --from=build_admin_ui /usr/src/snuba/snuba/admin/dist/ ./snuba/admin/dist/
-RUN apt-get install -y libjemalloc2 --no-install-recommends
 RUN set -ex; \
+    apt-get install -y libjemalloc2 --no-install-recommends; \
+    ln -s /usr/lib/*/libjemalloc.so.2 /usr/src/snuba/libjemalloc.so.2; \
     groupadd -r snuba --gid 1000; \
     useradd -r -g snuba --uid 1000 snuba; \
     chown -R snuba:snuba ./; \
@@ -117,7 +118,7 @@ RUN set -ex; \
     snuba --help
 
 ARG SOURCE_COMMIT
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+ENV LD_PRELOAD=/usr/src/snuba/libjemalloc.so.2 \
     SNUBA_RELEASE=$SOURCE_COMMIT \
     FLASK_DEBUG=0 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
The LD_PRELOAD path was hardcoded to an x86-specific path, causing random non-fatal errors in the docker build process for the ARM image such as:

```
#22 11.35 ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```

I don't exactly know how to use wildcards or commands inside of docker envvars,
so it seems simpler to symlink the file to a hardcoded location and
refer to that in LD_PRELOAD
