### PR TITLE
fix(optimize): Reduce parallel optimize job cutoff time

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -371,7 +371,7 @@ OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10 * 60  # 10 mins
 # merges larger than this will be considered large and will be waited on
 OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
 # Maximum jitter to add to the scheduling of threads of an optimize job
-OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30
+OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 0
 
 # Start time in hours from UTC 00:00:00 after which we are allowed to run
 # optimize jobs in parallel.
@@ -379,7 +379,8 @@ PARALLEL_OPTIMIZE_JOB_START_TIME = 0
 
 # Cutoff time from UTC 00:00:00 to stop running optimize jobs in
 # parallel to avoid running in parallel when peak traffic starts.
-PARALLEL_OPTIMIZE_JOB_END_TIME = OPTIMIZE_JOB_CUTOFF_TIME
+# Cutoff time in PST would be 6am of the next day.
+PARALLEL_OPTIMIZE_JOB_END_TIME = 14
 
 # Configuration directory settings
 CONFIG_FILES_PATH = f"{Path(__file__).parent.parent.as_posix()}/datasets/configuration"


### PR DESCRIPTION
When we introduced the parallel optimize job cutoff time, we made its value same as the overall optimize job cutoff time. As of April 2023, the optimize job would finish by 3am since the size of individual partitions was no more than 110GB. Today, the size of each partition is close to 180GB. With the bigger partitions, it takes longer for the optimize job to finish. Cap the amount of time the optimize job can run in parallel so that parallel optimizations are not running during peak hours.

Also, removed the jitter because I don't believe they are adding any value. Removing it would allow the parallel phase to run a bit longer during the starting phase of the job.