### PR TITLE
fix(rust): Actually drop before exiting

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -70,7 +70,7 @@ pub fn consumer_impl(
     max_poll_interval_ms: usize,
     python_max_queue_depth: Option<usize>,
     health_check_file: Option<&str>,
-) {
+) -> usize {
     setup_logging();
 
     let consumer_config = config::ConsumerConfig::load_from_str(consumer_config_raw).unwrap();
@@ -92,7 +92,7 @@ pub fn consumer_impl(
         tracing::debug!(sentry_dsn = dsn);
         // this forces anyhow to record stack traces when capturing an error:
         std::env::set_var("RUST_BACKTRACE", "1");
-        _sentry_guard = Some(setup_sentry(&dsn));
+        sentry_guard = Some(setup_sentry(&dsn));
     }
 
     // setup arroyo metrics
@@ -208,7 +208,9 @@ pub fn consumer_impl(
     if let Err(error) = processor.run() {
         let error: &dyn std::error::Error = &error;
         tracing::error!(error);
-        process::exit(1);
+        1
+    } else {
+        0
     }
 }
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,4 +1,3 @@
-use std::process;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -92,7 +91,7 @@ pub fn consumer_impl(
         tracing::debug!(sentry_dsn = dsn);
         // this forces anyhow to record stack traces when capturing an error:
         std::env::set_var("RUST_BACKTRACE", "1");
-        sentry_guard = Some(setup_sentry(&dsn));
+        _sentry_guard = Some(setup_sentry(&dsn));
     }
 
     // setup arroyo metrics

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from dataclasses import asdict
 from typing import Optional, Sequence
 
@@ -208,7 +209,7 @@ def rust_consumer(
         f"rust_consumer.{storage_names[0]}.concurrency"
     )
 
-    rust_snuba.consumer(  # type: ignore
+    exitcode = rust_snuba.consumer(  # type: ignore
         consumer_group,
         auto_offset_reset,
         no_strict_offset_reset,
@@ -221,3 +222,5 @@ def rust_consumer(
         python_max_queue_depth,
         health_check_file,
     )
+
+    sys.exit(exitcode)


### PR DESCRIPTION
process::exit does not permit destructors/Drop to run. specifically, sentry's `_sentry_guard` does not run Drop, and so we fail to flush errors to sentry