### PR TITLE
gocd: add s4s query replayer

### DIFF
--- a/gocd/templates/bash/s4s-replay-queries.sh
+++ b/gocd/templates/bash/s4s-replay-queries.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+args=( $REPLAYER_ARGS )
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-spawn-job.py \
+  --label-selector="service=${SNUBA_SERVICE_NAME}" \
+  --container-name="${SNUBA_SERVICE_NAME}" \
+  "snuba-migrate" \
+  "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- \
+  snuba query-replayer "${args[@]}"

--- a/gocd/templates/bash/s4s-replay-queries.sh
+++ b/gocd/templates/bash/s4s-replay-queries.sh
@@ -6,7 +6,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
 /devinfra/scripts/k8s/k8s-spawn-job.py \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
-  "snuba-migrate" \
+  "snuba-query-replayer" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \
   snuba query-replayer "${args[@]}"

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -8,6 +8,7 @@ local generate_replay_job(component) =
   {
     environment_variables: {
       // TODO - what env vars do we need ?
+      SENTRY_REGION='s4s'
       // TODO do correct interpolation
       LABEL_SELECTOR: 'service=snuba,' + 'component=' + component
     },

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -10,7 +10,7 @@ local generate_replay_job(component) =
       SENTRY_REGION: 's4s',
       SNUBA_SERVICE_NAME: 'snuba-admin',
       GOOGLE_CLOUD_PROJECT: 'search-and-storage',
-      REPLAYER_ARGS: 'your args here (e.g --gcs-bucket abcd)'
+      REPLAYER_ARGS: 'your args here (e.g --gcs-bucket abcd)',
     },
     elastic_profile_id: pipeline_group,
     tasks: [
@@ -32,14 +32,35 @@ local pipeline = {
   },
   stages: [
     {
-      replay-queries: {
+      'replay-queries': {
         approval: {
           type: 'manual',
         },
         jobs: {
-          query-replayer: generate_replay_job('query-replayer')
+          'query-replayer': generate_replay_job('query-replayer'),
         },
       },
     },
   ],
 };
+
+// We can output two variances of these pipelines.
+if std.extVar('output-files') then
+  // 1. We output each pipeline in a seperate file, this makes debugging easier.
+  {
+    [pipeline_name + '.yaml']: {
+      format_version: 10,
+      pipelines: {
+        [pipeline_name]: pipeline,
+      },
+    },
+  }
+else
+  // 2. Output all pipelines in a single file, needed for validation or passing
+  //    pipelines directly to GoCD.
+  {
+    format_version: 10,
+    pipelines: {
+      [pipeline_name]: pipeline,
+    },
+  }

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -7,7 +7,7 @@ local generate_replay_job(component) =
   {
     environment_variables: {
       SENTRY_REGION: 's4s',
-      SNUBA_SERVICE_NAME: 'snuba-admin',
+      SNUBA_SERVICE_NAME: 'query-replayer-gocd',
       GOOGLE_CLOUD_PROJECT: 'search-and-storage',
       REPLAYER_ARGS: 'your args here (e.g --gcs-bucket abcd)',
     },

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -1,5 +1,4 @@
 local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
-local regions = getsentry.prod_regions + getsentry.test_regions;
 
 local pipeline_group = 'snuba';
 local pipeline_name = 'clickhouse-query-replayer';

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -7,21 +7,20 @@ local pipeline_name = 'clickhouse-query-replayer';
 local generate_replay_job(component) =
   {
     environment_variables: {
-      // TODO - what env vars do we need ?
       SENTRY_REGION: 's4s',
-      // TODO do correct interpolation
-      LABEL_SELECTOR: 'service=snuba,' + 'component=' + component
+      SNUBA_SERVICE_NAME: 'snuba-admin',
+      GOOGLE_CLOUD_PROJECT: 'search-and-storage',
+      REPLAYER_ARGS: 'your args here (e.g --gcs-bucket abcd)'
     },
     elastic_profile_id: pipeline_group,
     tasks: [
-      gocdtasks.script(importstr './bash/replay-ch-queries.sh'),
+      gocdtasks.script(importstr './bash/s4s-replay-queries.sh'),
     ],
   };
 
 local pipeline = {
   group: pipeline_group,
   display_order: 100,  // Ensure it's last pipeline in UI
-  // TODO: for parameters, use parameters as parameters
   lock_behavior: 'unlockWhenFinished',
   materials: {
     snuba_repo: {
@@ -38,8 +37,7 @@ local pipeline = {
           type: 'manual',
         },
         jobs: {
-          ['replay-' + component]: generate_replay_job(component)
-          for component in ['query-replayer-1', 'query-replayer-2']
+          query-replayer: generate_replay_job('query-replayer)
         },
       },
     },

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -8,7 +8,7 @@ local generate_replay_job(component) =
   {
     environment_variables: {
       // TODO - what env vars do we need ?
-      SENTRY_REGION='s4s'
+      SENTRY_REGION='s4s',
       // TODO do correct interpolation
       LABEL_SELECTOR: 'service=snuba,' + 'component=' + component
     },

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -37,7 +37,7 @@ local pipeline = {
           type: 'manual',
         },
         jobs: {
-          query-replayer: generate_replay_job('query-replayer)
+          query-replayer: generate_replay_job('query-replayer')
         },
       },
     },

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -1,0 +1,46 @@
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
+local regions = getsentry.prod_regions + getsentry.test_regions;
+
+local pipeline_group = 'snuba';
+local pipeline_name = 'clickhouse-query-replayer';
+
+local generate_replay_job(component) =
+  {
+    environment_variables: {
+      // TODO - what env vars do we need ?
+      // TODO do correct interpolation
+      LABEL_SELECTOR: 'service=snuba,' + 'component=' + component
+    },
+    elastic_profile_id: pipeline_group,
+    tasks: [
+      gocdtasks.script(importstr './bash/replay-ch-queries.sh'),
+    ],
+  };
+
+local pipeline = {
+  group: pipeline_group,
+  display_order: 100,  // Ensure it's last pipeline in UI
+  // TODO: for parameters, use parameters as parameters
+  lock_behavior: 'unlockWhenFinished',
+  materials: {
+    snuba_repo: {
+      git: 'git@github.com:getsentry/snuba.git',
+      shallow_clone: true,
+      branch: 'master',
+      destination: 'snuba',
+    },
+  },
+  stages: [
+    {
+      replay-queries: {
+        approval: {
+          type: 'manual',
+        },
+        jobs: {
+          ['replay-' + component]: generate_replay_job(component)
+          for component in ['query-replayer-1', 'query-replayer-2']
+        },
+      },
+    },
+  ],
+};

--- a/gocd/templates/clickhouse-query-replayer.jsonnet
+++ b/gocd/templates/clickhouse-query-replayer.jsonnet
@@ -8,7 +8,7 @@ local generate_replay_job(component) =
   {
     environment_variables: {
       // TODO - what env vars do we need ?
-      SENTRY_REGION='s4s',
+      SENTRY_REGION: 's4s',
       // TODO do correct interpolation
       LABEL_SELECTOR: 'service=snuba,' + 'component=' + component
     },


### PR DESCRIPTION
follow up to #5597 

This adds a manual step that can be called to run the query replayer tool. Arguments to this step can be passed in via the `REPLAYER_ARGS`  environment variable in GoCD.