### PR TITLE
fix: Properly resolves bootstrap server overrides passed via CLI

### DIFF
--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -161,6 +161,11 @@ def resolve_consumer_config(
 
     assert resolved_raw_topic is not None
 
+    if bootstrap_servers:
+        resolved_raw_topic = _add_to_topic_broker_config(
+            resolved_raw_topic, "bootstrap.servers", ",".join(bootstrap_servers)
+        )
+
     if queued_max_messages_kbytes is not None:
         resolved_raw_topic = _add_to_topic_broker_config(
             resolved_raw_topic, "queued.max.messages.kbytes", queued_max_messages_kbytes
@@ -181,10 +186,24 @@ def resolve_consumer_config(
         "commit log", commit_log_topic_spec, commit_log_topic, slice_id
     )
 
+    if resolved_commit_log_topic and commit_log_bootstrap_servers:
+        resolved_commit_log_topic = _add_to_topic_broker_config(
+            resolved_commit_log_topic,
+            "bootstrap.servers",
+            ",".join(commit_log_bootstrap_servers),
+        )
+
     replacements_topic_spec = stream_loader.get_replacement_topic_spec()
     resolved_replacements_topic = _resolve_topic_config(
         "replacements topic", replacements_topic_spec, replacements_topic, slice_id
     )
+
+    if resolved_replacements_topic and replacement_bootstrap_servers:
+        resolved_replacements_topic = _add_to_topic_broker_config(
+            resolved_replacements_topic,
+            "bootstrap.servers",
+            ",".join(replacement_bootstrap_servers),
+        )
 
     resolved_env_config = _resolve_env_config()
 

--- a/tests/consumers/test_consumer_config.py
+++ b/tests/consumers/test_consumer_config.py
@@ -12,19 +12,27 @@ def test_consumer_config() -> None:
         slice_id=None,
         bootstrap_servers=["some_server:9092"],
         commit_log_bootstrap_servers=[],
-        replacement_bootstrap_servers=[],
+        replacement_bootstrap_servers=["replacements:9092", "replacements-2:9092"],
         max_batch_size=1,
         max_batch_time_ms=1000,
     )
 
     assert len(resolved.storages) == 1
     assert resolved.storages[0].clickhouse_table_name in ("errors_local", "errors_dist")
+    assert resolved.raw_topic.broker_config["bootstrap.servers"] == "some_server:9092"
     assert resolved.raw_topic.physical_topic_name == "new-events"
     assert resolved.raw_topic.logical_topic_name == "events"
     assert resolved.commit_log_topic is not None
+    assert (
+        resolved.commit_log_topic.broker_config["bootstrap.servers"] == "127.0.0.1:9092"
+    )
     assert resolved.commit_log_topic.physical_topic_name == "snuba-commit-log"
     assert resolved.replacements_topic is not None
     assert resolved.replacements_topic.physical_topic_name == "event-replacements"
+    assert (
+        resolved.replacements_topic.broker_config["bootstrap.servers"]
+        == "replacements:9092,replacements-2:9092"
+    )
     assert resolved.dlq_topic is None
 
     # Invalid storage raises

--- a/tests/consumers/test_consumer_config.py
+++ b/tests/consumers/test_consumer_config.py
@@ -23,9 +23,6 @@ def test_consumer_config() -> None:
     assert resolved.raw_topic.physical_topic_name == "new-events"
     assert resolved.raw_topic.logical_topic_name == "events"
     assert resolved.commit_log_topic is not None
-    assert (
-        resolved.commit_log_topic.broker_config["bootstrap.servers"] == "127.0.0.1:9092"
-    )
     assert resolved.commit_log_topic.physical_topic_name == "snuba-commit-log"
     assert resolved.replacements_topic is not None
     assert resolved.replacements_topic.physical_topic_name == "event-replacements"


### PR DESCRIPTION
This fixes the case where --bootstrap-server, --commit-log-bootstrap-server, or --replacement-bootstrap-server is passed via CLI, for both the rust and python consumers.

These options are generally passed only when we are migrating clusters, etc and we need to run 2 sets of consumers on different clusters side by side.
