### PR TITLE
ref: Set all global tags existing in metrics also in Sentry

### DIFF
--- a/rust_snuba/src/metrics/global_tags.rs
+++ b/rust_snuba/src/metrics/global_tags.rs
@@ -7,6 +7,9 @@ use statsdproxy::types::Metric;
 static GLOBAL_TAGS: RwLock<BTreeMap<String, String>> = RwLock::new(BTreeMap::new());
 
 pub fn set_global_tag(key: String, value: String) {
+    sentry::configure_scope(|scope| {
+        scope.set_tag(&key, &value);
+    });
     GLOBAL_TAGS.write().insert(key, value);
 }
 

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -225,6 +225,9 @@ def consumer(
     if slice_id:
         metrics_tags["slice_id"] = str(slice_id)
 
+    for key, value in metrics_tags.items():
+        sentry_sdk.set_tag(key, value)
+
     metrics = MetricsWrapper(environment.metrics, "consumer", tags=metrics_tags)
     configure_metrics(StreamMetricsAdapter(metrics))
 


### PR DESCRIPTION
This ensures consumer_group and storage tags are on all consumers
