### PR TITLE
feat(MQL): Bump snuba-sdk to 2.0.18 and support arbitrary functions in MQL parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ sentry-redis-tools==0.1.7
 sentry-relay==0.8.39
 sentry-sdk==1.28.0
 simplejson==3.17.6
-snuba-sdk==2.0.17
+snuba-sdk==2.0.18
 structlog==22.3.0
 structlog-sentry==2.0.0
 sql-metadata==2.6.0

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -379,7 +379,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         assert isinstance(target.expression, SelectedExpression)
         column = target.expression.expression
         arbitrary_function = SelectedExpression(
-            name=arbitrary_function_name,
+            name=target.expression.name,
             expression=FunctionCall(
                 alias=None,
                 function_name=arbitrary_function_name,

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -377,19 +377,18 @@ class MQLVisitor(NodeVisitor):  # type: ignore
             Literal(alias=None, value=param[-1]) for param in params
         ]
         assert isinstance(target.expression, SelectedExpression)
-        aggregate = target.expression.expression
-        assert isinstance(aggregate, FunctionCall)
-        new_aggregate = FunctionCall(
+        assert isinstance(target.expression.expression, FunctionCall)
+        aggregate = FunctionCall(
             alias=None,
-            function_name=aggregate.function_name,
-            parameters=aggregate.parameters,
+            function_name=target.expression.expression.function_name,
+            parameters=target.expression.expression.parameters,
         )
         arbitrary_function = SelectedExpression(
             name=target.expression.name,
             expression=FunctionCall(
                 alias=target.expression.name,
                 function_name=arbitrary_function_name,
-                parameters=(new_aggregate, *arbitrary_function_params),
+                parameters=(aggregate, *arbitrary_function_params),
             ),
         )
         target.expression = arbitrary_function

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -376,6 +376,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         arbitrary_function_params = [
             Literal(alias=None, value=param[-1]) for param in params
         ]
+        assert isinstance(target.expression, SelectedExpression)
         column = target.expression.expression
         arbitrary_function = SelectedExpression(
             name=arbitrary_function_name,

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -55,7 +55,7 @@ logger = logging.getLogger("snuba.mql.parser")
 
 @dataclass
 class InitialParseResult:
-    aggregate: SelectedExpression | None = None
+    expression: SelectedExpression | None = None
     groupby: List[SelectedExpression] | None = None
     conditions: List[Expression] | None = None
     mri: str | None = None
@@ -323,7 +323,7 @@ class MQLVisitor(NodeVisitor):  # type: ignore
                 parameters=tuple(Column(None, None, "value")),
             ),
         )
-        target.aggregate = selected_aggregate
+        target.expression = selected_aggregate
         return target
 
     def visit_curried_aggregate(
@@ -354,7 +354,38 @@ class MQLVisitor(NodeVisitor):  # type: ignore
                 (Column(None, None, "value"),),
             ),
         )
