### PR TITLE
fix(Makefile): Change ordering for Rust dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ reset-python:
 	rm -rf .venv
 .PHONY: reset-python
 
-develop: install-python-dependencies install-rs-dev install-brew-dev setup-git
+develop: install-python-dependencies install-brew-dev install-rs-dev setup-git
 
 setup-git:
 	mkdir -p .git/hooks && cd .git/hooks && ln -sf ../../config/hooks/* ./


### PR DESCRIPTION
Seems like `cmake` is a prereq for Rust dev