### PR TITLE
feat(hybrid): Support invalid message from python in rust consumer

### DIFF
--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -139,6 +139,7 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
         }
 
         let mut apply_backpressure = false;
+        let mut invalid_message: Option<InvalidMessage> = None;
 
         Python::with_gil(|py| -> PyResult<()> {
             let python_strategy = self.python_strategy.lock();
@@ -165,13 +166,23 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
                         timestamp,
                     );
 
-                    let rv: u8 = python_strategy
+                    let rv: (u8, Option<InvalidMessageMetadata>) = python_strategy
                         .call_method1(py, "submit", args)?
                         .extract(py)?;
 
                     match rv {
-                        1 => {
+                        (1, _) => {
                             apply_backpressure = true;
+                        }
+                        (2, meta) => {
+                            let metadata = meta.unwrap();
+                            invalid_message = Some(InvalidMessage {
+                                partition: Partition {
+                                    topic: Topic::new(&metadata.topic),
+                                    index: metadata.partition,
+                                },
+                                offset: metadata.offset,
+                            });
                         }
                         _ => {
                             tracing::debug!("successfully submitted to multiprocessing");
@@ -182,6 +193,10 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
             Ok(())
         })
         .unwrap();
+
+        if let Some(msg) = invalid_message {
+            return Err(SubmitError::InvalidMessage(msg));
+        }
 
         if apply_backpressure {
             return Err(SubmitError::MessageRejected(MessageRejected { message }));
@@ -241,6 +256,23 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
             self.commit_request_carried_over.take(),
             next_commit,
         ))
+    }
+}
+
+#[derive(Debug)]
+struct InvalidMessageMetadata {
+    pub topic: String,
+    pub partition: u16,
+    pub offset: u64,
+}
+
+impl FromPyObject<'_> for InvalidMessageMetadata {
+    fn extract(dict: &'_ PyAny) -> PyResult<Self> {
+        Ok(InvalidMessageMetadata {
+            topic: dict.get_item("topic")?.extract()?,
+            partition: dict.get_item("partition")?.extract()?,
+            offset: dict.get_item("offset")?.extract()?,
+        })
     }
 }
 

--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -16,7 +16,17 @@ import logging
 import os
 from collections import deque
 from datetime import datetime, timezone
-from typing import Deque, Mapping, Optional, Sequence, Tuple, Type, Union, cast
+from typing import (
+    Deque,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypedDict,
+    Union,
+    cast,
+)
 
 import rapidjson
 from arroyo.dlq import InvalidMessage
@@ -99,10 +109,12 @@ def wrap_process_message(
 ) -> Union[FilteredPayload, ReturnValue]:
     value = message.value
     assert isinstance(value, BrokerValue)
-
-    return process_rust_message(
-        value.payload, value.offset, value.partition.index, value.timestamp
-    )
+    try:
+        return process_rust_message(
+            value.payload, value.offset, value.partition.index, value.timestamp
+        )
+    except Exception:
+        raise InvalidMessage(value.partition, value.offset)
 
 
 class TransformedMessages:
@@ -136,6 +148,12 @@ class Next(ProcessingStrategy[Union[FilteredPayload, ReturnValue]]):
         self.__transformed_messages = transformed_messages
 
     def submit(self, message: Message[Union[FilteredPayload, ReturnValue]]) -> None:
+        # XXX: Filtered payload are created by the multiprocessing strategy in place
+        # of invalid messages so their offsets get committed. They are not currently
+        # supported in the hybrid consumer. This means the offsets of invalid messages
+        # do not get committed
+        if isinstance(message.payload, FilteredPayload):
+            return
         self.__transformed_messages.append(cast(Message[ReturnValue], message))
 
     def poll(self) -> None:
@@ -152,6 +170,11 @@ class Next(ProcessingStrategy[Union[FilteredPayload, ReturnValue]]):
 
 
 DEFAULT_BLOCK_SIZE = int(32 * 1e6)
+
+
+InvalidMessageMetadata = TypedDict(
+    "InvalidMessageMetadata", {"topic": str, "partition": int, "offset": int}
+)
 
 
 class RunPythonMultiprocessing:
@@ -187,25 +210,31 @@ class RunPythonMultiprocessing:
         offset: int,
         partition: int,
         timestamp: datetime,
-    ) -> int:
+    ) -> Tuple[int, Optional[InvalidMessageMetadata]]:
         # HACK: There is probably a better way to handle exceptions in Rust
         # 0 means message successfully submitted
         # 1 means backpressure
-        # Invalid message is not currently supported
+        # 2 means invalid message
         if self.__carried_over_message is not None:
-            return 1
+            return (1, None)
 
         message = Message(
             BrokerValue(payload, Partition(Topic(topic), partition), offset, timestamp)
         )
         try:
             self.__inner.submit(message)
-        except InvalidMessage:
-            logger.warning("Dropping invalid message", exc_info=True)
+        except InvalidMessage as exc:
+            return (
+                2,
+                {
+                    "topic": exc.partition.topic.name,
+                    "partition": exc.partition.index,
+                    "offset": exc.offset,
+                },
+            )
         except MessageRejected:
             self.__carried_over_message = message
-
-        return 0
+        return (0, None)
 
     def __get_transformed_messages(self) -> Sequence[ReturnValueWithCommittable]:
         return [


### PR DESCRIPTION
If the message processing function fails in the hybrid consumer, we raise an invalid message exception and DLQ the bad message if one is configured.
