### PR TITLE
ref(rust-docker): Build deps separately from main app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,13 @@ RUN set -ex; \
         g++ \
         gnupg \
     '; \
+    runtimeDeps=' \
+        libjemalloc2 \
+    '; \
     apt-get update; \
-    apt-get install -y $buildDeps --no-install-recommends; \
+    apt-get install -y $buildDeps $runtimeDeps --no-install-recommends; \
     pip install -r requirements-build.txt; \
+    ln -s /usr/lib/*/libjemalloc.so.2 /usr/src/snuba/libjemalloc.so.2; \
     echo "$buildDeps" > /tmp/build-deps.txt
 
 FROM build_base AS base
@@ -61,22 +65,39 @@ RUN set -ex; \
 # There are optimizations we can make in the future to split building of Rust
 # dependencies from building the Rust source code, see Relay Dockerfile.
 
-FROM build_base AS build_rust_snuba
+FROM build_base AS build_rust_snuba_base
 ARG RUST_TOOLCHAIN=1.74.1
-ARG SHOULD_BUILD_RUST=true
 
-COPY ./rust_snuba/ ./rust_snuba/
 RUN set -ex; \
-    cd ./rust_snuba/; \
-    mkdir -p ./target/wheels/; \
-    [ "$SHOULD_BUILD_RUST" = "true" ] || exit 0; \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain $RUST_TOOLCHAIN  --profile minimal -y; \
-    export PATH="$HOME/.cargo/bin/:$PATH"; \
     # use git CLI to avoid OOM on ARM64
     echo '[net]' > ~/.cargo/config; \
     echo 'git-fetch-with-cli = true' >> ~/.cargo/config; \
     echo '[registries.crates-io]' >> ~/.cargo/config; \
-    echo 'protocol = "sparse"' >> ~/.cargo/config; \
+    echo 'protocol = "sparse"' >> ~/.cargo/config
+
+ENV PATH="/root/.cargo/bin/:${PATH}"
+
+FROM build_rust_snuba_base AS build_rust_snuba_deps
+
+COPY ./rust_snuba/rust_arroyo/Cargo.toml ./rust_snuba/rust_arroyo/Cargo.toml
+COPY ./rust_snuba/rust_arroyo/Cargo.lock ./rust_snuba/rust_arroyo/Cargo.lock
+COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
+COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
+COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
+
+RUN set -ex; \
+    sh scripts/rust-dummy-build.sh; \
+    cd ./rust_snuba/; \
+    maturin build --release --compatibility linux --locked --strip
+
+FROM build_rust_snuba_base AS build_rust_snuba
+COPY . ./
+COPY --from=build_rust_snuba_deps /usr/src/snuba/rust_snuba/target/ ./rust_snuba/target/
+COPY --from=build_rust_snuba_deps /root/.cargo/ /root/.cargo/
+RUN set -ex; \
+    cd ./rust_snuba/; \
+    touch ./rust_arroyo/src/lib.rs; \
     maturin build --release --compatibility linux --locked --strip
 
 # Install nodejs and yarn and build the admin UI
@@ -104,8 +125,6 @@ COPY . ./
 COPY --from=build_rust_snuba /usr/src/snuba/rust_snuba/target/wheels/ /tmp/rust_wheels/
 COPY --from=build_admin_ui /usr/src/snuba/snuba/admin/dist/ ./snuba/admin/dist/
 RUN set -ex; \
-    apt-get install -y libjemalloc2 --no-install-recommends; \
-    ln -s /usr/lib/*/libjemalloc.so.2 /usr/src/snuba/libjemalloc.so.2; \
     groupadd -r snuba --gid 1000; \
     useradd -r -g snuba --uid 1000 snuba; \
     chown -R snuba:snuba ./; \
@@ -148,6 +167,6 @@ RUN pip install -r requirements-test.txt
 
 ARG RUST_TOOLCHAIN=1.74.1
 COPY ./rust_snuba/ ./rust_snuba/
-RUN bash -c "set -o pipefail && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain $RUST_TOOLCHAIN  --profile minimal -y"
+COPY --from=build_rust_snuba /root/.cargo/ /root/.cargo/
 ENV PATH="${PATH}:/root/.cargo/bin/"
 USER snuba

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,6 @@ ENV PATH="/root/.cargo/bin/:${PATH}"
 FROM build_rust_snuba_base AS build_rust_snuba_deps
 
 COPY ./rust_snuba/rust_arroyo/Cargo.toml ./rust_snuba/rust_arroyo/Cargo.toml
-COPY ./rust_snuba/rust_arroyo/Cargo.lock ./rust_snuba/rust_arroyo/Cargo.lock
 COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,8 +164,9 @@ FROM application_base AS testing
 USER 0
 RUN pip install -r requirements-test.txt
 
-ARG RUST_TOOLCHAIN=1.74.1
 COPY ./rust_snuba/ ./rust_snuba/
+# re-"install" rust for the testing image
 COPY --from=build_rust_snuba /root/.cargo/ /root/.cargo/
+COPY --from=build_rust_snuba /root/.rustup/ /root/.rustup/
 ENV PATH="${PATH}:/root/.cargo/bin/"
 USER snuba

--- a/scripts/rust-dummy-build.sh
+++ b/scripts/rust-dummy-build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+
+cd ./rust_snuba/
+mkdir -p ./target/wheels/
+for f in ./src/lib.rs ./rust_arroyo/src/lib.rs ./benches/processors.rs; do
+    mkdir -p "`dirname $f`"
+    touch "$f"
+done


### PR DESCRIPTION
this should make PRs where Rust consumers are touched is touched significantly faster, as only application code is being rebuilt rather than the entire rust deptree.

we considered using `cargo chef`, but it doesn't work because our build tool is `maturin`, not `cargo`.

we also saw that relay instead mounts the `target/` folder into the docker container for caching, but i felt that this was harder to implement though it's probably better