### PR TITLE
ref: snuba admin readme update

### DIFF
--- a/snuba/admin/README.md
+++ b/snuba/admin/README.md
@@ -1,8 +1,12 @@
 # Running
-
+You must have node and yarn installed. To do so:
+```
+volta install node
+volta install yarn
+make build-admin
+```
 
 To run the app locally:
-
 ```bash
 # assuming you're in the venv
 snuba admin
@@ -14,21 +18,12 @@ note: please ensure that sentry devservices are up via `sentry devservices up --
 
 # Developing the Javascript
 
-You must have node and yarn installed. To do so:
-
-```
-volta install node
-volta install yarn
-make build-admin
-```
-
-Then
-
+To start the yarn debug server and live reload your javascript changes.
 ```
 make watch-admin
 ```
 
-this will start the yarn debug server and live reload your javascript changes. If you change environment variables you'll have to restart the server
+ If you change environment variables you'll have to restart the server
 
 # Releasing new javascript
 


### PR DESCRIPTION
During Rachel's onboarding to snuba admin she had an issue where snuba admin page wasn't starting properly. The problem was solved by running `make build-admin` before `snuba admin`. I have updated the readme to ensure `make build-admin` gets ran first in the future so others dont run into the same issue.