### PR TITLE
cleanup(capman): remove legacy rate limit configs

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -448,16 +448,6 @@ query_processors:
       time_parse_columns:
         - timestamp
   - processor: BasicFunctionsProcessor
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/discover/entities/discover_events.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_events.yaml
@@ -511,16 +511,6 @@ query_processors:
   - processor: HandledFunctionsProcessor
     args:
       column: exception_stacks.mechanism_handled
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
@@ -327,16 +327,6 @@ query_processors:
   - processor: BasicFunctionsProcessor
   - processor: ApdexProcessor
   - processor: FailureRateProcessor
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/events/entities/events.yaml
+++ b/snuba/datasets/configuration/events/entities/events.yaml
@@ -445,16 +445,6 @@ query_processors:
   - processor: HandledFunctionsProcessor
     args:
       column: exception_stacks.mechanism_handled
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/functions/entities/functions.yaml
+++ b/snuba/datasets/configuration/functions/entities/functions.yaml
@@ -79,17 +79,7 @@ storage_selector:
   args:
     storage: functions
 
-query_processors:
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
+query_processors: []
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
@@ -114,19 +114,6 @@ query_processors:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
@@ -310,19 +310,6 @@ query_processors:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
@@ -251,19 +251,6 @@ query_processors:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: CalculatedAverageProcessor
 
 validators:

--- a/snuba/datasets/configuration/generic_metrics/entities/org_counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/org_counters.yaml
@@ -70,19 +70,6 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: TagsTypeTransformer
 
 validators:

--- a/snuba/datasets/configuration/generic_metrics/entities/org_distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/org_distributions.yaml
@@ -198,19 +198,6 @@ query_processors:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validators:
   - validator: GranularityValidator

--- a/snuba/datasets/configuration/generic_metrics/entities/org_sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/org_sets.yaml
@@ -83,19 +83,6 @@ query_processors:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validators:
   - validator: GranularityValidator

--- a/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
@@ -118,19 +118,6 @@ query_processors:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
@@ -35,16 +35,6 @@ storage_selector:
   selector: DefaultQueryStorageSelector
 
 query_processors:
-  - processor: ReferrerRateLimiterProcessor
-#  - processor: ProjectReferrerRateLimiter
-#    args:
-#      project_column: project_id
-#  - processor: ProjectRateLimiterProcessor
-#    args:
-#      project_column: project_id
-#  - processor: ResourceQuotaProcessor
-#    args:
-#      project_field: project_id
   - processor: BasicFunctionsProcessor
 
 validate_data_model: error

--- a/snuba/datasets/configuration/groupassignee/entities/groupassignee.yaml
+++ b/snuba/datasets/configuration/groupassignee/entities/groupassignee.yaml
@@ -21,9 +21,6 @@ storage_selector:
 
 query_processors:
   - processor: BasicFunctionsProcessor
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
 validate_data_model: error
 validators: []
 required_time_column: null

--- a/snuba/datasets/configuration/groupedmessage/entities/groupedmessage.yaml
+++ b/snuba/datasets/configuration/groupedmessage/entities/groupedmessage.yaml
@@ -23,9 +23,6 @@ storage_selector:
 
 query_processors:
   - processor: BasicFunctionsProcessor
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
 validate_data_model: error
 validators: []
 required_time_column: null

--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -191,19 +191,6 @@ storage_selector:
   selector: DefaultQueryStorageSelector
 
 query_processors:
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: organization_id
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: BasicFunctionsProcessor
 
 validate_data_model: error

--- a/snuba/datasets/configuration/metrics/entities/metrics_counters.yaml
+++ b/snuba/datasets/configuration/metrics/entities/metrics_counters.yaml
@@ -84,19 +84,6 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: TagsTypeTransformer
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/metrics/entities/metrics_distributions.yaml
+++ b/snuba/datasets/configuration/metrics/entities/metrics_distributions.yaml
@@ -280,19 +280,6 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: TagsTypeTransformer
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/metrics/entities/metrics_sets.yaml
+++ b/snuba/datasets/configuration/metrics/entities/metrics_sets.yaml
@@ -88,19 +88,6 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: TagsTypeTransformer
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/metrics/entities/org_counters.yaml
+++ b/snuba/datasets/configuration/metrics/entities/org_counters.yaml
@@ -38,19 +38,6 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: TagsTypeTransformer
 
 validators:

--- a/snuba/datasets/configuration/metrics/entities/org_distributions.yaml
+++ b/snuba/datasets/configuration/metrics/entities/org_distributions.yaml
@@ -183,19 +183,6 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: TagsTypeTransformer
 
 validators:

--- a/snuba/datasets/configuration/metrics/entities/org_sets.yaml
+++ b/snuba/datasets/configuration/metrics/entities/org_sets.yaml
@@ -68,16 +68,6 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
   - processor: ResourceQuotaProcessor
     args:
       project_field: project_id

--- a/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
+++ b/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
@@ -33,10 +33,6 @@ query_processors:
         time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
 validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/outcomes_raw/entities/outcomes_raw.yaml
+++ b/snuba/datasets/configuration/outcomes_raw/entities/outcomes_raw.yaml
@@ -33,16 +33,6 @@ query_processors:
         time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/profiles/entities/profiles.yaml
+++ b/snuba/datasets/configuration/profiles/entities/profiles.yaml
@@ -44,19 +44,6 @@ storage_selector:
   selector: DefaultQueryStorageSelector
 
 query_processors:
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: organization_id
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
   - processor: TimeSeriesProcessor
     args:
       time_group_columns:

