### PR TITLE
fix: Remove any panics in threads

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -33,7 +33,8 @@ impl TaskRunner<KafkaPayload, KafkaPayload, ProducerError> for ProduceMessage {
 
         Box::pin(async move {
             producer
-                .produce(&topic, message.payload().clone()).map_err(RunTaskError::Other)?;
+                .produce(&topic, message.payload().clone())
+                .map_err(RunTaskError::Other)?;
             Ok(message)
         })
     }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -15,16 +15,17 @@ use crate::utils::metrics::{get_metrics, BoxMetrics};
 use crate::utils::timing::Deadline;
 
 #[derive(Clone, Debug)]
-pub enum RunTaskError {
+pub enum RunTaskError<TError>{
     RetryableError,
     InvalidMessage(InvalidMessage),
+    Other(TError),
 }
 
-pub type RunTaskFunc<TTransformed> =
-    Pin<Box<dyn Future<Output = Result<Message<TTransformed>, RunTaskError>> + Send>>;
+pub type RunTaskFunc<TTransformed, TError> =
+    Pin<Box<dyn Future<Output = Result<Message<TTransformed>, RunTaskError<TError>>> + Send>>;
 
-pub trait TaskRunner<TPayload, TTransformed>: Send + Sync {
-    fn get_task(&self, message: Message<TPayload>) -> RunTaskFunc<TTransformed>;
+pub trait TaskRunner<TPayload, TTransformed, TError>: Send + Sync {
+    fn get_task(&self, message: Message<TPayload>) -> RunTaskFunc<TTransformed, TError>;
 }
 
 /// This is configuration for the [`RunTaskInThreads`] strategy.
@@ -77,22 +78,22 @@ enum RuntimeOrHandle {
     Runtime(Runtime),
 }
 
-pub struct RunTaskInThreads<TPayload, TTransformed> {
+pub struct RunTaskInThreads<TPayload, TTransformed, TError> {
     next_step: Box<dyn ProcessingStrategy<TTransformed>>,
-    task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
+    task_runner: Box<dyn TaskRunner<TPayload, TTransformed, TError>>,
     concurrency: usize,
     runtime: Handle,
-    handles: VecDeque<JoinHandle<Result<Message<TTransformed>, RunTaskError>>>,
+    handles: VecDeque<JoinHandle<Result<Message<TTransformed>, RunTaskError<TError>>>>,
     message_carried_over: Option<Message<TTransformed>>,
     commit_request_carried_over: Option<CommitRequest>,
     metrics: BoxMetrics,
     metric_name: String,
 }
 
-impl<TPayload, TTransformed> RunTaskInThreads<TPayload, TTransformed> {
+impl<TPayload, TTransformed, TError> RunTaskInThreads<TPayload, TTransformed, TError> {
     pub fn new<N>(
         next_step: N,
-        task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
+        task_runner: Box<dyn TaskRunner<TPayload, TTransformed, TError>>,
         concurrency: &ConcurrencyConfig,
         // If provided, this name is used for metrics
         custom_strategy_name: Option<&'static str>,
@@ -116,8 +117,10 @@ impl<TPayload, TTransformed> RunTaskInThreads<TPayload, TTransformed> {
     }
 }
 
-impl<TPayload, TTransformed: Send + Sync + 'static> ProcessingStrategy<TPayload>
-    for RunTaskInThreads<TPayload, TTransformed>
+impl<TPayload, TTransformed, TError> ProcessingStrategy<TPayload>
+    for RunTaskInThreads<TPayload, TTransformed, TError>
+    where TTransformed: Send + Sync + 'static,
+          TError: Into<Box<dyn std::error::Error>> + Send + Sync + 'static,
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         let commit_request = self.next_step.poll()?;
@@ -165,8 +168,17 @@ impl<TPayload, TTransformed: Send + Sync + 'static> ProcessingStrategy<TPayload>
                     Ok(Err(RunTaskError::RetryableError)) => {
                         tracing::error!("retryable error");
                     }
+                    Ok(Err(RunTaskError::Other(error))) => {
+                        // XXX: at some point we should extend the error return type of poll() to
+                        // pass those errors through to the stream processor
+                        let error: Box<dyn std::error::Error> = error.into();
+                        tracing::error!(error, "the thread errored");
+                        panic!("the thread errored");
+                    }
                     Err(error) => {
-                        let error: &dyn std::error::Error = &error;
+                        // XXX: at some point we should extend the error return type of poll() to
+                        // pass those errors through to the stream processor
+                        let error: Box<dyn std::error::Error> = error.into();
                         tracing::error!(error, "the thread crashed");
                         panic!("the thread crashed");
                     }
@@ -248,8 +260,8 @@ mod tests {
 
     struct IdentityTaskRunner {}
 
-    impl<T: Send + Sync + 'static> TaskRunner<T, T> for IdentityTaskRunner {
-        fn get_task(&self, message: Message<T>) -> RunTaskFunc<T> {
+    impl<T: Send + Sync + 'static> TaskRunner<T, T, ()> for IdentityTaskRunner {
+        fn get_task(&self, message: Message<T>) -> RunTaskFunc<T, TError> {
             Box::pin(async move { Ok(message) })
         }
     }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -15,7 +15,7 @@ use crate::utils::metrics::{get_metrics, BoxMetrics};
 use crate::utils::timing::Deadline;
 
 #[derive(Clone, Debug)]
-pub enum RunTaskError<TError>{
+pub enum RunTaskError<TError> {
     RetryableError,
     InvalidMessage(InvalidMessage),
     Other(TError),
@@ -119,8 +119,9 @@ impl<TPayload, TTransformed, TError> RunTaskInThreads<TPayload, TTransformed, TE
 
 impl<TPayload, TTransformed, TError> ProcessingStrategy<TPayload>
     for RunTaskInThreads<TPayload, TTransformed, TError>
-    where TTransformed: Send + Sync + 'static,
-          TError: Into<Box<dyn std::error::Error>> + Send + Sync + 'static,
+where
+    TTransformed: Send + Sync + 'static,
+    TError: Into<Box<dyn std::error::Error>> + Send + Sync + 'static,
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         let commit_request = self.next_step.poll()?;
@@ -260,8 +261,8 @@ mod tests {
 
     struct IdentityTaskRunner {}
 
-    impl<T: Send + Sync + 'static> TaskRunner<T, T, ()> for IdentityTaskRunner {
-        fn get_task(&self, message: Message<T>) -> RunTaskFunc<T, TError> {
+    impl<T: Send + Sync + 'static> TaskRunner<T, T, &'static str> for IdentityTaskRunner {
+        fn get_task(&self, message: Message<T>) -> RunTaskFunc<T, &'static str> {
             Box::pin(async move { Ok(message) })
         }
     }

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, CONNECTION};
 use reqwest::{Client, Response};
 use rust_arroyo::processing::strategies::run_task_in_threads::{
-    ConcurrencyConfig, RunTaskFunc, RunTaskInThreads, TaskRunner, RunTaskError,
+    ConcurrencyConfig, RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
 use rust_arroyo::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
@@ -34,7 +34,10 @@ impl ClickhouseWriter {
 }
 
 impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for ClickhouseWriter {
-    fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
+    fn get_task(
+        &self,
+        message: Message<BytesInsertBatch>,
+    ) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
         let skip_write = self.skip_write;
         let client = self.client.clone();
         let metrics = self.metrics;
@@ -48,7 +51,10 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for Clickhous
             } else {
                 tracing::debug!("performing write");
 
-                let response = client.send(insert_batch.encoded_rows()).await.map_err(RunTaskError::Other)?;
+                let response = client
+                    .send(insert_batch.encoded_rows())
+                    .await
+                    .map_err(RunTaskError::Other)?;
 
                 tracing::debug!(?response);
                 tracing::info!("Inserted {} rows", insert_batch.len());

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, CONNECTION};
 use reqwest::{Client, Response};
 use rust_arroyo::processing::strategies::run_task_in_threads::{
-    ConcurrencyConfig, RunTaskFunc, RunTaskInThreads, TaskRunner,
+    ConcurrencyConfig, RunTaskFunc, RunTaskInThreads, TaskRunner, RunTaskError,
 };
 use rust_arroyo::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
@@ -33,8 +33,8 @@ impl ClickhouseWriter {
     }
 }
 
-impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ClickhouseWriter {
-    fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch> {
+impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for ClickhouseWriter {
+    fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
         let skip_write = self.skip_write;
         let client = self.client.clone();
         let metrics = self.metrics;
@@ -48,7 +48,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ClickhouseWriter {
             } else {
                 tracing::debug!("performing write");
 
-                let response = client.send(insert_batch.encoded_rows()).await.unwrap();
+                let response = client.send(insert_batch.encoded_rows()).await.map_err(RunTaskError::Other)?;
 
                 tracing::debug!(?response);
                 tracing::info!("Inserted {} rows", insert_batch.len());
@@ -76,7 +76,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ClickhouseWriter {
 }
 
 pub struct ClickhouseWriterStep {
-    inner: RunTaskInThreads<BytesInsertBatch, BytesInsertBatch>,
+    inner: RunTaskInThreads<BytesInsertBatch, BytesInsertBatch, anyhow::Error>,
 }
 
 impl ClickhouseWriterStep {

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -122,7 +122,10 @@ impl ProduceMessage {
 }
 
 impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for ProduceMessage {
-    fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
+    fn get_task(
+        &self,
+        message: Message<BytesInsertBatch>,
+    ) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
         let producer = self.producer.clone();
         let destination: TopicOrPartition = self.destination.into();
         let topic = self.topic;

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -121,8 +121,8 @@ impl ProduceMessage {
     }
 }
 
-impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ProduceMessage {
-    fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch> {
+impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for ProduceMessage {
+    fn get_task(&self, message: Message<BytesInsertBatch>) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
         let producer = self.producer.clone();
         let destination: TopicOrPartition = self.destination.into();
         let topic = self.topic;
@@ -160,7 +160,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ProduceMessage {
 }
 
 pub struct ProduceCommitLog {
-    inner: RunTaskInThreads<BytesInsertBatch, BytesInsertBatch>,
+    inner: RunTaskInThreads<BytesInsertBatch, BytesInsertBatch, anyhow::Error>,
 }
 
 impl ProduceCommitLog {

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -70,7 +70,11 @@ impl MessageProcessor {
     ) -> Result<Message<BytesInsertBatch>, RunTaskError<anyhow::Error>> {
         let msg = match message.inner_message {
             InnerMessage::BrokerMessage(msg) => msg,
-            _ => return Err(RunTaskError::Other(anyhow::anyhow!("Unexpected message type"))),
+            _ => {
+                return Err(RunTaskError::Other(anyhow::anyhow!(
+                    "Unexpected message type"
+                )))
+            }
         };
 
         let maybe_err = RunTaskError::InvalidMessage(InvalidMessage {
@@ -170,8 +174,10 @@ impl MessageProcessor {
 }
 
 impl TaskRunner<KafkaPayload, BytesInsertBatch, anyhow::Error> for MessageProcessor {
-    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
-
+    fn get_task(
+        &self,
+        message: Message<KafkaPayload>,
+    ) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
         Box::pin(
             self.clone()
                 .process_message(message)

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -66,17 +66,26 @@ struct MessageProcessor {
 impl MessageProcessor {
     async fn process_message(
         self,
-        msg: BrokerMessage<KafkaPayload>,
-    ) -> Result<Message<BytesInsertBatch>, RunTaskError> {
+        message: Message<KafkaPayload>,
+    ) -> Result<Message<BytesInsertBatch>, RunTaskError<anyhow::Error>> {
+        let msg = match message.inner_message {
+            InnerMessage::BrokerMessage(msg) => msg,
+            _ => return Err(RunTaskError::Other(anyhow::anyhow!("Unexpected message type"))),
+        };
+
         let maybe_err = RunTaskError::InvalidMessage(InvalidMessage {
             partition: msg.partition,
             offset: msg.offset,
         });
 
         let kafka_payload = &msg.payload.clone();
-        let payload = kafka_payload.payload().ok_or(maybe_err.clone())?;
+        let Some(payload) = kafka_payload.payload() else {
+            return Err(maybe_err);
+        };
 
-        if self.validate_schema(payload).is_err() {
+        if let Err(error) = self.validate_schema(payload) {
+            let error: &dyn std::error::Error = &error;
+            tracing::error!(error, "Failed schema validation");
             return Err(maybe_err);
         };
 
@@ -160,16 +169,12 @@ impl MessageProcessor {
     }
 }
 
-impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
-    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<BytesInsertBatch> {
-        let broker_message = match message.inner_message {
-            InnerMessage::BrokerMessage(msg) => msg,
-            _ => panic!("Unexpected message type"),
-        };
+impl TaskRunner<KafkaPayload, BytesInsertBatch, anyhow::Error> for MessageProcessor {
+    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
 
         Box::pin(
             self.clone()
-                .process_message(broker_message)
+                .process_message(message)
                 .bind_hub(Hub::new_from_top(Hub::current())),
         )
     }


### PR DESCRIPTION
This causes a lot of double-erroring, and at least within
RunTaskInThreads we can carry forward errors normally. We still have to
remove panics in the main thread, but this should already cut down a few
duplicate errors we are seeing today.
