### PR TITLE
feat(metrics-summaries): Add segment-related columns to ease up querying

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -375,4 +375,5 @@ class MetricsSummariesLoader(DirectoryLoader):
         return [
             "0001_metrics_summaries_create_table",
             "0002_metrics_summaries_add_tags_hashmap",
+            "0003_metrics_summaries_add_segment_id_duration_group_columns",
         ]

--- a/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
+++ b/snuba/snuba_migrations/metrics_summaries/0001_metrics_summaries_create_table.py
@@ -42,7 +42,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=local_table_name,
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    order_by="(project_id, cityHash64(metric_mri), end_timestamp, cityHash64(span_id))",
+                    order_by="(project_id, cityHash64(metric_mri), end_timestamp, span_id)",
                     version_column="deleted",
                     partition_by="(retention_days, toMonday(end_timestamp))",
                     sample_by="cityHash64(metric_mri)",

--- a/snuba/snuba_migrations/metrics_summaries/0003_metrics_summaries_add_segment_id_duration_group_columns.py
+++ b/snuba/snuba_migrations/metrics_summaries/0003_metrics_summaries_add_segment_id_duration_group_columns.py
@@ -1,0 +1,55 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set_name = StorageSetKey.METRICS_SUMMARIES
+
+columns: List[Column[Modifiers]] = [
+    Column("segment_id", UInt(64)),
+    Column("duration_ms", UInt(32)),
+    Column("group", UInt(64)),
+    Column("is_segment", UInt(8)),
+]
+
+targets = [
+    (
+        OperationTarget.LOCAL,
+        "metrics_summaries_local",
+    ),
+    (
+        OperationTarget.DISTRIBUTED,
+        "metrics_summaries_dist",
+    ),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=table_name,
+                column=column,
+                target=target,
+            )
+            for column in columns
+            for table_name, target in targets
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column in columns
+            for target, table_name in targets
+        ]

--- a/snuba/snuba_migrations/metrics_summaries/0003_metrics_summaries_add_segment_id_duration_group_columns.py
+++ b/snuba/snuba_migrations/metrics_summaries/0003_metrics_summaries_add_segment_id_duration_group_columns.py
@@ -39,7 +39,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 target=target,
             )
             for column in columns
-            for table_name, target in targets
+            for target, table_name in targets
         ]
 
     def backwards_ops(self) -> Sequence[SqlOperation]:

--- a/snuba/snuba_migrations/metrics_summaries/0003_metrics_summaries_add_segment_id_duration_group_columns.py
+++ b/snuba/snuba_migrations/metrics_summaries/0003_metrics_summaries_add_segment_id_duration_group_columns.py
@@ -51,5 +51,5 @@ class Migration(migration.ClickhouseNodeMigration):
                 target=target,
             )
             for column in columns
-            for target, table_name in targets
+            for target, table_name in reversed(targets)
         ]


### PR DESCRIPTION
As we've learned more about what we wanted out of the product, we need to adapt a bit what we store in `metrics_summaries`.

This PR will add useful IDs to be able to query spans more efficiently.

This was the proposal: https://www.notion.so/sentry/Metrics-Correlations-Data-Model-Proposal-32b0979b48094247bdb5c3e866d5730c .