### PR TITLE
ref(rust): Don't panic in RunTaskInThreads::poll

### DIFF
--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -13,7 +13,8 @@ use rust_arroyo::processing::strategies::produce::Produce;
 use rust_arroyo::processing::strategies::run_task::RunTask;
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use rust_arroyo::processing::strategies::{
-    CommitRequest, InvalidMessage, ProcessingStrategy, ProcessingStrategyFactory, SubmitError,
+    CommitRequest, InvalidMessage, PollError, ProcessingStrategy, ProcessingStrategyFactory,
+    SubmitError,
 };
 use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::{Message, Topic, TopicOrPartition};
@@ -36,7 +37,7 @@ fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
 }
 struct Noop {}
 impl ProcessingStrategy<KafkaPayload> for Noop {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         Ok(None)
     }
     fn submit(&mut self, _message: Message<KafkaPayload>) -> Result<(), SubmitError<KafkaPayload>> {
@@ -44,10 +45,7 @@ impl ProcessingStrategy<KafkaPayload> for Noop {
     }
     fn close(&mut self) {}
     fn terminate(&mut self) {}
-    fn join(
-        &mut self,
-        _timeout: Option<Duration>,
-    ) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         Ok(None)
     }
 }

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -13,7 +13,7 @@ use rust_arroyo::processing::strategies::produce::Produce;
 use rust_arroyo::processing::strategies::run_task::RunTask;
 use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use rust_arroyo::processing::strategies::{
-    CommitRequest, InvalidMessage, PollError, ProcessingStrategy, ProcessingStrategyFactory,
+    CommitRequest, InvalidMessage, ProcessingStrategy, ProcessingStrategyFactory, StrategyError,
     SubmitError,
 };
 use rust_arroyo::processing::StreamProcessor;
@@ -37,7 +37,7 @@ fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
 }
 struct Noop {}
 impl ProcessingStrategy<KafkaPayload> for Noop {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(None)
     }
     fn submit(&mut self, _message: Message<KafkaPayload>) -> Result<(), SubmitError<KafkaPayload>> {
@@ -45,7 +45,7 @@ impl ProcessingStrategy<KafkaPayload> for Noop {
     }
     fn close(&mut self) {}
     fn terminate(&mut self) {}
-    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(None)
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -42,6 +42,8 @@ pub enum RunError {
     Pause(#[source] ConsumerError),
     #[error("strategy panicked")]
     StrategyPanic,
+    #[error("the thread errored")]
+    Thread(#[source] Box<dyn std::error::Error>),
 }
 
 const BACKPRESSURE_THRESHOLD: Duration = Duration::from_secs(1);
@@ -310,7 +312,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             }
 
             Err(StrategyError::Other(error)) => {
-                tracing::error!(error, "the thread errored");
+                return Err(RunError::Thread(error));
             }
         };
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -42,8 +42,8 @@ pub enum RunError {
     Pause(#[source] ConsumerError),
     #[error("strategy panicked")]
     StrategyPanic,
-    #[error("the thread errored")]
-    Thread(#[source] Box<dyn std::error::Error>),
+    #[error("the strategy errored")]
+    Strategy(#[source] Box<dyn std::error::Error>),
 }
 
 const BACKPRESSURE_THRESHOLD: Duration = Duration::from_secs(1);
@@ -312,7 +312,7 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
             }
 
             Err(StrategyError::Other(error)) => {
-                return Err(RunError::Thread(error));
+                return Err(RunError::Strategy(error));
             }
         };
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -309,11 +309,6 @@ impl<TPayload: Clone + Send + Sync + 'static> StreamProcessor<TPayload> {
                 }
             }
 
-            Err(StrategyError::JoinError(error)) => {
-                let error: &dyn std::error::Error = &error;
-                tracing::error!(error, "the thread crashed");
-            }
-
             Err(StrategyError::Other(error)) => {
                 tracing::error!(error, "the thread errored");
             }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Duration, Utc};
 
-use crate::processing::strategies::{
-    CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
-};
+use crate::processing::strategies::{CommitRequest, ProcessingStrategy, SubmitError};
 use crate::timer;
 use crate::types::{Message, Partition};
