### PR TITLE
fix(migrations): give team-sns permissions to run migrations

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -39,7 +39,8 @@
     },
     {
       "members": [
-        "group:team-ops@sentry.io"
+        "group:team-ops@sentry.io",
+        "group:team-sns@sentry.io"
       ],
       "role": "roles/AllMigrationsExecutor"
     }


### PR DESCRIPTION
Gives perms to SnS to run blocking migrations so that SnS can run blocking migrations from the snuba-admin site.
