### PR TITLE
feat: Run a separate billing consumer in devserver

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -66,6 +66,17 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
             ],
         ),
         (
+            "outcomes-billing-consumer",
+            [
+                "snuba",
+                "rust-consumer",
+                "--storage=outcomes_raw",
+                "--consumer-group=outcomes_billing_group",
+                "--raw-events-topic=outcomes-billing",
+                *COMMON_RUST_CONSUMER_DEV_OPTIONS,
+            ],
+        ),
+        (
             "errors-consumer",
             [
                 "snuba",

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -14,6 +14,7 @@ class Topic(Enum):
     TRANSACTIONS_COMMIT_LOG = "snuba-transactions-commit-log"
     METRICS = "snuba-metrics"
     OUTCOMES = "outcomes"
+    OUTCOMES_BILLING = "outcomes-billing"
     SESSIONS = "ingest-sessions"
     SESSIONS_COMMIT_LOG = "snuba-sessions-commit-log"
     METRICS_COMMIT_LOG = "snuba-metrics-commit-log"


### PR DESCRIPTION
In order to align behavior across different environments, billing related messages will be produced to the billing topic in dev, which matches how it is done in prod today. This runs the billing consumer in devserver so we ingest them properly.
