### PR TITLE
feat(spans): Reject queries with an invalid data model before they reach clickhouse

### DIFF
--- a/snuba/datasets/configuration/spans/entities/spans.yaml
+++ b/snuba/datasets/configuration/spans/entities/spans.yaml
@@ -164,6 +164,7 @@ query_processors:
     args:
       project_field: project_id
 
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -69,7 +69,7 @@ class PluggableEntity(Entity):
             EntityContainsColumnsValidator(
                 EntityColumnSet(self.columns),
                 mappers,
-                self.validate_data_model or ColumnValidationMode.WARN,
+                self.validate_data_model or ColumnValidationMode.ERROR,
             )
         ]
 


### PR DESCRIPTION
All other entities have this enabled, enable it for spans as well. Make it the default so we don't regress