### PR TITLE
ref: Upgrade rust-arroyo to 2.16.0

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2077,8 +2077,8 @@ dependencies = [
 
 [[package]]
 name = "rust_arroyo"
-version = "2.15.3"
-source = "git+https://github.com/getsentry/arroyo#f90eeff8cb07655bc4e3cafdb7633de5ead7e693"
+version = "2.16.0"
+source = "git+https://github.com/getsentry/arroyo#a28450e3ad76fe20460bdc40b3e3de138f4550b5"
 dependencies = [
  "chrono",
  "coarsetime",


### PR DESCRIPTION
I'm doing this to get https://github.com/getsentry/arroyo/pull/329 into snuba, so that we can fix dashboards