### PR TITLE
ref(rust): Do not double-report

### DIFF
--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -183,10 +183,6 @@ impl<TResult: Clone, TNext: Clone> MessageProcessor<TResult, TNext> {
                     scope.set_extra("payload", payload_as_value);
                 },
                 || {
-                    // FIXME: We are double-reporting errors here, as capturing
-                    // the error via `tracing::error` will not attach the anyhow
-                    // stack trace, but `capture_anyhow` will.
-                    sentry::integrations::anyhow::capture_anyhow(&error);
                     let error: &dyn std::error::Error = error.as_ref();
                     tracing::error!(error, "Failed processing message");
                 },


### PR DESCRIPTION
I don't think we actually care about the stacktrace, so capturing once
via tracing seems ok
