### PR TITLE
fix(COGS): Fix app_feature for generic metrics Clickhouse compute accounting

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -111,13 +111,18 @@ def _record_cogs(
     if not profile or (bytes_scanned := profile.get("progress_bytes")) is None:
         return
 
+    # The dataset is usually a good proxy for app_feature
     app_feature = query_metadata.dataset.replace("_", "")
+
     if (
-        query_metadata.dataset == "generic_metrics"
+        query_metadata.entity.startswith("generic_metrics")
         and (use_case_id := request.attribution_info.tenant_ids.get("use_case_id"))
         is not None
     ):
-        app_feature += f"_{use_case_id}"
+        app_feature = f"genericmetrics_{use_case_id}"
+
+    elif query_metadata.dataset == "events":
+        app_feature = "errors"
 
     cluster_name = query_metadata.query_list[0].stats.get("cluster_name", "")
 

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -112,6 +112,10 @@ def _record_cogs(
         return
 
     # The dataset is usually a good proxy for app_feature
+    # However, this is not always the case. We can
+    # check the entity as well as a fallback option
+    # if the dataset is incorrect in the querylog.
+
     app_feature = query_metadata.dataset.replace("_", "")
 
     if (

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -115,8 +115,10 @@ def _record_cogs(
     app_feature = query_metadata.dataset.replace("_", "")
 
     if (
-        query_metadata.entity.startswith("generic_metrics")
-        and (use_case_id := request.attribution_info.tenant_ids.get("use_case_id"))
+        query_metadata.dataset == "generic_metrics"
+        or query_metadata.entity.startswith("generic_metrics")
+    ) and (
+        use_case_id := request.attribution_info.tenant_ids.get("use_case_id")
         is not None
     ):
         app_feature = f"genericmetrics_{use_case_id}"


### PR DESCRIPTION
Uses the entity instead of the dataset for generic metrics -- this is a more reliable source for getting the `app_feature` from a query than dataset since it comes directly from the request body. 

I did notice that the entity in a `SnubaQueryMetadata` object is known only if the query is a `LogicalQuery`. Under which circumstances would it not be a `LogicalQuery`? If I understand correctly, the other kinds of queries would be nested/subqueries, and queries involving joins. I don't know how common these two cases are for generic metrics, but we can also fall back to dataset in these cases. 