### PR TITLE
fix(mql): Fix bug with Formulas on scalar values

### DIFF
--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -250,6 +250,8 @@ class MQLVisitor(NodeVisitor):  # type: ignore
 
                 if target.parameters is not None:
                     for param in target.parameters:
+                        if not isinstance(param, InitialParseResult):
+                            continue  # Don't push down scalar values e.g. sum(mri) / 3600
                         pushdown_filter(param)
             else:
                 if target.conditions is not None:


### PR DESCRIPTION
There was a bug where a Formula that had a scalar value, and had filters, would
fail because the scalar values weren't being handled correctly.