### PR TITLE
ref(ddm): Disable metrics in Snuba

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -87,12 +87,12 @@ def setup_sentry() -> None:
         release=os.getenv("SNUBA_RELEASE"),
         traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
         profiles_sample_rate=settings.SNUBA_PROFILES_SAMPLE_RATE,
-        _experiments={
-            # Turns on the metrics module
-            "enable_metrics": True,
-            # Enables sending of code locations for metrics
-            "metric_code_locations": True,
-        },
+        # _experiments={
+        #     # Turns on the metrics module
+        #     "enable_metrics": True,
+        #     # Enables sending of code locations for metrics
+        #     "metric_code_locations": True,
+        # },
     )
 
     from snuba.utils.profiler import run_ondemand_profiler


### PR DESCRIPTION
There is a bug in uwsgi + the python sdk that causes restarts and hangs when
using metrics. Going to disable this for now until things stabilize.