### PR TITLE
ref(errors): Remove trace context from extra contexts

### DIFF
--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -289,6 +289,8 @@ class ErrorsProcessor(DatasetMessageProcessor):
 
         if trace_id:
             output["trace_id"] = str(uuid.UUID(trace_id))
+            del contexts["trace"]
+
         if span_id:
             output["span_id"] = int(span_id, 16)
         if trace_sampled:


### PR DESCRIPTION
This data does not need to be stored twice.
