### PR TITLE
fix(ci): Add ddm_meta test to "full tests"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,7 @@ jobs:
               tests/sentry/snuba \
               tests/sentry/search/events \
               tests/sentry/event_manager \
+              tests/sentry/api/endpoints/test_organization_ddm_meta.py \
               -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 
       - name: Run CI module tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,7 @@ jobs:
               tests/sentry/search/events \
               tests/sentry/event_manager \
               tests/sentry/api/endpoints/test_organization_ddm_meta.py \
+              tests/sentry/api/endpoints/test_organization_profiling_functions.py \
               -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 
       - name: Run CI module tests


### PR DESCRIPTION
The current set doesn't cover anything in relation to metrics/spans, and
it resulted in a few bad PR merges related to INC-604

Add this file since it failed in almost all of those PRs and doesn't
take long to run.
