### PR TITLE
ref(docker): Remove obsolete build args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,6 @@ jobs:
           context: .
           # push: true
           load: true
-          build-args: |
-            SHOULD_BUILD_RUST=true
           target: testing
           tags: |
             ghcr.io/getsentry/snuba-ci:${{ github.sha }}
@@ -217,8 +215,6 @@ jobs:
           push: false
           tags: snuba-test
           load: true
-          build-args: |
-            SHOULD_BUILD_RUST=true
           target: testing
           cache-from: |
             type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
@@ -296,8 +292,6 @@ jobs:
           push: false
           tags: snuba-test
           load: true
-          build-args: |
-            SHOULD_BUILD_RUST=true
           target: testing
           cache-from: |
             type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
@@ -398,8 +392,6 @@ jobs:
           push: false
           tags: snuba-test
           load: true
-          build-args: |
-            SHOULD_BUILD_RUST=true
           target: testing
           cache-from: |
             type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,8 +25,6 @@ jobs:
         docker buildx build \
             "${args[@]}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --build-arg SHOULD_BUILD_ADMIN_UI="true" \
-            --build-arg SHOULD_BUILD_RUST=true \
             --platform linux/${{ matrix.arch }} \
             --tag "$IMG_VERSIONED" \
             --target application \

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,13 +101,11 @@ RUN set -ex; \
 
 # Install nodejs and yarn and build the admin UI
 FROM build_base AS build_admin_ui
-ARG SHOULD_BUILD_ADMIN_UI=true
 ENV NODE_VERSION=19
 
 COPY ./snuba/admin ./snuba/admin
 RUN set -ex; \
     mkdir -p snuba/admin/dist/; \
-    [ "$SHOULD_BUILD_ADMIN_UI" = "true" ] || exit 0; \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh | bash -s -- ${NODE_VERSION} &&\


### PR DESCRIPTION
We always build the admin UI and Rust nowadays.
