### PR TITLE
fix(rust): Deal with empty batches correctly

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2077,8 +2077,8 @@ dependencies = [
 
 [[package]]
 name = "rust_arroyo"
-version = "0.1.0"
-source = "git+https://github.com/getsentry/arroyo#6002ceea5ee7cfe21fa9da52190b96da6af27e09"
+version = "2.15.3"
+source = "git+https://github.com/getsentry/arroyo#f90eeff8cb07655bc4e3cafdb7633de5ead7e693"
 dependencies = [
  "chrono",
  "coarsetime",

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -151,8 +151,10 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             self.max_batch_size,
             self.max_batch_time,
             BytesInsertBatch::len,
-        );
-
+            // we need to enable this to deal with storages where we skip 100% of values, such as
+            // gen-metrics-gauges in s4s. we still need to commit there
+        )
+        .flush_empty_batches(true);
         let processor = match (
             self.use_rust_processor,
             processors::get_processing_function(


### PR DESCRIPTION
- bump arroyo
- enable empty batch flushing
- skip empty clickhouse inserts
