### PR TITLE
fix(querylog): don't change the readonly setting with QUERY settings

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -60,7 +60,7 @@ class ClickhouseClientSettings(Enum):
         10000,
     )
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
-    QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
+    QUERY = ClickhouseClientSettingsType({}, None)
     QUERYLOG = ClickhouseClientSettingsType({}, None)
     TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(


### PR DESCRIPTION
This readonly setting does not need to be changed on the client side. Remove this line so we can use system queries with the internal user profile that can change max threads