### PR TITLE
fix(docker): Actually stop publishing a multiarch image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -9,6 +9,7 @@ jobs:
         arch: [amd64]
     runs-on: ubuntu-latest
     env:
+      IMG_MAIN: ghcr.io/getsentry/snuba:${{ matrix.arch }}
       IMG_CACHE: ghcr.io/getsentry/snuba:${{ matrix.arch }}-latest
       IMG_VERSIONED: ghcr.io/getsentry/snuba:${{ matrix.arch }}-${{ github.sha }}
     steps:
@@ -28,21 +29,12 @@ jobs:
             --target application \
             .
         docker tag "$IMG_VERSIONED" "$IMG_CACHE"
+        docker tag "$IMG_VERSIONED" "$IMG_MAIN"
     - name: push
       run: |
         set -euxo pipefail
         docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
         docker push "$IMG_VERSIONED"
         docker push "$IMG_CACHE"
+        docker push "$IMG_MAIN"
       if: github.event_name != 'pull_request'
-
-  multiarch:
-    if: github.event_name != 'pull_request'
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-    - run: |
-        set -euxo pipefail
-        docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
-        docker manifest create ghcr.io/getsentry/snuba:latest ghcr.io/getsentry/snuba:amd64-latest
-        docker manifest push ghcr.io/getsentry/snuba:latest


### PR DESCRIPTION
Publishing a manifest with just one architecture (x86) actually somehow
prevents colima on MacOS from finding a suitable image, even though it is capable of x86 emulation.

Let's just re-tag the x86 image instead of wrapping it in a manifest and hope that
works.

followup to #5365 
