### PR TITLE
fix: Force a specific rust toolchain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,6 @@ repos:
         name: format rust code
         language: system
         entry: rustfmt
-        files: ^rust_snuba/
+        files: ^rust_snuba/.*\.rs$
 default_language_version:
   python: python3.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,10 @@ RUN set -ex; \
 # dependencies from building the Rust source code, see Relay Dockerfile.
 
 FROM build_base AS build_rust_snuba_base
-ARG RUST_TOOLCHAIN=1.74.1
 
 RUN set -ex; \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain $RUST_TOOLCHAIN  --profile minimal -y; \
+    # do not install any toolchain, as rust_snuba/rust-toolchain.toml defines that for us
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y; \
     # use git CLI to avoid OOM on ARM64
     echo '[net]' > ~/.cargo/config; \
     echo 'git-fetch-with-cli = true' >> ~/.cargo/config; \
@@ -82,6 +82,7 @@ FROM build_rust_snuba_base AS build_rust_snuba_deps
 
 COPY ./rust_snuba/rust_arroyo/Cargo.toml ./rust_snuba/rust_arroyo/Cargo.toml
 COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
+COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
 

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ test-rust:
 lint-rust:
 	. scripts/rust-envvars && \
 		cd rust_snuba && \
+		rustup component add clippy && \
 		cargo clippy --workspace --all-targets --no-deps -- -D warnings
 .PHONY: lint-rust
 

--- a/rust_snuba/rust-toolchain.toml
+++ b/rust_snuba/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.74.1"


### PR DESCRIPTION
Snuba contributors who just want a working consumer and are less
interested in their Rust "devenv" are confronted with random compile
errors because their toolchain is outdated by a few months.

This commit forces the same rust toolchain version for everybody. If
somebody runs `cargo build`, rustup will automatically download and
install the right rust version if it does not already exist.

We don't actually want to pin the exact version -- defining an
oldest-supported version is what we actually need, we don't care if the
default toolchain is newer. However, there's no way to declare that,
defining MSRV in Cargo.toml doesn't provide the same experience of
automatically downloading the right version.
