### PR TITLE
fix(devserver): Enforce schemas again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.3.4
 sentry-arroyo==2.15.3
-sentry-kafka-schemas==0.1.46
+sentry-kafka-schemas==0.1.47
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.39
 sentry-sdk==1.28.0

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -6,9 +6,7 @@ COMMON_CONSUMER_DEV_OPTIONS = [
     "--auto-offset-reset=latest",
     "--no-strict-offset-reset",
     "--log-level=debug",
-    # XXX(markus): there is some bug in transactions that crashes the consumer
-    # because it can't find the schema. revert once that problem is fixed and devserver actually starts
-    # "--enforce-schema",
+    "--enforce-schema",
 ]
 
 COMMON_RUST_CONSUMER_DEV_OPTIONS = COMMON_CONSUMER_DEV_OPTIONS + [


### PR DESCRIPTION
The bug crashing devserver got fixed in https://github.com/getsentry/sentry-kafka-schemas/pull/208, so we're reverting https://github.com/getsentry/snuba/pull/5446
