### PR TITLE
fix(mql) Only resolve tag values with the metrics dataset

### DIFF
--- a/tests/query/indexer/test_resolver.py
+++ b/tests/query/indexer/test_resolver.py
@@ -4,16 +4,25 @@ import pytest
 
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.factory import get_dataset
 from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.dsl import divide
 from snuba.query.expressions import Column, CurriedFunctionCall, FunctionCall, Literal
-from snuba.query.indexer.resolver import (
-    resolve_tag_key_mappings,
-    resolve_tag_value_mappings,
-)
+from snuba.query.indexer.resolver import resolve_mappings
 from snuba.query.logical import Query as LogicalQuery
+
+"""
+NOTES ABOUT THESE TESTS
+
+The resolver does not change columns into subscriptables, nor does it affect
+aliases of any expressions. That means that some of the queries in these tests
+are not exactly what would actually be passed in from the parser. However
+they are specific enough to ensure the resolver is working correctly.
+"""
+
 
 metric_id_test_cases = [
     pytest.param(
@@ -32,11 +41,19 @@ metric_id_test_cases = [
                     ),
                 ),
             ],
+            condition=FunctionCall(
+                None,
+                "equals",
+                (
+                    Column(None, None, "metric_id"),
+                    Literal(None, "d:transactions/duration@millisecond"),
+                ),
+            ),
             granularity=60,
             limit=1000,
             offset=0,
         ),
-        {"d:transactions/duration@millisecond": "123456"},
+        {"d:transactions/duration@millisecond": 123456},
         LogicalQuery(
             from_clause=QueryEntity(
                 EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
@@ -58,7 +75,7 @@ metric_id_test_cases = [
                 "equals",
                 (
                     Column(None, None, "metric_id"),
-                    Literal(None, "123456"),
+                    Literal(None, 123456),
                 ),
             ),
             limit=1000,
@@ -84,6 +101,14 @@ metric_id_test_cases = [
                     ),
                 ),
             ],
+            condition=FunctionCall(
+                None,
+                "equals",
+                (
+                    Column(None, None, "metric_id"),
+                    Literal(None, "transaction.user"),
+                ),
+            ),
             granularity=60,
             limit=1000,
             offset=0,
@@ -123,21 +148,6 @@ metric_id_test_cases = [
         ),
         id="resolve public name to metric id condition",
     ),