-        target.aggregate = selected_aggregate_column
+        target.expression = selected_aggregate_column
+        return target
+
+    def visit_arbitrary_function(
+        self,
+        node: Node,
+        children: Tuple[
+            str,
+            Tuple[
+                Any,
+                Sequence[InitialParseResult],
+                Sequence[Sequence[Union[str, int, float]]],
+                Any,
+            ],
+        ],
+    ) -> InitialParseResult:
+        arbitrary_function_name, zero_or_one = children
+        _, expr, params, *_ = zero_or_one
+        _, target, _ = expr
+        arbitrary_function_params = [
+            Literal(alias=None, value=param[-1]) for param in params
+        ]
+        column = target.expression.expression
+        arbitrary_function = SelectedExpression(
+            name=arbitrary_function_name,
+            expression=FunctionCall(
+                alias=None,
+                function_name=arbitrary_function_name,
+                parameters=(column, *arbitrary_function_params),
+            ),
+        )
+        target.expression = arbitrary_function
         return target
 
     def visit_param(
@@ -381,6 +412,14 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         return agg_params
 
     def visit_aggregate_name(self, node: Node, children: Sequence[Any]) -> str:
+        assert isinstance(node.text, str)
+        return node.text
+
+    def visit_curried_aggregate_name(self, node: Node, children: Sequence[Any]) -> str:
+        assert isinstance(node.text, str)
+        return node.text
+
+    def visit_arbitrary_function_name(self, node: Node, children: Sequence[Any]) -> str:
         assert isinstance(node.text, str)
         return node.text
 
@@ -438,10 +477,10 @@ def parse_mql_query_body(
         """
         exp_tree = MQL_GRAMMAR.parse(body)
         parsed: InitialParseResult = MQLVisitor().visit(exp_tree)
-        if not parsed.aggregate:
-            raise ParsingException("No aggregate specified in MQL query")
+        if not parsed.expression:
+            raise ParsingException("No expression specified in MQL query")
 
-        selected_columns = [parsed.aggregate]
+        selected_columns = [parsed.expression]
         if parsed.groupby:
             selected_columns.extend(parsed.groupby)
         groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -377,13 +377,19 @@ class MQLVisitor(NodeVisitor):  # type: ignore
             Literal(alias=None, value=param[-1]) for param in params
         ]
         assert isinstance(target.expression, SelectedExpression)
-        column = target.expression.expression
+        aggregate = target.expression.expression
+        assert isinstance(aggregate, FunctionCall)
+        new_aggregate = FunctionCall(
+            alias=None,
+            function_name=aggregate.function_name,
+            parameters=aggregate.parameters,
+        )
         arbitrary_function = SelectedExpression(
             name=target.expression.name,
             expression=FunctionCall(
-                alias=None,
+                alias=target.expression.name,
                 function_name=arbitrary_function_name,
-                parameters=(column, *arbitrary_function_params),
+                parameters=(new_aggregate, *arbitrary_function_params),
             ),
         )
         target.expression = arbitrary_function

--- a/tests/query/parser/test_mql_query.py
+++ b/tests/query/parser/test_mql_query.py
@@ -1374,6 +1374,259 @@ mql_test_cases = [
         "metrics",
         id="Select metric with filter for metrics dataset",
     ),
+    pytest.param(
+        'apdex(sum(`d:transactions/duration@millisecond`), 500){dist:["dist1", "dist2"]}',
+        {
+            "entity": "generic_metrics_distributions",
+            "start": "2021-01-01T00:00:00",
+            "end": "2021-01-02T00:00:00",
+            "rollup": {
+                "orderby": "ASC",
+                "granularity": 60,
+                "interval": None,
+                "with_totals": None,
+            },
+            "scope": {
+                "org_ids": [1],
+                "project_ids": [1],
+                "use_case_id": "transactions",
+            },
+            "limit": None,
+            "offset": None,
+            "indexer_mappings": {
+                "d:transactions/duration@millisecond": 123456,
+                "dist": 888,
+            },
+        },
+        Query(
+            QueryEntity(
+                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "apdex",
+                    FunctionCall(
+                        None,
+                        "apdex",
+                        (
+                            FunctionCall(
+                                "_snuba_aggregate_value",
+                                "sum",
+                                (Column("_snuba_value", None, "value"),),
+                            ),
+                            Literal(None, 500),
+                        ),
+                    ),
+                ),
+            ],
+            groupby=[],
+            condition=FunctionCall(
+                None,
+                "and",
+                (
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            Column(
+                                "_snuba_granularity",
+                                None,
+                                "granularity",
+                            ),
+                            Literal(None, 60),
+                        ),
+                    ),
+                    FunctionCall(
+                        None,
+                        "and",
+                        (
+                            FunctionCall(
+                                None,
+                                "in",
+                                (
+                                    Column(
+                                        "_snuba_project_id",
+                                        None,
+                                        "project_id",
+                                    ),
+                                    FunctionCall(
+                                        None,
+                                        "tuple",
+                                        (Literal(None, 1),),
+                                    ),
+                                ),
+                            ),
+                            FunctionCall(
+                                None,
+                                "and",
+                                (
+                                    FunctionCall(
+                                        None,
+                                        "in",
+                                        (
+                                            Column(
+                                                "_snuba_org_id",
+                                                None,
+                                                "org_id",
+                                            ),
+                                            FunctionCall(
+                                                None,
+                                                "tuple",
+                                                (Literal(None, 1),),
+                                            ),
+                                        ),
+                                    ),
+                                    FunctionCall(
+                                        None,
+                                        "and",
+                                        (
+                                            FunctionCall(
+                                                None,
+                                                "equals",
+                                                (
+                                                    Column(
+                                                        "_snuba_use_case_id",
+                                                        None,
+                                                        "use_case_id",
+                                                    ),
+                                                    Literal(None, "transactions"),
+                                                ),
+                                            ),
+                                            FunctionCall(
+                                                None,
+                                                "and",
+                                                (
+                                                    FunctionCall(
+                                                        None,
+                                                        "greaterOrEquals",
+                                                        (
+                                                            Column(
+                                                                "_snuba_timestamp",
+                                                                None,
+                                                                "timestamp",
+                                                            ),
+                                                            Literal(
+                                                                None,
+                                                                datetime(
+                                                                    2021, 1, 1, 0, 0
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    FunctionCall(
+                                                        None,
+                                                        "and",
+                                                        (
+                                                            FunctionCall(
+                                                                None,
+                                                                "less",
+                                                                (
+                                                                    Column(
+                                                                        "_snuba_timestamp",
+                                                                        None,
+                                                                        "timestamp",
+                                                                    ),
+                                                                    Literal(
+                                                                        None,
+                                                                        datetime(
+                                                                            2021,
+                                                                            1,
+                                                                            2,
+                                                                            0,
+                                                                            0,
+                                                                        ),
+                                                                    ),
+                                                                ),
+                                                            ),
+                                                            FunctionCall(
+                                                                None,
+                                                                "and",
+                                                                (
+                                                                    FunctionCall(
+                                                                        None,
+                                                                        "equals",
+                                                                        (
+                                                                            Column(
+                                                                                "_snuba_metric_id",
+                                                                                None,
+                                                                                "metric_id",
+                                                                            ),
+                                                                            Literal(
+                                                                                None,
+                                                                                123456,
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                    FunctionCall(
+                                                                        None,
+                                                                        "in",
+                                                                        (
+                                                                            SubscriptableReference(
+                                                                                "_snuba_tags_raw[888]",
+                                                                                column=Column(
+                                                                                    "_snuba_tags_raw",
+                                                                                    None,
+                                                                                    "tags_raw",
+                                                                                ),
+                                                                                key=Literal(
+                                                                                    None,
+                                                                                    "888",
+                                                                                ),
+                                                                            ),
+                                                                            FunctionCall(
+                                                                                None,
+                                                                                "tuple",
+                                                                                (
+                                                                                    Literal(
+                                                                                        None,
+                                                                                        "dist1",
+                                                                                    ),
+                                                                                    Literal(
+                                                                                        None,
+                                                                                        "dist2",
+                                                                                    ),
+                                                                                ),
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            order_by=[
+                OrderBy(
+                    OrderByDirection.ASC,
+                    FunctionCall(
+                        alias="_snuba_aggregate_value",
+                        function_name="sum",
+                        parameters=(
+                            (
+                                Column(
+                                    alias="_snuba_value",
+                                    table_name=None,
+                                    column_name="value",
+                                ),
+                            )
+                        ),
+                    ),
+                ),
+            ],
+            limit=1000,
+        ),
+        "generic_metrics",
+        id="Select metric with arbitrary function",
+    ),
 ]
 
 

--- a/tests/query/parser/test_mql_query.py
+++ b/tests/query/parser/test_mql_query.py
@@ -1407,11 +1407,11 @@ mql_test_cases = [
                 SelectedExpression(
                     "aggregate_value",
                     FunctionCall(
-                        None,
+                        "_snuba_aggregate_value",
                         "apdex",
                         (
                             FunctionCall(
-                                "_snuba_aggregate_value",
+                                None,
                                 "sum",
                                 (Column("_snuba_value", None, "value"),),
                             ),
@@ -1608,16 +1608,15 @@ mql_test_cases = [
                 OrderBy(
                     OrderByDirection.ASC,
                     FunctionCall(
-                        alias="_snuba_aggregate_value",
-                        function_name="sum",
-                        parameters=(
-                            (
-                                Column(
-                                    alias="_snuba_value",
-                                    table_name=None,
-                                    column_name="value",
-                                ),
-                            )
+                        "_snuba_aggregate_value",
+                        "apdex",
+                        (
+                            FunctionCall(
+                                None,
+                                "sum",
+                                (Column("_snuba_value", None, "value"),),
+                            ),
+                            Literal(None, 500),
                         ),
                     ),
                 ),

--- a/tests/query/parser/test_mql_query.py
+++ b/tests/query/parser/test_mql_query.py
@@ -1405,7 +1405,7 @@ mql_test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "apdex",
+                    "aggregate_value",
                     FunctionCall(
                         None,
                         "apdex",


### PR DESCRIPTION
### Overview
In [snuba-sdk 2.0.18](https://github.com/getsentry/snuba-sdk/releases/tag/2.0.18), support for arbitrary functions were added in the MQL grammar. This change needs to be reflected in the MQL to LogicalQuery visitor class as well. This PR is responsible for adding visitors to handle arbitrary functions and creates the appropriate expressions for them in the AST.