### PR TITLE
ref(ch-upgrades): update query_comparer

### DIFF
--- a/snuba/cli/query_comparer.py
+++ b/snuba/cli/query_comparer.py
@@ -8,19 +8,15 @@ import structlog
 
 from snuba import settings
 from snuba.admin.notifications.slack.client import SlackClient
+from snuba.clickhouse.upgrades.comparisons import (
+    BlobGetter,
+    FileManager,
+    QueryMeasurementResult,
+)
 from snuba.environment import setup_logging, setup_sentry
+from snuba.utils.gcs import GCSUploader
 
 logger = structlog.get_logger().bind(module=__name__)
-
-
-@dataclass(frozen=True)
-class QueryMeasurement:
-    query_id: str
-    query_duration_ms: int
-    result_rows: int
-    result_bytes: int
-    read_rows: int
-    read_bytes: int
 
 
 @dataclass(frozen=True)
@@ -111,26 +107,14 @@ def write_querylog_comparison_results_to_csv(
 
 @click.command()
 @click.option(
-    "--base-file",
-    help="Clickhouse queries results from base version.",
-    required=True,
-)
-@click.option(
-    "--upgrade-file",
-    help="Clickhouse queries results from upgrade version.",
-    required=True,
-)
-@click.option(
-    "--table",
-    help="Clickhouse queries results from upgrade version.",
+    "--gcs-bucket",
+    help="Name of gcs bucket to save query files to",
     required=True,
 )
 @click.option("--log-level", help="Logging level to use.")
 def query_comparer(
     *,
-    base_file: str,
-    upgrade_file: str,
-    table: str,
+    gcs_bucket: str,
     log_level: Optional[str] = None,
 ) -> None:
     """
@@ -139,48 +123,55 @@ def query_comparer(
     setup_logging(log_level)
     setup_sentry()
 
-    base = open(base_file)
-    upgrade = open(upgrade_file)
+    # check the result versions
+    # get the difference between the
+    uploader = GCSUploader(gcs_bucket)
+    file_manager = FileManager(uploader)
+    blob_getter = BlobGetter(uploader)
 
-    base_reader = csv.reader(base)
-    upgrade_reader = csv.reader(upgrade)
+    blob_prefixes = blob_getter._get_sub_dir_prefixes(prefix="")
+    v1, v2 = sorted(
+        [prefix for prefix in blob_prefixes if prefix.startswith("results")]
+    )
 
-    def query_measurement(row: Any) -> QueryMeasurement:
-        return QueryMeasurement(
-            query_id=row[0],
-            query_duration_ms=int(row[1]),
-            result_rows=int(row[2]),
-            result_bytes=int(row[3]),
-            read_rows=int(row[4]),
-            read_bytes=int(row[5]),
-        )
+    all_names = blob_getter.get_all_names(prefix="results")
+    unmatched_names = blob_getter.get_name_diffs((v1, v2)) + blob_getter.get_name_diffs(
+        (v2, v1)
+    )
 
-    mismatches = []
-    total_rows = 0
-    for v1_row, v2_row in itertools.zip_longest(base_reader, upgrade_reader):
-        if v1_row[0] == "query_id":
-            # csv header row
-            continue
+    def get_matched_pairs():
+        matches = []
+        v1_matches = sorted([name for name in all_names if name not in unmatched_names])
+        midpoint = int(len(v1_matches) / 2)
+        for i in range(0, midpoint):
+            v1_match = v1_matches[i]
+            v2_match = v1_match.replace(v1, v2)
+            matches.append((v1_match, v2_match))
+        return matches
 
-        assert v1_row[0] == v2_row[0], "Invalid query_ids: ids must match"
-        total_rows += 1
+    matched_pairs = get_matched_pairs()
+    for (v1_blob, v2_blob) in matched_pairs:
+        file_format = file_manager.parse_blob_name(v1_blob)
+        v1_results = file_manager.download(v1_blob)
+        v2_results = file_manager.download(v2_blob)
 
-        mismatches_exist = any(
-            [1 for i in range(1, len(v1_row)) if v1_row[i] != v2_row[i]]
-        )
-        if not mismatches_exist:
-            continue
+        mismatches = []
+        total_rows = 0
+        for v1_result, v2_result in itertools.zip_longest(v1_results, v2_results):
+            assert (
+                v1_result.query_id == v2_result.query_id
+            ), "Invalid query_ids: ids must match"
+            total_rows += 1
+            if v1_result == v2_result:
+                continue
 
-        v1_data = query_measurement(v1_row)
-        v2_data = query_measurement(v2_row)
+            mismatches.append(_create_mismatch(v1_result, v2_result))
 
-        mismatches.append(_create_mismatch(v1_data, v2_data))
-
-    _send_slack_report(total_rows, mismatches, table)
+        _send_slack_report(total_rows, mismatches, file_format.table)
 
 
 def _create_mismatch(
-    v1_data: QueryMeasurement, v2_data: QueryMeasurement
+    v1_data: QueryMeasurementResult, v2_data: QueryMeasurementResult
 ) -> QueryMismatch:
     mismatch = {}
     for m in MEASUREMENTS:

--- a/snuba/cli/query_comparer.py
+++ b/snuba/cli/query_comparer.py
@@ -1,7 +1,5 @@
-import csv
 import itertools
-from dataclasses import dataclass
-from typing import Any, NamedTuple, Optional, Sequence, Union
+from typing import Any, Optional, Sequence, Tuple
 
 import click
 import structlog
@@ -10,7 +8,10 @@ from snuba import settings
 from snuba.admin.notifications.slack.client import SlackClient
 from snuba.clickhouse.upgrades.comparisons import (
     BlobGetter,
+    DataMismatchResult,
+    FileFormat,
     FileManager,
+    PerfMismatchResult,
     QueryMeasurementResult,
 )
 from snuba.environment import setup_logging, setup_sentry
@@ -18,91 +19,7 @@ from snuba.utils.gcs import GCSUploader
 
 logger = structlog.get_logger().bind(module=__name__)
 
-
-@dataclass(frozen=True)
-class MismatchedValues:
-    base_value: int
-    new_value: int
-    delta: int
-
-
-class PerformanceMismatchResult(NamedTuple):
-    query_id: str
-    duration_ms_base: int
-    duration_ms_new: int
-    read_rows_base: int
-    read_rows_new: int
-    read_bytes_base: int
-    read_bytes_new: int
-    duration_ms_delta: int
-    read_rows_delta: int
-    read_bytes_delta: int
-
-
-class DataMismatchResult(NamedTuple):
-    query_id: str
-    result_rows_base: int
-    result_rows_new: int
-    result_bytes_base: int
-    result_bytes_new: int
-    result_rows_delta: int
-    result_bytes_delta: int
-
-
-@dataclass
-class QueryMismatch:
-    query_id: str
-    query_duration_ms: MismatchedValues
-    result_rows: MismatchedValues
-    result_bytes: MismatchedValues
-    read_rows: MismatchedValues
-    read_bytes: MismatchedValues
-
-    def performance_mismatches(self) -> PerformanceMismatchResult:
-        return PerformanceMismatchResult(
-            self.query_id,
-            self.query_duration_ms.base_value,
-            self.query_duration_ms.new_value,
-            self.read_rows.base_value,
-            self.read_rows.new_value,
-            self.read_bytes.base_value,
-            self.read_bytes.new_value,
-            self.query_duration_ms.delta,
-            self.read_rows.delta,
-            self.read_bytes.delta,
-        )
-
-    def data_mismatches(self) -> DataMismatchResult:
-        return DataMismatchResult(
-            self.query_id,
-            self.result_rows.base_value,
-            self.result_rows.new_value,
-            self.result_bytes.base_value,
-            self.result_bytes.new_value,
-            self.result_rows.delta,
-            self.result_bytes.delta,
-        )
-
-
-MEASUREMENTS = [
-    "query_duration_ms",
-    "result_rows",
-    "result_bytes",
-    "read_rows",
-    "read_bytes",
-]
-
-
-def write_querylog_comparison_results_to_csv(
-    results: Union[Sequence[DataMismatchResult], Sequence[PerformanceMismatchResult]],
-    filename: str,
-    header_row: Sequence[str],
-) -> None:
-    with open(filename, mode="w") as file:
-        writer = csv.writer(file)
-        writer.writerow(header_row)
-        for row in results:
-            writer.writerow(row)
+MismatchResultSet = Sequence[PerfMismatchResult | DataMismatchResult]
 
 
 @click.command()
@@ -111,10 +28,23 @@ def write_querylog_comparison_results_to_csv(
     help="Name of gcs bucket to save query files to",
     required=True,
 )
+@click.option(
+    "--compare-type",
+    help="Run comparisons on performance, data consistency or both (default).",
+    type=click.Choice(["perf", "data"]),
+)
+@click.option(
+    "--override",
+    help="Option to override any previously re-run results",
+    is_flag=True,
+    default=False,
+)
 @click.option("--log-level", help="Logging level to use.")
 def query_comparer(
     *,
     gcs_bucket: str,
+    compare_type: str,
+    override: bool,
     log_level: Optional[str] = None,
 ) -> None:
     """
@@ -123,93 +53,186 @@ def query_comparer(
     setup_logging(log_level)
     setup_sentry()
 
-    # check the result versions
-    # get the difference between the
     uploader = GCSUploader(gcs_bucket)
     file_manager = FileManager(uploader)
     blob_getter = BlobGetter(uploader)
 
     blob_prefixes = blob_getter._get_sub_dir_prefixes(prefix="")
-    v1, v2 = sorted(
-        [prefix for prefix in blob_prefixes if prefix.startswith("results")]
-    )
+    result_prefixes = sorted([p for p in blob_prefixes if p.startswith("results")])
 
-    all_names = blob_getter.get_all_names(prefix="results")
-    unmatched_names = blob_getter.get_name_diffs((v1, v2)) + blob_getter.get_name_diffs(
-        (v2, v1)
-    )
+    if len(result_prefixes) != 2:
+        logger.info("Not enough results to compare.")
+        return
 
-    def get_matched_pairs():
+    def get_matched_pairs() -> Sequence[Tuple[str, str]]:
         matches = []
-        v1_matches = sorted([name for name in all_names if name not in unmatched_names])
-        midpoint = int(len(v1_matches) / 2)
-        for i in range(0, midpoint):
-            v1_match = v1_matches[i]
-            v2_match = v1_match.replace(v1, v2)
-            matches.append((v1_match, v2_match))
+        v1_prefix, v2_prefix = result_prefixes
+        for v1_name in blob_getter.get_all_names(prefix=v1_prefix):
+            v2_name = v1_name.replace(v1_prefix, v2_prefix)
+            if uploader.blob_exists(v2_name):
+                matches.append((v1_name, v2_name))
         return matches
 
     matched_pairs = get_matched_pairs()
     for (v1_blob, v2_blob) in matched_pairs:
-        file_format = file_manager.parse_blob_name(v1_blob)
+        blob_suffix = v1_blob.split("/", 1)[-1]
+        compared_perf_blob = f"compared-perf/{blob_suffix}"
+        compared_data_blob = f"compared-data/{blob_suffix}"
+        perf_blob_exists = uploader.blob_exists(compared_perf_blob)
+        data_blob_exists = uploader.blob_exists(compared_data_blob)
+
+        if perf_blob_exists and data_blob_exists and not override:
+            continue
+
+        if compare_type == "perf" and perf_blob_exists and not override:
+            continue
+
+        if compare_type == "data" and data_blob_exists and not override:
+            continue
+
+        result_file_format = file_manager.parse_blob_name(v1_blob)
         v1_results = file_manager.download(v1_blob)
         v2_results = file_manager.download(v2_blob)
 
-        mismatches = []
+        perf_mismatches = []
+        data_mismatches = []
         total_rows = 0
         for v1_result, v2_result in itertools.zip_longest(v1_results, v2_results):
+
             assert (
                 v1_result.query_id == v2_result.query_id
-            ), "Invalid query_ids: ids must match"
+            ), f"Invalid query_ids: {v1_result.query_id} and {v2_result.query_id} must match"
             total_rows += 1
             if v1_result == v2_result:
                 continue
 
-            mismatches.append(_create_mismatch(v1_result, v2_result))
+            assert isinstance(v1_result, QueryMeasurementResult)
+            assert isinstance(v2_result, QueryMeasurementResult)
 
-        _send_slack_report(total_rows, mismatches, file_format.table)
+            perf_mismatch = create_perf_mismatch(v1_result, v2_result)
+            data_mismatch = create_data_mismatch(v1_result, v2_result)
+            if perf_mismatch:
+                perf_mismatches.append(perf_mismatch)
+            if data_mismatch:
+                data_mismatches.append(data_mismatch)
+
+        def save_comparisons(compare_type: str, mismatches: MismatchResultSet) -> None:
+            compared_file_format = FileFormat(
+                f"compared-{compare_type}",
+                result_file_format.date,
+                result_file_format.table,
+                result_file_format.hour,
+            )
+            file_manager.save(compared_file_format, mismatches, header_row=True)
+            # need the filename for the slack report
+            filename = file_manager.format_filename(compared_file_format)
+            _send_slack_report(
+                compare_type, total_rows, mismatches, result_file_format.table, filename
+            )
+
+        if compare_type == "perf":
+            save_comparisons(compare_type, perf_mismatches)
+        elif compare_type == "data":
+            save_comparisons(compare_type, data_mismatches)
+        else:
+            # no compare type == run both reports
+            save_comparisons("perf", perf_mismatches)
+            save_comparisons("data", data_mismatches)
 
 
-def _create_mismatch(
+PERF_THRESHOLDS = {
+    "query_duration_ms": 0,
+    "read_rows": 0,
+    "read_bytes": 0,
+}
+
+DATA_THRESHOLDS = {
+    "result_rows": 0,
+    "result_bytes": 0,
+}
+
+
+def create_perf_mismatch(
     v1_data: QueryMeasurementResult, v2_data: QueryMeasurementResult
-) -> QueryMismatch:
-    mismatch = {}
-    for m in MEASUREMENTS:
-        v1_value = v1_data.__getattribute__(m)
-        v2_value = v2_data.__getattribute__(m)
+) -> Optional[PerfMismatchResult]:
+    d_ms_1 = v1_data.query_duration_ms
+    d_ms_2 = v2_data.query_duration_ms
+    d_ms_delta = d_ms_2 - d_ms_1
 
-        delta = v2_value - v1_value
-        mismatched_values = MismatchedValues(
-            v1_value,
-            v2_value,
-            delta,
+    rd_r_1 = v1_data.read_rows
+    rd_r_2 = v2_data.read_rows
+    rd_r_delta = rd_r_2 - rd_r_1
+
+    rd_b_1 = v1_data.read_bytes
+    rd_b_2 = v2_data.read_bytes
+    rd_b_delta = rd_b_2 - rd_b_1
+
+    if (
+        (d_ms_delta > PERF_THRESHOLDS["query_duration_ms"])
+        or rd_r_delta > PERF_THRESHOLDS["read_rows"]
+        or rd_b_delta > PERF_THRESHOLDS["read_bytes"]
+    ):
+        # mismatch!
+        return PerfMismatchResult(
+            v1_data.query_id,
+            d_ms_1=d_ms_1,
+            d_ms_2=d_ms_2,
+            rd_r_1=rd_r_1,
+            rd_r_2=rd_r_2,
+            rd_b_1=rd_b_1,
+            rd_b_2=rd_b_2,
+            d_ms_delta=d_ms_delta,
+            rd_r_delta=rd_r_delta,
+            rd_b_delta=rd_b_delta,
         )
-        mismatch[m] = mismatched_values
-    return QueryMismatch(
-        query_id=v1_data.query_id,
-        query_duration_ms=mismatch["query_duration_ms"],
-        result_rows=mismatch["result_rows"],
-        result_bytes=mismatch["result_bytes"],
-        read_rows=mismatch["read_rows"],
-        read_bytes=mismatch["read_bytes"],
-    )
+    return None
+
+
+def create_data_mismatch(
+    v1_data: QueryMeasurementResult, v2_data: QueryMeasurementResult
+) -> Optional[DataMismatchResult]:
+    rt_r_1 = v1_data.result_rows
+    rt_r_2 = v2_data.result_rows
+    rt_r_delta = rt_r_2 - rt_r_1
+
+    rt_b_1 = v1_data.result_bytes
+    rt_b_2 = v2_data.result_bytes
+    rt_b_delta = rt_b_2 - rt_b_1
+
+    if (rt_r_delta > DATA_THRESHOLDS["result_rows"]) or rt_b_delta > DATA_THRESHOLDS[
+        "result_bytes"
+    ]:
+        # mismatch!
+        return DataMismatchResult(
+            v1_data.query_id,
+            rt_r_1=rt_r_1,
+            rt_r_2=rt_r_2,
+            rt_b_1=rt_b_1,
+            rt_b_2=rt_b_2,
+            rt_r_delta=rt_r_delta,
+            rt_b_delta=rt_b_delta,
+        )
+    return None
 
 
 def _format_slack_overview(
-    total_rows: int, mismatches: Sequence[QueryMismatch], table: str
+    total_rows: int,
+    mismatches: MismatchResultSet,
+    table: str,
+    compare_type: str,
 ) -> Any:
     queries = total_rows
     num_mismatches = len(mismatches)
     per_mismatches = len(mismatches) / total_rows
 
-    overview_text = f"*Overview: `{table}`*\n Total Queries: `{queries}`\n Total Mismatches: `{num_mismatches}`\n% Mismatch: `{per_mismatches}`"
+    overview_text = f"*`{table}`*\n Total Queries: `{queries}`\n Total Mismatches: `{num_mismatches}`\n% Mismatch: `{per_mismatches}`"
     return {
         "blocks": [
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "*Querylog Comparison `21.8` v `22.8`*\n",
+                    "text": f"*Querylog Comparison - {compare_type.upper()}  `21.8` v `22.8`*\n",
                 },
             },
             {
@@ -224,60 +247,23 @@ def _format_slack_overview(
 
 
 def _send_slack_report(
-    total_rows: int, mismatches: Sequence[QueryMismatch], table: str
+    compare_type: str,
+    total_rows: int,
+    mismatches: MismatchResultSet,
+    table: str,
+    filename: str,
 ) -> None:
     slack_client = SlackClient(
         channel_id=settings.SNUBA_SLACK_CHANNEL_ID, token=settings.SLACK_API_TOKEN
     )
 
     slack_client.post_message(
-        message=_format_slack_overview(total_rows, mismatches, table)
+        message=_format_slack_overview(total_rows, mismatches, table, compare_type)
     )
 
-    if not mismatches:
-        return
-
-    p_header_row = [
-        "query_id",
-        "ms_1",
-        "ms_2",
-        "rows1",
-        "rows2",
-        "bytes1",
-        "bytes2",
-        "duration_delta",
-        "read_rows_delta",
-        "read_bytes_delta",
-    ]
-    p_results: Sequence[PerformanceMismatchResult] = [
-        m.performance_mismatches() for m in mismatches
-    ]
-
-    d_header_row = [
-        "query_id",
-        "rows1",
-        "rows2",
-        "bytes1",
-        "bytes2",
-        "result_rows_delta",
-        "result_bytes_delta",
-    ]
-    d_results: Sequence[DataMismatchResult] = [m.data_mismatches() for m in mismatches]
-
-    p_filename = f"perf_{table}.csv"
-    d_filename = f"data_{table}.csv"
-
-    for results, header_row, filename in [
-        (p_results, p_header_row, p_filename),
-        (d_results, d_header_row, d_filename),
-    ]:
-        assert isinstance(results, (PerformanceMismatchResult, DataMismatchResult))
-        write_querylog_comparison_results_to_csv(
-            results, f"/tmp/{filename}", header_row
-        )
-        slack_client.post_file(
-            file_name=filename,
-            file_path=f"/tmp/{filename}",
-            file_type="csv",
-            initial_comment=f"Querylog Result Report: {filename}",
-        )
+    slack_client.post_file(
+        file_name=filename,
+        file_path=f"/tmp/{filename}",
+        file_type="csv",
+        initial_comment=f"report from: {filename}",
+    )

--- a/snuba/clickhouse/upgrades/comparisons.py
+++ b/snuba/clickhouse/upgrades/comparisons.py
@@ -21,31 +21,26 @@ class MismatchedValues:
 @dataclass
 class PerfMismatchResult:
     query_id: str
-    # duration_ms
-    d_ms_1: int
-    d_ms_2: int
-    # read_rows
-    rd_r_1: int
-    rd_r_2: int
-    # read_bytes
-    rd_b_1: int
-    rd_b_2: int
-    d_ms_delta: int
-    rd_r_delta: int
-    rd_b_delta: int
+    duration_ms: int
+    duration_ms_new: int
+    read_rows: int
+    read_rows_new: int
+    read_bytes: int
+    read_bytes_new: int
+    duration_ms_delta: int
+    read_rows_delta: int
+    read_bytes_delta: int
 
 
 @dataclass
 class DataMismatchResult:
     query_id: str
-    # result_rows
-    rt_r_1: int
-    rt_r_2: int
-    # result_bytes
-    rt_b_1: int
-    rt_b_2: int
-    rt_r_delta: int
-    rt_b_delta: int
+    result_rows: int
+    result_rows_new: int
+    result_bytes: int
+    result_bytes_new: int
+    result_rows_delta: int
+    result_bytes_delta: int
 
 
 @dataclass

--- a/snuba/clickhouse/upgrades/comparisons.py
+++ b/snuba/clickhouse/upgrades/comparisons.py
@@ -26,6 +26,19 @@ class QueryMeasurementResult:
     read_rows: int
     read_bytes: int
 
+    def __eq__(self, other: object) -> bool:
+        if self.query_duration_ms != other.query_duration_ms:
+            return False
+        if self.result_rows != other.result_rows:
+            return False
+        if self.result_bytes != other.result_bytes:
+            return False
+        if self.read_rows != other.read_rows:
+            return False
+        if self.read_bytes != other.read_bytes:
+            return False
+        return True
+
 
 Results = Union[QueryInfoResult, QueryMeasurementResult]
 


### PR DESCRIPTION
Updating the comparer to use the file_manager and grab the files to compare from GCS. Corresponding ops PR https://github.com/getsentry/ops/pull/9471

What the comparer does:

1. Looks at the `results-` directories to see if we have pairs of results that are ready to be compared and puts them together as a `matched_pairs`. e.g.
    ```python
     [('results-21-8/2024_02_15/meredith_test_1.csv', 'results-22-8/2024_02_15/meredith_test_1.csv')]
     ```
2. Iterates through those pairs to actually compare the results from those files. Before it does so though, it checks that we haven't already done the comparison (we ignore that if `--override` is used). We can check in the `compared-data/` and `compared-perf/` directories
3. We compare the results and generate mismatches for the `data` and `perf` categories based on the result data. Thresholds of what should be considered mismatching are in the corresponding `_THRESHOLDS` dicts.
4. We save the comparison results for each category separately, as well as send the slack overview + csv files per category as well. We do calculate the % mismatches based on the total rows of the files. Adding percentages of both categories might exceed 100% since the same query_id could have a mismatch in the performance AND the data consistency.