--- a/snuba/datasets/configuration/replays/entities/replays.yaml
+++ b/snuba/datasets/configuration/replays/entities/replays.yaml
@@ -145,9 +145,6 @@ query_processors:
         time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/sessions/entities/org.yaml
+++ b/snuba/datasets/configuration/sessions/entities/org.yaml
@@ -26,18 +26,5 @@ query_processors:
       time_parse_columns:
         - started
         - received
-  - processor: ReferrerRateLimiterProcessor
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 validate_data_model: error
 validators: []

--- a/snuba/datasets/configuration/sessions/entities/sessions.yaml
+++ b/snuba/datasets/configuration/sessions/entities/sessions.yaml
@@ -242,12 +242,6 @@ query_processors:
       time_parse_columns:
         - started
         - received
-  - processor: OrganizationRateLimiterProcessor
-    args:
-      org_column: org_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
 validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/spans/entities/metrics_summaries.yaml
+++ b/snuba/datasets/configuration/spans/entities/metrics_summaries.yaml
@@ -58,16 +58,6 @@ storage_selector:
 
 query_processors:
   - processor: BasicFunctionsProcessor
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validators:
   - validator: EntityRequiredColumnValidator

--- a/snuba/datasets/configuration/spans/entities/spans.yaml
+++ b/snuba/datasets/configuration/spans/entities/spans.yaml
@@ -153,16 +153,6 @@ query_processors:
         - end_timestamp
         - timestamp
   - processor: BasicFunctionsProcessor
-  - processor: ReferrerRateLimiterProcessor
-  - processor: ProjectReferrerRateLimiter
-    args:
-      project_column: project_id
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
-  - processor: ResourceQuotaProcessor
-    args:
-      project_field: project_id
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -359,16 +359,6 @@ query_processors:
     { processor: BasicFunctionsProcessor },
     { processor: ApdexProcessor },
     { processor: FailureRateProcessor },
-    { processor: ReferrerRateLimiterProcessor },
-    {
-      processor: ProjectReferrerRateLimiter,
-      args: { project_column: project_id },
-    },
-    {
-      processor: ProjectRateLimiterProcessor,
-      args: { project_column: project_id },
-    },
-    { processor: ResourceQuotaProcessor, args: { project_field: project_id } },
   ]
 validate_data_model: error
 validators:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1440,43 +1440,6 @@ class TestApi(SimpleAPITest):
         assert "timing" in result
         assert "timestamp" in result["timing"]
 
-    def test_project_rate_limiting(self) -> None:
-        # All projects except project 1 are allowed
-        state.set_config("project_concurrent_limit", 1)
-        state.set_config("project_concurrent_limit_1", 0)
-
-        response = self.post(
-            json.dumps(
-                {
-                    "project": 2,
-                    "tenant_ids": {"referrer": "r", "organization_id": 1234},
-                    "selected_columns": ["platform"],
-                    "from_date": self.base_time.isoformat(),
-                    "to_date": (
-                        self.base_time + timedelta(minutes=self.minutes)
-                    ).isoformat(),
-                }
-            )
-        )
-        assert response.status_code == 200
-
-        response = self.post(
-            json.dumps(
-                {
-                    "project": 1,
-                    "tenant_ids": {"referrer": "r", "organization_id": 1234},
-                    "selected_columns": ["platform"],
-                    "from_date": self.base_time.isoformat(),
-                    "to_date": (
-                        self.base_time + timedelta(minutes=self.minutes)
-                    ).isoformat(),
-                }
-            )
-        )
-        assert response.status_code == 429
-        data = json.loads(response.data)
-        assert data["error"]["message"] == "project concurrent of 1 exceeds limit of 0"
-
     def test_doesnt_select_deletions(self) -> None:
         query = {
             "project": 1,

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -233,15 +233,17 @@ class TestSnQLApi(BaseApiTest):
         assert response.status_code == 400, data
 
     def test_project_rate_limiting(self) -> None:
-        policies = get_storage(StorageKey("errors")).get_allocation_policies()
-        concurrent_rate_limit_policy = [
+        policies = (
+            get_storage(StorageKey("errors")).get_allocation_policies()
+            + get_storage(StorageKey("errors_ro")).get_allocation_policies()
+        )
+        concurrent_rate_limit_policies = [
             p
             for p in policies
             if p.config_key() == "ConcurrentRateLimitAllocationPolicy"
-        ][0]
-        concurrent_rate_limit_policy.set_config_value(
-            "project_override", 0, {"project_id": self.project_id}
-        )
+        ]
+        for p in concurrent_rate_limit_policies:
+            p.set_config_value("project_override", 0, {"project_id": self.project_id})
 
         response = self.post(
             "/events/snql",

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -12,11 +12,8 @@ import simplejson as json
 from snuba import state
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.storages.factory import (
-    StorageKey,
-    get_storage,
-    get_writable_storage,
-)
+from snuba.datasets.storages.factory import get_storage, get_writable_storage
+from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.allocation_policies import (
     AllocationPolicy,
     AllocationPolicyConfig,


### PR DESCRIPTION
These have not been running in production for weeks since https://github.com/getsentry/snuba/pull/5405

We can remove them from the config safely now. The following processors have been removed from config:



ReferrerRateLimiterProcessor - replaced by RefererrerGuardRailPolicy
ProjectReferrerRateLimiter - replaced by ConcurrentLimitAllocationPolicy
ProjectRateLimiterProcessor - replaced by ConcurrentLimitAllocationPolicy
ResourceQuotaProcessor - replaced by BytesScannedWindowAllocationPolicy
OrganizationRateLimiterProcessor - replaced by ConcurrentLimitAllocationPolicy