### PR TITLE
fix(devserver): Do not enforce schema

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -6,7 +6,9 @@ COMMON_CONSUMER_DEV_OPTIONS = [
     "--auto-offset-reset=latest",
     "--no-strict-offset-reset",
     "--log-level=debug",
-    "--enforce-schema",
+    # XXX(markus): there is some bug in transactions that crashes the consumer
+    # because it can't find the schema. revert once that problem is fixed and devserver actually starts
+    # "--enforce-schema",
 ]
 
 COMMON_RUST_CONSUMER_DEV_OPTIONS = COMMON_CONSUMER_DEV_OPTIONS + [


### PR DESCRIPTION
```
13:04:15 transaction-consumer                          | thread '<unnamed>' panicked at src/strategies/processor.rs:48:17:
13:04:15 transaction-consumer                          | Schema error: Topic not found
13:04:15 transaction-consumer                          | stack backtrace:
13:04:15 errors-consumer                               | 2024-01-23 13:04:15,551 New partitions assigned: {Partition(topic=Topic(name='events'), index=0): 0}
13:04:15 errors-consumer                               | 2024-01-23 13:04:15,551 Initialized processing strategy: <arroyo.processing.strategies.guard.StrategyGuard object at 0x10a1ac100>
13:04:15 transaction-consumer                          |    0: rust_begin_unwind
13:04:15 transaction-consumer                          |              at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/std/src/panicking.rs:597:5
13:04:15 transaction-consumer                          |    1: core::panicking::panic_fmt
13:04:15 transaction-consumer                          |              at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/panicking.rs:72:14
13:04:15 transaction-consumer                          |    2: rust_snuba::strategies::processor::get_schema
13:04:15 transaction-consumer                          |              at ./rust_snuba/src/strategies/processor.rs:48:17
13:04:15 transaction-consumer                          |    3: <rust_snuba::factory::ConsumerStrategyFactory as rust_arroyo::processing::strategies::ProcessingStrategyFactory<rust_arroyo::backends::kafka::types::KafkaPayload>>::create
13:04:15 transaction-consumer                          |              at ./rust_snuba/src/factory.rs:175:30
13:04:15 transaction-consumer                          |    4: <rust_arroyo::processing::Callbacks<TPayload> as rust_arroyo::backends::AssignmentCallbacks>::on_assign
13:04:15 transaction-consumer                          |              at /Users/johnyang/.cargo/git/checkouts/arroyo-2fe52eb044a47b23/f90eeff/rust-arroyo/src/processing/mod.rs:129:31
```