+
+use super::PollError;
 
 pub struct CommitOffsets {
     partitions: HashMap<Partition, u64>,
@@ -44,7 +44,7 @@ impl CommitOffsets {
 }
 
 impl<T> ProcessingStrategy<T> for CommitOffsets {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         Ok(self.commit(false))
     }
 
@@ -71,10 +71,7 @@ impl<T> ProcessingStrategy<T> for CommitOffsets {
 
     fn terminate(&mut self) {}
 
-    fn join(
-        &mut self,
-        _: Option<std::time::Duration>,
-    ) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, _: Option<std::time::Duration>) -> Result<Option<CommitRequest>, PollError> {
         Ok(self.commit(true))
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -6,7 +6,7 @@ use crate::processing::strategies::{CommitRequest, ProcessingStrategy, SubmitErr
 use crate::timer;
 use crate::types::{Message, Partition};
 
-use super::PollError;
+use super::StrategyError;
 
 pub struct CommitOffsets {
     partitions: HashMap<Partition, u64>,
@@ -44,7 +44,7 @@ impl CommitOffsets {
 }
 
 impl<T> ProcessingStrategy<T> for CommitOffsets {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(self.commit(false))
     }
 
@@ -71,7 +71,10 @@ impl<T> ProcessingStrategy<T> for CommitOffsets {
 
     fn terminate(&mut self) {}
 
-    fn join(&mut self, _: Option<std::time::Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(
+        &mut self,
+        _: Option<std::time::Duration>,
+    ) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(self.commit(true))
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/healthcheck.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/healthcheck.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use crate::counter;
-use crate::processing::strategies::{
-    CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
-};
+use crate::processing::strategies::{CommitRequest, ProcessingStrategy, SubmitError};
 use crate::types::Message;
+
+use super::PollError;
 
 const TOUCH_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -49,7 +49,7 @@ impl<TPayload, Next> ProcessingStrategy<TPayload> for HealthCheck<Next>
 where
     Next: ProcessingStrategy<TPayload> + 'static,
 {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         self.maybe_touch_file();
 
         self.next_step.poll()
@@ -67,7 +67,7 @@ where
         self.next_step.terminate()
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         self.next_step.join(timeout)
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/healthcheck.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/healthcheck.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use crate::counter;
-use crate::processing::strategies::{CommitRequest, ProcessingStrategy, SubmitError};
+use crate::processing::strategies::{
+    CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
+};
 use crate::types::Message;
-
-use super::StrategyError;
 
 const TOUCH_INTERVAL: Duration = Duration::from_secs(1);
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/healthcheck.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/healthcheck.rs
@@ -5,7 +5,7 @@ use crate::counter;
 use crate::processing::strategies::{CommitRequest, ProcessingStrategy, SubmitError};
 use crate::types::Message;
 
-use super::PollError;
+use super::StrategyError;
 
 const TOUCH_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -49,7 +49,7 @@ impl<TPayload, Next> ProcessingStrategy<TPayload> for HealthCheck<Next>
 where
     Next: ProcessingStrategy<TPayload> + 'static,
 {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         self.maybe_touch_file();
 
         self.next_step.poll()
@@ -67,7 +67,7 @@ where
         self.next_step.terminate()
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         self.next_step.join(timeout)
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -62,19 +62,19 @@ pub fn merge_commit_request(
 }
 
 #[derive(Debug)]
-pub enum PollError {
+pub enum StrategyError {
     InvalidMessage(InvalidMessage),
     JoinError(JoinError),
     Other(Box<dyn std::error::Error>),
 }
 
-impl From<InvalidMessage> for PollError {
+impl From<InvalidMessage> for StrategyError {
     fn from(value: InvalidMessage) -> Self {
         Self::InvalidMessage(value)
     }
 }
 
-impl From<JoinError> for PollError {
+impl From<JoinError> for StrategyError {
     fn from(value: JoinError) -> Self {
         Self::JoinError(value)
     }
@@ -98,7 +98,7 @@ pub trait ProcessingStrategy<TPayload>: Send + Sync {
     ///
     /// This method may raise exceptions that were thrown by asynchronous
     /// tasks since the previous call to ``poll``.
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError>;
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError>;
 
     /// Submit a message for processing.
     ///
@@ -136,11 +136,11 @@ pub trait ProcessingStrategy<TPayload>: Send + Sync {
     /// until this function exits, allowing any work in progress to be
     /// completed and committed before the continuing the rebalancing
     /// process.
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError>;
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError>;
 }
 
 impl<TPayload, S: ProcessingStrategy<TPayload> + ?Sized> ProcessingStrategy<TPayload> for Box<S> {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         (**self).poll()
     }
 
@@ -156,7 +156,7 @@ impl<TPayload, S: ProcessingStrategy<TPayload> + ?Sized> ProcessingStrategy<TPay
         (**self).terminate()
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         (**self).join(timeout)
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -1,5 +1,3 @@
-use tokio::task::JoinError;
-
 use crate::types::{Message, Partition};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -64,19 +62,12 @@ pub fn merge_commit_request(
 #[derive(Debug)]
 pub enum StrategyError {
     InvalidMessage(InvalidMessage),
-    JoinError(JoinError),
     Other(Box<dyn std::error::Error>),
 }
 
 impl From<InvalidMessage> for StrategyError {
     fn from(value: InvalidMessage) -> Self {
         Self::InvalidMessage(value)
-    }
-}
-
-impl From<JoinError> for StrategyError {
-    fn from(value: JoinError) -> Self {
-        Self::JoinError(value)
     }
 }
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
@@ -1,5 +1,5 @@
 use crate::processing::strategies::{
-    merge_commit_request, CommitRequest, InvalidMessage, MessageRejected, ProcessingStrategy,
+    merge_commit_request, CommitRequest, MessageRejected, PollError, ProcessingStrategy,
     SubmitError,
 };
 use crate::timer;
@@ -9,6 +9,8 @@ use std::collections::BTreeMap;
 use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
+
+use super::InvalidMessage;
 
 struct BatchState<T, TResult> {
     value: Option<TResult>,
@@ -61,7 +63,7 @@ pub struct Reduce<T, TResult> {
 }
 
 impl<T: Send + Sync, TResult: Clone + Send + Sync> ProcessingStrategy<T> for Reduce<T, TResult> {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         let commit_request = self.next_step.poll()?;
         self.commit_request_carried_over =
             merge_commit_request(self.commit_request_carried_over.take(), commit_request);
@@ -89,7 +91,7 @@ impl<T: Send + Sync, TResult: Clone + Send + Sync> ProcessingStrategy<T> for Red
         self.next_step.terminate();
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         let deadline = timeout.map(Deadline::new);
         if self.message_carried_over.is_some() {
             while self.message_carried_over.is_some() {
@@ -208,7 +210,7 @@ impl<T, TResult: Clone> Reduce<T, TResult> {
 mod tests {
     use crate::processing::strategies::reduce::Reduce;
     use crate::processing::strategies::{
-        CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
+        CommitRequest, PollError, ProcessingStrategy, SubmitError,
     };
     use crate::types::{BrokerMessage, InnerMessage, Message, Partition, Topic};
     use std::sync::{Arc, Mutex};
@@ -219,7 +221,7 @@ mod tests {
     }
 
     impl<T: Send + Sync> ProcessingStrategy<T> for NextStep<T> {
-        fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+        fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
             Ok(None)
         }
 
@@ -232,7 +234,7 @@ mod tests {
 
         fn terminate(&mut self) {}
 
-        fn join(&mut self, _: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage> {
+        fn join(&mut self, _: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
             Ok(None)
         }
     }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task.rs
@@ -1,11 +1,9 @@
 use crate::processing::strategies::{
     merge_commit_request, CommitRequest, InvalidMessage, MessageRejected, ProcessingStrategy,
-    SubmitError,
+    StrategyError, SubmitError,
 };
 use crate::types::Message;
 use std::time::Duration;
-
-use super::StrategyError;
 
 pub struct RunTask<TPayload, TTransformed> {
     pub function:

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -172,7 +172,7 @@ where
                         return Err(StrategyError::Other(error.into()));
                     }
                     Err(e) => {
-                        return Err(e.into());
+                        return Err(StrategyError::Other(e.into()));
                     }
                 }
             }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -14,6 +14,8 @@ use crate::processing::strategies::{
 use crate::types::Message;
 use crate::utils::timing::Deadline;
 
+use super::PollError;
+
 #[derive(Clone, Debug)]
 pub enum RunTaskError<TError> {
     RetryableError,
@@ -121,7 +123,7 @@ where
     TTransformed: Send + Sync + 'static,
     TError: Into<Box<dyn std::error::Error>> + Send + Sync + 'static,
 {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         let commit_request = self.next_step.poll()?;
         self.commit_request_carried_over =
             merge_commit_request(self.commit_request_carried_over.take(), commit_request);
@@ -136,7 +138,7 @@ where
                     self.message_carried_over = Some(transformed_message);
                 }
                 Err(SubmitError::InvalidMessage(invalid_message)) => {
-                    return Err(invalid_message);
+                    return Err(invalid_message.into());
                 }
                 Ok(_) => {}
             }
@@ -156,29 +158,21 @@ where
                             self.message_carried_over = Some(transformed_message);
                         }
                         Err(SubmitError::InvalidMessage(invalid_message)) => {
-                            return Err(invalid_message);
+                            return Err(invalid_message.into());
                         }
                         Ok(_) => {}
                     },
                     Ok(Err(RunTaskError::InvalidMessage(e))) => {
-                        return Err(e);
+                        return Err(e.into());
                     }
                     Ok(Err(RunTaskError::RetryableError)) => {
                         tracing::error!("retryable error");
                     }
                     Ok(Err(RunTaskError::Other(error))) => {
-                        // XXX: at some point we should extend the error return type of poll() to
-                        // pass those errors through to the stream processor
-                        let error: Box<dyn std::error::Error> = error.into();
-                        tracing::error!(error, "the thread errored");
-                        panic!("the thread errored");
+                        return Err(PollError::Other(error.into()));
                     }
-                    Err(error) => {
-                        // XXX: at some point we should extend the error return type of poll() to
-                        // pass those errors through to the stream processor
-                        let error: Box<dyn std::error::Error> = error.into();
-                        tracing::error!(error, "the thread crashed");
-                        panic!("the thread crashed");
+                    Err(e) => {
+                        return Err(e.into());
                     }
                 }
             }
@@ -215,7 +209,7 @@ where
         self.next_step.terminate();
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         let deadline = timeout.map(Deadline::new);
 
         // Poll until there are no more messages or timeout is hit
@@ -283,7 +277,7 @@ mod tests {
     }
 
     impl ProcessingStrategy<String> for Mock {
-        fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+        fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
             self.0.lock().unwrap().polled = true;
             Ok(None)
         }
@@ -293,10 +287,7 @@ mod tests {
         }
         fn close(&mut self) {}
         fn terminate(&mut self) {}
-        fn join(
-            &mut self,
-            _timeout: Option<Duration>,
-        ) -> Result<Option<CommitRequest>, InvalidMessage> {
+        fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
             Ok(None)
         }
     }

--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -10,9 +10,7 @@ use crate::backends::kafka::config::KafkaConfig;
 use crate::backends::kafka::producer::KafkaProducer;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
-use crate::processing::strategies::{
-    CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
-};
+use crate::processing::strategies::{CommitRequest, PollError, ProcessingStrategy, SubmitError};
 use crate::types::Message;
 use crate::types::Topic;
 
@@ -36,7 +34,7 @@ impl<T> TestStrategy<T> {
 }
 
 impl<T: Send> ProcessingStrategy<T> for TestStrategy<T> {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         Ok(None)
     }
 
@@ -47,10 +45,7 @@ impl<T: Send> ProcessingStrategy<T> for TestStrategy<T> {
 
     fn close(&mut self) {}
     fn terminate(&mut self) {}
-    fn join(
-        &mut self,
-        _timeout: Option<Duration>,
-    ) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         Ok(None)
     }
 }

--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -10,7 +10,9 @@ use crate::backends::kafka::config::KafkaConfig;
 use crate::backends::kafka::producer::KafkaProducer;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
-use crate::processing::strategies::{CommitRequest, PollError, ProcessingStrategy, SubmitError};
+use crate::processing::strategies::{
+    CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
+};
 use crate::types::Message;
 use crate::types::Topic;
 
@@ -34,7 +36,7 @@ impl<T> TestStrategy<T> {
 }
 
 impl<T: Send> ProcessingStrategy<T> for TestStrategy<T> {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(None)
     }
 
@@ -45,7 +47,7 @@ impl<T: Send> ProcessingStrategy<T> for TestStrategy<T> {
 
     fn close(&mut self) {}
     fn terminate(&mut self) {}
-    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(None)
     }
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,3 +1,4 @@
+use std::process;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -204,7 +205,11 @@ pub fn consumer_impl(
     })
     .expect("Error setting Ctrl-C handler");
 
-    processor.run().unwrap();
+    if let Err(error) = processor.run() {
+        let error: &dyn std::error::Error = &error;
+        tracing::error!(error);
+        process::exit(1);
+    }
 }
 
 pyo3::create_exception!(rust_snuba, SnubaRustError, pyo3::exceptions::PyException);

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -7,7 +7,7 @@ use rust_arroyo::processing::strategies::run_task_in_threads::{
     ConcurrencyConfig, RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
 use rust_arroyo::processing::strategies::{
-    CommitRequest, PollError, ProcessingStrategy, SubmitError,
+    CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
 };
 use rust_arroyo::types::Message;
 use rust_arroyo::{counter, timer};
@@ -104,7 +104,7 @@ impl ClickhouseWriterStep {
 }
 
 impl ProcessingStrategy<BytesInsertBatch> for ClickhouseWriterStep {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         self.inner.poll()
     }
 
@@ -123,7 +123,7 @@ impl ProcessingStrategy<BytesInsertBatch> for ClickhouseWriterStep {
         self.inner.terminate();
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         self.inner.join(timeout)
     }
 }

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -7,7 +7,7 @@ use rust_arroyo::processing::strategies::run_task_in_threads::{
     ConcurrencyConfig, RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
 use rust_arroyo::processing::strategies::{
-    CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
+    CommitRequest, PollError, ProcessingStrategy, SubmitError,
 };
 use rust_arroyo::types::Message;
 use rust_arroyo::{counter, timer};
@@ -104,7 +104,7 @@ impl ClickhouseWriterStep {
 }
 
 impl ProcessingStrategy<BytesInsertBatch> for ClickhouseWriterStep {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         self.inner.poll()
     }
 
@@ -123,7 +123,7 @@ impl ProcessingStrategy<BytesInsertBatch> for ClickhouseWriterStep {
         self.inner.terminate();
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         self.inner.join(timeout)
     }
 }

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -6,7 +6,7 @@ use rust_arroyo::processing::strategies::run_task_in_threads::{
     ConcurrencyConfig, RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
 use rust_arroyo::processing::strategies::{
-    CommitRequest, PollError, ProcessingStrategy, SubmitError,
+    CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
 };
 use rust_arroyo::types::{Message, Topic, TopicOrPartition};
 use serde::{Deserialize, Serialize};
@@ -197,7 +197,7 @@ impl ProduceCommitLog {
 }
 
 impl ProcessingStrategy<BytesInsertBatch> for ProduceCommitLog {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         self.inner.poll()
     }
 
@@ -216,7 +216,7 @@ impl ProcessingStrategy<BytesInsertBatch> for ProduceCommitLog {
         self.inner.terminate();
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         self.inner.join(timeout)
     }
 }
@@ -254,7 +254,7 @@ mod tests {
             pub payloads: Vec<BytesInsertBatch>,
         }
         impl ProcessingStrategy<BytesInsertBatch> for Noop {
-            fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+            fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
                 Ok(None)
             }
             fn submit(
@@ -269,7 +269,7 @@ mod tests {
             fn join(
                 &mut self,
                 _timeout: Option<Duration>,
-            ) -> Result<Option<CommitRequest>, PollError> {
+            ) -> Result<Option<CommitRequest>, StrategyError> {
                 Ok(None)
             }
         }

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -6,7 +6,7 @@ use rust_arroyo::processing::strategies::run_task_in_threads::{
     ConcurrencyConfig, RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
 use rust_arroyo::processing::strategies::{
-    CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
+    CommitRequest, PollError, ProcessingStrategy, SubmitError,
 };
 use rust_arroyo::types::{Message, Topic, TopicOrPartition};
 use serde::{Deserialize, Serialize};
@@ -197,7 +197,7 @@ impl ProduceCommitLog {
 }
 
 impl ProcessingStrategy<BytesInsertBatch> for ProduceCommitLog {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         self.inner.poll()
     }
 
@@ -216,7 +216,7 @@ impl ProcessingStrategy<BytesInsertBatch> for ProduceCommitLog {
         self.inner.terminate();
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         self.inner.join(timeout)
     }
 }
@@ -254,7 +254,7 @@ mod tests {
             pub payloads: Vec<BytesInsertBatch>,
         }
         impl ProcessingStrategy<BytesInsertBatch> for Noop {
-            fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+            fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
                 Ok(None)
             }
             fn submit(
@@ -269,7 +269,7 @@ mod tests {
             fn join(
                 &mut self,
                 _timeout: Option<Duration>,
-            ) -> Result<Option<CommitRequest>, InvalidMessage> {
+            ) -> Result<Option<CommitRequest>, PollError> {
                 Ok(None)
             }
         }

--- a/rust_snuba/src/strategies/noop.rs
+++ b/rust_snuba/src/strategies/noop.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 
 use rust_arroyo::processing::strategies::{
-    CommitRequest, PollError, ProcessingStrategy, SubmitError,
+    CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
 };
 use rust_arroyo::types::Message;
 
 pub struct Noop;
 
 impl<T> ProcessingStrategy<T> for Noop {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(None)
     }
 
@@ -20,7 +20,7 @@ impl<T> ProcessingStrategy<T> for Noop {
 
     fn terminate(&mut self) {}
 
-    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(None)
     }
 }

--- a/rust_snuba/src/strategies/noop.rs
+++ b/rust_snuba/src/strategies/noop.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 
 use rust_arroyo::processing::strategies::{
-    CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
+    CommitRequest, PollError, ProcessingStrategy, SubmitError,
 };
 use rust_arroyo::types::Message;
 
 pub struct Noop;
 
 impl<T> ProcessingStrategy<T> for Noop {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
         Ok(None)
     }
 
@@ -20,10 +20,7 @@ impl<T> ProcessingStrategy<T> for Noop {
 
     fn terminate(&mut self) {}
 
-    fn join(
-        &mut self,
-        _timeout: Option<Duration>,
-    ) -> Result<Option<CommitRequest>, InvalidMessage> {
+    fn join(&mut self, _timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
         Ok(None)
     }
 }

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -7,8 +7,8 @@ use parking_lot::Mutex;
 use pyo3::prelude::*;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::processing::strategies::{
-    merge_commit_request, CommitRequest, InvalidMessage, MessageRejected, PollError,
-    ProcessingStrategy, SubmitError,
+    merge_commit_request, CommitRequest, InvalidMessage, MessageRejected, ProcessingStrategy,
+    StrategyError, SubmitError,
 };
 use rust_arroyo::types::{BrokerMessage, InnerMessage, Message, Partition, Topic};
 use rust_arroyo::utils::timing::Deadline;
@@ -95,7 +95,7 @@ impl PythonTransformStep {
 }
 
 impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
-    fn poll(&mut self) -> Result<Option<CommitRequest>, PollError> {
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         let messages = Python::with_gil(|py| -> PyResult<Vec<PyReturnValue>> {
             let python_strategy = self.python_strategy.lock();
             let result = python_strategy.call_method0(py, "poll")?;
@@ -211,7 +211,7 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
         self.next_step.terminate()
     }
 
-    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, PollError> {
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         let deadline = timeout.map(Deadline::new);
         let timeout_secs = timeout.map(|d| d.as_secs());
 


### PR DESCRIPTION
This removes the panics in `RunTaskInThreads` that happened in cases of `JoinErrors` or "other" `RunTaskError`s. To this end, the error type of `poll` (and, by necessity, `join`) is changed from `InvalidMessage` to a new enum `PollError` covering exactly these three cases:

```rust
pub enum PollError {
    InvalidMessage(InvalidMessage),
    JoinError(JoinError),
    Other(Box<dyn std::error::Error>),
}
```
The logging of the latter two error cases is moved from `join` to `StreamProcessor::_run_once`.

Questions:
* ~`PollError` is IMO the natural name for the new error enum, but we already have a type of that name. This doesn't necessarily cause problems, but might be confusing. Should I change the name?~ Renamed to `StrategyError`.
* Are we logging the errors in the right place (`StreamProcessor::_run_once`)?
* ~Arguably the `PollError` enum is overcomplicated—there really is no functional difference between the `JoinError` and `Other` cases. Is there value in preserving the distinction? Otherwise I'll boil it down to just two cases.~ `JoinError` variant removed.

Fixes SNS-2594.