### PR TITLE
feat(spans): Add index on trace_id

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -354,6 +354,7 @@ class SpansLoader(DirectoryLoader):
             "0008_spans_add_index_on_span_id",
             "0009_spans_add_measure_hashmap",
             "0010_spans_add_compression",
+            "0011_spans_add_index_on_trace_id",
         ]
 
 

--- a/snuba/snuba_migrations/spans/0011_spans_add_index_on_trace_id.py
+++ b/snuba/snuba_migrations/spans/0011_spans_add_index_on_trace_id.py
@@ -17,7 +17,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=f"{table_name_prefix}_local",
                 index_name=f"bf_{column_name}",
                 index_expression=column_name,
-                index_type="bloom_filter()",
+                index_type="bloom_filter(0)",
                 granularity=1,
                 target=operations.OperationTarget.LOCAL,
             ),

--- a/snuba/snuba_migrations/spans/0011_spans_add_index_on_trace_id.py
+++ b/snuba/snuba_migrations/spans/0011_spans_add_index_on_trace_id.py
@@ -1,0 +1,34 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+table_name_prefix = "spans"
+column_name = "trace_id"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddIndex(
+                storage_set=StorageSetKey.SPANS,
+                table_name=f"{table_name_prefix}_local",
+                index_name=f"bf_{column_name}",
+                index_expression=column_name,
+                index_type="bloom_filter()",
+                granularity=1,
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropIndex(
+                StorageSetKey.SPANS,
+                table_name=f"{table_name_prefix}_local",
+                index_name=f"bf_{column_name}",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/spans/0011_spans_add_index_on_trace_id.py
+++ b/snuba/snuba_migrations/spans/0011_spans_add_index_on_trace_id.py
@@ -17,7 +17,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=f"{table_name_prefix}_local",
                 index_name=f"bf_{column_name}",
                 index_expression=column_name,
-                index_type="bloom_filter(0)",
+                index_type="bloom_filter(0.0)",
                 granularity=1,
                 target=operations.OperationTarget.LOCAL,
             ),


### PR DESCRIPTION
With the trace view screen coming up, we need a fast way to fetch spans for a given `trace_id`. Right now, we're having to do a full table scan. This will speed up the query.