### PR TITLE
fix(docker): Migrate away from deprecated nodesource script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN set -ex; \
     [ "$SHOULD_BUILD_ADMIN_UI" = "true" ] || exit 0; \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh | bash - ${NODE_VERSION} &&\
+    curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh | bash -s -- ${NODE_VERSION} &&\
     apt-get update && \
     apt-get install -y yarn nodejs --no-install-recommends && \
     cd snuba/admin && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN set -ex; \
     [ "$SHOULD_BUILD_ADMIN_UI" = "true" ] || exit 0; \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - &&\
+    curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh | bash - ${NODE_VERSION} &&\
     apt-get update && \
     apt-get install -y yarn nodejs --no-install-recommends && \
     cd snuba/admin && \


### PR DESCRIPTION
currently getting this in logs, plus a 60-second sleep() to really make it hurt

```
#17 0.874 
#17 0.874 ================================================================================
#17 0.874 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
#17 0.874 ================================================================================
#17 0.874 
#17 0.874                            SCRIPT DEPRECATION WARNING                    
#17 0.874 
#17 0.874   
#17 0.874   This script, located at https://deb.nodesource.com/setup_X, used to
#17 0.874   install Node.js is deprecated now and will eventually be made inactive.
#17 0.874 
#17 0.874   Please visit the NodeSource distributions Github and follow the
#17 0.874   instructions to migrate your repo.
#17 0.874   https://github.com/nodesource/distributions
#17 0.874 
#17 0.874   The NodeSource Node.js Linux distributions GitHub repository contains
#17 0.874   information about which versions of Node.js and which Linux distributions
#17 0.874   are supported and how to install it.
#17 0.874   https://github.com/nodesource/distributions
#17 0.874 
#17 0.874 
#17 0.874                           SCRIPT DEPRECATION WARNING
#17 0.874 
#17 0.874 ================================================================================
#17 0.874 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
#17 0.874 ================================================================================
#17 0.874 
#17 0.874 TO AVOID THIS WAIT MIGRATE THE SCRIPT
#17 0.874 Continuing in 60 seconds (press Ctrl-C to abort) ...
#17 0.874 
```