### PR TITLE
fix(COGS): Fix cluster name in COGS accounting for Snuba API

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -125,9 +125,12 @@ def _record_cogs(
         return  # Only track shared clusters
 
     # Sanitize the cluster name to line up with the resource_id naming convention
-    cluster_name = cluster_name.replace("-", "_").replace(
-        "snuba_gen_metrics", "generic_metrics_clickhouse"
+    cluster_name = (
+        cluster_name.replace("-", "_")
+        .replace("snuba_gen_metrics", "generic_metrics_clickhouse")
+        .replace("_0", "")
     )
+
     if random() < (state.get_config("snuba_api_cogs_probability") or 0):
         record_cogs(
             resource_id=f"{cluster_name}",

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -121,18 +121,16 @@ def _record_cogs(
 
     cluster_name = query_metadata.query_list[0].stats.get("cluster_name", "")
 
-    if not cluster_name.startswith("snuba_gen_metrics"):
+    if not cluster_name.startswith("snuba-gen-metrics"):
         return  # Only track shared clusters
 
     # Sanitize the cluster name to line up with the resource_id naming convention
-    cluster_name = (
-        cluster_name.replace("-", "_")
-        .replace("snuba_gen_metrics", "generic_metrics_clickhouse")
-        .replace("_0", "")
+    cluster_name = cluster_name.replace("-", "_").replace(
+        "snuba_gen_metrics", "generic_metrics_clickhouse"
     )
     if random() < (state.get_config("snuba_api_cogs_probability") or 0):
         record_cogs(
-            resource_id=f"{cluster_name}_snuba_api_bytes_scanned",
+            resource_id=f"{cluster_name}",
             app_feature=app_feature,
             amount=bytes_scanned,
             usage_type=UsageUnit.BYTES,


### PR DESCRIPTION
What `cluster_name` is today: `snuba-gen-metrics-xxxx` where xxxx is the metric type

What we want as the resource id: `generic_metrics_clickhouse_xxxx`