### PR TITLE
ref: Upgrade parsimonious

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
       day: "sunday"
     open-pull-requests-limit: 50
     ignore:
-      - dependency-name: "parsimonious"
       # sentry-kafka-schemas has its own lints to ensure it is reasonably
       # up-to-date -- we should rely on them
       - dependency-name: "sentry-kafka-schemas"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,7 @@ python-jose[cryptography]==3.3.0
 jsonschema==4.16.0
 fastjsonschema==2.16.2
 packaging==21.3
-# Do not update parsimonious, there is a performance issue in newer versions
-parsimonious==0.8.1
+parsimonious==0.10.0
 progressbar2==4.0.0
 pytest==7.1.3
 pytest-cov==3.0.0


### PR DESCRIPTION
Those updates are required for us to get to 3.11. There's speculation that the perf issue has been fixed in a recent version, so let's try and go to latest.

I need this for #5476 