### PR TITLE
feat(capman): Split global and tenant specific configs into two tables

### DIFF
--- a/snuba/admin/static/capacity_management/allocation_policy.tsx
+++ b/snuba/admin/static/capacity_management/allocation_policy.tsx
@@ -144,6 +144,9 @@ function AllocationPolicyConfigs(props: {
               row_data.edit,
             ])}
           columnWidths={[3, 2, 5, 1, 1]}
+          customStyles={createCustomTableStyles({
+            headerStyle: { backgroundColor: getTableColor(policy.configs) },
+          })}
         />
         <p style={paragraphStyle}>
           These are the tenant specific configurations.

--- a/snuba/admin/static/capacity_management/allocation_policy.tsx
+++ b/snuba/admin/static/capacity_management/allocation_policy.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import { Table, createCustomTableStyles} from "../table";
+import { Table, createCustomTableStyles } from "../table";
 import { COLORS } from "../theme";
 import Client from "../api_client";
 import { AllocationPolicy, AllocationPolicyConfig } from "./types";
@@ -9,28 +9,31 @@ import { getReadonlyRow } from "./row_data";
 import EditConfigModal from "./edit_config_modal";
 import AddConfigModal from "./add_config_modal";
 
-
 function getTableColor(configs: AllocationPolicyConfig[]): string {
   let policyIsActive = false;
   let policyIsEnforced = false;
-  configs.forEach(config => {
-        if (config.name == "is_active"){
-            if (parseInt(config.value) === 1) {policyIsActive = true;}
-            else {policyIsActive = false;}
-        }
-        if (config.name == "is_enforced"){
-            if (parseInt(config.value) === 1) {policyIsEnforced= true;}
-            else {policyIsEnforced= false;}
-        }
-  })
+  configs.forEach((config) => {
+    if (config.name == "is_active") {
+      if (parseInt(config.value) === 1) {
+        policyIsActive = true;
+      } else {
+        policyIsActive = false;
+      }
+    }
+    if (config.name == "is_enforced") {
+      if (parseInt(config.value) === 1) {
+        policyIsEnforced = true;
+      } else {
+        policyIsEnforced = false;
+      }
+    }
+  });
   if (policyIsActive && policyIsEnforced) {
-    return  COLORS.SNUBA_BLUE
-  }
-  else if (policyIsActive && !policyIsEnforced) {
-    return "orange"
-  }
-  else {
-    return "gray"
+    return COLORS.SNUBA_BLUE;
+  } else if (policyIsActive && !policyIsEnforced) {
+    return "orange";
+  } else {
+    return "gray";
   }
 }
 
