### PR TITLE
fix(cardinality): Increase time duration for finding all modules

### DIFF
--- a/snuba/cli/spans_cardinality_analyzer.py
+++ b/snuba/cli/spans_cardinality_analyzer.py
@@ -75,7 +75,7 @@ def spans_cardinality_analyzer(
     # Get the distinct span modules we are ingesting.
     logger.info("Getting distinct span modules")
     result = connection.execute(
-        span_grouping_distinct_modules_query(time_window_hrs=1),
+        span_grouping_distinct_modules_query(time_window_hrs=2),
     )
     distinct_span_groups = [row[0] for row in result.results]
     logger.info(f"Got distinct span modules: {distinct_span_groups}")

--- a/snuba/clickhouse/span_cardinality_analyzer.py
+++ b/snuba/clickhouse/span_cardinality_analyzer.py
@@ -30,7 +30,7 @@ def span_grouping_distinct_modules_query(time_window_hrs: int) -> SQL:
     Form the clickhouse query to get the distinct span modules we are ingesting.
     The result of this query can be used to get the cardinality of individual modules.
     """
-    if time_window_hrs > 2:
+    if time_window_hrs > 3:
         raise ValueError("Time window cannot be greater than 2 hours")
 
     query = f"""


### PR DESCRIPTION
With the newly added logs we see that the job is not able to get the distinct modules. When I run the query with 2 hour window on snuba-admin the query works. Lets increase the time window to 2 hours.

![Screenshot 2024-01-19 at 10 48 08 AM](https://github.com/getsentry/snuba/assets/84807402/c7369043-514a-419e-b598-fad03c21509f)

![Screenshot 2024-01-19 at 10 50 41 AM](https://github.com/getsentry/snuba/assets/84807402/90823be8-457c-4816-8b22-beff0af704df)
