### PR TITLE
Removing explicit context flag from k8s-deploys

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -4,7 +4,6 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
 
 /devinfra/scripts/k8s/k8stunnel \
 && /devinfra/scripts/k8s/k8s-deploy.py \
-  --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   --container-name="api" \


### PR DESCRIPTION
Context can be inferred by the `k8s-deploy.py` script via the environment variables retrieved from the `region config`. The main reason for this change now is that it is blocking de deploys.