@@ -125,7 +128,26 @@ function AllocationPolicyConfigs(props: {
       />
       <div style={containerStyle}>
         <p>{policy.policy_name}</p>
-        <p style={paragraphStyle}>These are the current configurations.</p>
+        <p style={paragraphStyle}>These are the global configurations.</p>
+        <Table
+          headerData={["Key", "Value", "Description", "Type", "Actions"]}
+          rowData={configs
+            .filter((configs) => Object.keys(configs.params).length == 0)
+            .map((config) =>
+              getReadonlyRow(config, () => enterEditMode(config))
+            )
+            .map((row_data) => [
+              row_data.name,
+              row_data.value,
+              row_data.description,
+              row_data.type,
+              row_data.edit,
+            ])}
+          columnWidths={[3, 2, 5, 1, 1]}
+        />
+        <p style={paragraphStyle}>
+          These are the tenant specific configurations.
+        </p>
         <Table
           headerData={[
             "Key",
@@ -135,12 +157,23 @@ function AllocationPolicyConfigs(props: {
             "Type",
             "Actions",
           ]}
-          rowData={configs.map((config) =>
-            getReadonlyRow(config, () => enterEditMode(config))
-          )}
+          rowData={configs
+            .filter((config) => Object.keys(config.params).length > 0)
+            .map((config) =>
+              getReadonlyRow(config, () => enterEditMode(config))
+            )
+            .map((row_data) => [
+              row_data.name,
+              row_data.params,
+              row_data.value,
+              row_data.description,
+              row_data.type,
+              row_data.edit,
+            ])}
           columnWidths={[3, 3, 2, 5, 1, 1]}
-          customStyles={createCustomTableStyles({headerStyle: {backgroundColor: getTableColor(policy.configs)}})}
-
+          customStyles={createCustomTableStyles({
+            headerStyle: { backgroundColor: getTableColor(policy.configs) },
+          })}
         />
         {!addingNew && policy.optional_config_definitions.length != 0 && (
           <a onClick={() => setAddingNew(true)} style={linkStyle}>
@@ -153,4 +186,4 @@ function AllocationPolicyConfigs(props: {
   );
 }
 
-export {AllocationPolicyConfigs, getTableColor};
+export { AllocationPolicyConfigs, getTableColor };

--- a/snuba/admin/static/capacity_management/row_data.tsx
+++ b/snuba/admin/static/capacity_management/row_data.tsx
@@ -6,30 +6,46 @@ function getReadonlyRow(
   config: AllocationPolicyConfig,
   edit: () => void
 ): RowData {
-  return [
-    <code style={{ wordBreak: "break-all", color: "black" }}>
-      {config.name}
-    </code>,
-    <code style={{ wordBreak: "break-all", color: "black" }}>
-      {Object.keys(config.params).length
-        ? JSON.stringify(config.params)
-        : "N/A"}
-    </code>,
-    <code style={{ wordBreak: "break-all", color: "black" }}>
-      {config.value}
-    </code>,
-    <code style={{ wordBreak: "normal", overflowWrap: "anywhere", color: "black" }}>
-      {config.description}
-    </code>,
-    config.type,
-    <Button
-      variant="outline-secondary"
-      onClick={() => edit()}
-      data-testid={config.name + "_edit"}
-    >
-      edit
-    </Button>,
-  ];
+  return {
+    name: (
+      <code style={{ wordBreak: "break-all", color: "black" }}>
+        {config.name}
+      </code>
+    ),
+    params: (
+      <code style={{ wordBreak: "break-all", color: "black" }}>
+        {Object.keys(config.params).length
+          ? JSON.stringify(config.params)
+          : "N/A"}
+      </code>
+    ),
+    value: (
+      <code style={{ wordBreak: "break-all", color: "black" }}>
+        {config.value}
+      </code>
+    ),
+    description: (
+      <code
+        style={{
+          wordBreak: "normal",
+          overflowWrap: "anywhere",
+          color: "black",
+        }}
+      >
+        {config.description}
+      </code>
+    ),
+    type: config.type,
+    edit: (
+      <Button
+        variant="outline-secondary"
+        onClick={() => edit()}
+        data-testid={config.name + "_edit"}
+      >
+        edit
+      </Button>
+    ),
+  };
 }
 
 export { getReadonlyRow };

--- a/snuba/admin/static/capacity_management/types.tsx
+++ b/snuba/admin/static/capacity_management/types.tsx
@@ -27,14 +27,14 @@ type AllocationPolicyOptionalConfigDefinition = {
   params: AllocationPolicyConfigParams[];
 };
 
-type RowData = [
-  ReactNode,
-  ReactNode,
-  ReactNode,
-  ReactNode,
-  ReactNode,
-  ReactNode
-];
+type RowData = {
+  name: ReactNode;
+  params: ReactNode;
+  value: ReactNode;
+  description: ReactNode;
+  type: ReactNode;
+  edit: ReactNode;
+};
 
 export {
   AllocationPolicy,

--- a/snuba/admin/static/tests/capacity_management/allocation_policies.spec.tsx
+++ b/snuba/admin/static/tests/capacity_management/allocation_policies.spec.tsx
@@ -1,6 +1,6 @@
 import Client from "../../api_client";
 
-import {AllocationPolicyConfigs} from "../../capacity_management/allocation_policy";
+import { AllocationPolicyConfigs } from "../../capacity_management/allocation_policy";
 import { it, expect } from "@jest/globals";
 import { AllocationPolicy } from "../../capacity_management/types";
 import { act, fireEvent, render } from "@testing-library/react";
@@ -47,7 +47,6 @@ it("should populate configs table upon render", async () => {
     />
   );
 
-  expect(getByText("N/A")).toBeTruthy(); // non optional key in table
   expect(getByText("key1")).toBeTruthy();
   expect(getByText("key2")).toBeTruthy();
   expect(

--- a/snuba/admin/static/tests/capacity_management/index.spec.tsx
+++ b/snuba/admin/static/tests/capacity_management/index.spec.tsx
@@ -73,7 +73,6 @@ it("should display allocation policy configs once a storage is selected", async 
   expect(getByText("10")).toBeTruthy();
   expect(getByText("something")).toBeTruthy();
   expect(getByText("int")).toBeTruthy();
-  expect(getByText("N/A")).toBeTruthy();
 
   // second policy
   expect(getByText("some_other_policy")).toBeTruthy();


### PR DESCRIPTION
### Overview

As as user it's a little hard to identify which option is applied globally and which is applied to a specific tenant.
This change splits the 2 types of configurations into separate tables.

The UI element distinguishes whether or not a configuration is global or not by checking if the `params` field is empty, based on the assumption that a configuration is applied globally iff it does not have params.

Also adds some handy functions in tests to verify table contents.

Before
<img width="1227" alt="image" src="https://github.com/getsentry/snuba/assets/14865283/03f72b0d-e893-4088-9fe4-2ff2889393bc">

After
<img width="1225" alt="image" src="https://github.com/getsentry/snuba/assets/14865283/af3040fb-87a5-4dd0-af43-6f296748eced">
