### PR TITLE
feat(capman): Referrer guard rail policy

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -247,16 +247,21 @@ allocation_policies:
         - referrer
         - project_id
       default_config_overrides:
-        is_enforced: 0
+        is_enforced: 1
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:
         - organization_id
         - referrer
       default_config_overrides:
-        is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 10000000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+            is_enforced: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/query/allocation_policies/per_referrer.py
+++ b/snuba/query/allocation_policies/per_referrer.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import logging
+
+from snuba.query.allocation_policies import (
+    AllocationPolicyConfig,
+    QueryResultOrError,
+    QuotaAllowance,
+)
+from snuba.query.allocation_policies.concurrent_rate_limit import (
+    BaseConcurrentRateLimitAllocationPolicy,
+)
+from snuba.redis import RedisClientKey, get_redis_client
+from snuba.state.rate_limit import RateLimitParameters
+
+DEFAULT_CONCURRENT_QUERIES_LIMIT = 22
+DEFAULT_PER_SECOND_QUERIES_LIMIT = 50
+
+rds = get_redis_client(RedisClientKey.RATE_LIMITER)
+
+logger = logging.getLogger("snuba.query.allocation_policy_per_referrer")
+
+_DEFAULT_MAX_THREADS = 10
+_PASS_THROUGH_REFERRERS = set(
+    [
+        "subscriptions_executor",
+    ]
+)
+
+
+class ReferrerGuardRailPolicy(BaseConcurrentRateLimitAllocationPolicy):
+    """
+    A policy to prevent runaway referrers from consuming too many queries. This concern is orthogonal to customer rate limits.
+
+    For example, a product team may push out a feature that sends 20 snuba queries every 5 seconds on the UI. In that case, that feature should break,
+    not all of clickhouse.
+
+    """
+
+    @property
+    def rate_limit_name(self) -> str:
+        return "referrer_guard_rail_policy"
+
+    def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
+        return super()._additional_config_definitions() + [
+            AllocationPolicyConfig(
+                name="default_concurrent_request_per_referrer",
+                description="""how many concurrent requests does a referrer get by default? This is set to a pretty high number.
+                If every referrer did this number of concurrent queries we would not have enough capacity
+                """,
+                value_type=int,
+                param_types={},
+                default=100,
+            ),
+            AllocationPolicyConfig(
+                name="referrer_concurrent_override",
+                description="""override the concurrent limit for a referrer""",
+                value_type=int,
+                param_types={"referrer": str},
+                default=-1,
+            ),
+            AllocationPolicyConfig(
+                name="referrer_max_threads_override",
+                description="""override the max_threads for a referrer, applies to every query made by that referrer""",
+                param_types={"referrer": str},
+                value_type=int,
+                default=-1,
+            ),
+        ]
+
+    def _get_max_threads(self, referrer: str) -> int:
+        thread_override = int(
+            self.get_config_value(
+                "referrer_max_threads_override", {"referrer": referrer}
+            )
+        )
+        return thread_override if thread_override != -1 else _DEFAULT_MAX_THREADS
+
+    def _get_concurrent_limit(self, referrer: str) -> int:
+        concurrent_override = int(
+            self.get_config_value(
+                "referrer_concurrent_override", {"referrer": referrer}
+            )
+        )
+        default_concurrent_value = int(
+            self.get_config_value("default_concurrent_request_per_referrer")
+        )
+        return (
+            concurrent_override
+            if concurrent_override != -1
+            else default_concurrent_value
+        )
+
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
+        referrer = str(tenant_ids.get("referrer", "no_referrer"))
+        if referrer in _PASS_THROUGH_REFERRERS:
+            return QuotaAllowance(
+                True,
+                _DEFAULT_MAX_THREADS,
+                {"reason": f"{referrer} is a pass through referrer"},
+            )
+        concurrent_limit = self._get_concurrent_limit(referrer)
+        can_run, explanation = self._is_within_rate_limit(
+            query_id,
+            RateLimitParameters(self.rate_limit_name, referrer, None, concurrent_limit),
+        )
+        decision_explanation = {
+            "reason": explanation,
+            "policy": self.rate_limit_name,
+            "referrer": referrer,
+        }
+        return QuotaAllowance(
+            can_run=can_run,
+            max_threads=self._get_max_threads(referrer),
+            explanation=decision_explanation,
+        )
+
+    def _update_quota_balance(
+        self,
+        tenant_ids: dict[str, str | int],
+        query_id: str,
+        result_or_error: QueryResultOrError,
+    ) -> None:
+        referrer = str(tenant_ids.get("referrer", "no_referrer"))
+        if referrer in _PASS_THROUGH_REFERRERS:
+            return
+
+        rate_limit_params = RateLimitParameters(
+            self.rate_limit_name,
+            referrer,
+            None,
+            # limit number does not matter for ending a query so I just picked 22
+            22,
+        )
+        self._end_query(query_id, rate_limit_params, result_or_error)

