### PR TITLE
ref: Send metrics to DDM from Rust consumers

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2551,7 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "statsdproxy"
-version = "0.1.1"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793ec303cef342e5a80e717016050673430851d5e3159ba8275c0f801cc83c11"
 dependencies = [
  "anyhow",
  "cadence",

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2552,8 +2552,6 @@ dependencies = [
 [[package]]
 name = "statsdproxy"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c3ca857ffc876cad78f6c1489356c962d214fe500117c61865550e6304509d"
 dependencies = [
  "anyhow",
  "cadence",
@@ -2561,6 +2559,8 @@ dependencies = [
  "crc32fast",
  "env_logger",
  "log",
+ "rand 0.8.5",
+ "sentry",
  "serde",
  "serde_yaml",
  "signal-hook",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0"
 tokio = { version = "1.19.2", features = ["full"] }
-statsdproxy = { version = "0.1.1", features = ["cadence-adapter"] }
+statsdproxy = { version = "0.1.1", features = ["cadence-adapter", "sentry"], path = "../../statsdproxy" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = "1.5.0"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0"
 tokio = { version = "1.19.2", features = ["full"] }
-statsdproxy = { version = "0.1.1", features = ["cadence-adapter", "sentry"], path = "../../statsdproxy" }
+statsdproxy = { version = "0.1.2", features = ["cadence-adapter", "sentry"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = "1.5.0"

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -195,7 +195,7 @@ fn run_processor_bench(
 
 fn main() {
     // this sends to nowhere, but because it's UDP we won't error.
-    metrics::init(StatsDBackend::new("127.0.0.1", 8081, "snuba.consumer")).unwrap();
+    metrics::init(StatsDBackend::new("127.0.0.1", 8081, "snuba.consumer", 0.0)).unwrap();
 
     let mut c = Criterion::default().configure_from_args();
 

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -106,6 +106,7 @@ pub struct EnvConfig {
     pub lower_retention_days: u16,
     pub valid_retention_days: HashSet<u16>,
     pub record_cogs: bool,
+    pub ddm_metrics_sample_rate: f64,
 }
 
 impl Default for EnvConfig {
@@ -118,6 +119,7 @@ impl Default for EnvConfig {
             lower_retention_days: 30,
             valid_retention_days: [30, 90].iter().cloned().collect(),
             record_cogs: false,
+            ddm_metrics_sample_rate: 0.0,
         }
     }
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -108,7 +108,13 @@ pub fn consumer_impl(
         set_global_tag("storage".to_owned(), storage_name);
         set_global_tag("consumer_group".to_owned(), consumer_group.to_owned());
 
-        metrics::init(StatsDBackend::new(&host, port, "snuba.consumer")).unwrap();
+        metrics::init(StatsDBackend::new(
+            &host,
+            port,
+            "snuba.consumer",
+            env_config.ddm_metrics_sample_rate,
+        ))
+        .unwrap();
     }
 
     if !use_rust_processor {

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -29,12 +29,17 @@ impl MetricSink for Wrapper {
 }
 
 impl StatsDBackend {
-    pub fn new(host: &str, port: u16, prefix: &str) -> Self {
+    pub fn new(host: &str, port: u16, prefix: &str, ddm_metrics_sample_rate: f64) -> Self {
         let upstream_addr = format!("{}:{}", host, port);
         let aggregator_sink = StatsdProxyMetricSink::new(move || {
             let next_step = Upstream::new(upstream_addr.clone()).unwrap();
 
-            let next_step_sentry = Sample::new(SampleConfig { sample_rate: 0.01 }, Sentry::new());
+            let next_step_sentry = Sample::new(
+                SampleConfig {
+                    sample_rate: ddm_metrics_sample_rate,
+                },
+                Sentry::new(),
+            );
 
             let next_step = Mirror::new(next_step, next_step_sentry);
 

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn statsd_metric_backend() {
-        let backend = StatsDBackend::new("0.0.0.0", 8125, "test");
+        let backend = StatsDBackend::new("0.0.0.0", 8125, "test", 0.0);
 
         backend.record_metric(metric!(Counter: "a", 1, "tag1" => "value1"));
         backend.record_metric(metric!(Gauge: "b", 20, "tag2" => "value2"));

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -51,6 +51,7 @@ class EnvConfig:
     lower_retention_days: int
     valid_retention_days: list[int]
     record_cogs: bool
+    ddm_metrics_sample_rate: float
 
 
 @dataclass(frozen=True)
@@ -122,6 +123,7 @@ def _resolve_env_config() -> EnvConfig:
     sentry_dsn = settings.SENTRY_DSN
     dogstatsd_host = settings.DOGSTATSD_HOST
     dogstatsd_port = settings.DOGSTATSD_PORT
+    ddm_metrics_sample_rate = settings.DDM_METRICS_SAMPLE_RATE
     default_retention_days = settings.DEFAULT_RETENTION_DAYS
     lower_retention_days = settings.LOWER_RETENTION_DAYS
     valid_retention_days = list(settings.VALID_RETENTION_DAYS)
@@ -134,6 +136,7 @@ def _resolve_env_config() -> EnvConfig:
         lower_retention_days=lower_retention_days,
         valid_retention_days=valid_retention_days,
         record_cogs=record_cogs,
+        ddm_metrics_sample_rate=ddm_metrics_sample_rate,
     )
 
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -126,6 +126,7 @@ DOGSTATSD_SAMPLING_RATES = {
     "metrics.processor.set.size": 0.1,
     "metrics.processor.distribution.size": 0.1,
 }
+DDM_METRICS_SAMPLE_RATE = float(os.environ.get("SNUBA_DDM_METRICS_SAMPLE_RATE", 0.001))
 
 CLICKHOUSE_READONLY_USER = os.environ.get("CLICKHOUSE_READONLY_USER", "default")
 CLICKHOUSE_READONLY_PASSWORD = os.environ.get("CLICKHOUSE_READONLY_PASS", "")


### PR DESCRIPTION
We use statsdproxy to pre-aggregate metrics within the application
(counters, gauges). Therefore we should be able to dogfood DDM with
relatively low instrumentation overhead.

Still, add a sampling rate for now.

https://github.com/getsentry/statsdproxy/pull/47
