### PR TITLE
temporarily remove migrations dangerous checks

### DIFF
--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -10,4 +10,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   "snuba-migrate" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \
-  snuba migrations migrate --check-dangerous -r complete -r partial
+  snuba migrations migrate -r complete -r partial


### PR DESCRIPTION
Temporarily remove the dangerous migrations check to unblock a deployment issue
