### PR TITLE
feat: bump-version action also bumps rust

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -50,6 +50,8 @@ jobs:
         re="$(sed 's/[_-]/[_-]/g' <<< "$PACKAGE")"
         sed -i "s/^$re==.*/$PACKAGE==$VERSION/g" -- requirements*.txt
 
+        sed -i "s/^$re==.*/$PACKAGE\s=\s$VERSION/g" -- rust_snuba/Cargo.toml
+
         if git diff --exit-code; then
           exit 0
         fi


### PR DESCRIPTION
I always forget to bump the rust versions of our libraries since it's not covered by this action
