### PR TITLE
fix(rust): Remove noise from output of make install-rs-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install-python-dependencies:
 
 # install-rs-dev/install-py-dev mimick sentry's naming conventions
 install-rs-dev:
-	which cargo || (echo "!!! You need an installation of Rust in order to develop snuba. Go to https://rustup.rs to get one." && exit 1)
+	@which cargo || (echo "!!! You need an installation of Rust in order to develop snuba. Go to https://rustup.rs to get one." && exit 1)
 	. scripts/rust-envvars && cd rust_snuba/ && maturin develop
 .PHONY: install-rs-dev
 

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -49,7 +49,7 @@ sentry_usage_accountant = "0.0.3"
 
 
 [patch.crates-io]
-rdkafka = { git = "https://github.com/getsentry/rust-rdkafka", branch = "base-consumer", features = ["cmake-build", "tracing"] }
+rdkafka = { git = "https://github.com/getsentry/rust-rdkafka", branch = "base-consumer" }
 
 [dev-dependencies]
 criterion = "0.5.1"


### PR DESCRIPTION
Hide a line that make was printing, and also fix a warning emitted by
cargo (features are still defined in dependencies apparently)
