### PR TITLE
draft(MQL): Parse multi-entity type formulas

### DIFF
--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -322,13 +322,14 @@ def build_match(
     param_type: Optional[Any] = None,
     alias: Optional[str] = None,
     key: Optional[str] = None,
+    rhs_function_call: bool = False,
 ) -> Or[Expression]:
     """
     There is a common use case of matching a specific condition in our code base.
     This function provides a simplified interface to creating those types of patterns.
-    The specific pattern is <column/subscriptable> <op> <literal(s)>. The column/subscriptable
-    name is provided, along with the specific ops to check and optional parameter type, alias
-    and subscriptable key.
+    The specific pattern is <column/subscriptable> <op> <literal(s)/functioncall>.
+    The column/subscriptable name is provided, along with the specific ops to check and
+    optional parameter type, alias and subscriptable key.
     If ops/array_ops are not provided, they default to EQ and IN respectively. If param_type
     is not provided, the matcher will match a Literal with any type.
     The returned matcher will also tag the left and right expressions with `column` and `rhs`
@@ -360,22 +361,25 @@ def build_match(
     rhs_param = None
     if param_type is not None:
         rhs_param = AnyPattern(param_type)
+    rhs_pattern = LiteralPattern
+    if rhs_function_call:
+        rhs_pattern = FunctionCallPattern
 
     return Or(
         [
             FunctionCallPattern(
-                Or([String(op) for op in ops]),
-                (column_match, Param("rhs", LiteralPattern(rhs_param))),
+                function_name=Or([String(op) for op in ops]),
+                parameters=(column_match, Param("rhs", rhs_pattern(rhs_param))),
             ),
             FunctionCallPattern(
-                Or([String(op) for op in array_ops]),
-                (
+                function_name=Or([String(op) for op in array_ops]),
+                parameters=(
                     column_match,
                     Param(
                         "rhs",
                         FunctionCallPattern(
                             Or([String("array"), String("tuple")]),
-                            all_parameters=LiteralPattern(rhs_param),
+                            all_parameters=rhs_pattern(rhs_param),
                         ),
                     ),
                 ),

--- a/snuba/query/mql/mql_context.py
+++ b/snuba/query/mql/mql_context.py
@@ -19,7 +19,7 @@ class MQLContext:
     the request itself. It should not do any validation beyond type checks.
     """
 
-    entity: str
+    entity: dict[str, str]
     start: str
     end: str
     rollup: Rollup
@@ -32,7 +32,9 @@ class MQLContext:
         self.validate()
 
     def validate(self) -> None:
-        for field in ["entity", "start", "end"]:
+        if not isinstance(self.entity, dict):
+            raise ParsingException("MQL context: entity must be a dict")
+        for field in ["start", "end"]:
             if not isinstance(getattr(self, field), str) or getattr(self, field) == "":
                 raise ParsingException(f"MQL context: {field} must be a str")
         if not isinstance(self.rollup, Rollup):

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -18,7 +18,15 @@ from snuba.query.conditions import (
     BooleanFunctions,
     ConditionFunctions,
     binary_condition,
+    build_match,
     combine_and_conditions,
+)
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinType,
 )
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.exceptions import InvalidQueryException
@@ -71,6 +79,16 @@ ARITHMETIC_OPERATORS_MAPPING = {
     "/": "divide",
 }
 
+COMMON_AGGREGATION_FUNCTIONS = [
+    "count",
+    "min",
+    "max",
+    "sum",
+    "avg",
+    "last",
+    "uniq",
+]
+
 
 class MQLVisitor(NodeVisitor):  # type: ignore
     """
@@ -108,6 +126,10 @@ class MQLVisitor(NodeVisitor):  # type: ignore
 
         Given an input parse result from `sum(mri){x:y}`, this should output
         an expression like `sumIf(value, x = y AND metric_id = mri)`.
+
+        If the timeseries inside the formula query is different entity type, then
+        the select expression should be left alone. But we don't know this until later.
+        For now, we update the expression with aggIf, then overwrite it later.
         """
         assert param.expression is not None
         exp = param.expression.expression
@@ -657,7 +679,7 @@ def parse_mql_query_body(
     body: str,
 ) -> LogicalQuery:
     """
-    Parse the MQL to create an initial query. Then augments that query using the context
+    Parse the MQL to create an InitialParseResult. Then augments that query using the context
     information provided.
     """
     try:
