### PR TITLE
feat(on-call): Add illegal aggregate function in conditions entity validator

### DIFF
--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, List, Mapping, Optional, Sequence
 
+from snuba import state
 from snuba.clickhouse.columns import Column
 from snuba.datasets.entities.entity_data_model import EntityColumnSet
 from snuba.datasets.entities.entity_key import EntityKey
@@ -27,6 +28,7 @@ from snuba.query.validation import FunctionCallValidator
 from snuba.query.validation.validators import (
     ColumnValidationMode,
     EntityContainsColumnsValidator,
+    IllegalAggregateInConditionValidator,
     QueryValidator,
 )
 from snuba.utils.schemas import SchemaModifiers
@@ -65,13 +67,20 @@ class PluggableEntity(Entity):
 
     def _get_builtin_validators(self) -> Sequence[QueryValidator]:
         mappers = [s.translation_mappers for s in self.storages]
-        return [
+        builtin_validators = [
             EntityContainsColumnsValidator(
                 EntityColumnSet(self.columns),
                 mappers,
                 self.validate_data_model or ColumnValidationMode.ERROR,
             )
         ]
+        enable_illegal_aggregate_validator = state.get_config(
+            "enable_illegal_aggregate_in_condition_validator", 0
+        )
+        assert enable_illegal_aggregate_validator is not None
+        if int(enable_illegal_aggregate_validator) == 1:
+            builtin_validators.append(IllegalAggregateInConditionValidator())
+        return builtin_validators
 
     def get_query_processors(self) -> Sequence[LogicalQueryProcessor]:
         return self.query_processors

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -512,8 +512,9 @@ class IllegalAggregateInConditionValidator(QueryValidator):
         )
         assert enable_illegal_aggregate_validator is not None
         if int(enable_illegal_aggregate_validator) == 1:
-            if query.get_condition():
-                matches = find_illegal_aggregate_functions(query.get_condition())
+            conditions = query.get_condition()
+            if conditions:
+                matches = find_illegal_aggregate_functions(conditions)
                 if len(matches) > 0:
                     raise InvalidQueryException(
                         "Aggregate function found in WHERE clause of query"

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -33,7 +33,7 @@ from snuba.query.expressions import SubscriptableReference as SubscriptableRefer
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.matchers import AnyExpression
 from snuba.query.matchers import FunctionCall as FunctionCallMatcher
-from snuba.query.matchers import Or, Param, String
+from snuba.query.matchers import MatchResult, Or, Param, String
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.registered_class import RegisteredClass
 from snuba.utils.schemas import ColumnSet, Date, DateTime
@@ -467,8 +467,8 @@ class IllegalAggregateInConditionValidator(QueryValidator):
     def validate(self, query: Query, alias: Optional[str] = None) -> None:
         def find_illegal_aggregate_functions(
             expression: Expression,
-        ) -> list[Expression]:
-            matches = []
+        ) -> list[MatchResult]:
+            matches: list[MatchResult] = []
             match = FunctionCallMatcher(
                 function_name=Param(
                     "aggregate",
@@ -507,7 +507,7 @@ class IllegalAggregateInConditionValidator(QueryValidator):
             return matches
 
         matches = find_illegal_aggregate_functions(query.get_condition())
-        if matches:
+        if len(matches) > 0:
             raise InvalidQueryException(
                 "Aggregate function found in WHERE clause of query"
             )

--- a/tests/datasets/validation/test_illegal_aggregate_conditions_validation.py
+++ b/tests/datasets/validation/test_illegal_aggregate_conditions_validation.py
@@ -1,0 +1,108 @@
+import datetime
+from typing import Optional
+
+import pytest
+
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query import SelectedExpression
+from snuba.query.conditions import binary_condition
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.exceptions import InvalidQueryException
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.logical import Query as LogicalQuery
+from snuba.query.validation.validators import IllegalAggregateInConditionValidator
+
+conditions = [
+    pytest.param(
+        FunctionCall(
+            None,
+            "greater",
+            (
+                FunctionCall(
+                    None,
+                    "sumIf",
+                    (
+                        Column(None, None, "duration"),
+                        FunctionCall(
+                            None,
+                            "equals",
+                            (Column(None, None, "is_segment"), Literal(None, 1)),
+                        ),
+                    ),
+                ),
+                Literal(None, 42),
+            ),
+        ),
+        id="aggregate function in top level",
+    ),
+    pytest.param(
+        binary_condition(
+            "and",
+            binary_condition(
+                "equals",
+                Column("_snuba_received", None, "received"),
+                Literal(None, datetime.datetime(2023, 1, 25, 20, 3, 13)),
+            ),
+            FunctionCall(
+                None,
+                "less",
+                (
+                    FunctionCall(
+                        None,
+                        "countIf",
+                        (
+                            Column(None, None, "duration"),
+                            FunctionCall(
+                                None,
+                                "equals",
+                                (Column(None, None, "is_segment"), Literal(None, 1)),
+                            ),
+                        ),
+                    ),
+                    Literal(None, 42),
+                ),
+            ),
+        ),
+        id="aggregate function in nested condition 1",
+    ),
+    pytest.param(
+        binary_condition(
+            "and",
+            binary_condition(
+                "equals",
+                Column("_snuba_received", None, "received"),
+                Literal(None, datetime.datetime(2023, 1, 25, 20, 3, 13)),
+            ),
+            FunctionCall(
+                None,
+                "less",
+                (
+                    FunctionCall(
+                        None,
+                        "max",
+                        (Column(None, None, "duration"),),
+                    ),
+                    Literal(None, 42),
+                ),
+            ),
+        ),
+        id="aggregate function in nested condition 2",
+    ),
+]
+
+
+@pytest.mark.parametrize("condition", conditions)
+def test_illegal_aggregate_in_condition_validator(
+    condition: Optional[Expression],
+) -> None:
+    query = LogicalQuery(
+        QueryEntity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()),
+        selected_columns=[
+            SelectedExpression("time", Column("_snuba_timestamp", None, "timestamp")),
+        ],
+        condition=condition,
+    )
+    validator = IllegalAggregateInConditionValidator()
+    with pytest.raises(InvalidQueryException):
+        validator.validate(query)

--- a/tests/datasets/validation/test_illegal_aggregate_conditions_validation.py
+++ b/tests/datasets/validation/test_illegal_aggregate_conditions_validation.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 
+from snuba import state
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.query import SelectedExpression
@@ -13,7 +14,7 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.validation.validators import IllegalAggregateInConditionValidator
 
-conditions = [
+tests = [
     pytest.param(
         FunctionCall(
             None,
@@ -34,6 +35,8 @@ conditions = [
                 Literal(None, 42),
             ),
         ),
+        None,
+        InvalidQueryException,
         id="aggregate function in top level",
     ),
     pytest.param(
@@ -64,6 +67,8 @@ conditions = [
                 ),
             ),
         ),
+        None,
+        InvalidQueryException,
         id="aggregate function in nested condition 1",
     ),
     pytest.param(
@@ -87,22 +92,64 @@ conditions = [
                 ),
             ),
         ),
