### PR TITLE
ref(rust): Make errors better for errors processor

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2105,6 +2105,7 @@ dependencies = [
  "sentry_usage_accountant",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "statsdproxy",
  "thiserror",
  "tikv-jemallocator",
@@ -2423,6 +2424,16 @@ checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -47,6 +47,7 @@ sentry_usage_accountant = "0.0.4"
 adler = "1.0.2"
 schemars = { version = "0.8.16", features = ["uuid1"] }
 json-schema-diff = "0.1.7"
+serde_path_to_error = "0.1.15"
 
 
 [patch.crates-io]


### PR DESCRIPTION
The payloads in the errors processor are so large that they're
impossible to debug, so add another crate that keeps track of where a
deserialization error occurs.

We might want to do this for other processors, but the performance
implications of this are unclear, so I'd want to avoid it for payloads
which are already small and easily debuggable.
