### PR TITLE
fix(rust): Ensure Python does not return naive datetime to Rust consumer

### DIFF
--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -15,7 +15,7 @@ import importlib
 import logging
 import os
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Deque, Mapping, Optional, Sequence, Tuple, Type, Union, cast
 
 import rapidjson
@@ -57,6 +57,11 @@ def initialize_processor(
 initialize_processor()
 
 
+def ensure_utc(value: Optional[datetime]) -> Optional[datetime]:
+    if value.tzinfo is None:
+        value.replace(tzinfo=timezone.utc)
+    return value
+
 def process_rust_message(
     message: bytes, offset: int, partition: int, timestamp: datetime
 ) -> Tuple[Sequence[bytes], Optional[datetime], Optional[datetime]]:
@@ -74,8 +79,8 @@ def process_rust_message(
 
     return (
         [json_row_encoder.encode(row) for row in rv.rows],
-        rv.origin_timestamp,
-        rv.sentry_received_timestamp,
+        ensure_utc(rv.origin_timestamp),
+        ensure_utc(rv.sentry_received_timestamp),
     )
 
 

--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -59,7 +59,7 @@ initialize_processor()
 
 def ensure_utc(value: Optional[datetime]) -> Optional[datetime]:
     if value and value.tzinfo is None:
-        value.replace(tzinfo=timezone.utc)
+        return value.replace(tzinfo=timezone.utc)
     return value
 
 

--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -58,7 +58,7 @@ initialize_processor()
 
 
 def ensure_utc(value: Optional[datetime]) -> Optional[datetime]:
-    if value.tzinfo is None:
+    if value and value.tzinfo is None:
         value.replace(tzinfo=timezone.utc)
     return value
 

--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -62,6 +62,7 @@ def ensure_utc(value: Optional[datetime]) -> Optional[datetime]:
         value.replace(tzinfo=timezone.utc)
     return value
 
+
 def process_rust_message(
     message: bytes, offset: int, partition: int, timestamp: datetime
 ) -> Tuple[Sequence[bytes], Optional[datetime], Optional[datetime]]:


### PR DESCRIPTION
This fixes crashloop in the hybrid spans consumer
