### PR TITLE
ref: Upgrade pre-commit, fix PYTHONPATH hacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ develop: install-python-dependencies install-brew-dev install-rs-dev setup-git
 
 setup-git:
 	mkdir -p .git/hooks && cd .git/hooks && ln -sf ../../config/hooks/* ./
-	pip install 'pre-commit==2.18.1'
+	pip install 'pre-commit==3.6.0'
 	pre-commit install --install-hooks
 
 test:

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -30,3 +30,6 @@ pub use processors::{ProcessingFunction, PROCESSORS};
 pub use strategies::noop::Noop;
 pub use strategies::python::PythonTransformStep;
 pub use types::KafkaMessageMetadata;
+
+#[cfg(test)]
+mod testutils;

--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -20,6 +20,7 @@ mod tests {
 
     #[test]
     fn test_runtime_config() {
+        crate::testutils::initialize_python();
         let config = get_str_config("test");
         assert_eq!(config.unwrap(), None);
     }

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -281,21 +281,9 @@ mod tests {
     use super::*;
     use rust_arroyo::testutils::TestStrategy;
 
-    fn set_sys_executable() {
-        let python_executable = std::env::var("SNUBA_PYTHONEXECUTABLE").unwrap();
-        Python::with_gil(|py| -> PyResult<()> {
-            PyModule::import(py, "sys")?.setattr("executable", python_executable)?;
-            Ok(())
-        })
-        .unwrap();
-    }
-
     #[test]
-    // test is flaky in CI and fails 100% of the time locally with " signal only works in main
-    // thread of the main interpreter"
-    #[ignore]
     fn test_python() {
-        set_sys_executable();
+        crate::testutils::initialize_python();
 
         let sink = TestStrategy::new();
 

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -282,7 +282,7 @@ mod tests {
     use rust_arroyo::testutils::TestStrategy;
 
     fn set_sys_executable() {
-        let python_executable = std::env::var("PYTHONEXECUTABLE").unwrap();
+        let python_executable = std::env::var("SNUBA_PYTHONEXECUTABLE").unwrap();
         Python::with_gil(|py| -> PyResult<()> {
             PyModule::import(py, "sys")?.setattr("executable", python_executable)?;
             Ok(())

--- a/rust_snuba/src/testutils.rs
+++ b/rust_snuba/src/testutils.rs
@@ -1,0 +1,19 @@
+use pyo3::prelude::*;
+
+pub fn initialize_python() {
+    let python_executable = std::env::var("SNUBA_TEST_PYTHONEXECUTABLE").unwrap();
+    let python_path = std::env::var("SNUBA_TEST_PYTHONPATH").unwrap();
+    let python_path: Vec<_> = python_path.split(':').map(String::from).collect();
+
+    Python::with_gil(|py| -> PyResult<()> {
+        PyModule::import(py, "sys")?.setattr("executable", python_executable)?;
+        PyModule::import(py, "sys")?.setattr("path", python_path)?;
+
+        // monkeypatch signal handlers in Python to noop, because otherwise python multiprocessing
+        // strategies cannot be tested
+        let noop_fn = py.eval("lambda *a, **kw: None", None, None).unwrap();
+        PyModule::import(py, "signal")?.setattr("signal", noop_fn)?;
+        Ok(())
+    })
+    .unwrap();
+}

--- a/scripts/rust-envvars
+++ b/scripts/rust-envvars
@@ -1,8 +1,8 @@
 # Related thread: https://github.com/PyO3/pyo3/issues/1741
-# But couldn't repro this problem anymore
 
 # This is required for the tests in python.rs
-export SNUBA_PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
+export SNUBA_TEST_PYTHONPATH="$(python -c 'import sys; print(":".join(sys.path))')"
+export SNUBA_TEST_PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
 
 # load cargo envvars explicitly in case user forgot
 . "$HOME/.cargo/env"

--- a/scripts/rust-envvars
+++ b/scripts/rust-envvars
@@ -3,7 +3,6 @@
 #
 # Related thread: https://github.com/PyO3/pyo3/issues/1741
 
-export PYTHONPATH="$(python -c 'import sys; print(":".join(sys.path))')"
 export PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
 
 # load cargo envvars explicitly in case user forgot

--- a/scripts/rust-envvars
+++ b/scripts/rust-envvars
@@ -1,8 +1,7 @@
-# For local development, override PYTHONPATH explicitly so that `cargo test`
-# works for the Rust consumer. This _probably_ does not cause problems elsewhere.
-#
 # Related thread: https://github.com/PyO3/pyo3/issues/1741
+# But couldn't repro this problem anymore
 
+# This is required for the tests in python.rs
 export SNUBA_PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
 
 # load cargo envvars explicitly in case user forgot

--- a/scripts/rust-envvars
+++ b/scripts/rust-envvars
@@ -3,7 +3,7 @@
 #
 # Related thread: https://github.com/PyO3/pyo3/issues/1741
 
-export PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
+export SNUBA_PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
 
 # load cargo envvars explicitly in case user forgot
 . "$HOME/.cargo/env"


### PR DESCRIPTION
bug to repro:

1. clone the snuba repo
2. run `direnv allow` to create virtualenv and pre-commit hooks
3. verify pre-commit works by running `pre-commit run --files  snuba/cogs/accountant.py`
4. `rm -rf .venv` (to deal with a python upgrade, for example)
5. run `direnv allow` again to recreate
6. `pre-commit` is broken, the command from step 3 breaks with errors like `Executable check-case-conflict not found`

~The PYTHONPATH was supposed to fix _something_, but I can't recall now what it is. `cargo test` works fine. If it resurfaces we could re-introduce it as `SNUBA_PYTHONPATH` and set it similarly to how we set `SNUBA_PYTHONEXECUTABLE`, if we don't have any better ideas.~ it happened again on my machine, so I've renamed everything to be prefixed with `SNUBA_TEST_`