### PR TITLE
fix(rust-consumers): Define consumer group for functions consumer

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -362,6 +362,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                     "snuba",
                     "rust-consumer",
                     "--storage=functions_raw",
+                    "--consumer-group=functions_group",
                     *COMMON_RUST_CONSUMER_DEV_OPTIONS,
                 ],
             ),


### PR DESCRIPTION
The consumer group is a required arg here otherwise the consumer will not start crashing all of dev server.