### PR TITLE
fix(admin): fix admin nav ui bug (SNS-2621)

### DIFF
--- a/snuba/admin/README.md
+++ b/snuba/admin/README.md
@@ -10,6 +10,8 @@ snuba admin
 
 The server should be running on http://127.0.0.1:1219
 
+note: please ensure that sentry devservices are up via `sentry devservices up --exclude=snuba` from within the sentry repository
+
 # Developing the Javascript
 
 You must have node and yarn installed. To do so:

--- a/snuba/admin/static/data.tsx
+++ b/snuba/admin/static/data.tsx
@@ -32,7 +32,7 @@ const NAV_ITEMS = [
     component: SnubaExplain,
   },
   {
-    id: "clickhouse",
+    id: "system-queries",
     display: "🏚️ System Queries",
     component: ClickhouseQueries,
   },


### PR DESCRIPTION
This PR is fix for the following bug [https://getsentry.atlassian.net/browse/SNS-2621](SNS-2621)

When users have ProductTools role, System Queries was not showing up in the nav bar when it should be. After investigating I found the cause of this bug to be as follows:
* In the backend, tool_policies.py, AdminTools Enum, the tab for system queries is defined as `SYSTEM_QUERIES = "system-queries"` which is supposed to match its id on the front-end
* In the frontend however, data.tsx, NAV_ITEMS, this tab was defined as having ```id: "clickhouse"```
* This was causing the problem when the Nav element was rendering. In order to solve the issue I changed the id on the frontend to match "system-queries"
* I tested it worked properly by limiting myself to only having the ProductTools role, and verified the nav bar worked as expected with system queries showing up

