### PR TITLE
feat(spans): Set origin_timestamp for spans

### DIFF
--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -14,6 +14,7 @@ pub fn process_message(
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: InputMessage = serde_json::from_slice(payload_bytes)?;
+
     let functions = msg.functions.iter().map(|from| {
         Function {
             profile_id: msg.profile_id,
@@ -39,8 +40,8 @@ pub fn process_message(
     });
 
     Ok(InsertBatch {
-        rows: RowData::from_rows(functions)?,
         origin_timestamp: DateTime::from_timestamp(msg.received, 0),
+        rows: RowData::from_rows(functions)?,
         sentry_received_timestamp: None,
     })
 }

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -5,24 +5,26 @@ use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::processors::utils::enforce_retention;
 use crate::types::{InsertBatch, KafkaMessageMetadata, RowData};
 
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-    _config: &ProcessorConfig,
+    config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
     let mut msg: ProfileMessage = serde_json::from_slice(payload_bytes)?;
 
+    msg.retention_days = Some(enforce_retention(msg.retention_days, &config.env_config));
     msg.offset = metadata.offset;
     msg.partition = metadata.partition;
 
     let origin_timestamp = DateTime::from_timestamp(msg.received, 0);
 
     Ok(InsertBatch {
-        rows: RowData::from_rows([msg])?,
         origin_timestamp,
+        rows: RowData::from_rows([msg])?,
         sentry_received_timestamp: None,
     })
 }
@@ -50,7 +52,7 @@ struct ProfileMessage {
     profile_id: Uuid,
     project_id: u64,
     received: i64,
-    retention_days: u32,
+    retention_days: Option<u16>,
     trace_id: Uuid,
     transaction_id: Uuid,
     transaction_name: String,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -418,6 +418,7 @@ mod tests {
         parent_span_id: Option<String>,
         profile_id: Option<Uuid>,
         project_id: Option<u64>,
+        received: Option<f64>,
         retention_days: Option<u16>,
         segment_id: Option<String>,
         sentry_tags: TestSentryTags,
@@ -438,15 +439,8 @@ mod tests {
             profile_id: Some(Uuid::new_v4()),
             project_id: Some(1),
             retention_days: Some(90),
+            received: Some(1691105878.720),
             segment_id: Some("deadbeefdeadbeef".into()),
-            span_id: Some("deadbeefdeadbeef".into()),
-            start_timestamp_ms: Some(1691105878720),
-            trace_id: Some(Uuid::new_v4()),
-            tags: Some(BTreeMap::from([
-                ("tag1".into(), "value1".into()),
-                ("tag2".into(), "123".into()),
-                ("tag3".into(), "true".into()),
-            ])),
             sentry_tags: TestSentryTags {
                 action: Some("GET".into()),
                 domain: Some("targetdomain.tld:targetport".into()),
@@ -461,6 +455,14 @@ mod tests {
                 transaction_method: Some("GET".into()),
                 transaction_op: Some("navigation".into()),
             },
+            span_id: Some("deadbeefdeadbeef".into()),
+            start_timestamp_ms: Some(1691105878720),
+            tags: Some(BTreeMap::from([
+                ("tag1".into(), "value1".into()),
+                ("tag2".into(), "123".into()),
+                ("tag3".into(), "true".into()),
+            ])),
+            trace_id: Some(Uuid::new_v4()),
         }
     }
 


### PR DESCRIPTION
We're now setting a `received` field for a span message: https://github.com/getsentry/relay/blob/master/relay-server/src/actors/store.rs#L1168