### PR TITLE
fix(gcb): Remove build steps from GCB

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
         "--build-arg",
         "SOURCE_COMMIT=$COMMIT_SHA",
         "--destination=us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA",
+        "--target=application",
         "-f",
         "./Dockerfile",
       ]


### PR DESCRIPTION
We were building the testing image instead of the application image in
GCB, which means that an additional 5 minutes were spent on installing
test dependencies.
