### PR TITLE
ref(rust): Update statsdproxy

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "statsdproxy"
 version = "0.1.0"
-source = "git+https://github.com/getsentry/statsdproxy#9690f9f15a923c0a789d83a31ce4dc368c23b424"
+source = "git+https://github.com/getsentry/statsdproxy#254df23dd886a0a7c8259ccb75bf284309a92bfe"
 dependencies = [
  "anyhow",
  "cadence",


### PR DESCRIPTION
we're still trying to figure out why some consumers are missing a decent amount of metrics. now trying to apply https://github.com/getsentry/statsdproxy/pull/41