### PR TITLE
Avoid calling `Topic::new` for every received Message

### DIFF
--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -80,14 +80,13 @@ impl KafkaConsumerState {
 
 fn create_kafka_message(topics: &[Topic], msg: BorrowedMessage) -> BrokerMessage<KafkaPayload> {
     let topic = msg.topic();
-    let topic = *topics
-        .iter()
-        .find(|t| t.as_str() == topic)
-        .unwrap_or_else(|| {
-            panic!("Received message for topic `{topic}` that we never subscribed to");
-        });
+    // NOTE: We avoid calling `Topic::new` here, as that uses a lock to intern the `topic` name.
+    // As we only ever expect one of our pre-defined topics, we can also guard against Broker errors.
+    let Some(topic) = topics.iter().find(|t| t.as_str() == topic) else {
+        panic!("Received message for topic `{topic}` that we never subscribed to");
+    };
     let partition = Partition {
-        topic,
+        topic: *topic,
         index: msg.partition() as u16,
     };
     let time_millis = msg.timestamp().to_millis().unwrap_or(0);
@@ -300,12 +299,7 @@ struct OffsetState {
 }
 
 pub struct KafkaConsumer<C: AssignmentCallbacks> {
-    // TODO: This has to be an option as of now because rdkafka requires
-    // callbacks during the instantiation. While the streaming processor
-    // can only pass the callbacks during the subscribe call.
-    // So we need to build the kafka consumer upon subscribe and not
-    // in the constructor.
-    pub consumer: BaseConsumer<CustomContext<C>>,
+    consumer: BaseConsumer<CustomContext<C>>,
     topics: Vec<Topic>,
     state: KafkaConsumerState,
     offset_state: Arc<Mutex<OffsetState>>,

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -82,11 +82,11 @@ fn create_kafka_message(topics: &[Topic], msg: BorrowedMessage) -> BrokerMessage
     let topic = msg.topic();
     // NOTE: We avoid calling `Topic::new` here, as that uses a lock to intern the `topic` name.
     // As we only ever expect one of our pre-defined topics, we can also guard against Broker errors.
-    let Some(topic) = topics.iter().find(|t| t.as_str() == topic) else {
+    let Some(&topic) = topics.iter().find(|t| t.as_str() == topic) else {
         panic!("Received message for topic `{topic}` that we never subscribed to");
     };
     let partition = Partition {
-        topic: *topic,
+        topic,
         index: msg.partition() as u16,
     };
     let time_millis = msg.timestamp().to_millis().unwrap_or(0);


### PR DESCRIPTION
That function is interning the topic name, and thus aquiring a Mutex. If we keep a list of subscribed topics locally, we avoid that and can also guard against errors.
