### PR TITLE
on-call(admin): Allow viewing migrations for product tools role

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -82,6 +82,7 @@ TOOL_RESOURCES = {
     "cardinality-analyzer": ToolResource("cardinality-analyzer"),
     "production-queries": ToolResource("production-queries"),
     "system-queries": ToolResource("system-queries"),
+    "clickhouse-migrations": ToolResource("clickhouse-migrations"),
     "all": ToolResource("all"),
 }
 
@@ -157,6 +158,7 @@ ROLES = {
                     TOOL_RESOURCES["tracing"],
                     TOOL_RESOURCES["production-queries"],
                     TOOL_RESOURCES["system-queries"],
+                    TOOL_RESOURCES["clickhouse-migrations"],
                 ]
             )
         },

--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -14,7 +14,8 @@
     },
     {
       "members": [
-        "group:team-sns@sentry.io"
+        "group:team-sns@sentry.io",
+        "group:access-snuba-admin@sentry.io"
       ],
       "role": "roles/MigrationsReader"
     },

--- a/snuba/admin/tool_policies.py
+++ b/snuba/admin/tool_policies.py
@@ -21,7 +21,7 @@ class AdminTools(Enum):
     CONFIGURATION = "configuration"
     SNQL_TO_SQL = "snql-to-sql"
     SYSTEM_QUERIES = "system-queries"
-    MIGRATIONS = "migrations"
+    MIGRATIONS = "clickhouse-migrations"
     QUERY_TRACING = "tracing"
     QUERYLOG = "querylog"
     AUDIT_LOG = "audit-log"

--- a/tests/admin/test_authorization.py
+++ b/tests/admin/test_authorization.py
@@ -39,4 +39,5 @@ def test_product_tools_role(
     assert "tracing" in data["tools"]
     assert "system-queries" in data["tools"]
     assert "production-queries" in data["tools"]
+    assert "clickhouse-migrations" in data["tools"]
     assert "all" not in data["tools"]


### PR DESCRIPTION
Product owners should be able to view which migrations have been executed in production to get a better sense of what their datasets/tables look like in prod. This can help product developers validate whether or not their tables have been created in a new environment without having to traverse GoCD. 