### PR TITLE
fix(ci): Do not annotate diff with missing coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -22,3 +22,8 @@ coverage:
 
 github_checks:
   annotations: false
+
+ignore:
+  # This file is exercised by Rust testsuite, and we have no coverage for Rust
+  # (let alone coverage for the FFI contraption Rust + Python)
+  - "snuba/consumers/rust_processor.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,3 +19,6 @@ coverage:
         # intitialization code doesn't need to be retried
         # and so that code is not executed during that test run
         threshold: 1%
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
<img width="517" alt="Screenshot 2024-01-04 at 20 01 25" src="https://github.com/getsentry/snuba/assets/837573/405a0bcf-d0c7-45d4-882e-c9fdbc756141">

this is incredibly annoying with rust