### PR TITLE
feat(capman): add referrer guard rail policy to every storage

### DIFF
--- a/snuba/datasets/configuration/discover/storages/discover.yaml
+++ b/snuba/datasets/configuration/discover/storages/discover.yaml
@@ -156,6 +156,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_splitters:
   - splitter: ColumnSplitQueryStrategy
     args:

--- a/snuba/datasets/configuration/functions/storages/functions.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions.yaml
@@ -99,3 +99,10 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0

--- a/snuba/datasets/configuration/functions/storages/functions_raw.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions_raw.yaml
@@ -38,6 +38,14 @@ schema:
     ]
   local_table_name: functions_raw_local
   dist_table_name: functions_raw_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 stream_loader:
   processor: FunctionsMessageProcessor
   default_topic: profiles-call-tree

--- a/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
@@ -97,6 +97,13 @@ allocation_policies:
         dynamic_sampling.counters.get_active_orgs:
             max_threads: 4
             concurrent_limit: 10
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 query_processors:
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
@@ -47,6 +47,14 @@ schema:
     ]
   local_table_name: generic_metric_counters_raw_local
   dist_table_name: generic_metric_counters_raw_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 stream_loader:
   processor: GenericCountersMetricsProcessor
   default_topic: snuba-generic-metrics

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -125,6 +125,13 @@ allocation_policies:
         statistical_detectors.distributions.fetch_transaction_timeseries:
           max_threads: 4
           concurrent_limit: 20
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 
 

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -47,6 +47,14 @@ schema:
     ]
   local_table_name: generic_metric_distributions_raw_local
   dist_table_name: generic_metric_distributions_raw_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 stream_loader:
   processor: GenericDistributionsMetricsProcessor
   default_topic: snuba-generic-metrics

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
@@ -114,6 +114,13 @@ allocation_policies:
         statistical_detectors.distributions.fetch_top_transaction_names:
           max_threads: 4
           concurrent_limit: 10
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 query_processors:
   - processor: MappingOptimizer

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
@@ -62,6 +62,14 @@ schema:
     ]
   local_table_name: generic_metric_gauges_raw_local
   dist_table_name: generic_metric_gauges_raw_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 stream_loader:
   processor: GenericGaugesMetricsProcessor
   default_topic: snuba-generic-metrics

--- a/snuba/datasets/configuration/generic_metrics/storages/org_counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/org_counters.yaml
@@ -48,6 +48,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 query_processors:
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -77,6 +77,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 query_processors:
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -47,6 +47,14 @@ schema:
     ]
   local_table_name: generic_metric_sets_raw_local
   dist_table_name: generic_metric_sets_raw_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 stream_loader:
   processor: GenericSetsMetricsProcessor
   default_topic: snuba-generic-metrics

--- a/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
@@ -46,10 +46,13 @@ allocation_policies:
         - project_id
       default_config_overrides:
         is_enforced: 0
-  - name: PassthroughPolicy
+  - name: ReferrerGuardRailPolicy
     args:
       required_tenant_types:
-        - blank
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 query_processors:
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
+++ b/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
@@ -63,6 +63,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: PrewhereProcessor
     args:

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -81,6 +81,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 query_processors:
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/metrics/storages/counters.yaml
@@ -43,6 +43,14 @@ schema:
     ]
   local_table_name: metrics_counters_v2_local
   dist_table_name: metrics_counters_v2_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: ArrayJoinKeyValueOptimizer
     args:

--- a/snuba/datasets/configuration/metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/metrics/storages/distributions.yaml
@@ -72,6 +72,14 @@ schema:
     ]
   local_table_name: metrics_distributions_v2_local
   dist_table_name: metrics_distributions_v2_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: ArrayJoinKeyValueOptimizer
     args:

--- a/snuba/datasets/configuration/metrics/storages/org_counters.yaml
+++ b/snuba/datasets/configuration/metrics/storages/org_counters.yaml
@@ -16,5 +16,13 @@ schema:
     ]
   local_table_name: metrics_counters_v2_local
   dist_table_name: metrics_counters_v2_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/metrics/storages/raw.yaml
+++ b/snuba/datasets/configuration/metrics/storages/raw.yaml
@@ -43,6 +43,15 @@ schema:
     ]
   local_table_name: metrics_raw_v2_local
   dist_table_name: metrics_raw_v2_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
+
 stream_loader:
   processor: PolymorphicMetricsProcessor
   default_topic: snuba-metrics

--- a/snuba/datasets/configuration/metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/metrics/storages/sets.yaml
@@ -47,6 +47,14 @@ schema:
     ]
   local_table_name: metrics_sets_v2_local
   dist_table_name: metrics_sets_v2_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: ArrayJoinKeyValueOptimizer
     args:

--- a/snuba/datasets/configuration/outcomes/storages/hourly.yaml
+++ b/snuba/datasets/configuration/outcomes/storages/hourly.yaml
@@ -38,6 +38,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: PrewhereProcessor
     args:

--- a/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
+++ b/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
@@ -42,6 +42,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: TableRateLimit
 mandatory_condition_checkers:

--- a/snuba/datasets/configuration/profiles/storages/profiles.yaml
+++ b/snuba/datasets/configuration/profiles/storages/profiles.yaml
@@ -73,6 +73,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer
     args:

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -198,3 +198,10 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0

--- a/snuba/datasets/configuration/sessions/storages/hourly.yaml
+++ b/snuba/datasets/configuration/sessions/storages/hourly.yaml
@@ -168,6 +168,14 @@ schema:
     ]
   local_table_name: sessions_hourly_local
   dist_table_name: sessions_hourly_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: PrewhereProcessor
     args:

--- a/snuba/datasets/configuration/sessions/storages/org.yaml
+++ b/snuba/datasets/configuration/sessions/storages/org.yaml
@@ -168,6 +168,14 @@ schema:
     ]
   local_table_name: sessions_hourly_local
   dist_table_name: sessions_hourly_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: PrewhereProcessor
     args:

--- a/snuba/datasets/configuration/sessions/storages/raw.yaml
+++ b/snuba/datasets/configuration/sessions/storages/raw.yaml
@@ -27,6 +27,14 @@ schema:
     ]
   local_table_name: sessions_raw_local
   dist_table_name: sessions_raw_dist
+allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: MinuteResolutionProcessor
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/spans/storages/metrics_summaries.yaml
+++ b/snuba/datasets/configuration/spans/storages/metrics_summaries.yaml
@@ -66,6 +66,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: UUIDColumnProcessor

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -122,6 +122,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: UUIDColumnProcessor

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -170,7 +170,7 @@ allocation_policies:
         - referrer
         - project_id
       default_config_overrides:
-        is_enforced: 0
+        is_enforced: 1
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:
@@ -180,7 +180,13 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
-
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: MappingColumnPromoter


### PR DESCRIPTION
This has been running in prod with errors for over a week now. Add it to all other storages. Don't make them active by default, turn them on one by one to make sure redis load is not unreasonable