-]
-
-
-@pytest.mark.skip(reason="resolver is not being used yet")
-@pytest.mark.parametrize("query, mappings, expected_query", metric_id_test_cases)
-def test_resolve_tag_value_mappings_processor(
-    query: CompositeQuery[QueryEntity] | LogicalQuery,
-    mappings: dict[str, str | int],
-    expected_query: CompositeQuery[QueryEntity] | LogicalQuery,
-) -> None:
-    resolve_tag_value_mappings(query, mappings)
-    assert query == expected_query
-
-
-tag_test_cases = [
     pytest.param(
         LogicalQuery(
             from_clause=QueryEntity(
@@ -146,6 +156,139 @@ tag_test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
+                    "sum(transaction.user) / sum(transaction.duration)",
+                    divide(
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "metric_id"),
+                                    Literal(None, "transaction.user"),
+                                ),
+                            ),
+                        ),
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "metric_id"),
+                                    Literal(None, "transaction.duration"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            condition=FunctionCall(
+                None,
+                "in",
+                (
+                    Column(None, None, "metric_id"),
+                    FunctionCall(
+                        None,
+                        "array",
+                        (
+                            Literal(None, "transaction.user"),
+                            Literal(None, "transaction.duration"),
+                        ),
+                    ),
+                ),
+            ),
+            granularity=60,
+            limit=1000,
+            offset=0,
+        ),
+        {
+            "transaction.user": "s:transactions/user@none",
+            "s:transactions/user@none": 123456,
+            "transaction.duration": "s:transactions/duration@none",
+            "s:transactions/duration@none": 567890,
+        },
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.GENERIC_METRICS_SETS,
+                get_entity(EntityKey.GENERIC_METRICS_SETS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "sum(transaction.user) / sum(transaction.duration)",
+                    divide(
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "metric_id"),
+                                    Literal(None, 123456),
+                                ),
+                            ),
+                        ),
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "metric_id"),
+                                    Literal(None, 567890),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            condition=FunctionCall(
+                None,
+                "in",
+                (
+                    Column(None, None, "metric_id"),
+                    FunctionCall(
+                        None,
+                        "array",
+                        (
+                            Literal(None, 123456),
+                            Literal(None, 567890),
+                        ),
+                    ),
+                ),
+            ),
+            granularity=60,
+            limit=1000,
+            offset=0,
+        ),
+        id="resolve public name to metric id in formula",
+    ),
+]
+
+
+@pytest.mark.parametrize("query, mappings, expected_query", metric_id_test_cases)
+def test_resolve_tag_value_mappings_processor(
+    query: CompositeQuery[QueryEntity] | LogicalQuery,
+    mappings: dict[str, str | int],
+    expected_query: CompositeQuery[QueryEntity] | LogicalQuery,
+) -> None:
+    resolve_mappings(query, mappings, get_dataset("generic_metrics"))
+    assert query == expected_query
+
+
+tag_test_cases = [
+    pytest.param(
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.METRICS_SETS,
+                get_entity(EntityKey.METRICS_SETS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
                     "quantiles(0.5, 0.75)(transaction.user)",
                     CurriedFunctionCall(
                         "_snuba_aggregate_value",
@@ -155,31 +298,18 @@ tag_test_cases = [
                         (Column("_snuba_value", None, "value"),),
                     ),
                 ),
-                SelectedExpression(
-                    "quantiles(0.5, 0.75)(transaction.user)",
-                    Column(
-                        None,
-                        None,
-                        "transactions",
-                    ),
-                ),
+                SelectedExpression("transaction", Column(None, None, "transaction")),
             ],
-            groupby=[
-                Column(
-                    None,
-                    None,
-                    "transactions",
-                )
-            ],
+            groupby=[Column(None, None, "transaction")],
             granularity=60,
             limit=1000,
             offset=0,
         ),
-        {"transactions": "111111"},
+        {"transaction": 111111},
         LogicalQuery(
             from_clause=QueryEntity(
-                EntityKey.GENERIC_METRICS_SETS,
-                get_entity(EntityKey.GENERIC_METRICS_SETS).get_data_model(),
+                EntityKey.METRICS_SETS,
+                get_entity(EntityKey.METRICS_SETS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression(
@@ -193,22 +323,14 @@ tag_test_cases = [
                     ),
                 ),
                 SelectedExpression(
-                    "quantiles(0.5, 0.75)(transaction.user)",
-                    Column(
-                        "transactions",
-                        None,
-                        "tags_raw[111111]",
-                    ),
+                    "transaction",
+                    Column(None, None, "tags[111111]"),
                 ),
             ],
             granularity=60,
             condition=None,
             groupby=[
-                Column(
-                    "transactions",
-                    None,
-                    "tags_raw[111111]",
-                ),
+                Column(None, None, "tags[111111]"),
             ],
             limit=1000,
             offset=0,
@@ -218,8 +340,8 @@ tag_test_cases = [
     pytest.param(
         LogicalQuery(
             from_clause=QueryEntity(
-                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
-                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression(
@@ -235,11 +357,7 @@ tag_test_cases = [
                 None,
                 "equals",
                 (
-                    Column(
-                        "foo",
-                        None,
-                        "foo",
-                    ),
+                    Column(None, None, "foo"),
                     Literal(None, "bar"),
                 ),
             ),
@@ -247,11 +365,11 @@ tag_test_cases = [
             limit=1000,
             offset=0,
         ),
-        {"foo": "999999"},
+        {"foo": 999999, "bar": 111111},
         LogicalQuery(
             from_clause=QueryEntity(
-                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
-                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression(
@@ -268,12 +386,8 @@ tag_test_cases = [
                 None,
                 "equals",
                 (
-                    Column(
-                        "foo",
-                        None,
-                        "tags_raw[999999]",
-                    ),
-                    Literal(None, "bar"),
+                    Column(None, None, "tags[999999]"),
+                    Literal(None, 111111),
                 ),
             ),
             limit=1000,
@@ -284,8 +398,8 @@ tag_test_cases = [
     pytest.param(
         LogicalQuery(
             from_clause=QueryEntity(
-                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
-                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression(
@@ -304,7 +418,7 @@ tag_test_cases = [
                     "notIn",
                     (
                         Column(
-                            "dist",
+                            None,
                             None,
                             "dist",
                         ),
@@ -323,7 +437,7 @@ tag_test_cases = [
                     "equals",
                     (
                         Column(
-                            "foo",
+                            None,
                             None,
                             "foo",
                         ),
@@ -335,7 +449,164 @@ tag_test_cases = [
             limit=1000,
             offset=0,
         ),
-        {"foo": "999999", "dist": "888888"},
+        {
+            "foo": 999999,
+            "dist": 888888,
+            "dist1": 777777,
+            "dist2": 666666,
+            "bar": 111111,
+        },
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "sum(d:transactions/duration@millisecond)",
+                    FunctionCall(
+                        "_snuba_aggregate_value",
+                        "sum",
+                        (Column("_snuba_value", None, "value"),),
+                    ),
+                ),
+            ],
+            granularity=60,
+            condition=binary_condition(
+                "and",
+                FunctionCall(
+                    None,
+                    "notIn",
+                    (
+                        Column(
+                            None,
+                            None,
+                            "tags[888888]",
+                        ),
+                        FunctionCall(
+                            None,
+                            "tuple",
+                            (
+                                Literal(None, 777777),
+                                Literal(None, 666666),
+                            ),
+                        ),
+                    ),
+                ),
+                FunctionCall(
+                    None,
+                    "equals",
+                    (
+                        Column(
+                            None,
+                            None,
+                            "tags[999999]",
+                        ),
+                        Literal(None, 111111),
+                    ),
+                ),
+            ),
+            limit=1000,
+            offset=0,
+        ),
+        id="resolve multiple tag filters",
+    ),
+    pytest.param(
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "sum(d:transactions/duration@millisecond)",
+                    FunctionCall(
+                        "_snuba_aggregate_value",
+                        "sum",
+                        (Column("_snuba_value", None, "value"),),
+                    ),
+                ),
+            ],
+            condition=binary_condition(
+                "and",
+                binary_condition(
+                    "equals",
+                    Column(None, None, "event_type"),
+                    Literal(None, "transaction"),
+                ),
+                binary_condition(
+                    "equals", Column(None, None, "transaction"), Literal(None, "t1")
+                ),
+            ),
+            granularity=60,
+            limit=1000,
+            offset=0,
+        ),
+        {"transaction": 999999, "event_type": 888888, "t1": 777777},
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "sum(d:transactions/duration@millisecond)",
+                    FunctionCall(
+                        "_snuba_aggregate_value",
+                        "sum",
+                        (Column("_snuba_value", None, "value"),),
+                    ),
+                ),
+            ],
+            granularity=60,
+            condition=binary_condition(
+                "and",
+                binary_condition(
+                    "equals",
+                    Column(None, None, "tags[888888]"),
+                    Literal(None, 999999),
+                ),
+                binary_condition(
+                    "equals", Column(None, None, "tags[999999]"), Literal(None, 777777)
+                ),
+            ),
+            limit=1000,
+            offset=0,
+        ),
+        id="resolve tag keys and values",
+    ),
+    pytest.param(
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "sum(d:transactions/duration@millisecond)",
+                    FunctionCall(
+                        "_snuba_aggregate_value",
+                        "sum",
+                        (Column("_snuba_value", None, "value"),),
+                    ),
+                ),
+            ],
+            condition=binary_condition(
+                "and",
+                binary_condition(
+                    "equals",
+                    Column(None, None, "event_type"),
+                    Literal(None, "transaction"),
+                ),
+                binary_condition(
+                    "equals", Column(None, None, "transaction"), Literal(None, "t1")
+                ),
+            ),
+            granularity=60,
+            limit=1000,
+            offset=0,
+        ),
+        {"transaction": 999999, "event_type": 888888, "t1": 777777},
         LogicalQuery(
             from_clause=QueryEntity(
                 EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
@@ -354,52 +625,241 @@ tag_test_cases = [
             granularity=60,
             condition=binary_condition(
                 "and",
-                FunctionCall(
-                    None,
-                    "notIn",
-                    (
-                        Column(
-                            "dist",
-                            None,
-                            "tags_raw[888888]",
-                        ),
-                        FunctionCall(
-                            None,
-                            "tuple",
-                            (
-                                Literal(None, "dist1"),
-                                Literal(None, "dist2"),
-                            ),
-                        ),
-                    ),
-                ),
-                FunctionCall(
-                    None,
+                binary_condition(
                     "equals",
-                    (
-                        Column(
-                            "foo",
-                            None,
-                            "tags_raw[999999]",
-                        ),
-                        Literal(None, "bar"),
-                    ),
+                    Column(None, None, "tags_raw[888888]"),
+                    Literal(None, "transaction"),
+                ),
+                binary_condition(
+                    "equals",
+                    Column(None, None, "tags_raw[999999]"),
+                    Literal(None, "t1"),
                 ),
             ),
             limit=1000,
             offset=0,
         ),
-        id="resolve multiple tag filters",
+        id="only resolve tag keys despite crossover",
+    ),
+    pytest.param(
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "(sum(user){status_code:500} / avg(duration){status_code:200}){foo:bar}",
+                    divide(
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "status_code"),
+                                    Literal(None, "500"),
+                                ),
+                            ),
+                        ),
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "avgIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "status_code"),
+                                    Literal(None, "200"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            condition=binary_condition(
+                "equals",
+                Column(None, None, "foo"),
+                Literal(None, "bar"),
+            ),
+            granularity=60,
+            limit=1000,
+            offset=0,
+        ),
+        {
+            "user": 111111,
+            "duration": 222222,
+            "status_code": 333333,
+            "500": 444444,
+            "200": 555555,
+            "foo": 666666,
+            "bar": 777777,
+        },
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "(sum(user){status_code:500} / avg(duration){status_code:200}){foo:bar}",
+                    divide(
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "tags_raw[333333]"),
+                                    Literal(None, "500"),
+                                ),
+                            ),
+                        ),
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "avgIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "tags_raw[333333]"),
+                                    Literal(None, "200"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            granularity=60,
+            condition=binary_condition(
+                "equals",
+                Column(None, None, "tags_raw[666666]"),
+                Literal(None, "bar"),
+            ),
+            limit=1000,
+            offset=0,
+        ),
+        id="resolving with a formula in generic",
+    ),
+    pytest.param(
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "(sum(user){status_code:500} / avg(duration){status_code:200}){foo:bar}",
+                    divide(
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "status_code"),
+                                    Literal(None, "500"),
+                                ),
+                            ),
+                        ),
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "avgIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "status_code"),
+                                    Literal(None, "200"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            condition=binary_condition(
+                "equals",
+                Column(None, None, "foo"),
+                Literal(None, "bar"),
+            ),
+            granularity=60,
+            limit=1000,
+            offset=0,
+        ),
+        {
+            "user": 111111,
+            "duration": 222222,
+            "status_code": 333333,
+            "500": 444444,
+            "200": 555555,
+            "foo": 666666,
+            "bar": 777777,
+        },
+        LogicalQuery(
+            from_clause=QueryEntity(
+                EntityKey.METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "(sum(user){status_code:500} / avg(duration){status_code:200}){foo:bar}",
+                    divide(
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "sumIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "tags[333333]"),
+                                    Literal(None, 444444),
+                                ),
+                            ),
+                        ),
+                        FunctionCall(
+                            "_snuba_aggregate_value",
+                            "avgIf",
+                            (
+                                Column("_snuba_value", None, "value"),
+                                binary_condition(
+                                    "equals",
+                                    Column(None, None, "tags[333333]"),
+                                    Literal(None, 555555),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            granularity=60,
+            condition=binary_condition(
+                "equals",
+                Column(None, None, "tags[666666]"),
+                Literal(None, 777777),
+            ),
+            limit=1000,
+            offset=0,
+        ),
+        id="resolving with a formula in sessions",
     ),
 ]
 
 
-@pytest.mark.skip(reason="resolver is not being used yet")
 @pytest.mark.parametrize("query, mappings, expected_query", tag_test_cases)
 def test_resolve_tag_key_mappings_processor(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
     mappings: dict[str, str | int],
     expected_query: CompositeQuery[QueryEntity] | LogicalQuery,
 ) -> None:
-    resolve_tag_key_mappings(query, mappings)
+    from_clause = query.get_from_clause()
+    assert isinstance(from_clause, QueryEntity)
+    if from_clause.key.value.startswith("generic"):
+        dataset = get_dataset("generic_metrics")
+    else:
+        dataset = get_dataset("metrics")
+
+    resolve_mappings(query, mappings, dataset)
     assert query == expected_query

--- a/tests/query/parser/test_mql_query.py
+++ b/tests/query/parser/test_mql_query.py
@@ -781,10 +781,10 @@ mql_test_cases = [
             "offset": 3,
             "indexer_mappings": {
                 "transaction.user": "s:transactions/user@none",
-                "s:transactions/user@none": "567890",
-                "dist": "000888",
-                "foo": "000777",
-                "transaction": "111111",
+                "s:transactions/user@none": 567890,
+                "dist": 888888,
+                "foo": 777777,
+                "transaction": 111111,
             },
         },
         Query(
@@ -958,7 +958,7 @@ mql_test_cases = [
                                                                                 "notIn",
                                                                                 (
                                                                                     SubscriptableReference(
-                                                                                        "_snuba_tags_raw[000888]",
+                                                                                        "_snuba_tags_raw[888888]",
                                                                                         column=Column(
                                                                                             "_snuba_tags_raw",
                                                                                             None,
@@ -966,7 +966,7 @@ mql_test_cases = [
                                                                                         ),
                                                                                         key=Literal(
                                                                                             None,
-                                                                                            "000888",
+                                                                                            "888888",
                                                                                         ),
                                                                                     ),
                                                                                     FunctionCall(
@@ -990,7 +990,7 @@ mql_test_cases = [
                                                                                 "equals",
                                                                                 (
                                                                                     SubscriptableReference(
-                                                                                        "_snuba_tags_raw[000777]",
+                                                                                        "_snuba_tags_raw[777777]",
                                                                                         column=Column(
                                                                                             "_snuba_tags_raw",
                                                                                             None,
@@ -998,7 +998,7 @@ mql_test_cases = [
                                                                                         ),
                                                                                         key=Literal(
                                                                                             None,
-                                                                                            "000777",
+                                                                                            "777777",
                                                                                         ),
                                                                                     ),
                                                                                     Literal(
@@ -2149,10 +2149,10 @@ mql_test_cases = [
             "offset": 3,
             "indexer_mappings": {
                 "transaction.user": "s:transactions/user@none",
-                "s:transactions/user@none": "567890",
-                "dist": "000888",
-                "foo": "000777",
-                "transaction": "111111",
+                "s:transactions/user@none": 567890,
+                "dist": 888888,
+                "foo": 777777,
+                "transaction": 111111,
             },
         },
         Query(
@@ -2324,6 +2324,253 @@ mql_test_cases = [
         ),
         "generic_metrics",
         id="Select metric with curried arbitrary function",
+    ),
+    pytest.param(
+        'avg(d:custom/sentry.event_manager.save_transactions.fetch_organizations@second){(event_type:"transaction" AND transaction:"sentry.tasks.store.save_event_transaction")}',
+        {
+            "entity": "generic_metrics_distributions",
+            "start": "2021-01-01T00:00:00",
+            "end": "2021-01-02T00:00:00",
+            "rollup": {
+                "orderby": None,
+                "granularity": 60,
+                "interval": None,
+                "with_totals": None,
+            },
+            "scope": {
+                "org_ids": [1],
+                "project_ids": [1],
+                "use_case_id": "custom",
+            },
+            "limit": None,
+            "offset": None,
+            "indexer_mappings": {
+                "d:custom/sentry.event_manager.save_transactions.fetch_organizations@second": 111111,
+                "event_type": 222222,
+                "transaction": 333333,
+            },
+        },
+        Query(
+            QueryEntity(
+                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "aggregate_value",
+                    FunctionCall(
+                        "_snuba_aggregate_value",
+                        "avg",
+                        (Column("_snuba_value", None, "value"),),
+                    ),
+                ),
+            ],
+            condition=FunctionCall(
+                None,
+                "and",
+                (
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            Column(
+                                "_snuba_granularity",
+                                None,
+                                "granularity",
+                            ),
+                            Literal(None, 60),
+                        ),
+                    ),
+                    FunctionCall(
+                        None,
+                        "and",
+                        (
+                            FunctionCall(
+                                None,
+                                "in",
+                                (
+                                    Column(
+                                        "_snuba_project_id",
+                                        None,
+                                        "project_id",
+                                    ),
+                                    FunctionCall(
+                                        None,
+                                        "tuple",
+                                        (Literal(None, 1),),
+                                    ),
+                                ),
+                            ),
+                            FunctionCall(
+                                None,
+                                "and",
+                                (
+                                    FunctionCall(
+                                        None,
+                                        "in",
+                                        (
+                                            Column(
+                                                "_snuba_org_id",
+                                                None,
+                                                "org_id",
+                                            ),
+                                            FunctionCall(
+                                                None,
+                                                "tuple",
+                                                (Literal(None, 1),),
+                                            ),
+                                        ),
+                                    ),
+                                    FunctionCall(
+                                        None,
+                                        "and",
+                                        (
+                                            FunctionCall(
+                                                None,
+                                                "equals",
+                                                (
+                                                    Column(
+                                                        "_snuba_use_case_id",
+                                                        None,
+                                                        "use_case_id",
+                                                    ),
+                                                    Literal(None, "custom"),
+                                                ),
+                                            ),
+                                            FunctionCall(
+                                                None,
+                                                "and",
+                                                (
+                                                    FunctionCall(
+                                                        None,
+                                                        "greaterOrEquals",
+                                                        (
+                                                            Column(
+                                                                "_snuba_timestamp",
+                                                                None,
+                                                                "timestamp",
+                                                            ),
+                                                            Literal(
+                                                                None,
+                                                                datetime(
+                                                                    2021, 1, 1, 0, 0
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    FunctionCall(
+                                                        None,
+                                                        "and",
+                                                        (
+                                                            FunctionCall(
+                                                                None,
+                                                                "less",
+                                                                (
+                                                                    Column(
+                                                                        "_snuba_timestamp",
+                                                                        None,
+                                                                        "timestamp",
+                                                                    ),
+                                                                    Literal(
+                                                                        None,
+                                                                        datetime(
+                                                                            2021,
+                                                                            1,
+                                                                            2,
+                                                                            0,
+                                                                            0,
+                                                                        ),
+                                                                    ),
+                                                                ),
+                                                            ),
+                                                            FunctionCall(
+                                                                None,
+                                                                "and",
+                                                                (
+                                                                    FunctionCall(
+                                                                        None,
+                                                                        "equals",
+                                                                        (
+                                                                            Column(
+                                                                                "_snuba_metric_id",
+                                                                                None,
+                                                                                "metric_id",
+                                                                            ),
+                                                                            Literal(
+                                                                                None,
+                                                                                111111,
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                    FunctionCall(
+                                                                        None,
+                                                                        "and",
+                                                                        (
+                                                                            FunctionCall(
+                                                                                None,
+                                                                                "equals",
+                                                                                (
+                                                                                    SubscriptableReference(
+                                                                                        "_snuba_tags_raw[222222]",
+                                                                                        column=Column(
+                                                                                            "_snuba_tags_raw",
+                                                                                            None,
+                                                                                            "tags_raw",
+                                                                                        ),
+                                                                                        key=Literal(
+                                                                                            None,
+                                                                                            "222222",
+                                                                                        ),
+                                                                                    ),
+                                                                                    Literal(
+                                                                                        None,
+                                                                                        "transaction",
+                                                                                    ),
+                                                                                ),
+                                                                            ),
+                                                                            FunctionCall(
+                                                                                None,
+                                                                                "equals",
+                                                                                (
+                                                                                    SubscriptableReference(
+                                                                                        "_snuba_tags_raw[333333]",
+                                                                                        column=Column(
+                                                                                            "_snuba_tags_raw",
+                                                                                            None,
+                                                                                            "tags_raw",
+                                                                                        ),
+                                                                                        key=Literal(
+                                                                                            None,
+                                                                                            "333333",
+                                                                                        ),
+                                                                                    ),
+                                                                                    Literal(
+                                                                                        None,
+                                                                                        "sentry.tasks.store.save_event_transaction",
+                                                                                    ),
+                                                                                ),
+                                                                            ),
+                                                                        ),
+                                                                    ),
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            groupby=[],
+            order_by=[],
+            limit=1000,
+        ),
+        "generic_metrics",
     ),
 ]
 


### PR DESCRIPTION
The resolver was always resolving everything it possibly could for both generic
and regular metrics. However generic metrics don't resolve tag values. This
generally wasn't a problem, unless a string was both a tag key and a tag value
(e.g. transaction).

The other issue is that metric_id resolving was being done as a part of tag
value resolution. Break that out into a separate check, and then only do tag
value resolving for metrics.

Also unskip all the resolver tests, which meant bring them up to date with how
the resolver currently works.