### PR TITLE
ref(optimize): Use time-machine instead of freezegun

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
-freezegun==1.2.2
+time-machine==2.13.0
 
 # for typing
 mypy==1.1.1

--- a/tests/clickhouse/optimize/test_optimize_scheduler.py
+++ b/tests/clickhouse/optimize/test_optimize_scheduler.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from typing import Sequence
 
 import pytest
-from freezegun import freeze_time
+import time_machine
 
 from snuba import settings
 from snuba.clickhouse.optimize.optimize_scheduler import (
@@ -250,16 +250,17 @@ def test_get_next_schedule(
 ) -> None:
     optimize_scheduler = OptimizeScheduler(parallel=parallel)
 
-    with freeze_time(current_time):
+    with time_machine.travel(current_time, tick=False):
         assert optimize_scheduler.get_next_schedule(partitions) == expected
 
 
 def test_get_next_schedule_raises_exception() -> None:
     optimize_scheduler = OptimizeScheduler(parallel=1)
-    with freeze_time(
+    with time_machine.travel(
         last_midnight
         + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)
-        + timedelta(minutes=20)
+        + timedelta(minutes=20),
+        tick=False,
     ):
         with pytest.raises(OptimizedSchedulerTimeout):
             optimize_scheduler.get_next_schedule(


### PR DESCRIPTION
Lets move off freezegun since Sentry also moved away from it. With time machine maybe some of the flakiness might go away. Will keep an eye on the test flakiness. If it reappears we can disable it again.