### PR TITLE
experiment(capman): try explicitly expiring the query bucket in rate_limit_finish_request

### DIFF
--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -354,6 +354,7 @@ def rate_limit_finish_request(
         try:
             pipe.zrem(query_bucket, query_id)  # not allowed / not counted
             pipe.expire(query_bucket, max_query_duration_s)
+            pipe.execute()
         except Exception as ex:
             logger.exception(ex)
     else:
@@ -361,6 +362,7 @@ def rate_limit_finish_request(
             # return the query to its start time, if the query_id was actually added.
             pipe.zincrby(query_bucket, -float(max_query_duration_s), query_id)
             pipe.expire(query_bucket, max_query_duration_s)
+            pipe.execute()
         except Exception as ex:
             logger.exception(ex)
 

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -349,15 +349,18 @@ def rate_limit_finish_request(
         rate_limit_prefix, rate_limit_params.bucket, bucket_shard
     )
     max_query_duration_s = max_query_duration_s or state.max_query_duration_s
+    pipe = rds.pipeline()
     if was_rate_limited:
         try:
-            rds.zrem(query_bucket, query_id)  # not allowed / not counted
+            pipe.zrem(query_bucket, query_id)  # not allowed / not counted
+            pipe.expire(query_bucket, max_query_duration_s)
         except Exception as ex:
             logger.exception(ex)
     else:
         try:
             # return the query to its start time, if the query_id was actually added.
-            rds.zincrby(query_bucket, -float(max_query_duration_s), query_id)
+            pipe.zincrby(query_bucket, -float(max_query_duration_s), query_id)
+            pipe.expire(query_bucket, max_query_duration_s)
         except Exception as ex:
             logger.exception(ex)
 


### PR DESCRIPTION
@untitaker pointed out that it's possible to call zincr or zrem on a set that has expired and create a non-expiring set. Add an expire call to `rate_limit_finish_request` to see if that improves memory usage