### PR TITLE
deps(rust): Change rdkafka dep to upstream master

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1873,8 +1873,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.36.0"
-source = "git+https://github.com/getsentry/rust-rdkafka?branch=base-consumer#95f6cd84317bf97f75c4dd12193d61652e8dba31"
+version = "0.36.1"
+source = "git+https://github.com/fede1024/rust-rdkafka#85539acd38a19d71fa749a16c0a0980f309d4713"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "4.7.0+2.3.0"
-source = "git+https://github.com/getsentry/rust-rdkafka?branch=base-consumer#95f6cd84317bf97f75c4dd12193d61652e8dba31"
+source = "git+https://github.com/fede1024/rust-rdkafka#85539acd38a19d71fa749a16c0a0980f309d4713"
 dependencies = [
  "cmake",
  "libc",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -50,7 +50,7 @@ adler = "1.0.2"
 
 
 [patch.crates-io]
-rdkafka = { git = "https://github.com/getsentry/rust-rdkafka", branch = "base-consumer" }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/rust_snuba/rust_arroyo/Cargo.toml
+++ b/rust_snuba/rust_arroyo/Cargo.toml
@@ -10,7 +10,7 @@ chrono = "0.4.26"
 coarsetime = "0.1.33"
 once_cell = "1.18.0"
 rand = "0.8.5"
-rdkafka = { git = "https://github.com/getsentry/rust-rdkafka", branch = "base-consumer", features = ["cmake-build", "tracing"] }
+rdkafka = { version = "0.36.1", features = ["cmake-build", "tracing"] }
 sentry = { version = "0.32.0" }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"


### PR DESCRIPTION
Use upstream master until they cut a new release containing https://github.com/fede1024/rust-rdkafka/pull/636. 