### PR TITLE
feat: Use topic configuration from sentry_kafka_schemas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.3.4
 sentry-arroyo==2.16.1
-sentry-kafka-schemas==0.1.49
+sentry-kafka-schemas==0.1.52
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.44
 sentry-sdk==1.39.2

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Mapping
 
+from sentry_kafka_schemas import SchemaNotFound, get_topic
+
 
 # These are the default topic names, they can be changed via settings
 class Topic(Enum):
@@ -64,51 +66,8 @@ class Topic(Enum):
 
 
 def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
-    config = {
-        Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.TRANSACTIONS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.METRICS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.PROFILES: {"message.timestamp.type": "LogAppendTime"},
-        Topic.REPLAYEVENTS: {
-            "message.timestamp.type": "LogAppendTime",
-            "max.message.bytes": "15000000",
-        },
-        Topic.GENERIC_METRICS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.GENERIC_EVENTS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.QUERYLOG: {"max.message.bytes": "2000000"},
-        Topic.GROUP_ATTRIBUTES: {"message.timestamp.type": "LogAppendTime"},
-        Topic.COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-        Topic.TRANSACTIONS_COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-        Topic.SESSIONS_COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-        Topic.METRICS_COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-        Topic.GENERIC_METRICS_SETS_COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-        Topic.GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-        Topic.GENERIC_METRICS_COUNTERS_COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-        Topic.GENERIC_EVENTS_COMMIT_LOG: {
-            "cleanup.policy": "compact,delete",
-            "min.compaction.lag.ms": "3600000",
-        },
-    }
-
-    return config.get(topic, {})
+    try:
+        return get_topic(topic.value)["topic_creation_config"]
+    # TODO: Remove this once all topics needed by snuba are registered in sentry-kafka-schemas
+    except SchemaNotFound:
+        return {}


### PR DESCRIPTION
Topic configuration for sentry is now centralized in sentry-kafka-schemas in an effort to ensure it is aligned across all projects and deployments.

This remove the duplication from snuba.
