### PR TITLE
fix(rust): Disable ARM64 builds on PRs

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -32,6 +32,10 @@ jobs:
             --target application \
             .
         docker tag "$IMG_VERSIONED" "$IMG_CACHE"
+      # arm64 builds are so slow due to compiling Rust code using QEMU, let's
+      # exclude them from PR builds. we could eventually reenable them once we
+      # have improved caching by a lot.
+      if: matrix.arch != 'arm64' || github.event_name != 'pull_request'
     - name: push
       run: |
         set -euxo pipefail


### PR DESCRIPTION
there appears to be two problems with ARM64 builds:

* caches get invalidated for no obvious reasons
* QEMU is just really slow

let's disable for now. also https://github.com/getsentry/snuba/pull/5285 was probably a mistake, but not sure if it matters now with this PR. Rust is prohibitively expensive anyway and can't be built outside of the docker image.

the build is not required, but it's still expensive to run it