### PR TITLE
ref(rust): Remove concurrency override

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence
 
 import click
 
-from snuba import settings, state
+from snuba import settings
 from snuba.consumers.consumer_config import resolve_consumer_config
 from snuba.datasets.storages.factory import get_writable_storage_keys
 
@@ -203,19 +203,13 @@ def rust_consumer(
 
     os.environ["RUST_LOG"] = log_level.lower()
 
-    # XXX: Temporary way to quickly test different values for concurrency
-    # Should be removed before this is put into  prod
-    concurrency_override = state.get_int_config(
-        f"rust_consumer.{storage_names[0]}.concurrency"
-    )
-
     exitcode = rust_snuba.consumer(  # type: ignore
         consumer_group,
         auto_offset_reset,
         no_strict_offset_reset,
         consumer_config_raw,
         skip_write,
-        concurrency_override or concurrency or 1,
+        concurrency or 1,
         use_rust_processor,
         enforce_schema,
         max_poll_interval_ms,


### PR DESCRIPTION
This was temporary for fast iteration on the rust consumer. It should not be used anymore.

