### PR TITLE
fix(docker): Use macos to build arm image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -12,7 +12,7 @@ jobs:
             # macos-m1 is the only ARM64 machine that GitHub actions offers,
             # but it works "fine" to build linux/arm64 images with. Faster than
             # QEMU/binfmt
-            os: macos-m1
+            os: macos-latest-xlarge
           - arch: amd64
             os: ubuntu-latest
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -24,8 +24,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: install docker
-      run: brew install docker
+    - name: install docker and start it
+      run: |
+        set -euxo pipefail
+        brew install docker
+        colima start
       if: matrix.os == 'macos-latest-xlarge'
     - name: build
       run: |

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,7 +27,7 @@ jobs:
     - name: install docker and start it
       run: |
         set -euxo pipefail
-        brew install docker
+        brew install docker colima
         colima start
       if: matrix.os == 'macos-latest-xlarge'
     - name: build

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: install docker
       run: brew install docker
-      if: matrix.os == macos-latest-xlarge
+      if: matrix.os == "macos-latest-xlarge"
     - name: build
       run: |
         set -euxo pipefail

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: install docker
       run: brew install docker
-      if: matrix.os == "macos-latest-xlarge"
+      if: matrix.os == 'macos-latest-xlarge'
     - name: build
       run: |
         set -euxo pipefail

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -24,6 +24,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: install docker
+      run: brew install docker
+      if: matrix.os == macos-latest-xlarge
     - name: build
       run: |
         set -euxo pipefail

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -7,14 +7,23 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    runs-on: ubuntu-latest
+        include:
+          - arch: arm64
+            # macos-m1 is the only ARM64 machine that GitHub actions offers,
+            # but it works "fine" to build linux/arm64 images with. Faster than
+            # QEMU/binfmt
+            os: macos-m1
+          - arch: amd64
+            os: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
     env:
       IMG_CACHE: ghcr.io/getsentry/snuba:${{ matrix.arch }}-latest
       IMG_VERSIONED: ghcr.io/getsentry/snuba:${{ matrix.arch }}-${{ github.sha }}
+
     steps:
     - uses: actions/checkout@v3
-    - run: docker run --rm --privileged tonistiigi/binfmt --install arm64
-      if: matrix.arch == 'arm64'
     - name: build
       run: |
         set -euxo pipefail
@@ -32,10 +41,6 @@ jobs:
             --target application \
             .
         docker tag "$IMG_VERSIONED" "$IMG_CACHE"
-      # arm64 builds are so slow due to compiling Rust code using QEMU, let's
-      # exclude them from PR builds. we could eventually reenable them once we
-      # have improved caching by a lot.
-      if: matrix.arch != 'arm64' || github.event_name != 'pull_request'
     - name: push
       run: |
         set -euxo pipefail


### PR DESCRIPTION
instead of using QEMU to build arm64, use macos-m1. in theory this could be faster, assuming GHA actually gives us a runner in time