### PR TITLE
fix(metrics): Update gauges to handle avgIf functions

### DIFF
--- a/snuba/query/processors/logical/calculated_average_processor.py
+++ b/snuba/query/processors/logical/calculated_average_processor.py
@@ -1,10 +1,8 @@
-from typing import cast
-
-from snuba.query.expressions import Column, Expression, FunctionCall
+from snuba.query.expressions import Expression, FunctionCall
 from snuba.query.logical import Query
 from snuba.query.matchers import Column as ColumnMatch
 from snuba.query.matchers import FunctionCall as FunctionCallMatch
-from snuba.query.matchers import Param, String
+from snuba.query.matchers import Or, String
 from snuba.query.processors.logical import LogicalQueryProcessor
 from snuba.query.query_settings import QuerySettings
 
@@ -18,41 +16,31 @@ class CalculatedAverageProcessor(LogicalQueryProcessor):
     """
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
-        # use a matched to find something like avg(value)
+        # use a matcher to find something like avg(value)
         matcher = FunctionCallMatch(
-            String("avg"),
-            (Param("avg_column", ColumnMatch(column_name=String("value"))),),
+            Or([String("avg"), String("avgIf")]),
+            (ColumnMatch(column_name=String("value")),),
+            with_optionals=True,
         )
 
         def transform_expression(exp: Expression) -> Expression:
             match = matcher.match(exp)
-            if match is not None:
-                column = cast(Column, match.expression("avg_column"))
+            if isinstance(exp, FunctionCall) and match is not None:
+                suffix = "If" if exp.function_name == "avgIf" else ""
+
                 return FunctionCall(
                     alias=exp.alias,
                     function_name="divide",
                     parameters=(
                         FunctionCall(
                             alias=None,
-                            function_name="sum",
-                            parameters=(
-                                Column(
-                                    alias=column.alias,
-                                    table_name=column.table_name,
-                                    column_name="value",
-                                ),
-                            ),
+                            function_name=f"sum{suffix}",
+                            parameters=exp.parameters,
                         ),
                         FunctionCall(
                             alias=None,
-                            function_name="count",
-                            parameters=(
-                                Column(
-                                    alias=column.alias,
-                                    table_name=column.table_name,
-                                    column_name="value",
-                                ),
-                            ),
+                            function_name=f"count{suffix}",
+                            parameters=exp.parameters,
                         ),
                     ),
                 )


### PR DESCRIPTION
The query processor that converts avg -> sum / count for gauges was not
updated to handle the case when the avg was in a formula. In that case, the
function is avgIf instead of avg and has extra condition parameters.