### PR TITLE
fix(docker): Tag snuba:amd64-latest again

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,6 +22,7 @@ jobs:
         if [ ${{ github.event_name }} = 'push' ]; then
           args=(
             --tag ghcr.io/getsentry/snuba:latest
+            --tag ghcr.io/getsentry/snuba:amd64-latest
             --push
           )
         else
@@ -30,6 +31,7 @@ jobs:
 
         docker buildx build \
           --pull \
+          --platform linux/amd64 \
           --cache-from ghcr.io/getsentry/snuba:latest \
           --cache-to type=inline \
           --tag ghcr.io/getsentry/snuba:${{ github.sha }} \


### PR DESCRIPTION
We are seeing some weirdness on snuba:latest on MacOS where either
pulling or starting fails, presumably because snuba:latest used to be a
multiarch image and no longer is. snuba:amd64-latest works

also add --platform tag on the off chance that fixes anything, since it
appears to be present in Relay's dockerfile
