### PR TITLE
ref(rust): Refactor Kafka configuration

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -24,7 +24,7 @@ fn main() {
         InitialOffset::Latest,
         false,
         30_000,
-        None,
+        Default::default(),
     );
 
     let topic = Topic::new("test_static");

--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -1,6 +1,6 @@
 extern crate rust_arroyo;
 
-use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::config::KafkaConsumerConfig;
 use rust_arroyo::backends::kafka::InitialOffset;
 use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::backends::AssignmentCallbacks;
@@ -18,7 +18,7 @@ impl AssignmentCallbacks for EmptyCallbacks {
 fn main() {
     tracing_subscriber::fmt::init();
 
-    let config = KafkaConfig::new_consumer_config(
+    let config = KafkaConsumerConfig::new(
         vec!["127.0.0.1:9092".to_string()],
         "my_group".to_string(),
         InitialOffset::Latest,

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -25,7 +25,7 @@ fn main() {
         InitialOffset::Latest,
         false,
         30_000,
-        None,
+        Default::default(),
     );
 
     let mut processor =

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -1,7 +1,7 @@
 extern crate rust_arroyo;
 
 use chrono::Duration;
-use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::config::KafkaConsumerConfig;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::kafka::InitialOffset;
 use rust_arroyo::processing::strategies::commit_offsets::CommitOffsets;
@@ -19,7 +19,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for TestFactory {
 fn main() {
     tracing_subscriber::fmt::init();
 
-    let config = KafkaConfig::new_consumer_config(
+    let config = KafkaConsumerConfig::new(
         vec!["127.0.0.1:9092".to_string()],
         "my_group".to_string(),
         InitialOffset::Latest,

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -5,7 +5,7 @@
 extern crate rust_arroyo;
 
 use rdkafka::message::ToBytes;
-use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::config::{KafkaConfig, KafkaConsumerConfig};
 use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::kafka::InitialOffset;
@@ -73,7 +73,7 @@ async fn main() {
         }
     }
 
-    let config = KafkaConfig::new_consumer_config(
+    let config = KafkaConsumerConfig::new(
         vec!["0.0.0.0:9092".to_string()],
         "my_group".to_string(),
         InitialOffset::Latest,
@@ -84,7 +84,7 @@ async fn main() {
 
     let factory = ReverseStringAndProduceStrategyFactory {
         concurrency: ConcurrencyConfig::new(5),
-        config: config.clone(),
+        config: config.core.clone(),
         topic: Topic::new("test_out"),
     };
 

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -79,7 +79,7 @@ async fn main() {
         InitialOffset::Latest,
         false,
         30_000,
-        None,
+        Default::default(),
     );
 
     let factory = ReverseStringAndProduceStrategyFactory {

--- a/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
@@ -11,45 +11,39 @@ pub struct OffsetResetConfig {
 
 #[derive(Debug, Clone)]
 pub struct KafkaConfig {
-    config_map: HashMap<String, String>,
+    bootstrap_servers: Vec<String>,
+    extra_config: HashMap<String, String>,
 }
 
 impl KafkaConfig {
     pub fn new_config(
         bootstrap_servers: Vec<String>,
-        override_params: Option<HashMap<String, String>>,
+        extra_config: HashMap<String, String>,
     ) -> Self {
-        let mut config_map = HashMap::new();
-        config_map.insert("bootstrap.servers".to_string(), bootstrap_servers.join(","));
-        let mut config = Self { config_map };
-
-        config.apply_override_params(override_params);
-        config
+        Self {
+            bootstrap_servers,
+            extra_config,
+        }
     }
 
     pub fn new_producer_config(
         bootstrap_servers: Vec<String>,
-        override_params: Option<HashMap<String, String>>,
+        extra_config: HashMap<String, String>,
     ) -> Self {
-        let mut config = KafkaConfig::new_config(bootstrap_servers, None);
-
-        config.apply_override_params(override_params);
-        config
-    }
-
-    fn apply_override_params(&mut self, override_params: Option<HashMap<String, String>>) {
-        if let Some(params) = override_params {
-            for (param, value) in params {
-                self.config_map.insert(param, value);
-            }
-        }
+        Self::new_config(bootstrap_servers, extra_config)
     }
 }
 
 impl From<KafkaConfig> for RdKafkaConfig {
     fn from(cfg: KafkaConfig) -> Self {
         let mut config_obj = RdKafkaConfig::new();
-        for (key, val) in cfg.config_map.iter() {
+
+        config_obj.set(
+            "bootstrap.servers".to_string(),
+            cfg.bootstrap_servers.join(","),
+        );
+
+        for (key, val) in cfg.extra_config.into_iter() {
             config_obj.set(key, val);
         }
 
@@ -60,6 +54,9 @@ impl From<KafkaConfig> for RdKafkaConfig {
 #[derive(Debug, Clone)]
 pub struct KafkaConsumerConfig {
     pub core: KafkaConfig,
+    pub group_id: String,
+    pub max_poll_interval_ms: usize,
+    pub session_timeout_ms: Option<usize>,
     pub offset_reset: OffsetResetConfig,
 }
 
@@ -70,31 +67,22 @@ impl KafkaConsumerConfig {
         auto_offset_reset: InitialOffset,
         strict_offset_reset: bool,
         max_poll_interval_ms: usize,
-        override_params: Option<HashMap<String, String>>,
+        extra_config: HashMap<String, String>,
     ) -> Self {
-        let mut core = KafkaConfig::new_config(bootstrap_servers, None);
-        core.config_map.insert("group.id".to_string(), group_id);
-        core.config_map
-            .insert("enable.auto.commit".to_string(), "false".to_string());
-
-        core.config_map.insert(
-            "max.poll.interval.ms".to_string(),
-            max_poll_interval_ms.to_string(),
-        );
-
+        let core = KafkaConfig::new_config(bootstrap_servers, extra_config);
         // HACK: If the max poll interval is less than 45 seconds, set the session timeout
         // to the same. (its default is 45 seconds and it must be <= to max.poll.interval.ms)
-        if max_poll_interval_ms < 45_000 {
-            core.config_map.insert(
-                "session.timeout.ms".to_string(),
-                max_poll_interval_ms.to_string(),
-            );
-        }
-
-        core.apply_override_params(override_params);
+        let session_timeout_ms = if max_poll_interval_ms < 45_000 {
+            Some(max_poll_interval_ms)
+        } else {
+            None
+        };
 
         Self {
             core,
+            group_id,
+            max_poll_interval_ms,
+            session_timeout_ms,
             offset_reset: OffsetResetConfig {
                 auto_offset_reset,
                 strict_offset_reset,
@@ -105,8 +93,23 @@ impl KafkaConsumerConfig {
 
 impl From<KafkaConsumerConfig> for RdKafkaConfig {
     fn from(cfg: KafkaConsumerConfig) -> Self {
-        let KafkaConsumerConfig { core, offset_reset } = cfg;
+        let KafkaConsumerConfig {
+            core,
+            group_id,
+            max_poll_interval_ms,
+            session_timeout_ms,
+            offset_reset,
+        } = cfg;
+
         let mut result = Self::from(core);
+
+        result.set("enable.auto.commit".to_string(), "false".to_string());
+        result.set("group.id", group_id);
+        result.set("max.poll.interval.ms", max_poll_interval_ms.to_string());
+
+        if let Some(session_timeout_ms) = session_timeout_ms {
+            result.set("session.timeout.ms", session_timeout_ms.to_string());
+        }
 
         // NOTE: Offsets are explicitly managed as part of the assignment
         // callback, so preemptively resetting offsets is not enabled when
@@ -137,10 +140,10 @@ mod tests {
             InitialOffset::Error,
             false,
             30_000,
-            Some(HashMap::from([(
+            HashMap::from([(
                 "queued.max.messages.kbytes".to_string(),
                 "1000000".to_string(),
-            )])),
+            )]),
         );
 
         let rdkafka_config: RdKafkaConfig = config.into();

--- a/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
@@ -12,8 +12,6 @@ pub struct OffsetResetConfig {
 #[derive(Debug, Clone)]
 pub struct KafkaConfig {
     config_map: HashMap<String, String>,
-    // Only applies to consumers
-    offset_reset_config: Option<OffsetResetConfig>,
 }
 
 impl KafkaConfig {
@@ -23,60 +21,28 @@ impl KafkaConfig {
     ) -> Self {
         let mut config_map = HashMap::new();
         config_map.insert("bootstrap.servers".to_string(), bootstrap_servers.join(","));
-        let config = Self {
-            config_map,
-            offset_reset_config: None,
-        };
+        let mut config = Self { config_map };
 
-        apply_override_params(config, override_params)
-    }
-
-    pub fn new_consumer_config(
-        bootstrap_servers: Vec<String>,
-        group_id: String,
-        auto_offset_reset: InitialOffset,
-        strict_offset_reset: bool,
-        max_poll_interval_ms: usize,
-        override_params: Option<HashMap<String, String>>,
-    ) -> Self {
-        let mut config = KafkaConfig::new_config(bootstrap_servers, None);
-        config.offset_reset_config = Some(OffsetResetConfig {
-            auto_offset_reset,
-            strict_offset_reset,
-        });
-        config.config_map.insert("group.id".to_string(), group_id);
+        config.apply_override_params(override_params);
         config
-            .config_map
-            .insert("enable.auto.commit".to_string(), "false".to_string());
-
-        config.config_map.insert(
-            "max.poll.interval.ms".to_string(),
-            max_poll_interval_ms.to_string(),
-        );
-
-        // HACK: If the max poll interval is less than 45 seconds, set the session timeout
-        // to the same. (its default is 45 seconds and it must be <= to max.poll.interval.ms)
-        if max_poll_interval_ms < 45_000 {
-            config.config_map.insert(
-                "session.timeout.ms".to_string(),
-                max_poll_interval_ms.to_string(),
-            );
-        }
-
-        apply_override_params(config, override_params)
     }
 
     pub fn new_producer_config(
         bootstrap_servers: Vec<String>,
         override_params: Option<HashMap<String, String>>,
     ) -> Self {
-        let config = KafkaConfig::new_config(bootstrap_servers, None);
+        let mut config = KafkaConfig::new_config(bootstrap_servers, None);
 
-        apply_override_params(config, override_params)
+        config.apply_override_params(override_params);
+        config
     }
 
-    pub fn offset_reset_config(&self) -> Option<&OffsetResetConfig> {
-        self.offset_reset_config.as_ref()
+    fn apply_override_params(&mut self, override_params: Option<HashMap<String, String>>) {
+        if let Some(params) = override_params {
+            for (param, value) in params {
+                self.config_map.insert(param, value);
+            }
+        }
     }
 }
 
@@ -87,44 +53,85 @@ impl From<KafkaConfig> for RdKafkaConfig {
             config_obj.set(key, val);
         }
 
-        // NOTE: Offsets are explicitly managed as part of the assignment
-        // callback, so preemptively resetting offsets is not enabled when
-        // strict_offset_reset is enabled.
-        if let Some(config) = cfg.offset_reset_config {
-            let auto_offset_reset = if config.strict_offset_reset {
-                InitialOffset::Error
-            } else {
-                config.auto_offset_reset
-            };
-            config_obj.set("auto.offset.reset", auto_offset_reset.to_string());
-        }
         config_obj
     }
 }
 
-fn apply_override_params(
-    mut config: KafkaConfig,
-    override_params: Option<HashMap<String, String>>,
-) -> KafkaConfig {
-    if let Some(params) = override_params {
-        for (param, value) in params {
-            config.config_map.insert(param, value);
+#[derive(Debug, Clone)]
+pub struct KafkaConsumerConfig {
+    pub core: KafkaConfig,
+    pub offset_reset: OffsetResetConfig,
+}
+
+impl KafkaConsumerConfig {
+    pub fn new(
+        bootstrap_servers: Vec<String>,
+        group_id: String,
+        auto_offset_reset: InitialOffset,
+        strict_offset_reset: bool,
+        max_poll_interval_ms: usize,
+        override_params: Option<HashMap<String, String>>,
+    ) -> Self {
+        let mut core = KafkaConfig::new_config(bootstrap_servers, None);
+        core.config_map.insert("group.id".to_string(), group_id);
+        core.config_map
+            .insert("enable.auto.commit".to_string(), "false".to_string());
+
+        core.config_map.insert(
+            "max.poll.interval.ms".to_string(),
+            max_poll_interval_ms.to_string(),
+        );
+
+        // HACK: If the max poll interval is less than 45 seconds, set the session timeout
+        // to the same. (its default is 45 seconds and it must be <= to max.poll.interval.ms)
+        if max_poll_interval_ms < 45_000 {
+            core.config_map.insert(
+                "session.timeout.ms".to_string(),
+                max_poll_interval_ms.to_string(),
+            );
+        }
+
+        core.apply_override_params(override_params);
+
+        Self {
+            core,
+            offset_reset: OffsetResetConfig {
+                auto_offset_reset,
+                strict_offset_reset,
+            },
         }
     }
-    config
+}
+
+impl From<KafkaConsumerConfig> for RdKafkaConfig {
+    fn from(cfg: KafkaConsumerConfig) -> Self {
+        let KafkaConsumerConfig { core, offset_reset } = cfg;
+        let mut result = Self::from(core);
+
+        // NOTE: Offsets are explicitly managed as part of the assignment
+        // callback, so preemptively resetting offsets is not enabled when
+        // strict_offset_reset is enabled.
+        let auto_offset_reset = if offset_reset.strict_offset_reset {
+            InitialOffset::Error
+        } else {
+            offset_reset.auto_offset_reset
+        };
+        result.set("auto.offset.reset", auto_offset_reset.to_string());
+
+        result
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::backends::kafka::InitialOffset;
+    use crate::backends::kafka::{config::KafkaConsumerConfig, InitialOffset};
 
-    use super::KafkaConfig;
     use rdkafka::config::ClientConfig as RdKafkaConfig;
     use std::collections::HashMap;
 
     #[test]
     fn test_build_consumer_configuration() {
-        let config = KafkaConfig::new_consumer_config(
+        let config = KafkaConsumerConfig::new(
             vec!["127.0.0.1:9092".to_string()],
             "my-group".to_string(),
             InitialOffset::Error,

--- a/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
@@ -16,21 +16,11 @@ pub struct KafkaConfig {
 }
 
 impl KafkaConfig {
-    pub fn new_config(
-        bootstrap_servers: Vec<String>,
-        extra_config: HashMap<String, String>,
-    ) -> Self {
+    pub fn new(bootstrap_servers: Vec<String>, extra_config: HashMap<String, String>) -> Self {
         Self {
             bootstrap_servers,
             extra_config,
         }
-    }
-
-    pub fn new_producer_config(
-        bootstrap_servers: Vec<String>,
-        extra_config: HashMap<String, String>,
-    ) -> Self {
-        Self::new_config(bootstrap_servers, extra_config)
     }
 }
 
@@ -69,7 +59,7 @@ impl KafkaConsumerConfig {
         max_poll_interval_ms: usize,
         extra_config: HashMap<String, String>,
     ) -> Self {
-        let core = KafkaConfig::new_config(bootstrap_servers, extra_config);
+        let core = KafkaConfig::new(bootstrap_servers, extra_config);
         // HACK: If the max poll interval is less than 45 seconds, set the session timeout
         // to the same. (its default is 45 seconds and it must be <= to max.poll.interval.ms)
         let session_timeout_ms = if max_poll_interval_ms < 45_000 {

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -591,7 +591,7 @@ mod tests {
             Default::default(),
         );
 
-        let producer_configuration = KafkaConfig::new_producer_config(
+        let producer_configuration = KafkaConfig::new(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
             Default::default(),
         );

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -540,7 +540,7 @@ mod tests {
             InitialOffset::Latest,
             false,
             30_000,
-            None,
+            Default::default(),
         );
         let topic = Topic::new("test");
         KafkaConsumer::new(configuration, &[topic], EmptyCallbacks {}).unwrap();
@@ -555,7 +555,7 @@ mod tests {
             InitialOffset::Latest,
             false,
             30_000,
-            None,
+            Default::default(),
         );
         let mut consumer =
             KafkaConsumer::new(configuration, &[topic.topic], EmptyCallbacks {}).unwrap();
@@ -647,7 +647,7 @@ mod tests {
             InitialOffset::Latest,
             false,
             30_000,
-            None,
+            Default::default(),
         );
 
         let mut consumer =

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -588,12 +588,12 @@ mod tests {
             InitialOffset::Earliest,
             true,
             30_000,
-            None,
+            Default::default(),
         );
 
         let producer_configuration = KafkaConfig::new_producer_config(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
-            None,
+            Default::default(),
         );
 
         let producer = KafkaProducer::new(producer_configuration);
@@ -687,7 +687,7 @@ mod tests {
             InitialOffset::Earliest,
             true,
             60_000,
-            None,
+            Default::default(),
         );
 
         let mut consumer =

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -48,8 +48,10 @@ mod tests {
     fn test_producer() {
         let topic = Topic::new("test");
         let destination = TopicOrPartition::Topic(topic);
-        let configuration =
-            KafkaConfig::new_producer_config(vec!["127.0.0.1:9092".to_string()], None);
+        let configuration = KafkaConfig::new_producer_config(
+            vec!["127.0.0.1:9092".to_string()],
+            Default::default(),
+        );
 
         let producer = KafkaProducer::new(configuration);
 

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -48,10 +48,8 @@ mod tests {
     fn test_producer() {
         let topic = Topic::new("test");
         let destination = TopicOrPartition::Topic(topic);
-        let configuration = KafkaConfig::new_producer_config(
-            vec!["127.0.0.1:9092".to_string()],
-            Default::default(),
-        );
+        let configuration =
+            KafkaConfig::new(vec!["127.0.0.1:9092".to_string()], Default::default());
 
         let producer = KafkaProducer::new(configuration);
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use parking_lot::{Mutex, MutexGuard};
 use thiserror::Error;
 
-use crate::backends::kafka::config::KafkaConfig;
+use crate::backends::kafka::config::KafkaConsumerConfig;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::kafka::KafkaConsumer;
 use crate::backends::{AssignmentCallbacks, CommitOffsets, Consumer, ConsumerError};
@@ -204,7 +204,7 @@ pub struct StreamProcessor<TPayload: Clone> {
 
 impl StreamProcessor<KafkaPayload> {
     pub fn with_kafka<F: ProcessingStrategyFactory<KafkaPayload> + 'static>(
-        config: KafkaConfig,
+        config: KafkaConsumerConfig,
         factory: F,
         topic: Topic,
         dlq_policy: Option<DlqPolicy<KafkaPayload>>,

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -91,7 +91,7 @@ mod tests {
     use std::time::SystemTime;
 
     use super::*;
-    use crate::backends::kafka::config::KafkaConfig;
+    use crate::backends::kafka::config::KafkaConsumerConfig;
     use crate::backends::kafka::producer::KafkaProducer;
     use crate::backends::kafka::InitialOffset;
     use crate::backends::local::broker::LocalBroker;
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_produce() {
-        let config = KafkaConfig::new_consumer_config(
+        let config = KafkaConsumerConfig::new(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
             "my_group".to_string(),
             InitialOffset::Latest,
@@ -176,7 +176,7 @@ mod tests {
             }
         }
 
-        let producer: KafkaProducer = KafkaProducer::new(config);
+        let producer: KafkaProducer = KafkaProducer::new(config.core.clone());
         let concurrency = ConcurrencyConfig::new(10);
         let mut strategy = Produce::new(
             Noop {},

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -91,9 +91,8 @@ mod tests {
     use std::time::SystemTime;
 
     use super::*;
-    use crate::backends::kafka::config::{KafkaConfig, KafkaConsumerConfig};
+    use crate::backends::kafka::config::KafkaConfig;
     use crate::backends::kafka::producer::KafkaProducer;
-    use crate::backends::kafka::InitialOffset;
     use crate::backends::local::broker::LocalBroker;
     use crate::backends::local::LocalProducer;
     use crate::backends::storages::memory::MemoryMessageStorage;
@@ -144,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_produce() {
-        let config = KafkaConfig::new_config(
+        let config = KafkaConfig::new(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
             Default::default(),
         );

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -150,7 +150,7 @@ mod tests {
             InitialOffset::Latest,
             false,
             30_000,
-            None,
+            Default::default(),
         );
 
         let partition = Partition::new(Topic::new("test"), 0);

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -91,7 +91,7 @@ mod tests {
     use std::time::SystemTime;
 
     use super::*;
-    use crate::backends::kafka::config::KafkaConsumerConfig;
+    use crate::backends::kafka::config::{KafkaConfig, KafkaConsumerConfig};
     use crate::backends::kafka::producer::KafkaProducer;
     use crate::backends::kafka::InitialOffset;
     use crate::backends::local::broker::LocalBroker;
@@ -144,12 +144,8 @@ mod tests {
 
     #[test]
     fn test_produce() {
-        let config = KafkaConsumerConfig::new(
+        let config = KafkaConfig::new_config(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
-            "my_group".to_string(),
-            InitialOffset::Latest,
-            false,
-            30_000,
             Default::default(),
         );
 
@@ -176,7 +172,7 @@ mod tests {
             }
         }
 
-        let producer: KafkaProducer = KafkaProducer::new(config.core.clone());
+        let producer: KafkaProducer = KafkaProducer::new(config);
         let concurrency = ConcurrencyConfig::new(10);
         let mut strategy = Produce::new(
             Noop {},

--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -105,7 +105,7 @@ impl TestTopic {
 
     pub fn produce(&self, payload: KafkaPayload) {
         let producer_configuration =
-            KafkaConfig::new_producer_config(vec![get_default_broker()], Default::default());
+            KafkaConfig::new(vec![get_default_broker()], Default::default());
 
         let producer = KafkaProducer::new(producer_configuration);
 

--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -105,7 +105,7 @@ impl TestTopic {
 
     pub fn produce(&self, payload: KafkaPayload) {
         let producer_configuration =
-            KafkaConfig::new_producer_config(vec![get_default_broker()], None);
+            KafkaConfig::new_producer_config(vec![get_default_broker()], Default::default());
 
         let producer = KafkaProducer::new(producer_configuration);
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 
-use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::config::{KafkaConfig, KafkaConsumerConfig};
 use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::processing::dlq::{DlqLimit, DlqPolicy, KafkaDlqProducer};
@@ -122,7 +122,7 @@ pub fn consumer_impl(
         first_storage.name,
     );
 
-    let config = KafkaConfig::new_consumer_config(
+    let config = KafkaConsumerConfig::new(
         vec![],
         consumer_group.to_owned(),
         auto_offset_reset.parse().expect(

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -163,8 +163,7 @@ pub fn consumer_impl(
     };
 
     let commit_log_producer = if let Some(topic_config) = consumer_config.commit_log_topic {
-        let producer_config =
-            KafkaConfig::new_producer_config(vec![], Some(topic_config.broker_config));
+        let producer_config = KafkaConfig::new_producer_config(vec![], topic_config.broker_config);
         let producer = KafkaProducer::new(producer_config);
         Some((
             Arc::new(producer),

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -130,7 +130,7 @@ pub fn consumer_impl(
         ),
         !no_strict_offset_reset,
         max_poll_interval_ms,
-        Some(consumer_config.raw_topic.broker_config),
+        consumer_config.raw_topic.broker_config,
     );
 
     let logical_topic_name = consumer_config.raw_topic.logical_topic_name;
@@ -141,7 +141,7 @@ pub fn consumer_impl(
         true => None,
         false => consumer_config.dlq_topic.map(|dlq_topic_config| {
             let producer_config =
-                KafkaConfig::new_producer_config(vec![], Some(dlq_topic_config.broker_config));
+                KafkaConfig::new_producer_config(vec![], dlq_topic_config.broker_config);
             let producer = KafkaProducer::new(producer_config);
 
             let kafka_dlq_producer = Box::new(KafkaDlqProducer::new(


### PR DESCRIPTION
This introduces a `KafkaConsumerConfig` struct containing all the fields a `KafkaConsumer` needs. Unfortunately this leaves the base `KafkaConfig` a bit anemic—it only has `bootstrap_servers` and a map `extra_config` of additional options.

Arguably this is overcomplicated. Feel free to reject if you don't think it's worth the trouble.