### PR TITLE
fix(rust): Port retention days logic from Python

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -20,7 +20,7 @@ use rust_arroyo::utils::clock::SystemClock;
 use rust_arroyo::utils::metrics::configure_metrics;
 use rust_snuba::{
     get_processing_function, ClickhouseConfig, ConsumerStrategyFactory, EnvConfig,
-    KafkaMessageMetadata, MessageProcessorConfig, StatsDBackend, StorageConfig,
+    KafkaMessageMetadata, MessageProcessorConfig, ProcessorConfig, StatsDBackend, StorageConfig,
 };
 use uuid::Uuid;
 
@@ -40,7 +40,7 @@ static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
         .unwrap()
 });
 
-static ENV_CONFIG: Lazy<EnvConfig> = Lazy::new(EnvConfig::default);
+static PROCESSOR_CONFIG: Lazy<ProcessorConfig> = Lazy::new(ProcessorConfig::default);
 
 fn create_factory(
     concurrency: usize,
@@ -144,7 +144,8 @@ fn run_fn_bench(bencher: &mut BenchmarkGroup<WallTime>, schema: &str) {
             b.iter(|| {
                 for payload in payloads {
                     let payload = KafkaPayload::new(None, None, Some(payload.to_vec()));
-                    let processed = processor_fn(payload, metadata.clone(), &ENV_CONFIG).unwrap();
+                    let processed =
+                        processor_fn(payload, metadata.clone(), &PROCESSOR_CONFIG).unwrap();
                     black_box(processed);
                 }
             })

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -3,6 +3,11 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
+#[derive(Clone, Default)]
+pub struct ProcessorConfig {
+    pub env_config: EnvConfig,
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ConsumerConfig {

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;
@@ -90,12 +90,28 @@ pub struct MessageProcessorConfig {
     pub python_module: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct EnvConfig {
     pub sentry_dsn: Option<String>,
     pub dogstatsd_host: Option<String>,
     pub dogstatsd_port: Option<u16>,
+    pub default_retention_days: u16,
+    pub lower_retention_days: u16,
+    pub valid_retention_days: HashSet<u16>,
+}
+
+impl Default for EnvConfig {
+    fn default() -> Self {
+        Self {
+            sentry_dsn: None,
+            dogstatsd_host: None,
+            dogstatsd_port: None,
+            default_retention_days: 90,
+            lower_retention_days: 30,
+            valid_retention_days: [30, 90].iter().cloned().collect(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -236,7 +236,7 @@ pub fn process_message(
         timestamp,
     };
 
-    let res = func(payload, meta, &config::EnvConfig::default())
+    let res = func(payload, meta, &config::ProcessorConfig::default())
         .map_err(|e| SnubaRustError::new_err(format!("invalid message: {:?}", e)))?;
     Ok(res.rows.into_encoded_rows())
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -84,6 +84,8 @@ pub fn consumer_impl(
 
     let mut _sentry_guard = None;
 
+    let env_config = consumer_config.env.clone();
+
     // setup sentry
     if let Some(dsn) = consumer_config.env.sentry_dsn {
         tracing::debug!(sentry_dsn = dsn);
@@ -176,6 +178,7 @@ pub fn consumer_impl(
 
     let factory = ConsumerStrategyFactory::new(
         first_storage,
+        env_config,
         logical_topic_name,
         max_batch_size,
         max_batch_time,
@@ -233,7 +236,7 @@ pub fn process_message(
         timestamp,
     };
 
-    let res = func(payload, meta)
+    let res = func(payload, meta, &config::EnvConfig::default())
         .map_err(|e| SnubaRustError::new_err(format!("invalid message: {:?}", e)))?;
     Ok(res.rows.into_encoded_rows())
 }

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -20,6 +20,7 @@ use crate::types::BytesInsertBatch;
 
 pub struct ConsumerStrategyFactory {
     storage_config: config::StorageConfig,
+    env_config: config::EnvConfig,
     logical_topic_name: String,
     max_batch_size: usize,
     max_batch_time: Duration,
@@ -40,6 +41,7 @@ impl ConsumerStrategyFactory {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         storage_config: config::StorageConfig,
+        env_config: config::EnvConfig,
         logical_topic_name: String,
         max_batch_size: usize,
         max_batch_time: Duration,
@@ -57,6 +59,7 @@ impl ConsumerStrategyFactory {
     ) -> Self {
         Self {
             storage_config,
+            env_config,
             logical_topic_name,
             max_batch_size,
             max_batch_time,
@@ -122,6 +125,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
                 &self.logical_topic_name,
                 self.enforce_schema,
                 &self.processing_concurrency,
+                self.env_config.clone(),
             ),
             _ => Box::new(
                 PythonTransformStep::new(

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -125,7 +125,9 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
                 &self.logical_topic_name,
                 self.enforce_schema,
                 &self.processing_concurrency,
-                self.env_config.clone(),
+                config::ProcessorConfig {
+                    env_config: self.env_config.clone(),
+                },
             ),
             _ => Box::new(
                 PythonTransformStep::new(

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -21,7 +21,7 @@ fn rust_snuba(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 // These are exported for the benchmarks.
 // Ideally, we would have a normal rust crate we can use in examples and benchmarks,
 // plus a pyo3 specific crate as `cdylib`.
-pub use config::{ClickhouseConfig, MessageProcessorConfig, StorageConfig};
+pub use config::{ClickhouseConfig, EnvConfig, MessageProcessorConfig, StorageConfig};
 pub use factory::ConsumerStrategyFactory;
 pub use metrics::statsd::StatsDBackend;
 pub use processors::get_processing_function;

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -21,7 +21,9 @@ fn rust_snuba(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 // These are exported for the benchmarks.
 // Ideally, we would have a normal rust crate we can use in examples and benchmarks,
 // plus a pyo3 specific crate as `cdylib`.
-pub use config::{ClickhouseConfig, EnvConfig, MessageProcessorConfig, StorageConfig};
+pub use config::{
+    ClickhouseConfig, EnvConfig, MessageProcessorConfig, ProcessorConfig, StorageConfig,
+};
 pub use factory::ConsumerStrategyFactory;
 pub use metrics::statsd::StatsDBackend;
 pub use processors::get_processing_function;

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -1,3 +1,4 @@
+use crate::config::EnvConfig;
 use anyhow::Context;
 use chrono::DateTime;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
@@ -10,6 +11,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
+    _config: &EnvConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: InputMessage = serde_json::from_slice(payload_bytes)?;
@@ -167,6 +169,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -1,4 +1,4 @@
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use anyhow::Context;
 use chrono::DateTime;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
@@ -11,7 +11,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
-    _config: &EnvConfig,
+    _config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: InputMessage = serde_json::from_slice(payload_bytes)?;
@@ -169,7 +169,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/metrics_summaries.rs
+++ b/rust_snuba/src/processors/metrics_summaries.rs
@@ -1,4 +1,4 @@
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata};
 pub fn process_message(
     payload: KafkaPayload,
     _: KafkaMessageMetadata,
-    config: &EnvConfig,
+    config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let from: InputMessage = serde_json::from_slice(payload_bytes)?;
@@ -35,7 +35,7 @@ pub fn process_message(
                 metric_mri,
                 min: summary.min,
                 project_id: from.project_id,
-                retention_days: enforce_retention(from.retention_days, config),
+                retention_days: enforce_retention(from.retention_days, &config.env_config),
                 span_id: from.span_id,
                 sum: summary.sum,
                 tag_keys,
@@ -149,7 +149,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/metrics_summaries.rs
+++ b/rust_snuba/src/processors/metrics_summaries.rs
@@ -55,7 +55,7 @@ struct InputMessage {
     #[serde(default)]
     duration_ms: u32,
     project_id: u64,
-    // #[serde(default = "default_retention_days")]
+    #[serde(default)]
     retention_days: Option<u16>,
     #[serde(deserialize_with = "hex_to_u64")]
     span_id: u64,

--- a/rust_snuba/src/processors/metrics_summaries.rs
+++ b/rust_snuba/src/processors/metrics_summaries.rs
@@ -1,15 +1,17 @@
+use crate::config::EnvConfig;
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
-use crate::processors::utils::{default_retention_days, hex_to_u64, DEFAULT_RETENTION_DAYS};
+use crate::processors::utils::{enforce_retention, hex_to_u64};
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     _: KafkaMessageMetadata,
+    config: &EnvConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let from: InputMessage = serde_json::from_slice(payload_bytes)?;
@@ -33,7 +35,7 @@ pub fn process_message(
                 metric_mri,
                 min: summary.min,
                 project_id: from.project_id,
-                retention_days: from.retention_days.unwrap_or(DEFAULT_RETENTION_DAYS),
+                retention_days: enforce_retention(from.retention_days, config),
                 span_id: from.span_id,
                 sum: summary.sum,
                 tag_keys,
@@ -53,7 +55,7 @@ struct InputMessage {
     #[serde(default)]
     duration_ms: u32,
     project_id: u64,
-    #[serde(default = "default_retention_days")]
+    // #[serde(default = "default_retention_days")]
     retention_days: Option<u16>,
     #[serde(deserialize_with = "hex_to_u64")]
     span_id: u64,
@@ -147,6 +149,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -7,12 +7,12 @@ mod replays;
 mod spans;
 mod utils;
 
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 
 pub type ProcessingFunction =
-    fn(KafkaPayload, KafkaMessageMetadata, config: &EnvConfig) -> anyhow::Result<InsertBatch>;
+    fn(KafkaPayload, KafkaMessageMetadata, config: &ProcessorConfig) -> anyhow::Result<InsertBatch>;
 
 pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
     match name {

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -7,10 +7,12 @@ mod replays;
 mod spans;
 mod utils;
 
+use crate::config::EnvConfig;
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 
-pub type ProcessingFunction = fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<InsertBatch>;
+pub type ProcessingFunction =
+    fn(KafkaPayload, KafkaMessageMetadata, config: &EnvConfig) -> anyhow::Result<InsertBatch>;
 
 pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
     match name {

--- a/rust_snuba/src/processors/outcomes.rs
+++ b/rust_snuba/src/processors/outcomes.rs
@@ -1,3 +1,4 @@
+use crate::config::EnvConfig;
 use crate::processors::utils::ensure_valid_datetime;
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 use anyhow::Context;
@@ -28,6 +29,7 @@ const CLIENT_DISCARD_REASONS: &[&str] = &[
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
+    _config: &EnvConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let mut msg: Outcome = serde_json::from_slice(payload_bytes)?;
@@ -102,7 +104,8 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        let result = process_message(payload, meta).expect("The message should be processed");
+        let result = process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
 
         let expected = b"{\"org_id\":1,\"project_id\":1,\"key_id\":null,\"timestamp\":1680029444,\"outcome\":4,\"category\":1,\"quantity\":3,\"reason\":null,\"event_id\":null}\n";
 

--- a/rust_snuba/src/processors/outcomes.rs
+++ b/rust_snuba/src/processors/outcomes.rs
@@ -1,4 +1,4 @@
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use crate::processors::utils::ensure_valid_datetime;
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 use anyhow::Context;
@@ -29,7 +29,7 @@ const CLIENT_DISCARD_REASONS: &[&str] = &[
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
-    _config: &EnvConfig,
+    _config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let mut msg: Outcome = serde_json::from_slice(payload_bytes)?;
@@ -104,7 +104,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        let result = process_message(payload, meta, &EnvConfig::default())
+        let result = process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
 
         let expected = b"{\"org_id\":1,\"project_id\":1,\"key_id\":null,\"timestamp\":1680029444,\"outcome\":4,\"category\":1,\"quantity\":3,\"reason\":null,\"event_id\":null}\n";

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -1,3 +1,4 @@
+use crate::config::EnvConfig;
 use anyhow::Context;
 use chrono::DateTime;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
@@ -9,6 +10,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
+    _config: &EnvConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let mut msg: ProfileMessage = serde_json::from_slice(payload_bytes)?;
@@ -100,6 +102,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -1,4 +1,4 @@
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use anyhow::Context;
 use chrono::DateTime;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
@@ -10,7 +10,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-    _config: &EnvConfig,
+    _config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let mut msg: ProfileMessage = serde_json::from_slice(payload_bytes)?;
@@ -102,7 +102,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
+use crate::config::EnvConfig;
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -12,6 +13,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata};
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
+    _config: &EnvConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let from: FromQuerylogMessage = serde_json::from_slice(payload_bytes)?;
@@ -424,6 +426,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -13,7 +13,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata};
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-    _config: &EnvConfig,
+    _config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let from: FromQuerylogMessage = serde_json::from_slice(payload_bytes)?;
@@ -426,7 +426,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -1,4 +1,4 @@
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata};
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-    _config: &EnvConfig,
+    _config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
 
@@ -487,7 +487,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 
@@ -533,7 +533,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 
@@ -565,7 +565,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 
@@ -596,7 +596,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -1,3 +1,4 @@
+use crate::config::EnvConfig;
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
@@ -9,6 +10,7 @@ use crate::types::{InsertBatch, KafkaMessageMetadata};
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
+    _config: &EnvConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
 
@@ -485,7 +487,8 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 
     #[test]
@@ -530,7 +533,8 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 
     #[test]
@@ -561,7 +565,8 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 
     #[test]
@@ -591,6 +596,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -6,17 +6,20 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::processors::utils::{default_retention_days, hex_to_u64, DEFAULT_RETENTION_DAYS};
+use crate::config::EnvConfig;
+use crate::processors::utils::{enforce_retention, hex_to_u64};
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
+    config: &EnvConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
 
     let mut span: Span = msg.try_into()?;
+    span.retention_days = Some(enforce_retention(span.retention_days, config));
 
     span.offset = metadata.offset;
     span.partition = metadata.partition;
@@ -40,7 +43,6 @@ struct FromSpanMessage {
     parent_span_id: u64,
     profile_id: Option<Uuid>,
     project_id: u64,
-    #[serde(default = "default_retention_days")]
     retention_days: Option<u16>,
     #[serde(default, deserialize_with = "hex_to_u64")]
     segment_id: u64,
@@ -169,7 +171,7 @@ struct Span {
     platform: String,
     profile_id: Option<Uuid>,
     project_id: u64,
-    retention_days: u16,
+    retention_days: Option<u16>,
     segment_id: u64,
     segment_name: String,
     #[serde(rename(serialize = "sentry_tags.key"))]
@@ -255,7 +257,7 @@ impl TryFrom<FromSpanMessage> for Span {
             platform: from.sentry_tags.system.unwrap_or_default(),
             profile_id: from.profile_id,
             project_id: from.project_id,
-            retention_days: from.retention_days.unwrap_or(DEFAULT_RETENTION_DAYS),
+            retention_days: from.retention_days,
             segment_id: from.segment_id,
             segment_name: from.sentry_tags.transaction.unwrap_or_default(),
             sentry_tag_keys,
@@ -474,7 +476,8 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 
     #[test]
@@ -488,7 +491,8 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 
     #[test]
@@ -502,21 +506,24 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 
     #[test]
     fn test_null_retention_days() {
         let mut span = valid_span();
-        span.retention_days = default_retention_days();
+        span.retention_days = None;
         let data = serde_json::to_vec(&span).unwrap();
         let payload = KafkaPayload::new(None, None, Some(data));
+
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 
     #[test]
@@ -530,6 +537,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta).expect("The message should be processed");
+        process_message(payload, meta, &EnvConfig::default())
+            .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -6,20 +6,20 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use crate::processors::utils::{enforce_retention, hex_to_u64};
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-    config: &EnvConfig,
+    config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
 
     let mut span: Span = msg.try_into()?;
-    span.retention_days = Some(enforce_retention(span.retention_days, config));
+    span.retention_days = Some(enforce_retention(span.retention_days, &config.env_config));
 
     span.offset = metadata.offset;
     span.partition = metadata.partition;
@@ -476,7 +476,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 
@@ -491,7 +491,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 
@@ -506,7 +506,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 
@@ -522,7 +522,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 
@@ -537,7 +537,7 @@ mod tests {
             offset: 1,
             timestamp: DateTime::from(SystemTime::now()),
         };
-        process_message(payload, meta, &EnvConfig::default())
+        process_message(payload, meta, &ProcessorConfig::default())
             .expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -1,12 +1,22 @@
+use crate::config::EnvConfig;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Deserializer};
 
-pub const DEFAULT_RETENTION_DAYS: u16 = 90;
 // Equivalent to "%Y-%m-%dT%H:%M:%S.%fZ" in python
 pub const PAYLOAD_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S.%6fZ";
 
-pub fn default_retention_days() -> Option<u16> {
-    Some(DEFAULT_RETENTION_DAYS)
+pub fn enforce_retention(value: Option<u16>, config: &EnvConfig) -> u16 {
+    let mut retention_days = value.unwrap_or(config.default_retention_days);
+
+    if !config.valid_retention_days.contains(&retention_days) {
+        if retention_days <= config.lower_retention_days {
+            retention_days = config.lower_retention_days;
+        } else {
+            retention_days = config.default_retention_days;
+        }
+    }
+
+    retention_days
 }
 
 pub fn hex_to_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -11,7 +11,7 @@ use rust_arroyo::utils::metrics::{get_metrics, BoxMetrics};
 use sentry::{Hub, SentryFutureExt};
 use sentry_kafka_schemas::{Schema, SchemaError};
 
-use crate::config::EnvConfig;
+use crate::config::ProcessorConfig;
 use crate::processors::ProcessingFunction;
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
@@ -21,7 +21,7 @@ pub fn make_rust_processor(
     schema_name: &str,
     enforce_schema: bool,
     concurrency: &ConcurrencyConfig,
-    env_config: EnvConfig,
+    processor_config: ProcessorConfig,
 ) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
     let schema = get_schema(schema_name, enforce_schema);
     let metrics = get_metrics();
@@ -31,7 +31,7 @@ pub fn make_rust_processor(
         enforce_schema,
         metrics,
         func,
-        env_config,
+        processor_config,
     };
 
     Box::new(RunTaskInThreads::new(
@@ -64,7 +64,7 @@ struct MessageProcessor {
     enforce_schema: bool,
     metrics: BoxMetrics,
     func: ProcessingFunction,
-    env_config: EnvConfig,
+    processor_config: ProcessorConfig,
 }
 
 impl MessageProcessor {
@@ -146,7 +146,7 @@ impl MessageProcessor {
             timestamp: msg.timestamp,
         };
 
-        let transformed = (self.func)(msg.payload, metadata, &self.env_config)?;
+        let transformed = (self.func)(msg.payload, metadata, &self.processor_config)?;
 
         let payload = BytesInsertBatch::new(
             transformed.rows,
@@ -187,7 +187,6 @@ mod tests {
     use rust_arroyo::backends::kafka::types::KafkaPayload;
     use rust_arroyo::types::{Message, Partition, Topic};
 
-    use crate::config::EnvConfig;
     use crate::types::InsertBatch;
     use crate::Noop;
 
@@ -199,7 +198,7 @@ mod tests {
         fn noop_processor(
             _payload: KafkaPayload,
             _metadata: KafkaMessageMetadata,
-            _config: &EnvConfig,
+            _config: &ProcessorConfig,
         ) -> anyhow::Result<InsertBatch> {
             Ok(InsertBatch::default())
         }
@@ -210,7 +209,7 @@ mod tests {
             "outcomes",
             true,
             &concurrency,
-            EnvConfig::default(),
+            ProcessorConfig::default(),
         );
 
         let example = "{

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -46,6 +46,9 @@ class EnvConfig:
     sentry_dsn: Optional[str]
     dogstatsd_host: Optional[str]
     dogstatsd_port: Optional[int]
+    default_retention_days: int
+    lower_retention_days: int
+    valid_retention_days: list[int]
 
 
 @dataclass(frozen=True)
@@ -116,10 +119,16 @@ def _resolve_env_config() -> EnvConfig:
     sentry_dsn = settings.SENTRY_DSN
     dogstatsd_host = settings.DOGSTATSD_HOST
     dogstatsd_port = settings.DOGSTATSD_PORT
+    default_retention_days = settings.DEFAULT_RETENTION_DAYS
+    lower_retention_days = settings.LOWER_RETENTION_DAYS
+    valid_retention_days = list(settings.VALID_RETENTION_DAYS)
     return EnvConfig(
         sentry_dsn=sentry_dsn,
         dogstatsd_host=dogstatsd_host,
         dogstatsd_port=dogstatsd_port,
+        default_retention_days=default_retention_days,
+        lower_retention_days=lower_retention_days,
+        valid_retention_days=valid_retention_days,
     )
 
 


### PR DESCRIPTION
Validates that the retention days matches one of the valid retention days provided via settings. This is very important otherwise invalid values can create too many clickhouse parts. This function is used in most of our message processors as is also needed for metrics, errors, etc.

