### PR TITLE
ref(ddm): Dual write to Sentry metrics as well as Datadog

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -87,6 +87,12 @@ def setup_sentry() -> None:
         release=os.getenv("SNUBA_RELEASE"),
         traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
         profiles_sample_rate=settings.SNUBA_PROFILES_SAMPLE_RATE,
+        _experiments={
+            # Turns on the metrics module
+            "enable_metrics": True,
+            # Enables sending of code locations for metrics
+            "metric_code_locations": True,
+        },
     )
 
     from snuba.utils.profiler import run_ondemand_profiler

--- a/snuba/utils/metrics/backends/abstract.py
+++ b/snuba/utils/metrics/backends/abstract.py
@@ -11,7 +11,11 @@ class MetricsBackend(ABC):
 
     @abstractmethod
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         """
         Increment a counter metric. These increments can also be
@@ -27,7 +31,11 @@ class MetricsBackend(ABC):
 
     @abstractmethod
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         """
         Emit a metric that is the authoritative value for a quantity at a point in time
@@ -40,7 +48,11 @@ class MetricsBackend(ABC):
 
     @abstractmethod
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         """
         Emit a metric for the timing performance of an operation.
@@ -48,6 +60,23 @@ class MetricsBackend(ABC):
         Example:
 
         metrics.timing("request.latency", request_latency_in_ms)
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def distribution(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
+    ) -> None:
+        """
+        Emit a metric for the performance of an operation.
+
+        Example:
+
+        metrics.distribution("request.size", request_size_in_bytes)
         """
         raise NotImplementedError
 

--- a/snuba/utils/metrics/backends/datadog.py
+++ b/snuba/utils/metrics/backends/datadog.py
@@ -47,7 +47,11 @@ class DatadogMetricsBackend(MetricsBackend):
             return [f"{key}:{value.replace('|', '_')}" for key, value in tags.items()]
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         self.__client.increment(
             name,
@@ -57,7 +61,11 @@ class DatadogMetricsBackend(MetricsBackend):
         )
 
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         self.__client.gauge(
             name,
@@ -67,9 +75,27 @@ class DatadogMetricsBackend(MetricsBackend):
         )
 
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         self.__client.timing(
+            name,
+            value,
+            tags=self.__normalize_tags(tags),
+            sample_rate=self.__sample_rates.get(name, 1.0),
+        )
+
+    def distribution(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
+    ) -> None:
+        self.__client.distribution(
             name,
             value,
             tags=self.__normalize_tags(tags),

--- a/snuba/utils/metrics/backends/dualwrite.py
+++ b/snuba/utils/metrics/backends/dualwrite.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import random
+
+from snuba import settings
+from snuba.utils.metrics.backends.abstract import MetricsBackend
+from snuba.utils.metrics.backends.datadog import DatadogMetricsBackend
+from snuba.utils.metrics.backends.sentry import SentryMetricsBackend
+from snuba.utils.metrics.types import Tags
+
+
+class SentryDatadogMetricsBackend(MetricsBackend):
+    """
+    A metrics backend that records metrics to Sentry and Datadog.
+    """
+
+    def __init__(
+        self, datadog: DatadogMetricsBackend, sentry: SentryMetricsBackend
+    ) -> None:
+        self.datadog = datadog
+        self.sentry = sentry
+
+    def _use_sentry(self) -> bool:
+        from snuba import state
+
+        if state.get_config("use_sentry_metrics", "0") == "1":
+            return bool(random.random() < settings.DDM_METRICS_SAMPLE_RATE)
+        return False
+
+    def increment(
+        self,
+        name: str,
+        value: int | float = 1,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        self.datadog.increment(name, value, tags, unit)
+        if self._use_sentry():
+            self.sentry.increment(name, value, tags, unit)
+
+    def gauge(
+        self,
+        name: str,
+        value: int | float,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        self.datadog.gauge(name, value, tags, unit)
+        if self._use_sentry():
+            self.sentry.gauge(name, value, tags, unit)
+
+    def timing(
+        self,
+        name: str,
+        value: int | float,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        self.datadog.timing(name, value, tags, unit)
+        if self._use_sentry():
+            self.sentry.timing(name, value, tags, unit)
+
+    def distribution(
+        self,
+        name: str,
+        value: int | float,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        self.datadog.distribution(name, value, tags, unit)
+        if self._use_sentry():
+            self.sentry.distribution(name, value, tags, unit)
+
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Tags | None = None,
+    ) -> None:
+        self.datadog.events(title, text, alert_type, priority, tags)

--- a/snuba/utils/metrics/backends/dummy.py
+++ b/snuba/utils/metrics/backends/dummy.py
@@ -26,7 +26,11 @@ class DummyMetricsBackend(MetricsBackend):
             assert isinstance(v, str)
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         if self.__strict:
             assert isinstance(name, str)
@@ -35,7 +39,11 @@ class DummyMetricsBackend(MetricsBackend):
                 self.__validate_tags(tags)
 
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         if self.__strict:
             assert isinstance(name, str)
@@ -44,7 +52,24 @@ class DummyMetricsBackend(MetricsBackend):
                 self.__validate_tags(tags)
 
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
+    ) -> None:
+        if self.__strict:
+            assert isinstance(name, str)
+            assert isinstance(value, (int, float))
+            if tags is not None:
+                self.__validate_tags(tags)
+
+    def distribution(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         if self.__strict:
             assert isinstance(name, str)

--- a/snuba/utils/metrics/backends/sentry.py
+++ b/snuba/utils/metrics/backends/sentry.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from sentry_sdk import metrics
+
+from snuba.utils.metrics.backends.abstract import MetricsBackend
+from snuba.utils.metrics.types import Tags
+
+
+class SentryMetricsBackend(MetricsBackend):
+    """
+    A metrics backend that records metrics to Sentry.
+    """
+
+    def __init__(self) -> None:
+        return None  # Sentry doesn't require any setup
+
+    def increment(
+        self,
+        name: str,
+        value: int | float = 1,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        metrics.incr(name, value, unit or "none", tags)
+
+    def gauge(
+        self,
+        name: str,
+        value: int | float,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        metrics.gauge(name, value, unit or "none", tags)
+
+    def timing(
+        self,
+        name: str,
+        value: int | float,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        # The Sentry SDK has strict typing on the unit, so it doesn't allow passing arbitrary units
+        metrics.timing(name, value, unit or "millisecond", tags)  # type: ignore
+
+    def distribution(
+        self,
+        name: str,
+        value: int | float,
+        tags: Tags | None = None,
+        unit: str | None = None,
+    ) -> None:
+        metrics.distribution(name, value, unit or "none", tags)
+
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Tags | None = None,
+    ) -> None:
+        return None  # Sentry doesn't support events

--- a/snuba/utils/metrics/util.py
+++ b/snuba/utils/metrics/util.py
@@ -38,18 +38,23 @@ def create_metrics(
     from datadog import DogStatsd
 
     from snuba.utils.metrics.backends.datadog import DatadogMetricsBackend
+    from snuba.utils.metrics.backends.dualwrite import SentryDatadogMetricsBackend
+    from snuba.utils.metrics.backends.sentry import SentryMetricsBackend
 
-    return DatadogMetricsBackend(
-        partial(
-            DogStatsd,
-            host=host,
-            port=port,
-            namespace=prefix,
-            constant_tags=[f"{key}:{value}" for key, value in tags.items()]
-            if tags is not None
-            else None,
+    return SentryDatadogMetricsBackend(
+        DatadogMetricsBackend(
+            partial(
+                DogStatsd,
+                host=host,
+                port=port,
+                namespace=prefix,
+                constant_tags=[f"{key}:{value}" for key, value in tags.items()]
+                if tags is not None
+                else None,
+            ),
+            sample_rates,
         ),
-        sample_rates,
+        SentryMetricsBackend(),
     )
 
 

--- a/snuba/utils/metrics/wrapper.py
+++ b/snuba/utils/metrics/wrapper.py
@@ -30,21 +30,48 @@ class MetricsWrapper(MetricsBackend):
             return {**tags, **self.__tags}
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
         self.__backend.increment(
-            self.__merge_name(name), value, self.__merge_tags(tags)
+            self.__merge_name(name), value, self.__merge_tags(tags), unit
         )
 
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
-        self.__backend.gauge(self.__merge_name(name), value, self.__merge_tags(tags))
+        self.__backend.gauge(
+            self.__merge_name(name), value, self.__merge_tags(tags), unit
+        )
 
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
-        self.__backend.timing(self.__merge_name(name), value, self.__merge_tags(tags))
+        self.__backend.timing(
+            self.__merge_name(name), value, self.__merge_tags(tags), unit
+        )
+
+    def distribution(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
+    ) -> None:
+        self.__backend.distribution(
+            self.__merge_name(name), value, self.__merge_tags(tags), unit
+        )
 
     def events(
         self,

--- a/tests/backends/metrics.py
+++ b/tests/backends/metrics.py
@@ -8,18 +8,28 @@ class Increment(NamedTuple):
     name: str
     value: Union[int, float]
     tags: Optional[Tags]
+    unit: Optional[str] = None
 
 
 class Gauge(NamedTuple):
     name: str
     value: Union[int, float]
     tags: Optional[Tags]
+    unit: Optional[str] = None
 
 
 class Timing(NamedTuple):
     name: str
     value: Union[int, float]
     tags: Optional[Tags]
+    unit: Optional[str] = None
+
+
+class Distribution(NamedTuple):
+    name: str
+    value: Union[int, float]
+    tags: Optional[Tags]
+    unit: Optional[str] = None
 
 
 class Events(NamedTuple):
@@ -40,22 +50,45 @@ class TestingMetricsBackend(MetricsBackend):
     # TODO: This might make sense to extend the dummy metrics backend.
 
     def __init__(self) -> None:
-        self.calls: MutableSequence[Union[Increment, Gauge, Timing, Events]] = []
+        self.calls: MutableSequence[
+            Union[Increment, Gauge, Timing, Distribution, Events]
+        ] = []
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
-        self.calls.append(Increment(name, value, tags))
+        self.calls.append(Increment(name, value, tags, unit))
 
     def gauge(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
-        self.calls.append(Gauge(name, value, tags))
+        self.calls.append(Gauge(name, value, tags, unit))
 
     def timing(
-        self, name: str, value: Union[int, float], tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
     ) -> None:
-        self.calls.append(Timing(name, value, tags))
+        self.calls.append(Timing(name, value, tags, unit))
+
+    def distribution(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        unit: Optional[str] = None,
+    ) -> None:
+        self.calls.append(Distribution(name, value, tags, unit))
 
     def events(
         self,


### PR DESCRIPTION
This PR wraps the Datadog and Sentry metrics into a single backend, so we can
start dogfooding Sentry metrics. Currently the Sentry portion is feature
flagged and has a sampling rate.

Sentry also provides a way to specify the unit and record distributions, so add
that to the abstract so we can start using it later.

Recreated from  #5474, with bug fixes.