@@ -666,10 +688,13 @@ def parse_mql_query_body(
         'max(transaction.user{dist:["dist1", "dist2"]}) by transaction',
 
         InitialParseResult(
-            'public_name': 'transaction.user',
-            'selected_aggregate': [SelectedExpression(name='aggregate_value', expression=sum(value) AS `sum(d:transactions/duration@millisecond)`)],
-            'filters': [in(Column('dist'), tuple('dist1', 'dist2'))],
+            'expression': SelectedExpression(name='aggregate_value', expression=max(value) AS `max(d:transactions/duration@millisecond)`),
+            'formula': None,
+            'parameters': None,
             'groupby': [SelectedExpression(name='transaction', Column('transaction')],
+            'conditions': [in(Column('dist'), tuple('dist1', 'dist2'))],
+            'mri': None,
+            'public_name': 'transaction.user',
         )
         """
         exp_tree = MQL_GRAMMAR.parse(body)
@@ -678,77 +703,187 @@ def parse_mql_query_body(
             raise ParsingException(
                 "No aggregate/expression or formula specified in MQL query"
             )
-
-        if parsed.formula:
-
-            def extract_expression(param: InitialParseResult | Any) -> Expression:
-                if not isinstance(param, InitialParseResult):
-                    return Literal(None, param)
-                elif param.expression is not None:
-                    return param.expression.expression
-                elif param.formula:
-                    parameters = param.parameters or []
-                    return FunctionCall(
-                        None,
-                        param.formula,
-                        tuple(extract_expression(p) for p in parameters),
-                    )
-                else:
-                    raise InvalidQueryException("Could not parse formula")
-
-            parameters = parsed.parameters or []
-            selected_columns = [
-                SelectedExpression(
-                    name=AGGREGATE_ALIAS,
-                    expression=FunctionCall(
-                        alias=AGGREGATE_ALIAS,
-                        function_name=parsed.formula,
-                        parameters=tuple(extract_expression(p) for p in parameters),
-                    ),
-                )
-            ]
-            if parsed.groupby:
-                selected_columns.extend(parsed.groupby)
-            groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
-            query = LogicalQuery(
-                from_clause=None,
-                selected_columns=selected_columns,
-                groupby=groupby,
-            )
-        if parsed.expression:
-            selected_columns = [parsed.expression]
-            if parsed.groupby:
-                selected_columns.extend(parsed.groupby)
-            groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
-
-            metric_value = parsed.mri or parsed.public_name
-            conditions: list[Expression] = [
-                binary_condition(
-                    ConditionFunctions.EQ,
-                    Column(None, None, "metric_id"),
-                    Literal(None, metric_value),
-                )
-            ]
-            if parsed.conditions:
-                conditions.extend(parsed.conditions)
-
-            final_conditions = (
-                combine_and_conditions(conditions) if conditions else None
-            )
-
-            query = LogicalQuery(
-                from_clause=None,
-                selected_columns=selected_columns,
-                condition=final_conditions,
-                groupby=groupby,
-            )
     except Exception as e:
         raise e
+    return parsed
+
+
+def populate_query_ast_initial(
+    parsed: InitialParseResult, mql_context_dict: dict[str, Any]
+) -> Tuple[LogicalQuery | CompositeQuery, dict[str, EntityKey]]:
+    """
+    Determines whether if query contains a formula or timeseries. If the formula is present,
+    determine if it is a single or multiple entity type formula. Depending on which type it is,
+    populate the query AST (LogicalQuery or CompositeQuery) appropriately.
+    """
+
+    def extract_expression(param: InitialParseResult | Any) -> Expression:
+        if not isinstance(param, InitialParseResult):
+            return Literal(None, param)
+        elif param.expression is not None:
+            return param.expression.expression
+        elif param.formula:
+            parameters = param.parameters or []
+            return FunctionCall(
+                None,
+                param.formula,
+                tuple(extract_expression(p) for p in parameters),
+            )
+        else:
+            raise InvalidQueryException("Could not parse formula")
+
+    one_or_more_entities = extract_entity(mql_context_dict)
+    if len(one_or_more_entities) == 0:
+        raise ParsingException("No entity specified in MQL query")
+
+    if parsed.formula:
+        parameters = parsed.parameters or []
+        selected_columns = [
+            SelectedExpression(
+                name=AGGREGATE_ALIAS,
+                expression=FunctionCall(
+                    alias=AGGREGATE_ALIAS,
+                    function_name=parsed.formula,
+                    parameters=tuple(extract_expression(p) for p in parameters),
+                ),
+            )
+        ]
+        if parsed.groupby:
+            selected_columns.extend(parsed.groupby)
+        groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
+
+        if len(one_or_more_entities) == 1:
+            query = LogicalQuery(
+                from_clause=None,
+                selected_columns=selected_columns,
+                groupby=groupby,
+            )
+        else:
+            query = CompositeQuery(
+                from_clause=None,
+                selected_columns=selected_columns,
+                condition=None,
+                groupby=groupby,
+            )
+            query = process_table_names_in_selected_expressions(
+                query, one_or_more_entities
+            )
+    if parsed.expression:
+        selected_columns = [parsed.expression]
+        if parsed.groupby:
+            selected_columns.extend(parsed.groupby)
+        groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
+
+        metric_value = parsed.mri or parsed.public_name
+        conditions: list[Expression] = [
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column(None, None, "metric_id"),
+                Literal(None, metric_value),
+            )
+        ]
+        if parsed.conditions:
+            conditions.extend(parsed.conditions)
+
+        final_conditions = combine_and_conditions(conditions) if conditions else None
+
+        query = LogicalQuery(
+            from_clause=None,
+            selected_columns=selected_columns,
+            condition=final_conditions,
+            groupby=groupby,
+        )
+
+    return query, one_or_more_entities
+
+
+def process_table_names_in_selected_expressions(
+    query: CompositeQuery, entities: dict[str, EntityKey]
+) -> CompositeQuery:
+    """
+    This function is responsible for processing formulas that contain multiple entity types.
+    It sets the appropriate table names for the selected columns in the query.
+    """
+    metric_id_match = build_match(col="metric_id", param_type=str)
+    value_match = build_match(
+        col="value",
+        ops=[f"{agg_name}If" for agg_name in COMMON_AGGREGATION_FUNCTIONS],
+        rhs_function_call=True,
+    )
+
+    def update_metric_id_column_with_table_name(exp: Expression) -> Expression:
+        if match := metric_id_match.match(exp):
+            metric_name = match.expression("rhs").value
+            entity = entities.get(metric_name)
+            if not entity:
+                raise ParsingException(f"Entity not found for {metric_name}")
+            entity_name = entity.value
+            assert isinstance(exp, FunctionCall)
+            metric_id_column = exp.parameters[0]
+            new_metric_id_column = replace(metric_id_column, table_name=entity_name)
+            rhs = exp.parameters[1]
+            return replace(exp, parameters=(new_metric_id_column, rhs))
+        return exp
+
+    def update_columns_with_table_name(exp: Expression) -> Expression:
+        def find_metric_id_column(exp: Expression) -> Optional[str]:
+            if isinstance(exp, FunctionCall):
+                for param in exp.parameters:
+                    match = find_metric_id_column(param)
+                    if match:
+                        return match
+            match = metric_id_match.match(exp)
+            if match:
+                metric_name = exp.parameters[1].value
+                return metric_name
+            return None
+
+        def update_inner_columns(exp: Expression, entity: str) -> Optional[str]:
+            if isinstance(exp, FunctionCall):
+                new_parameters = [
+                    update_inner_columns(param, entity) for param in exp.parameters
+                ]
+                return replace(exp, parameters=tuple(new_parameters))
+            elif isinstance(exp, Column):
+                return replace(exp, table_name=entity)
+            else:
+                return exp
+
+        if value_match.match(exp):
+            assert isinstance(exp, FunctionCall)
+            rhs = exp.parameters[1]
+            metric_name = find_metric_id_column(rhs)
+            if metric_name:
+                entity = entities.get(metric_name)
+                if not entity:
+                    raise ParsingException(
+                        "Entity not found when updating column's table name."
+                    )
+                # replace value column
+                value_column = exp.parameters[0]
+                new_value_column = replace(value_column, table_name=entity.value)
+
+                # replace column inside the parameters
+                new_rhs = update_inner_columns(rhs, entity.value)
+                return replace(exp, parameters=(new_value_column, new_rhs))
+        return exp
+
+    def update_tags_column_with_table_name(exp: Expression) -> Expression:
+        value_match = build_match(col="tags_raw")
+        if value_match.match(exp):
+            return replace(exp)
+        return exp
+
+    query.transform_expressions(update_metric_id_column_with_table_name)
+    query.transform_expressions(update_columns_with_table_name)
+    query.transform_expressions(update_tags_column_with_table_name)
     return query
 
 
 def populate_start_end_time(
-    query: LogicalQuery, mql_context: MQLContext, entity_key: EntityKey
+    query: LogicalQuery,
+    mql_context: MQLContext,
+    entity_keys: list[EntityKey],
 ) -> None:
     try:
         start = parse_datetime(mql_context.start)
@@ -756,69 +891,79 @@ def populate_start_end_time(
     except Exception as e:
         raise ParsingException("Invalid start or end time") from e
 
-    entity = get_entity(entity_key)
-    required_timestamp_column = (
-        entity.required_time_column if entity.required_time_column else "timestamp"
-    )
+    for entity_key in entity_keys:
+        entity = get_entity(entity_key)
+        required_timestamp_column = (
+            entity.required_time_column if entity.required_time_column else "timestamp"
+        )
+        filters = []
+        filters.append(
+            binary_condition(
+                ConditionFunctions.GTE,
+                Column(None, entity_key.value, column_name=required_timestamp_column),
+                Literal(None, value=start),
+            ),
+        )
+        filters.append(
+            binary_condition(
+                ConditionFunctions.LT,
+                Column(None, entity_key.value, column_name=required_timestamp_column),
+                Literal(None, value=end),
+            ),
+        )
+        query.add_condition_to_ast(combine_and_conditions(filters))
+
+
+def populate_scope(
+    query: LogicalQuery, mql_context: MQLContext, entity_keys: list[EntityKey]
+) -> None:
     filters = []
-    filters.append(
-        binary_condition(
-            ConditionFunctions.GTE,
-            Column(None, None, column_name=required_timestamp_column),
-            Literal(None, value=start),
-        ),
-    )
-    filters.append(
-        binary_condition(
-            ConditionFunctions.LT,
-            Column(None, None, column_name=required_timestamp_column),
-            Literal(None, value=end),
-        ),
-    )
+    for entity_key in entity_keys:
+        filters.append(
+            binary_condition(
+                ConditionFunctions.IN,
+                Column(
+                    alias=None, table_name=entity_key.value, column_name="project_id"
+                ),
+                FunctionCall(
+                    alias=None,
+                    function_name="tuple",
+                    parameters=tuple(
+                        Literal(alias=None, value=project_id)
+                        for project_id in mql_context.scope.project_ids
+                    ),
+                ),
+            )
+        )
+        filters.append(
+            binary_condition(
+                ConditionFunctions.IN,
+                Column(alias=None, table_name=entity_key.value, column_name="org_id"),
+                FunctionCall(
+                    alias=None,
+                    function_name="tuple",
+                    parameters=tuple(
+                        Literal(alias=None, value=int(org_id))
+                        for org_id in mql_context.scope.org_ids
+                    ),
+                ),
+            )
+        )
+        filters.append(
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column(
+                    alias=None, table_name=entity_key.value, column_name="use_case_id"
+                ),
+                Literal(alias=None, value=mql_context.scope.use_case_id),
+            )
+        )
     query.add_condition_to_ast(combine_and_conditions(filters))
 
 
-def populate_scope(query: LogicalQuery, mql_context: MQLContext) -> None:
-    filters = []
-    filters.append(
-        binary_condition(
-            ConditionFunctions.IN,
-            Column(alias=None, table_name=None, column_name="project_id"),
-            FunctionCall(
-                alias=None,
-                function_name="tuple",
-                parameters=tuple(
-                    Literal(alias=None, value=project_id)
-                    for project_id in mql_context.scope.project_ids
-                ),
-            ),
-        )
-    )
-    filters.append(
-        binary_condition(
-            ConditionFunctions.IN,
-            Column(alias=None, table_name=None, column_name="org_id"),
-            FunctionCall(
-                alias=None,
-                function_name="tuple",
-                parameters=tuple(
-                    Literal(alias=None, value=int(org_id))
-                    for org_id in mql_context.scope.org_ids
-                ),
-            ),
-        )
-    )
-    filters.append(
-        binary_condition(
-            ConditionFunctions.EQ,
-            Column(alias=None, table_name=None, column_name="use_case_id"),
-            Literal(alias=None, value=mql_context.scope.use_case_id),
-        )
-    )
-    query.add_condition_to_ast(combine_and_conditions(filters))
-
-
-def populate_rollup(query: LogicalQuery, mql_context: MQLContext) -> None:
+def populate_rollup(
+    query: LogicalQuery, mql_context: MQLContext, entity_keys: list[EntityKey]
+) -> None:
     rollup = mql_context.rollup
 
     # Validate/populate granularity
@@ -827,13 +972,14 @@ def populate_rollup(query: LogicalQuery, mql_context: MQLContext) -> None:
             f"granularity '{rollup.granularity}' is not valid, must be one of {GRANULARITIES_AVAILABLE}"
         )
 
-    query.add_condition_to_ast(
-        binary_condition(
-            ConditionFunctions.EQ,
-            Column(None, None, "granularity"),
-            Literal(None, rollup.granularity),
+    for entity_key in entity_keys:
+        query.add_condition_to_ast(
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column(None, entity_key.value, "granularity"),
+                Literal(None, rollup.granularity),
+            )
         )
-    )
 
     # Validate totals/orderby
     if rollup.with_totals is not None and rollup.with_totals not in ("True", "False"):
@@ -854,31 +1000,36 @@ def populate_rollup(query: LogicalQuery, mql_context: MQLContext) -> None:
     if rollup.interval:
         # If an interval is specified, then we need to group the time by that interval,
         # return the time in the select, and order the results by that time.
-        time_expression = FunctionCall(
-            "time",
-            "toStartOfInterval",
-            parameters=(
-                Column(None, None, "timestamp"),
-                FunctionCall(
-                    None,
-                    "toIntervalSecond",
-                    (Literal(None, rollup.interval),),
+        for entity_key in entity_keys:
+            time_expression = FunctionCall(
+                "time",
+                "toStartOfInterval",
+                parameters=(
+                    Column(None, entity_key.value, "timestamp"),
+                    FunctionCall(
+                        None,
+                        "toIntervalSecond",
+                        (Literal(None, rollup.interval),),
+                    ),
+                    Literal(None, "Universal"),
                 ),
-                Literal(None, "Universal"),
-            ),
-        )
-        selected = list(query.get_selected_columns())
-        selected.append(SelectedExpression("time", time_expression))
-        query.set_ast_selected_columns(selected)
+            )
+            selected = list(query.get_selected_columns())
+            selected.append(SelectedExpression("time", time_expression))
+            query.set_ast_selected_columns(selected)
 
-        groupby = query.get_groupby()
-        if groupby:
-            query.set_ast_groupby(list(groupby) + [time_expression])
-        else:
-            query.set_ast_groupby([time_expression])
+            groupby = query.get_groupby()
+            if groupby:
+                query.set_ast_groupby(list(groupby) + [time_expression])
+            else:
+                query.set_ast_groupby([time_expression])
 
-        orderby = OrderBy(OrderByDirection.ASC, time_expression)
-        query.set_ast_orderby([orderby])
+            new_order_by = OrderBy(OrderByDirection.ASC, time_expression)
+            order_by = query.get_orderby()
+            if order_by:
+                query.set_ast_orderby(list(order_by) + [new_order_by])
+            else:
+                query.set_ast_orderby([new_order_by])
 
         if with_totals:
             query.set_totals(True)
@@ -909,24 +1060,86 @@ def populate_offset(query: LogicalQuery, mql_context: MQLContext) -> None:
         query.set_offset(mql_context.offset)
 
 
-def populate_query_from_mql_context(
-    query: LogicalQuery, mql_context_dict: dict[str, Any]
-) -> tuple[LogicalQuery, MQLContext]:
+def extract_entity(mql_context_dict: dict[str, Any]) -> dict[str, EntityKey]:
     mql_context = MQLContext.from_dict(mql_context_dict)
-
+    entities = {}
     try:
-        entity_key = EntityKey(mql_context.entity)
-        query.set_from_clause(
-            QueryEntity(key=entity_key, schema=get_entity(entity_key).get_data_model())
-        )
+        for metric_name, entity_name in mql_context.entity.items():
+            entities[metric_name] = EntityKey(entity_name)
+        return entities
     except Exception as e:
         raise ParsingException(f"Invalid entity {mql_context.entity}") from e
 
-    populate_start_end_time(query, mql_context, entity_key)
-    populate_scope(query, mql_context)
-    populate_rollup(query, mql_context)
+
+def populate_query_from_mql_context(
+    query: LogicalQuery | CompositeQuery,
+    mql_context_dict: dict[str, Any],
+    one_or_more_entities: dict[str, EntityKey],
+) -> tuple[LogicalQuery, MQLContext]:
+    mql_context = MQLContext.from_dict(mql_context_dict)
+    entity_keys = list(set(one_or_more_entities.values()))
+    if len(entity_keys) == 1:
+        metric_name = next(iter(one_or_more_entities))
+        query.set_from_clause(
+            QueryEntity(
+                key=one_or_more_entities[metric_name],
+                schema=get_entity(
+                    key=one_or_more_entities[metric_name]
+                ).get_data_model(),
+            )
+        )
+    else:
+        assert len(entity_keys) >= 2
+        join_clause = JoinClause(
+            left_node=IndividualNode(
+                entity_keys[0].value,
+                QueryEntity(
+                    key=entity_keys[0],
+                    schema=get_entity(entity_keys[0]).get_data_model(),
+                ),
+            ),
+            right_node=IndividualNode(
+                entity_keys[1].value,
+                QueryEntity(
+                    key=entity_keys[1],
+                    schema=get_entity(entity_keys[1]).get_data_model(),
+                ),
+            ),
+            keys=[
+                JoinCondition(
+                    JoinConditionExpression(entity_keys[0].value, "timestamp"),
+                    JoinConditionExpression(entity_keys[1].value, "timestamp"),
+                )
+            ],
+            join_type=JoinType.INNER,
+        )
+        for i in range(2, len(entity_keys)):
+            entity_key = entity_keys[i]
+            join_clause = JoinClause(
+                left_node=join_clause,
+                right_node=IndividualNode(
+                    entity_key.value,
+                    QueryEntity(
+                        key=entity_key,
+                        schema=get_entity(entity_key).get_data_model(),
+                    ),
+                ),
+                keys=[
+                    JoinCondition(
+                        JoinConditionExpression(entity_key.value, "timestamp"),
+                        JoinConditionExpression(entity_keys[i - 1].value, "timestamp"),
+                    )
+                ],
+                join_type=JoinType.INNER,
+            )
+        query.set_from_clause(join_clause)
+
+    populate_start_end_time(query, mql_context, entity_keys)
+    populate_scope(query, mql_context, entity_keys)
+    populate_rollup(query, mql_context, entity_keys)
     populate_limit(query, mql_context)
     populate_offset(query, mql_context)
+    print(query.__dict__)
 
     return query, mql_context
 
@@ -944,11 +1157,17 @@ def parse_mql_query(
     settings: QuerySettings | None = None,
 ) -> Tuple[Union[CompositeQuery[QueryEntity], LogicalQuery], str]:
     with sentry_sdk.start_span(op="parser", description="parse_mql_query_initial"):
-        query = parse_mql_query_body(body)
+        initial_parse_result = parse_mql_query_body(body)
+    with sentry_sdk.start_span(op="parser", description="populate_query_ast_initial"):
+        query_initial, one_or_more_entities = populate_query_ast_initial(
+            initial_parse_result, mql_context_dict
+        )
     with sentry_sdk.start_span(
-        op="parser", description="populate_query_from_mql_context"
+        op="parser", description="populate_query_ast_from_mql_context"
     ):
-        query, mql_context = populate_query_from_mql_context(query, mql_context_dict)
+        query, mql_context = populate_query_from_mql_context(
+            query_initial, mql_context_dict, one_or_more_entities
+        )
     with sentry_sdk.start_span(op="processor", description="resolve_indexer_mappings"):
         resolve_mappings(query, mql_context.indexer_mappings, dataset)
 


### PR DESCRIPTION
This is a draft PR for implementing what parsing multi-entity type formulas might look like in snuba.

Depends on:
* https://github.com/getsentry/snuba-sdk/pull/169

This change breaks up the parsing pipeline into multiple sub-tasks: 
1. `parse_mql_query_body()`: Parses the MQL into the `InitialParseResult` tree
2. `populate_query_ast_initial()`: Creates `LogicalQuery | CompositeQuery` objects with the appropriate expressions. If multi-type formula query, calls some processing function (`process_table_names_in_selected_expressions()`) which traverses AST and adds the appropriate join table names to the expressions.
3. `populate_query_from_mql_context` Parses MQL Context and transforms fields into expressions that inject into the AST. If multi-type formula query, patch the appropriate join table names.


To see preview of CompositeQuery AST (with joins), run `pytest tests/query/parser/test_formula_mql_query.py::test_multi_type_formula -s -vv`