### PR TITLE
fix(rust): Fix unbatched inserts

### DIFF
--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -149,6 +149,7 @@ impl BytesInsertBatch {
             .encoded_rows
             .extend_from_slice(&other.rows.encoded_rows);
         self.commit_log_offsets.extend(other.commit_log_offsets);
+        self.rows.num_rows += self.rows.num_rows;
         self.message_timestamp.merge(other.message_timestamp);
         self.origin_timestamp.merge(other.origin_timestamp);
         self.sentry_received_timestamp
@@ -168,7 +169,7 @@ impl BytesInsertBatch {
     }
 
     pub fn len(&self) -> usize {
-        self.rows.encoded_rows.len()
+        self.rows.num_rows
     }
 
     pub fn encoded_rows(&self) -> &[u8] {


### PR DESCRIPTION
This was an accidental change done in https://github.com/getsentry/snuba/pull/5289 between review rounds. We were counting our batch sizes in bytes, not messages.
