### PR TITLE
fix(cardinality): Allow longer running queries

### DIFF
--- a/snuba/cli/spans_cardinality_analyzer.py
+++ b/snuba/cli/spans_cardinality_analyzer.py
@@ -73,10 +73,12 @@ def spans_cardinality_analyzer(
     )
 
     # Get the distinct span modules we are ingesting.
+    logger.info("Getting distinct span modules")
     result = connection.execute(
         span_grouping_distinct_modules_query(time_window_hrs=1),
     )
     distinct_span_groups = [row[0] for row in result.results]
+    logger.info(f"Got distinct span modules: {distinct_span_groups}")
 
     # Get the cardinality of each module and write to CSV file and send to Slack
     for span_group in distinct_span_groups:

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -88,6 +88,8 @@ class ClickhouseClientSettings(Enum):
             "max_threads": 10,
             # Don't use up production cache for cardinality analyzer queries.
             "use_uncompressed_cache": 0,
+            # Allow longer running queries.
+            "max_execution_time": 60,
         },
         None,
     )


### PR DESCRIPTION
The cardinality analyzer seems to be failing. There is no Sentry error. Also nothing in the logs. Trying few things to debug the problem