### PR TITLE
fix: Upgrade SDK and reenable DDM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ sentry-arroyo==2.16.1
 sentry-kafka-schemas==0.1.52
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.44
-sentry-sdk==1.39.2
+sentry-sdk==1.40.4
 simplejson==3.17.6
 snuba-sdk==2.0.28
 structlog==22.3.0

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -89,12 +89,12 @@ def setup_sentry() -> None:
         release=os.getenv("SNUBA_RELEASE"),
         traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
         profiles_sample_rate=settings.SNUBA_PROFILES_SAMPLE_RATE,
-        # _experiments={
-        #     # Turns on the metrics module
-        #     "enable_metrics": True,
-        #     # Enables sending of code locations for metrics
-        #     "metric_code_locations": True,
-        # },
+        _experiments={
+            # Turns on the metrics module
+            "enable_metrics": True,
+            # Enables sending of code locations for metrics
+            "metric_code_locations": True,
+        },
     )
 
     from snuba.utils.profiler import run_ondemand_profiler


### PR DESCRIPTION
it seems https://github.com/getsentry/sentry-python/issues/2699 is
closed, and the outcome is:

* deadlock is fixed
* segfault is caused by improper uwsgi settings, and the SDK should warn
  if those are present

I ran `snuba api` locally and the warning doesn't trigger, so I assume
we're good. But also, I think we may have only encountered the deadlock,
not the segfault.
