### PR TITLE
fix: Fix broken DDL changes job

### DIFF
--- a/.github/workflows/ddl-changes.yml
+++ b/.github/workflows/ddl-changes.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 200
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This was still running under Python 3.8, and that breaks PRs like
https://github.com/getsentry/snuba/pull/5395 -- there, we were unable to
install sentry-relay since that now requires Python 3.9
