### PR TITLE
ci: configure dependabot for security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0  # security updates only
     groups:
       maintine-dependencies:
         patterns:
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    open-pull-requests-limit: 50
+    open-pull-requests-limit: 0  # security updates only
     ignore:
       # sentry-kafka-schemas has its own lints to ensure it is reasonably
       # up-to-date -- we should rely on them


### PR DESCRIPTION
Dependabot was configured to open PRs for general library updates. Most of those PRs have gone stale or are not managed. The extra noise desensitizes us to the Dependabot PRs. 

This PR changes the configuration to instruct Dependabot to only open a PR to update a dependency if it solves a known security issue.