### PR TITLE
fix(capman): fix config validation for cross org policy

### DIFF
--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -64,11 +64,15 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
         user: str | None = None,
     ) -> None:
         """makes sure only registered referrers can be overridden"""
-        referrer = params.get("referrer", "")
-        if not self._referrer_is_registered(referrer):
-            raise InvalidPolicyConfig(
-                f"Referrer {referrer} is not registered in the the {self._storage_key.value} yaml. Register it first to be able to override its limits"
-            )
+        if config_key in (
+            "referrer_concurrent_override",
+            "referrer_max_threads_override",
+        ):
+            referrer = params.get("referrer", None)
+            if referrer is not None and not self._referrer_is_registered(referrer):
+                raise InvalidPolicyConfig(
+                    f"Referrer {referrer} is not registered in the the {self._storage_key.value} yaml. Register it first to be able to override its limits"
+                )
         super().set_config_value(config_key, value, params, user)
 
     def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:

--- a/tests/query/allocation_policies/test_cross_org_policy.py
+++ b/tests/query/allocation_policies/test_cross_org_policy.py
@@ -158,6 +158,11 @@ class TestCrossOrgQueryAllocationPolicy:
             6,
             {"referrer": "statistical_detectors"},
         )
+        # can still set regular configs
+        policy.set_config_value("is_enforced", False)
+        assert not policy.is_enforced
+        policy.set_config_value("is_enforced", True)
+        assert policy.is_enforced
 
     @pytest.mark.redis_db
     def test_throttle_cross_org_query_with_unregistered_referrer(self):


### PR DESCRIPTION
The config validation was a little non-standard and not adequately tested. Add some tests and unbreak the config validation logic to allow changing non-referrer related configs