### PR TITLE
fix(py311): Explicitly import importlib.abc

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -441,6 +441,7 @@ def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     provide a full absolute path such as `/foo/bar/my_settings.py`."""
 
     import importlib
+    import importlib.abc
     import importlib.util
     import os
 


### PR DESCRIPTION
a few lines down we try to access `importlib.abc`, and it crashes in _some_ environments, probably subject to race conditions.