### PR TITLE
rust: log batch byte size

### DIFF
--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -10,7 +10,7 @@ use rust_arroyo::processing::strategies::{
     CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
 };
 use rust_arroyo::types::Message;
-use rust_arroyo::{counter, gauge, timer};
+use rust_arroyo::{counter, timer};
 
 use crate::config::ClickhouseConfig;
 use crate::types::BytesInsertBatch;
@@ -73,7 +73,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for Clickhous
                 timer!("insertions.batch_write_ms", elapsed);
             }
             counter!("insertions.batch_write_msgs", insert_batch.len() as i64);
-            gauge!(
+            counter!(
                 "insertions.batch_write_bytes",
                 insert_batch.encoded_rows().len() as i64
             );

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -10,7 +10,7 @@ use rust_arroyo::processing::strategies::{
     CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
 };
 use rust_arroyo::types::Message;
-use rust_arroyo::{counter, timer};
+use rust_arroyo::{counter, gauge, timer};
 
 use crate::config::ClickhouseConfig;
 use crate::types::BytesInsertBatch;
@@ -73,6 +73,10 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for Clickhous
                 timer!("insertions.batch_write_ms", elapsed);
             }
             counter!("insertions.batch_write_msgs", insert_batch.len() as i64);
+            gauge!(
+                "insertions.batch_write_bytes",
+                insert_batch.encoded_rows().len() as i64
+            );
             insert_batch.record_message_latency();
 
             Ok(message)


### PR DESCRIPTION
Log the bytes size of batches written to Clickhouse. This is useful for debugging.