### PR TITLE
fix(devenv): Make post-merge hook exactly like sentry's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: develop setup-git test install-python-dependencies install-py-dev
 
+apply-migrations:
+	snuba migrations migrate --force
+.PHONY: apply-migrations
+
 reset-python:
 	pre-commit clean
 	rm -rf .venv

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,35 +1,43 @@
 #!/usr/bin/env bash
+## vim: shiftwidth=2
 
 red="$(tput setaf 1)"
 bold="$(tput bold)"
 reset="$(tput sgr0)"
-
 
 files_changed_upstream="$(mktemp)"
 trap "rm -f ${files_changed_upstream}" EXIT
 
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD > "$files_changed_upstream"
 
-grep -E --quiet 'migrations/groups.py' "$files_changed_upstream" && cat <<EOF
+commandline=
 
-[${red}${bold}!!!${reset}] Some migrations have changed, you may need to run:
+if grep -E --quiet 'migrations/groups.py' "$files_changed_upstream"; then
+  commandline+=" apply-migrations"
+fi
 
-  snuba migrations migrate --force
+if grep -E --quiet 'requirements.txt' "$files_changed_upstream"; then
+  commandline+=" install-py-dev"
+fi
+
+if grep -E --quiet 'rust_snuba/' "$files_changed_upstream"; then
+  commandline+=" install-rs-dev"
+fi
+
+if [ -n "$commandline" ]; then
+  command="make$commandline"
+  cat <<EOF
+
+[${red}${bold}!!!${reset}] ${red} It looks like some dependencies have changed that will require your intervention. Run the following to update:${reset}
+
+    ${red}${bold}${command}${reset}
 
 EOF
 
-grep -E --quiet 'requirements.txt' "$files_changed_upstream" && cat <<EOF
-
-[${red}${bold}!!!${reset}] Python dependencies updated, you may need to run:
-
-  make install-python-dependencies
-
-EOF
-
-grep -E --quiet 'rust_snuba/' "$files_changed_upstream" && cat <<EOF
-
-[${red}${bold}!!!${reset}] Rust code changed, you may need to run:
-
-  make install-rs-dev
-
-EOF
+  if [ "$SENTRY_POST_MERGE_AUTO_UPDATE" ]; then
+    echo "${yellow}Automatically running update command because SENTRY_POST_MERGE_AUTO_UPDATE is set.${reset}"
+    $commmand
+  else
+    echo "${yellow}If you want these commands to be executed automatically after pulling code, you can export the SENTRY_POST_MERGE_AUTO_UPDATE variable.${reset}"
+  fi
+fi


### PR DESCRIPTION
I was a bit annoyed that post-merge in snuba printed multiple commands
on separate lines, so I copied what sentry did. Now instead of this:

    ...
    make install-python-dependencies
    ...
    make install-rs-dev

We print this:

    make install-py-dev install-rs-dev

This is useful to me personally because it's easier to copypaste one
line of terminal scrollback vs many.

install-py-dev is an alias for install-python-dependencies that is also
named consistently with sentry.

Also added apply-migrations, which again, is the same name we use in
sentry.

A new feature is to automatically run those commands on merge, something
that sentry apparently has. I don't know if anybody uses that, i just
copied it over.