+        None,
+        InvalidQueryException,
         id="aggregate function in nested condition 2",
+    ),
+    pytest.param(
+        binary_condition(
+            "and",
+            binary_condition(
+                "equals",
+                Column("_snuba_received", None, "received"),
+                Literal(None, datetime.datetime(2023, 1, 25, 20, 3, 13)),
+            ),
+            FunctionCall(
+                None,
+                "less",
+                (
+                    Column("_snuba_group_id", None, "group_id"),
+                    Literal(None, 2),
+                ),
+            ),
+        ),
+        FunctionCall(
+            None,
+            "less",
+            (
+                FunctionCall(
+                    None,
+                    "max",
+                    (Column(None, None, "duration"),),
+                ),
+                Literal(None, 42),
+            ),
+        ),
+        None,
+        id="no aggregate function in where clause but in having clause",
     ),
 ]
 
 
-@pytest.mark.parametrize("condition", conditions)
+@pytest.mark.parametrize("condition, having, exception", tests)
+@pytest.mark.redis_db
 def test_illegal_aggregate_in_condition_validator(
     condition: Optional[Expression],
+    having: Optional[Expression],
+    exception: Exception,
 ) -> None:
+    state.set_config("enable_illegal_aggregate_in_condition_validator", 1)
     query = LogicalQuery(
         QueryEntity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()),
         selected_columns=[
             SelectedExpression("time", Column("_snuba_timestamp", None, "timestamp")),
         ],
         condition=condition,
+        having=having,
     )
     validator = IllegalAggregateInConditionValidator()
-    with pytest.raises(InvalidQueryException):
+    if exception:
+        with pytest.raises(exception):
+            validator.validate(query)
+    else:
         validator.validate(query)

--- a/tests/test_spans_api.py
+++ b/tests/test_spans_api.py
@@ -49,7 +49,7 @@ class TestSpansApi(BaseApiTest):
         ) - timedelta(minutes=self.minutes)
         self.storage = get_writable_storage(StorageKey.SPANS)
         state.set_config("log_bad_span_message_percentage", 1)
-        # self.generate_fizzbuzz_events()
+        self.generate_fizzbuzz_events()
 
         yield
 

--- a/tests/test_spans_api.py
+++ b/tests/test_spans_api.py
@@ -49,7 +49,7 @@ class TestSpansApi(BaseApiTest):
         ) - timedelta(minutes=self.minutes)
         self.storage = get_writable_storage(StorageKey.SPANS)
         state.set_config("log_bad_span_message_percentage", 1)
-        self.generate_fizzbuzz_events()
+        # self.generate_fizzbuzz_events()
 
         yield
 


### PR DESCRIPTION
### Overview
Aggregation functions (e.g. `sum(duration)`) are being found in the WHERE clause of incoming queries to snuba. These should be put in the HAVING clause instead.  Example [sentry issue](https://sentry.sentry.io/issues/4875058423/?project=300688&query=start%3D2024-01-18T11%3A52%3A00%26end%3D2024-01-18T18%3A27%3A17%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream).


This PR is responsible for adding a new built-in entity validator that checks if aggregation functions are being used in the conditions of a query. If an aggregation function expression is found, reject the query.

### Testing
Use runtime config `enable_illegal_aggregate_in_condition_validator` to enable validator. 