### PR TITLE
ref(docker): Remove ARM64 images [INC-604]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,15 +6,13 @@ jobs:
   build:
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64]
     runs-on: ubuntu-latest
     env:
       IMG_CACHE: ghcr.io/getsentry/snuba:${{ matrix.arch }}-latest
       IMG_VERSIONED: ghcr.io/getsentry/snuba:${{ matrix.arch }}-${{ github.sha }}
     steps:
     - uses: actions/checkout@v3
-    - run: docker run --rm --privileged tonistiigi/binfmt --install arm64
-      if: matrix.arch == 'arm64'
     - name: build
       run: |
         set -euxo pipefail
@@ -32,10 +30,6 @@ jobs:
             --target application \
             .
         docker tag "$IMG_VERSIONED" "$IMG_CACHE"
-      # arm64 builds are so slow due to compiling Rust code using QEMU, let's
-      # exclude them from PR builds. we could eventually reenable them once we
-      # have improved caching by a lot.
-      if: matrix.arch != 'arm64' || github.event_name != 'pull_request'
     - name: push
       run: |
         set -euxo pipefail
@@ -52,7 +46,5 @@ jobs:
     - run: |
         set -euxo pipefail
         docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
-        docker manifest create ghcr.io/getsentry/snuba:latest \
-          ghcr.io/getsentry/snuba:arm64-latest \
-          ghcr.io/getsentry/snuba:amd64-latest
+        docker manifest create ghcr.io/getsentry/snuba:latest ghcr.io/getsentry/snuba:amd64-latest
         docker manifest push ghcr.io/getsentry/snuba:latest


### PR DESCRIPTION
A while ago we added ARM64 images in #3094  because there was some issue with
running the x86 docker container on macos. We can't reproduce that issue
anymore with either colima or orbstack. colton tested colima, i tested
orbstack.

meanwhile, our ARM64 build is ridiculously slow especially since we added Rust,
and for some reason we don't understand also keeps invalidating caches,
guaranteeing a 80 minute build time on almost every commit.

Because of the slow build time, the multiarch image also takes 80 minutes to build, and so every breakage we push to snuba master only manifests in broken sentry CI after 80 minutes. That's a problem for reverting the breaking commits in Snuba efficiently as well, because the revert also takes 80 minutes.