### PR TITLE
feat(gen-metrics): Support encoding in gen metrics processor

### DIFF
--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -532,6 +532,21 @@ mod tests {
         "value": [0, 1, 2, 3, 4, 5]
     }"#;
 
+    const DUMMY_ARR_ENCODED_SET_MESSAGE: &str = r#"{
+        "version": 2,
+        "use_case_id": "spans",
+        "org_id": 1,
+        "project_id": 3,
+        "metric_id": 65562,
+        "timestamp": 1704614940,
+        "sentry_received_timestamp": 1704614940,
+        "tags": {"9223372036854776010":"production","9223372036854776017":"errored","65690":"metric_e2e_spans_set_v_VUW93LMS"},
+        "retention_days": 90,
+        "mapping_meta":{"h":{"9223372036854776017":"session.status","9223372036854776010":"environment"},"f":{"65690":"metric_e2e_spans_set_k_VUW93LMS"},"d":{"65562":"s:spans/error@none"}},
+        "type": "s",
+        "value": {"format": "array", "data": [0, 1, 2, 3, 4, 5]}
+    }"#;
+
     const DUMMY_LEGACY_DISTRIBUTION_MESSAGE: &str = r#"{
         "version": 2,
         "use_case_id": "spans",

--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -100,9 +100,7 @@ where
     T: Deserialize<'de>,
     D: Deserializer<'de>,
 {
-    struct Visitor<U> {
-        phantom: PhantomData<U>,
-    }
+    struct Visitor<U>(PhantomData<U>);
 
     impl<'de, U> serde::de::Visitor<'de> for Visitor<U>
     where
@@ -130,9 +128,7 @@ where
         }
     }
 
-    deserializer.deserialize_any(Visitor {
-        phantom: PhantomData::<T>,
-    })
+    deserializer.deserialize_any(Visitor(PhantomData))
 }
 
 #[derive(Debug, Serialize, Default)]

--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -67,9 +67,9 @@ struct FromGenericMetricsMessage {
 enum MetricValue {
     #[serde(rename = "c")]
     Counter(f64),
-    #[serde(rename = "s", deserialize_with = "encoded_series_deserializer")]
+    #[serde(rename = "s", deserialize_with = "encoded_series_compat_deserializer")]
     Set(EncodedSeries<u64>),
-    #[serde(rename = "d", deserialize_with = "encoded_series_deserializer")]
+    #[serde(rename = "d", deserialize_with = "encoded_series_compat_deserializer")]
     Distribution(EncodedSeries<f64>),
     #[serde(rename = "g")]
     Gauge {
@@ -95,7 +95,9 @@ impl<T> EncodedSeries<T> {
     }
 }
 
-fn encoded_series_deserializer<'de, T, D>(deserializer: D) -> Result<EncodedSeries<T>, D::Error>
+fn encoded_series_compat_deserializer<'de, T, D>(
+    deserializer: D,
+) -> Result<EncodedSeries<T>, D::Error>
 where
     T: Deserialize<'de>,
     D: Deserializer<'de>,
@@ -109,7 +111,7 @@ where
         type Value = EncodedSeries<U>;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("expected either old or new distribution value format")
+            formatter.write_str("expected either legacy or new distribution value format")
         }
 
         fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>

--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -1095,4 +1095,59 @@ mod tests {
         );
         assert_eq!(result.unwrap(), InsertBatch::skip());
     }
+
+    #[test]
+    fn test_set_processor_with_v1_set_message() {
+        let result = test_processor_with_payload(
+            &(process_set_message
+                as fn(
+                    rust_arroyo::backends::kafka::types::KafkaPayload,
+                    crate::types::KafkaMessageMetadata,
+                    &crate::ProcessorConfig,
+                )
+                    -> std::result::Result<crate::types::InsertBatch, anyhow::Error>),
+            DUMMY_ARR_ENCODED_SET_MESSAGE,
+        );
+        let expected_row = SetsRawRow {
+            common_fields: CommonMetricFields {
+                use_case_id: "spans".to_string(),
+                org_id: 1,
+                project_id: 3,
+                metric_id: 65562,
+                timestamp: 1704614940,
+                retention_days: 90,
+                tags_key: vec![65690, 9223372036854776010, 9223372036854776017],
+                tags_indexed_value: vec![0; 3],
+                tags_raw_value: vec![
+                    "metric_e2e_spans_set_v_VUW93LMS".to_string(),
+                    "production".to_string(),
+                    "errored".to_string(),
+                ],
+                metric_type: "set".to_string(),
+                materialization_version: 2,
+                timeseries_id: 828906429,
+                granularities: vec![
+                    GRANULARITY_ONE_MINUTE,
+                    GRANULARITY_ONE_HOUR,
+                    GRANULARITY_ONE_DAY,
+                ],
+                decasecond_retention_days: None,
+                min_retention_days: Some(90),
+                hr_retention_days: None,
+                day_retention_days: None,
+            },
+            set_values: vec![0, 1, 2, 3, 4, 5],
+        };
+        assert_eq!(
+            result.unwrap(),
+            InsertBatch {
+                rows: RowData::from_rows([expected_row]).unwrap(),
+                origin_timestamp: None,
+                sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
+                cogs_data: Some(CogsData {
+                    data: BTreeMap::from([("genericmetrics_spans".to_string(), 651)])
+                })
+            }
+        );
+    }
 }


### PR DESCRIPTION
### Overview

Adds some serde logic to support new schema format for the `values` field.

Before

```json
{
  "values": [1, 2, 3]
}
```

Now

```json
{
  "values": {
    "format": "array",
    "data": [1, 2, 3]
  }
}
```

Both are supported