### PR TITLE
fix(capman): escape delimiter characters in allocation policy

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -578,7 +578,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
                     logger.exception(
                         f"AllocationPolicy could not deserialize a key: {key}"
                     )
-                    continue
+                    raise
                 detailed_configs.append(
                     definitions[config_key].to_config_dict(
                         value=runtime_configs[key], params=params
@@ -602,7 +602,9 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         """
         parameters = "."
         for param in sorted(list(params.keys())):
-            parameters += f"{param}:{params[param]},"
+            param_sanitized = param.replace(".", "\\.")
+            value_sanitized = str(params[param]).replace(".", "\\.")
+            parameters += f"{param_sanitized}:{value_sanitized},"
         parameters = parameters[:-1]
         return f"{self.runtime_config_prefix}.{config}{parameters}"
 

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -496,3 +496,18 @@ def test_is_not_enforced() -> None:
     )
     assert throttled_metrics[0].tags["is_enforced"] == "True"
     assert throttled_metrics[1].tags["is_enforced"] == "False"
+
+
+def test_outdated_configs() -> None:
+    # test that if config items get removed from the definitions, they get removed from redis
+    # on read
+    pass
+
+
+@pytest.mark.redis_db
+def test_configs_with_dot_values() -> None:
+    # test that configs with dots can be stored and read
+    policy = SomeParametrizedConfigPolicy(StorageKey("something"), [], {})
+    policy.set_config_value("my_param_config", 5, {"ref": "a.b.c", "org": 1})
+    configs = policy.get_current_configs()
+    print(configs)

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -498,12 +498,6 @@ def test_is_not_enforced() -> None:
     assert throttled_metrics[1].tags["is_enforced"] == "False"
 
 
-def test_outdated_configs() -> None:
-    # test that if config items get removed from the definitions, they get removed from redis
-    # on read
-    pass
-
-
 @pytest.mark.redis_db
 def test_configs_with_delimiter_values() -> None:
     # test that configs with dots can be stored and read

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -505,9 +505,25 @@ def test_outdated_configs() -> None:
 
 
 @pytest.mark.redis_db
-def test_configs_with_dot_values() -> None:
+def test_configs_with_delimiter_values() -> None:
     # test that configs with dots can be stored and read
     policy = SomeParametrizedConfigPolicy(StorageKey("something"), [], {})
-    policy.set_config_value("my_param_config", 5, {"ref": "a.b.c", "org": 1})
+    policy.set_config_value("my_param_config", 5, {"ref": "a,::.b.c", "org": 1})
     configs = policy.get_current_configs()
     print(configs)
+    assert {
+        "name": "my_param_config",
+        "type": "int",
+        "default": -1,
+        "description": "",
+        "value": 5,
+        "params": {"org": 1, "ref": "a,::.b.c"},
+    } in configs
+
+
+def test_cannot_use_escape_sequences() -> None:
+    policy = SomeParametrizedConfigPolicy(StorageKey("something"), [], {})
+    with pytest.raises(InvalidPolicyConfig):
+        policy.set_config_value(
+            "my_param_config", 5, {"ref": "a__dot_literal__.b.c", "org": 1}
+        )


### PR DESCRIPTION
fixes: https://getsentry.atlassian.net/browse/SNS-2589

Basically we have some custom serialization for the complex configurations in the allocation policy. However it breaks when the actual configuration has a `.`, `:`, or `,` in it and it becomes unserializable. 

The better thing to do would be to change serialization to JSON however that would require a migration of the old keys to the new format which is not an urgent matter. 