### PR TITLE
fix(rust): Fix bug with hybrid consumer backpressure state

### DIFF
--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -229,6 +229,14 @@ class RunPythonMultiprocessing:
         except InvalidMessage:
             logger.warning("Dropping invalid message", exc_info=True)
 
+        # If there is a carried over message we should attempt to submit and clear it
+        if self.__carried_over_message is not None:
+            try:
+                self.__inner.submit(self.__carried_over_message)
+                self.__carried_over_message = None
+            except MessageRejected:
+                pass
+
         return self.__get_transformed_messages()
 
     def join(


### PR DESCRIPTION
If the hybrid consumer got a carried over message due to backpressure, we need to actually attempt to re-submit and clear it on poll. Otherwise it gets stuck in backpressure forever.
