### PR TITLE
ref(errors): Fix some nullability issues in the processor [SNS-2619]

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -532,12 +532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,16 +1721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,7 +2095,6 @@ dependencies = [
  "md5",
  "once_cell",
  "parking_lot",
- "pretty_assertions",
  "procspawn",
  "pyo3",
  "reqwest",
@@ -3405,12 +3388,6 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -56,7 +56,6 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
 criterion = "0.5.1"
 insta = { version = "1.34.0", features = ["json", "redactions"] }
 once_cell = "1.18.0"
-pretty_assertions = "1.4.0"
 procspawn = { version = "1.0.0", features = ["test-support", "json"] }
 pyo3 = { version = "*", features = ["auto-initialize"] }
 

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -158,6 +158,6 @@ mod tests {
 
     #[test]
     fn schema() {
-        run_schema_type_test::<InputMessage>("profiles-call-tree");
+        run_schema_type_test::<InputMessage>("profiles-call-tree", None);
     }
 }

--- a/rust_snuba/src/processors/metrics_summaries.rs
+++ b/rust_snuba/src/processors/metrics_summaries.rs
@@ -230,6 +230,6 @@ mod tests {
 
     #[test]
     fn schema() {
-        run_schema_type_test::<FromSpanMessage>("snuba-spans");
+        run_schema_type_test::<FromSpanMessage>("snuba-spans", None);
     }
 }

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -88,14 +88,27 @@ mod tests {
 
     use super::*;
 
-    pub fn run_schema_type_test<M: JsonSchema>(schema_name: &str) {
+    pub fn run_schema_type_test<M: JsonSchema>(schema_name: &str, subschema: Option<&str>) {
         let schema = schemars::schema_for!(M);
+
         let old_schema = sentry_kafka_schemas::get_schema(schema_name, None).unwrap();
-        let mut diff = json_schema_diff::diff(
-            serde_json::from_str(old_schema.raw_schema()).unwrap(),
-            serde_json::to_value(schema).unwrap(),
-        )
-        .unwrap();
+        let mut old_schema: serde_json::Value =
+            serde_json::from_str(old_schema.raw_schema()).unwrap();
+        if let Some(subschema) = subschema {
+            old_schema = old_schema
+                .as_object()
+                .unwrap()
+                .get("definitions")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get(subschema)
+                .unwrap()
+                .clone();
+        }
+
+        let mut diff =
+            json_schema_diff::diff(old_schema, serde_json::to_value(schema).unwrap()).unwrap();
         diff.retain(|change| change.change.is_breaking());
         assert_eq!(diff, vec![]);
     }

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -82,7 +82,6 @@ mod tests {
     use std::time::SystemTime;
 
     use chrono::DateTime;
-    use pretty_assertions::assert_eq;
     use schemars::JsonSchema;
     use sentry_kafka_schemas::get_schema;
 

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -110,7 +110,9 @@ mod tests {
         let mut diff =
             json_schema_diff::diff(old_schema, serde_json::to_value(schema).unwrap()).unwrap();
         diff.retain(|change| change.change.is_breaking());
-        assert_eq!(diff, vec![]);
+        if !diff.is_empty() {
+            insta::assert_debug_snapshot!(diff);
+        }
     }
 
     #[test]

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -121,6 +121,6 @@ mod tests {
 
     #[test]
     fn schema() {
-        run_schema_type_test::<InputMessage>("processed-profiles");
+        run_schema_type_test::<InputMessage>("processed-profiles", None);
     }
 }

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -418,6 +418,6 @@ mod tests {
 
     #[test]
     fn schema() {
-        run_schema_type_test::<FromQuerylogMessage>("snuba-queries");
+        run_schema_type_test::<FromQuerylogMessage>("snuba-queries", None);
     }
 }

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__run_schema_type_test.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__run_schema_type_test.snap
@@ -1,0 +1,352 @@
+---
+source: src/processors/mod.rs
+expression: diff
+---
+[
+    Change {
+        path: "",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "location",
+        },
+    },
+    Change {
+        path: "",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "title",
+        },
+    },
+    Change {
+        path: ".contexts.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "replay",
+        },
+    },
+    Change {
+        path: ".contexts.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "trace",
+        },
+    },
+    Change {
+        path: ".contexts",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".contexts",
+        change: TypeRemove {
+            removed: Number,
+        },
+    },
+    Change {
+        path: ".contexts",
+        change: TypeRemove {
+            removed: Integer,
+        },
+    },
+    Change {
+        path: ".contexts",
+        change: TypeRemove {
+            removed: Array,
+        },
+    },
+    Change {
+        path: ".contexts",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+    Change {
+        path: ".exception.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "values",
+        },
+    },
+    Change {
+        path: ".exception",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".exception",
+        change: TypeRemove {
+            removed: Number,
+        },
+    },
+    Change {
+        path: ".exception",
+        change: TypeRemove {
+            removed: Integer,
+        },
+    },
+    Change {
+        path: ".exception",
+        change: TypeRemove {
+            removed: Array,
+        },
+    },
+    Change {
+        path: ".exception",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+    Change {
+        path: ".received",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".received",
+        change: TypeRemove {
+            removed: Object,
+        },
+    },
+    Change {
+        path: ".received",
+        change: TypeRemove {
+            removed: Array,
+        },
+    },
+    Change {
+        path: ".received",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+    Change {
+        path: ".request.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "headers",
+        },
+    },
+    Change {
+        path: ".request.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "method",
+        },
+    },
+    Change {
+        path: ".request",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".request",
+        change: TypeRemove {
+            removed: Number,
+        },
+    },
+    Change {
+        path: ".request",
+        change: TypeRemove {
+            removed: Integer,
+        },
+    },
+    Change {
+        path: ".request",
+        change: TypeRemove {
+            removed: Array,
+        },
+    },
+    Change {
+        path: ".request",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+    Change {
+        path: ".sdk.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "integrations",
+        },
+    },
+    Change {
+        path: ".sdk.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "name",
+        },
+    },
+    Change {
+        path: ".sdk.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "version",
+        },
+    },
+    Change {
+        path: ".sdk",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".sdk",
+        change: TypeRemove {
+            removed: Number,
+        },
+    },
+    Change {
+        path: ".sdk",
+        change: TypeRemove {
+            removed: Integer,
+        },
+    },
+    Change {
+        path: ".sdk",
+        change: TypeRemove {
+            removed: Array,
+        },
+    },
+    Change {
+        path: ".sdk",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+    Change {
+        path: ".tags",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".tags",
+        change: TypeRemove {
+            removed: Number,
+        },
+    },
+    Change {
+        path: ".tags",
+        change: TypeRemove {
+            removed: Integer,
+        },
+    },
+    Change {
+        path: ".tags",
+        change: TypeRemove {
+            removed: Object,
+        },
+    },
+    Change {
+        path: ".tags",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+    Change {
+        path: ".threads.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "values",
+        },
+    },
+    Change {
+        path: ".threads",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".threads",
+        change: TypeRemove {
+            removed: Number,
+        },
+    },
+    Change {
+        path: ".threads",
+        change: TypeRemove {
+            removed: Integer,
+        },
+    },
+    Change {
+        path: ".threads",
+        change: TypeRemove {
+            removed: Array,
+        },
+    },
+    Change {
+        path: ".threads",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+    Change {
+        path: ".user.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "email",
+        },
+    },
+    Change {
+        path: ".user.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "geo",
+        },
+    },
+    Change {
+        path: ".user.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "id",
+        },
+    },
+    Change {
+        path: ".user.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "ip_address",
+        },
+    },
+    Change {
+        path: ".user.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "username",
+        },
+    },
+    Change {
+        path: ".user",
+        change: TypeRemove {
+            removed: String,
+        },
+    },
+    Change {
+        path: ".user",
+        change: TypeRemove {
+            removed: Number,
+        },
+    },
+    Change {
+        path: ".user",
+        change: TypeRemove {
+            removed: Integer,
+        },
+    },
+    Change {
+        path: ".user",
+        change: TypeRemove {
+            removed: Array,
+        },
+    },
+    Change {
+        path: ".user",
+        change: TypeRemove {
+            removed: Boolean,
+        },
+    },
+]

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -456,6 +456,6 @@ mod tests {
 
     #[test]
     fn schema() {
-        run_schema_type_test::<FromSpanMessage>("snuba-spans");
+        run_schema_type_test::<FromSpanMessage>("snuba-spans", None);
     }
 }


### PR DESCRIPTION
We are seeing a lot of serde errors in our dummy deployment, mostly related to nullability. I can fix them all one by one, but I don't want to write a test for each possible nullable field.

We have an existing jsonschema that, for the fields it actually types at all, is correct about nullability. Unfortunately there are two problems with our schema validation:

1. there are large gaps in the schema, some fields do not exist
2. the schema is sufficiently complex to trigger a ton of different bugs in json-schema-diff

to work around both issues, I:

1. only fix some issues, and check in the rest of the diff as "known accepted drift" via insta
2. only validate an inner definition for InsertEvent, not the entire message payload, to work around a bug resulting from our grotesque use of untagged enums + anyOf