### PR TITLE
feat: update launch json for pytest current file in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Pytest Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/.venv/bin/pytest",
+            "args": [
+                "${file}"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": true  // wasn't sure if I should keep or delete
+        }
+    ]
+}


### PR DESCRIPTION
This PR re-adds launch.json and should enable pytest current file for vscode users