### PR TITLE
ref: refactored tests for snuba health

### DIFF
--- a/tests/cli/test_health.py
+++ b/tests/cli/test_health.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from snuba.cli.health import health
 
 
-def test_check_health() -> None:
+def test_down_file_exists_pod_healthy() -> None:
     runner = CliRunner()
     # down file existing does not mean the pod is unhealthy
     with mock.patch(
@@ -13,14 +13,26 @@ def test_check_health() -> None:
     ):
         result = runner.invoke(health)
         assert result.exit_code == 0
+
+
+def test_do_not_check_clickhouse_if_not_thorough() -> None:
+    runner = CliRunner()
     # don't check clickhouse if not thorough
     with mock.patch("snuba.utils.health_info.check_clickhouse", return_value=False):
         result = runner.invoke(health)
         assert result.exit_code == 0
+
+
+def test_bad_clickhouse_connection_thorough_healthcheck_fails() -> None:
+    runner = CliRunner()
     # thorough healthcheck fails on bad clickhouse connection
     with mock.patch("snuba.utils.health_info.check_clickhouse", return_value=False):
         result = runner.invoke(health, "--thorough")
         assert result.exit_code == 1
+
+
+def test_good_clickhouse_connection_thorough_healthcheck_passes() -> None:
+    runner = CliRunner()
     # thorough healthcheck passes on good clickhouse connection
     with mock.patch("snuba.utils.health_info.check_clickhouse", return_value=True):
         result = runner.invoke(health, "--thorough")

--- a/tests/utils/test_check_clickhouse.py
+++ b/tests/utils/test_check_clickhouse.py
@@ -10,7 +10,12 @@ from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.readiness_state import ReadinessState
 from snuba.datasets.storage import ReadableTableStorage
-from snuba.utils.health_info import check_clickhouse, filter_checked_storages
+from snuba.utils.health_info import (
+    _set_shutdown,
+    check_clickhouse,
+    filter_checked_storages,
+    get_shutdown,
+)
 
 
 class BadStorage(mock.MagicMock):
@@ -149,3 +154,12 @@ def test_filter_checked_storages(
 
     # check that the storage with a non-supported readiness state is excluded in list
     assert MockStorage() not in storages
+
+
+def test_get_shutdown() -> None:
+    assert not get_shutdown()
+    _set_shutdown(True)
+    assert get_shutdown()
+
+    _set_shutdown(False)
+    assert not get_shutdown()


### PR DESCRIPTION
refactored `snuba health` tests as a follow up to https://github.com/getsentry/snuba/pull/5579

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
