### PR TITLE
ref(rust): Introduce statsdproxy v3

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -330,6 +330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +432,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -742,6 +764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +888,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "iso8601"
@@ -1742,6 +1781,7 @@ dependencies = [
  "sentry-kafka-schemas",
  "serde",
  "serde_json",
+ "statsdproxy",
  "thiserror",
  "tokio",
  "tracing",
@@ -2121,6 +2161,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "statsdproxy"
+version = "0.1.0"
+source = "git+https://github.com/getsentry/statsdproxy#ccdd4ac90f1a3f24c75666a1313a5d006089fd88"
+dependencies = [
+ "anyhow",
+ "cadence",
+ "crc32fast",
+ "env_logger",
+ "log",
+ "thread_local",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2239,15 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2698,6 +2760,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "statsdproxy"
 version = "0.1.0"
-source = "git+https://github.com/getsentry/statsdproxy#ccdd4ac90f1a3f24c75666a1313a5d006089fd88"
+source = "git+https://github.com/getsentry/statsdproxy#60e5888a6152dc1a1d12e5905211ddee752c4ccd"
 dependencies = [
  "anyhow",
  "cadence",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0"
 tokio = { version = "1.19.2", features = ["full"] }
+statsdproxy = { version = "0.1.0", features = ["cadence-adapter"], git = "https://github.com/getsentry/statsdproxy", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = "1.5.0"

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -1,5 +1,4 @@
 use parking_lot::Mutex;
-use rust_arroyo::utils::metrics::configure_metrics;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -15,6 +14,7 @@ use rust_arroyo::processing::strategies::ProcessingStrategyFactory;
 use rust_arroyo::processing::{Callbacks, ConsumerState, RunError, StreamProcessor};
 use rust_arroyo::types::{Partition, Topic};
 use rust_arroyo::utils::clock::SystemClock;
+use rust_arroyo::utils::metrics::configure_metrics;
 use rust_snuba::{
     ClickhouseConfig, ConsumerStrategyFactory, MessageProcessorConfig, StatsDBackend, StorageConfig,
 };

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -1,4 +1,5 @@
 use parking_lot::Mutex;
+use rust_arroyo::utils::metrics::configure_metrics;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -15,11 +16,13 @@ use rust_arroyo::processing::{Callbacks, ConsumerState, RunError, StreamProcesso
 use rust_arroyo::types::{Partition, Topic};
 use rust_arroyo::utils::clock::SystemClock;
 use rust_snuba::{
-    ClickhouseConfig, ConsumerStrategyFactory, MessageProcessorConfig, StorageConfig,
+    ClickhouseConfig, ConsumerStrategyFactory, MessageProcessorConfig, StorageConfig, StatsDBackend,
 };
 use uuid::Uuid;
 
 fn main() {
+    // this sends to nowhere, but because it's UDP we won't error.
+    configure_metrics(StatsDBackend::new("127.0.0.1", 8081, "snuba.consumer", Default::default()));
     divan::main();
 }
 

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -16,13 +16,18 @@ use rust_arroyo::processing::{Callbacks, ConsumerState, RunError, StreamProcesso
 use rust_arroyo::types::{Partition, Topic};
 use rust_arroyo::utils::clock::SystemClock;
 use rust_snuba::{
-    ClickhouseConfig, ConsumerStrategyFactory, MessageProcessorConfig, StorageConfig, StatsDBackend,
+    ClickhouseConfig, ConsumerStrategyFactory, MessageProcessorConfig, StatsDBackend, StorageConfig,
 };
 use uuid::Uuid;
 
 fn main() {
     // this sends to nowhere, but because it's UDP we won't error.
-    configure_metrics(StatsDBackend::new("127.0.0.1", 8081, "snuba.consumer", Default::default()));
+    configure_metrics(StatsDBackend::new(
+        "127.0.0.1",
+        8081,
+        "snuba.consumer",
+        Default::default(),
+    ));
     divan::main();
 }
 

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -23,6 +23,6 @@ fn rust_snuba(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 // plus a pyo3 specific crate as `cdylib`.
 pub use config::{ClickhouseConfig, MessageProcessorConfig, StorageConfig};
 pub use factory::ConsumerStrategyFactory;
+pub use metrics::statsd::StatsDBackend;
 pub use strategies::noop::Noop;
 pub use strategies::python::PythonTransformStep;
-pub use metrics::statsd::StatsDBackend;

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -25,3 +25,4 @@ pub use config::{ClickhouseConfig, MessageProcessorConfig, StorageConfig};
 pub use factory::ConsumerStrategyFactory;
 pub use strategies::noop::Noop;
 pub use strategies::python::PythonTransformStep;
+pub use metrics::statsd::StatsDBackend;


### PR DESCRIPTION
re-attempt introduction of statsdproxy, failed previously at #5064. remove dbg!() statement that slows down the entire rust consumer. also fix up benchmarks to actually include statsd overhead.

main branch with benchmark fixes:

```

Timer precision: 41 ns
processors    fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ functions                │               │               │               │         │
│  ├─ 1       80.34 ms      │ 177.5 ms      │ 91.45 ms      │ 92.68 ms      │ 100     │ 100
│  │          62.23 Kitem/s │ 28.16 Kitem/s │ 54.67 Kitem/s │ 53.94 Kitem/s │         │
│  ├─ 4       51.08 ms      │ 110.4 ms      │ 57.13 ms      │ 59.04 ms      │ 100     │ 100
│  │          97.87 Kitem/s │ 45.28 Kitem/s │ 87.51 Kitem/s │ 84.68 Kitem/s │         │
│  ╰─ 16      29.58 ms      │ 51.14 ms      │ 32.56 ms      │ 34.68 ms      │ 100     │ 100
│             169 Kitem/s   │ 97.75 Kitem/s │ 153.5 Kitem/s │ 144.1 Kitem/s │         │
├─ profiles                 │               │               │               │         │
│  ├─ 1       65.33 ms      │ 95.38 ms      │ 69.42 ms      │ 71.36 ms      │ 100     │ 100
│  │          76.53 Kitem/s │ 52.42 Kitem/s │ 72.02 Kitem/s │ 70.06 Kitem/s │         │
│  ├─ 4       41.42 ms      │ 96.97 ms      │ 46.57 ms      │ 48 ms         │ 100     │ 100
│  │          120.7 Kitem/s │ 51.56 Kitem/s │ 107.3 Kitem/s │ 104.1 Kitem/s │         │
│  ╰─ 16      25.23 ms      │ 45.74 ms      │ 28.54 ms      │ 30.2 ms       │ 100     │ 100
│             198.1 Kitem/s │ 109.2 Kitem/s │ 175.1 Kitem/s │ 165.5 Kitem/s │         │
├─ querylog                 │               │               │               │         │
│  ├─ 1       167.6 ms      │ 311.9 ms      │ 184 ms        │ 188.6 ms      │ 100     │ 100
│  │          29.81 Kitem/s │ 16.02 Kitem/s │ 27.16 Kitem/s │ 26.51 Kitem/s │         │
│  ├─ 4       111.8 ms      │ 139.3 ms      │ 121 ms        │ 122.1 ms      │ 100     │ 100
│  │          44.7 Kitem/s  │ 35.88 Kitem/s │ 41.29 Kitem/s │ 40.91 Kitem/s │         │
│  ╰─ 16      66.76 ms      │ 137.9 ms      │ 74.17 ms      │ 78.17 ms      │ 100     │ 100
│             74.89 Kitem/s │ 36.23 Kitem/s │ 67.4 Kitem/s  │ 63.95 Kitem/s │         │
╰─ spans                    │               │               │               │         │
   ├─ 1       97.55 ms      │ 138.1 ms      │ 105.4 ms      │ 107.8 ms      │ 100     │ 100
   │          51.25 Kitem/s │ 36.19 Kitem/s │ 47.4 Kitem/s  │ 46.37 Kitem/s │         │
   ├─ 4       64.31 ms      │ 139.5 ms      │ 69.88 ms      │ 74.01 ms      │ 100     │ 100
   │          77.74 Kitem/s │ 35.82 Kitem/s │ 71.54 Kitem/s │ 67.55 Kitem/s │         │
   ╰─ 16      36.41 ms      │ 62.35 ms      │ 41.85 ms      │ 43.42 ms      │ 100     │ 100
              137.3 Kitem/s │ 80.18 Kitem/s │ 119.4 Kitem/s │ 115.1 Kitem/s │         │
```

this branch:

```
Timer precision: 41 ns [statsdproxy]
processors    fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ functions                │               │               │               │         │
│  ├─ 1       50.07 ms      │ 106.3 ms      │ 53.8 ms       │ 55.97 ms      │ 100     │ 100
│  │          99.85 Kitem/s │ 47 Kitem/s    │ 92.92 Kitem/s │ 89.32 Kitem/s │         │
│  ├─ 4       27.59 ms      │ 30.41 ms      │ 29.06 ms      │ 29.06 ms      │ 100     │ 100
│  │          181.2 Kitem/s │ 164.4 Kitem/s │ 172 Kitem/s   │ 172 Kitem/s   │         │
│  ╰─ 16      19.64 ms      │ 32.11 ms      │ 20.54 ms      │ 20.72 ms      │ 100     │ 100
│             254.4 Kitem/s │ 155.7 Kitem/s │ 243.4 Kitem/s │ 241.2 Kitem/s │         │
├─ profiles                 │               │               │               │         │
│  ├─ 1       41.35 ms      │ 72.7 ms       │ 43.74 ms      │ 45.5 ms       │ 100     │ 100
│  │          120.8 Kitem/s │ 68.77 Kitem/s │ 114.2 Kitem/s │ 109.8 Kitem/s │         │
│  ├─ 4       24.98 ms      │ 63.48 ms      │ 26.59 ms      │ 27.37 ms      │ 100     │ 100
│  │          200.1 Kitem/s │ 78.75 Kitem/s │ 188 Kitem/s   │ 182.6 Kitem/s │         │
│  ╰─ 16      18.28 ms      │ 40.68 ms      │ 19.53 ms      │ 20.64 ms      │ 100     │ 100
│             273.3 Kitem/s │ 122.8 Kitem/s │ 255.9 Kitem/s │ 242.1 Kitem/s │         │
├─ querylog                 │               │               │               │         │
│  ├─ 1       101.1 ms      │ 152.1 ms      │ 104.8 ms      │ 107.1 ms      │ 100     │ 100
│  │          49.45 Kitem/s │ 32.86 Kitem/s │ 47.68 Kitem/s │ 46.68 Kitem/s │         │
│  ├─ 4       53.53 ms      │ 70.61 ms      │ 57.42 ms      │ 58.19 ms      │ 100     │ 100
│  │          93.38 Kitem/s │ 70.8 Kitem/s  │ 87.07 Kitem/s │ 85.91 Kitem/s │         │
│  ╰─ 16      41.95 ms      │ 49.09 ms      │ 44.71 ms      │ 44.69 ms      │ 100     │ 100
│             119.1 Kitem/s │ 101.8 Kitem/s │ 111.8 Kitem/s │ 111.8 Kitem/s │         │
╰─ spans                    │               │               │               │         │
   ├─ 1       55.5 ms       │ 76.2 ms       │ 58.85 ms      │ 60.54 ms      │ 100     │ 100
   │          90.08 Kitem/s │ 65.61 Kitem/s │ 84.95 Kitem/s │ 82.57 Kitem/s │         │
   ├─ 4       31.67 ms      │ 56.38 ms      │ 34.49 ms      │ 35.72 ms      │ 100     │ 100
   │          157.8 Kitem/s │ 88.68 Kitem/s │ 144.9 Kitem/s │ 139.9 Kitem/s │         │
   ╰─ 16      22.08 ms      │ 72.64 ms      │ 24.25 ms      │ 25.54 ms      │ 100     │ 100
              226.3 Kitem/s │ 68.82 Kitem/s │ 206.1 Kitem/s │ 195.6 Kitem/s │         │
```