### PR TITLE
fix(rust): Actually count num_rows correctly

### DIFF
--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -149,7 +149,7 @@ impl BytesInsertBatch {
             .encoded_rows
             .extend_from_slice(&other.rows.encoded_rows);
         self.commit_log_offsets.extend(other.commit_log_offsets);
-        self.rows.num_rows += self.rows.num_rows;
+        self.rows.num_rows += other.rows.num_rows;
         self.message_timestamp.merge(other.message_timestamp);
         self.origin_timestamp.merge(other.origin_timestamp);
         self.sentry_received_timestamp


### PR DESCRIPTION
In https://github.com/getsentry/snuba/pull/5314 I introduced another
bug: Rowcount is always zero, as we always add 0 to 0.

This means:

1. bad metrics and logs
2. bad batching

need to be careful when rolling out
