### PR TITLE
perf: use `--release` when watching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ generate-config-docs:
 
 watch-rust-snuba:
 	. scripts/rust-envvars && \
-		cd rust_snuba/ && cargo watch -s 'maturin develop'
+		cd rust_snuba/ && cargo watch -s 'maturin develop --release'
 .PHONY: watch-rust-snuba
 
 test-rust:


### PR DESCRIPTION
It's useful to eliminate false positives when benchmarking and watching.