### PR TITLE
ref(replays): Re-add e2e latency metric [SNS-2606]

### DIFF
--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -1,4 +1,4 @@
-use crate::{config::ProcessorConfig, types::RowData};
+use crate::config::ProcessorConfig;
 use anyhow::{anyhow, Context};
 use chrono::DateTime;
 use rust_arroyo::backends::kafka::types::KafkaPayload;


### PR DESCRIPTION
This was lost in the port to Rust