--- a/tests/query/allocation_policies/test_per_referrer.py
+++ b/tests/query/allocation_policies/test_per_referrer.py
@@ -1,0 +1,107 @@
+import pytest
+
+from snuba.query.allocation_policies import (
+    AllocationPolicyViolation,
+    QueryResultOrError,
+)
+from snuba.query.allocation_policies.per_referrer import (
+    _PASS_THROUGH_REFERRERS,
+    ReferrerGuardRailPolicy,
+)
+from snuba.web import QueryResult
+
+_RESULT_SUCCESS = QueryResultOrError(
+    QueryResult(
+        result={"profile": {"bytes": 42069}},
+        extra={"stats": {}, "sql": "", "experiments": {}},
+    ),
+    error=None,
+)
+
+
+class TestCrossOrgQueryAllocationPolicy:
+    @pytest.mark.redis_db
+    def test_policy_pass_basic(self):
+        policy = ReferrerGuardRailPolicy.from_kwargs(
+            **{
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+            }
+        )
+
+        policy.set_config_value("default_concurrent_request_per_referrer", 2)
+        policy.get_quota_allowance(
+            tenant_ids={"referrer": "statistical_detectors"}, query_id="1"
+        )
+
+        policy.get_quota_allowance(
+            tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
+        )
+
+        with pytest.raises(AllocationPolicyViolation):
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="3"
+            )
+        # clean up the failed request
+        policy.update_quota_balance(
+            tenant_ids={"referrer": "statistical_detectors"},
+            query_id="3",
+            result_or_error=_RESULT_SUCCESS,
+        )
+        # finish first request, now should be room for one more
+        policy.update_quota_balance(
+            tenant_ids={"referrer": "statistical_detectors"},
+            query_id="1",
+            result_or_error=_RESULT_SUCCESS,
+        )
+        assert policy.get_quota_allowance(
+            tenant_ids={"referrer": "statistical_detectors"}, query_id="4"
+        ).can_run
+
+    @pytest.mark.redis_db
+    def test_override(self):
+        policy = ReferrerGuardRailPolicy.from_kwargs(
+            **{
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+            }
+        )
+        policy.set_config_value(
+            "referrer_max_threads_override",
+            2,
+            {"referrer": "statistical_detectors"},
+        )
+        assert (
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="1"
+            ).max_threads
+            == 2
+        )
+        policy.update_quota_balance(
+            tenant_ids={"referrer": "statistical_detectors"},
+            query_id="1",
+            result_or_error=_RESULT_SUCCESS,
+        )
+        policy.set_config_value(
+            "referrer_concurrent_override",
+            0,
+            {"referrer": "statistical_detectors"},
+        )
+        with pytest.raises(AllocationPolicyViolation):
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
+            )
+
+    @pytest.mark.redis_db
+    def test_pass_through(self):
+        policy = ReferrerGuardRailPolicy.from_kwargs(
+            **{
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+            }
+        )
+        policy.set_config_value("default_concurrent_request_per_referrer", 0)
+        for i, referrer in enumerate(_PASS_THROUGH_REFERRERS):
+            assert policy.get_quota_allowance(
+                {"referrer": referrer}, query_id=str(i)
+            ).can_run


### PR DESCRIPTION
To prevent a specific referrer from taking over all capacity, put a default limit on all referrers which can be overidden. 

Put it just on errors first to test it in production (that's the capacity we're most concerned with protecting)