### PR TITLE
ref(capman): Simplify allocation policy error reporting

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -257,7 +257,7 @@ allocation_policies:
       required_tenant_types:
         - referrer
       default_config_overrides:
-        is_enforced: 0
+        is_enforced: 1
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -159,27 +159,32 @@ class InvalidTenantsForAllocationPolicy(SerializableException):
 
 class AllocationPolicyViolations(SerializableException):
     """
-    An exception class which is used to collect multiple AllocationPolicyViolation
-    exceptions and raise them at once, useful for storages with multiple policies
-    defined on them.
-
-    Do not manually raise this exception! Use AllocationPolicyViolation instead within
-    your Allocation Policies for when a violation occurs and this exception will be
-    raised containing your raised exceptions at the end.
+    An exception class which is used to communicate that the query cannot be run because
+    at least one policy of many said no
     """
 
-    def __init__(
-        self,
-        message: str | None = None,
-        violations: dict[str, AllocationPolicyViolation] = field(default_factory=dict),
-        should_report: bool = True,
-        **extra_data: JsonSerializable,
-    ) -> None:
-        self.violations = violations
-        super().__init__(message, should_report, **extra_data)
-
     def __str__(self) -> str:
-        return str({k: str(v) for k, v in self.violations.items()})
+        return f"{self.message}, details: {self.violations}"
+
+    @property
+    def violations(self) -> dict[str, dict[str, Any]]:
+        return {k: v for k, v in self.quota_allowance.items() if v["can_run"] == False}
+
+    @property
+    def quota_allowance(self) -> dict[str, dict[str, Any]]:
+        return cast(
+            dict[str, dict[str, Any]], self.extra_data.get("quota_allowances", {})
+        )
+
+    @classmethod
+    def from_args(cls, quota_allowances: dict[str, QuotaAllowance]):
+        return cls(
+            "Query on could not be run due to allocation policies",
+            quota_allowances={
+                key: quota_allowance.to_dict()
+                for key, quota_allowance in quota_allowances.items()
+            },
+        )
 
 
 class AllocationPolicy(ABC, metaclass=RegisteredClass):
@@ -357,11 +362,8 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
 
     * Because allocation policies are attached to query objects, they have to be pickleable. Don't put non-pickleable members onto the allocation policy
     * At time of writing (29-03-2023), not all allocation policy decisions are made in the allocation policy,
-        rate limiters are still applied in the query pipeline, those should be moved into an allocation policy as they
+        table rate limiters are still applied in the query pipeline, those should be moved into an allocation policy as they
         are also policy decisions
-    * get_quota_allowance will throw an AllocationPolicyViolation if _get_quota_allowance().can_run is false.
-        this is to keep with the pattern in `db_query.py` which communicates error states with exceptions. There is no other
-        reason. For more information see snuba.web.db_query.db_query
     * Every allocation policy takes a `storage_key` in its init. The storage_key is like a pseudo-tenant. In different
         environments, storages may be co-located on the same cluster. To facilitate resource sharing, every allocation policy
         knows which storage_key it is serving. This is used to create unique keys for saving the config values.
@@ -772,8 +774,6 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
                 "db_request_rejected",
                 tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
             )
-            if self.is_enforced:
-                raise AllocationPolicyViolation.from_args(tenant_ids, allowance)
         elif allowance.max_threads < self.max_threads:
             # NOTE: The elif is very intentional here. Don't count the throttling
             # if the request was rejected.

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -7,7 +7,6 @@ from snuba import state
 from snuba.query.allocation_policies import (
     AllocationPolicy,
     AllocationPolicyConfig,
-    AllocationPolicyViolation,
     AllocationPolicyViolations,
     InvalidTenantsForAllocationPolicy,
     QueryResultOrError,
@@ -103,7 +102,7 @@ class BaseConcurrentRateLimitAllocationPolicy(AllocationPolicy):
 
         was_rate_limited = result_or_error.error is not None and isinstance(
             result_or_error.error.__cause__,
-            (AllocationPolicyViolation, AllocationPolicyViolations),
+            AllocationPolicyViolations,
         )
         rate_limit_finish_request(
             rate_limit_params,

--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -15,6 +15,7 @@ from snuba.query.allocation_policies.concurrent_rate_limit import (
 )
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.state.rate_limit import RateLimitParameters
+from snuba.utils.serializable_exception import JsonSerializable
 
 DEFAULT_CONCURRENT_QUERIES_LIMIT = 22
 DEFAULT_PER_SECOND_QUERIES_LIMIT = 50
@@ -173,7 +174,7 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
             query_id,
             RateLimitParameters(self.rate_limit_name, referrer, None, concurrent_limit),
         )
-        decision_explanation = {"reason": explanation}
+        decision_explanation: dict[str, JsonSerializable] = {"reason": explanation}
         if not self._referrer_is_registered(referrer):
             decision_explanation[
                 "cross_org_query"

--- a/snuba/query/allocation_policies/per_referrer.py
+++ b/snuba/query/allocation_policies/per_referrer.py
@@ -12,6 +12,7 @@ from snuba.query.allocation_policies.concurrent_rate_limit import (
 )
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.state.rate_limit import RateLimitParameters
+from snuba.utils.serializable_exception import JsonSerializable
 
 rds = get_redis_client(RedisClientKey.RATE_LIMITER)
 
@@ -96,7 +97,7 @@ class ReferrerGuardRailPolicy(BaseConcurrentRateLimitAllocationPolicy):
             query_id,
             RateLimitParameters(self.rate_limit_name, referrer, None, concurrent_limit),
         )
-        decision_explanation = {
+        decision_explanation: dict[str, JsonSerializable] = {
             "reason": explanation,
             "policy": self.rate_limit_name,
             "referrer": referrer,

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -66,7 +66,7 @@ class QueryResult:
     extra: QueryExtraData
 
     @property
-    def allocation_policies(self) -> Mapping[str, Mapping[str, Any]]:
+    def quota_allowance(self) -> Mapping[str, Mapping[str, Any]]:
         return self.extra.get("stats", {}).get("quota_allowance", {})
 
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -384,14 +384,8 @@ def dataset_query(
                 "type": "rate-limited",
                 "message": str(cause),
             }
-            # HACK (Volo): Ideally, the `allocation_policies` key would look the same for success/non-success responses
-            # however there are implementation details of db_query that make this harder than in needs to be atm (21/02/2024)
-            # I plan to change those but in the meantime want to surface this info to the caller so this is a halfway measure
             if isinstance(cause, AllocationPolicyViolations):
-                details["allocation_policies_violations"] = {
-                    policy_name: violation.to_dict()
-                    for policy_name, violation in cause.violations.items()
-                }
+                details["quota_allowance"] = cause.quota_allowance
         elif isinstance(cause, ClickhouseError):
             status = get_http_status_for_clickhouse_error(cause)
             details = {

--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -66,6 +66,7 @@ def test_consume_quota(policy: BytesScannedWindowAllocationPolicy) -> None:
         "is_enforced": True,
         "granted_quota": 0,
         "limit": ORG_SCAN_LIMIT,
+        "storage_key": "StorageKey.ERRORS",
     }
 
 

--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 import pytest
 
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.query.allocation_policies import (
-    AllocationPolicy,
-    AllocationPolicyViolation,
-    QueryResultOrError,
-)
+from snuba.query.allocation_policies import AllocationPolicy, QueryResultOrError
 from snuba.query.allocation_policies.bytes_scanned_window_policy import (
     _ORG_LESS_REFERRERS,
     BytesScannedWindowAllocationPolicy,
@@ -151,12 +147,12 @@ def test_enforcement_switch(policy: AllocationPolicy) -> None:
 @pytest.mark.redis_db
 def test_reject_queries_without_tenant_ids(policy: AllocationPolicy) -> None:
     _configure_policy(policy)
-    with pytest.raises(AllocationPolicyViolation):
-        policy.get_quota_allowance(
-            tenant_ids={"organization_id": 1234}, query_id=QUERY_ID
-        )
-    with pytest.raises(AllocationPolicyViolation):
-        policy.get_quota_allowance(tenant_ids={"referrer": "bloop"}, query_id=QUERY_ID)
+    assert not policy.get_quota_allowance(
+        tenant_ids={"organization_id": 1234}, query_id=QUERY_ID
+    ).can_run
+    assert not policy.get_quota_allowance(
+        tenant_ids={"referrer": "bloop"}, query_id=QUERY_ID
+    ).can_run
     # These should not fail because we know they don't have an org id
     for referrer in _ORG_LESS_REFERRERS:
         tenant_ids: dict[str, str | int] = {"referrer": referrer}

--- a/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
+++ b/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
@@ -7,7 +7,6 @@ import pytest
 
 from snuba.datasets.storage import StorageKey
 from snuba.query.allocation_policies import (
-    AllocationPolicyViolation,
     AllocationPolicyViolations,
     InvalidTenantsForAllocationPolicy,
     QueryResultOrError,
@@ -54,10 +53,9 @@ def test_rate_limit_concurrent(policy: ConcurrentRateLimitAllocationPolicy) -> N
             tenant_ids={"organization_id": 123}, query_id=f"abc{i}"
         )
 
-    with pytest.raises(AllocationPolicyViolation):
-        policy.get_quota_allowance(
-            tenant_ids={"organization_id": 123}, query_id=f"abc{MAX_CONCURRENT_QUERIES}"
-        )
+    assert not policy.get_quota_allowance(
+        tenant_ids={"organization_id": 123}, query_id=f"abc{MAX_CONCURRENT_QUERIES}"
+    ).can_run
 
 
 @pytest.mark.redis_db
@@ -71,11 +69,10 @@ def test_rate_limit_concurrent_diff_tenants(
             tenant_ids={"organization_id": RATE_LIMITED_ORG_ID}, query_id=f"abc{i}"
         )
 
-    with pytest.raises(AllocationPolicyViolation):
-        policy.get_quota_allowance(
-            tenant_ids={"organization_id": RATE_LIMITED_ORG_ID},
-            query_id=f"abc{MAX_CONCURRENT_QUERIES}",
-        )
+    assert not policy.get_quota_allowance(
+        tenant_ids={"organization_id": RATE_LIMITED_ORG_ID},
+        query_id=f"abc{MAX_CONCURRENT_QUERIES}",
+    ).can_run
     policy.get_quota_allowance(
         tenant_ids={"organization_id": OTHER_ORG_ID},
         query_id=f"abc{MAX_CONCURRENT_QUERIES}",
@@ -93,12 +90,9 @@ def test_configure_max_query_duration(
 
     policy.get_quota_allowance(tenant_ids={"organization_id": 123}, query_id="abc1")
     time.sleep(sleep_time)
-    try:
-        policy.get_quota_allowance(tenant_ids={"organization_id": 123}, query_id="abc2")
-    except AllocationPolicyViolation:
-        assert (
-            False
-        ), "max_query_duration_s is set to {max_query_duration_s}, test sleeps for {sleep_time} seconds, the first query should have no longer been counted towards the concurrent limit"
+    assert policy.get_quota_allowance(
+        tenant_ids={"organization_id": 123}, query_id="abc2"
+    ).can_run, "max_query_duration_s is set to {max_query_duration_s}, test sleeps for {sleep_time} seconds, the first query should have no longer been counted towards the concurrent limit"
 
 
 @pytest.mark.redis_db
@@ -112,10 +106,9 @@ def test_rate_limit_concurrent_complete_query(
         )
 
     # cant submit anymore
-    with pytest.raises(AllocationPolicyViolation):
-        policy.get_quota_allowance(
-            tenant_ids={"organization_id": 123}, query_id=f"abc{MAX_CONCURRENT_QUERIES}"
-        )
+    assert not policy.get_quota_allowance(
+        tenant_ids={"organization_id": 123}, query_id=f"abc{MAX_CONCURRENT_QUERIES}"
+    ).can_run
 
     # one query finishes
     policy.update_quota_balance(
@@ -130,11 +123,10 @@ def test_rate_limit_concurrent_complete_query(
     )
 
     # but no more than that
-    with pytest.raises(AllocationPolicyViolation):
-        policy.get_quota_allowance(
-            tenant_ids={"organization_id": 123},
-            query_id="some_query_id",
-        )
+    assert not policy.get_quota_allowance(
+        tenant_ids={"organization_id": 123},
+        query_id="some_query_id",
+    ).can_run
 
 
 @pytest.mark.redis_db
@@ -265,11 +257,11 @@ def test_apply_overrides(
         policy.set_config_value(*override)
     for i in range(expected_concurrent_limit):
         policy.get_quota_allowance(tenant_ids=tenant_ids, query_id=f"{i}")
-    with pytest.raises(AllocationPolicyViolation) as e:
-        policy.get_quota_allowance(
-            tenant_ids=tenant_ids, query_id=f"{expected_concurrent_limit+1}"
-        )
-    assert e.value.explanation["overrides"] == expected_overrides
+    allowance = policy.get_quota_allowance(
+        tenant_ids=tenant_ids, query_id=f"{expected_concurrent_limit+1}"
+    )
+    assert not allowance.can_run
+    assert allowance.explanation["overrides"] == expected_overrides
 
 
 @pytest.mark.redis_db
@@ -290,13 +282,10 @@ def test_override_isolation(
             query_id=str(i),
         )
     # query the override referrer, it should not reject because overrides are counted on their own
-    try:
-        policy.get_quota_allowance(
-            tenant_ids={"project_id": project_id, "referrer": overridden_referrer},
-            query_id="uniq_string_1",
-        )
-    except AllocationPolicyViolation:
-        pytest.fail("overridden limits should not be affected by defaults")
+    assert policy.get_quota_allowance(
+        tenant_ids={"project_id": project_id, "referrer": overridden_referrer},
+        query_id="uniq_string_1",
+    ).can_run
 
     # finish the overridden referrer query, make sure another one can run
     policy.update_quota_balance(
@@ -322,23 +311,19 @@ def test_override_isolation(
     )
 
     # our overridden referrer should still error because an update to the non-overridden limits shouldn't affect the overridden ones
-    with pytest.raises(AllocationPolicyViolation):
-        policy.get_quota_allowance(
-            tenant_ids={"project_id": project_id, "referrer": overridden_referrer},
-            query_id="uniq_string_3",
-        )
+    assert not policy.get_quota_allowance(
+        tenant_ids={"project_id": project_id, "referrer": overridden_referrer},
+        query_id="uniq_string_3",
+    ).can_run
 
 
 def test_pass_through(policy: ConcurrentRateLimitAllocationPolicy) -> None:
     ## should not be blocked because the subscriptions_executor referrer is not rate limited
-    try:
-        for i in range(MAX_CONCURRENT_QUERIES * 2):
-            policy.get_quota_allowance(
-                tenant_ids={"referrer": "subscriptions_executor", "project_id": 1234},
-                query_id=f"abc{i}",
-            )
-    except AllocationPolicyViolation:
-        pytest.fail("should not have been blocked")
+    for i in range(MAX_CONCURRENT_QUERIES * 2):
+        assert policy.get_quota_allowance(
+            tenant_ids={"referrer": "subscriptions_executor", "project_id": 1234},
+            query_id=f"abc{i}",
+        ).can_run
 
 
 @pytest.mark.redis_db
@@ -361,8 +346,7 @@ def test_cross_org(policy: ConcurrentRateLimitAllocationPolicy) -> None:
 def test_bad_tenants(policy: ConcurrentRateLimitAllocationPolicy):
     bad_tenant_ids: dict[str, str | int] = {"referrer": "abcd"}
     with mock.patch("snuba.settings.RAISE_ON_ALLOCATION_POLICY_FAILURES", False):
-        with pytest.raises(AllocationPolicyViolation):
-            policy.get_quota_allowance(bad_tenant_ids, "1234")
+        assert not policy.get_quota_allowance(bad_tenant_ids, "1234").can_run
 
         # does not raise
         policy.update_quota_balance(bad_tenant_ids, "1234", _RESULT_SUCCESS)

--- a/tests/query/allocation_policies/test_cross_org_policy.py
+++ b/tests/query/allocation_policies/test_cross_org_policy.py
@@ -33,7 +33,10 @@ class TestCrossOrgQueryAllocationPolicy:
         )
         assert unimportant_allowance.can_run is True
         assert unimportant_allowance.max_threads == 10
-        assert unimportant_allowance.explanation == {"reason": "pass_through"}
+        assert unimportant_allowance.explanation == {
+            "reason": "pass_through",
+            "storage_key": "StorageKey.GENERIC_METRICS_DISTRIBUTIONS",
+        }
         cross_org_allowance = policy.get_quota_allowance(
             tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
         )

--- a/tests/query/allocation_policies/test_cross_org_policy.py
+++ b/tests/query/allocation_policies/test_cross_org_policy.py
@@ -1,10 +1,6 @@
 import pytest
 
-from snuba.query.allocation_policies import (
-    AllocationPolicyViolation,
-    InvalidPolicyConfig,
-    QueryResultOrError,
-)
+from snuba.query.allocation_policies import InvalidPolicyConfig, QueryResultOrError
 from snuba.query.allocation_policies.cross_org import CrossOrgQueryAllocationPolicy
 from snuba.web import QueryResult
 
@@ -44,10 +40,9 @@ class TestCrossOrgQueryAllocationPolicy:
         assert cross_org_allowance.can_run is True
         assert cross_org_allowance.max_threads == 1
 
-        with pytest.raises(AllocationPolicyViolation):
-            policy.get_quota_allowance(
-                tenant_ids={"referrer": "statistical_detectors"}, query_id="3"
-            )
+        assert not policy.get_quota_allowance(
+            tenant_ids={"referrer": "statistical_detectors"}, query_id="3"
+        ).can_run
         policy.update_quota_balance(
             tenant_ids={"referrer": "statistical_detectors"},
             query_id="2",
@@ -126,10 +121,9 @@ class TestCrossOrgQueryAllocationPolicy:
             0,
             {"referrer": "statistical_detectors"},
         )
-        with pytest.raises(AllocationPolicyViolation):
-            policy.get_quota_allowance(
-                tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
-            )
+        assert not policy.get_quota_allowance(
+            tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
+        ).can_run
 
     @pytest.mark.redis_db
     def test_override_unregistered_referrer(self):
@@ -185,10 +179,9 @@ class TestCrossOrgQueryAllocationPolicy:
         assert allowance.can_run is True
         assert allowance.max_threads == 1
 
-        with pytest.raises(AllocationPolicyViolation) as violation:
-            allowance = policy.get_quota_allowance(
-                tenant_ids={"referrer": "unregistered", "cross_org_query": 1},
-                query_id="2",
-            )
-
-        assert violation.value.quota_allowance["explanation"]["cross_org_query"] == "This referrer is not registered for the current storage generic_metrics_distributions, if you want to increase its limits, register it in the yaml of the CrossOrgQueryAllocationPolicy"  # type: ignore
+        allowance = policy.get_quota_allowance(
+            tenant_ids={"referrer": "unregistered", "cross_org_query": 1},
+            query_id="2",
+        )
+        assert not allowance.can_run
+        assert allowance.explanation["cross_org_query"] == "This referrer is not registered for the current storage generic_metrics_distributions, if you want to increase its limits, register it in the yaml of the CrossOrgQueryAllocationPolicy"  # type: ignore

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -305,7 +305,7 @@ class TestSnQLApi(BaseApiTest):
                 }
             ),
         )
-        allocation_policies = response.json["error"]["allocation_policies_violations"]
+        allocation_policies = response.json["error"]["quota_allowance"]
         assert allocation_policies["ConcurrentRateLimitAllocationPolicy"]
         assert response.status_code == 429
 
@@ -1303,7 +1303,7 @@ class TestSnQLApi(BaseApiTest):
             assert response.status_code == 429
             assert (
                 response.json["error"]["message"]
-                == "{'RejectAllocationPolicy123': \"Allocation policy violated, explanation: {'reason': 'policy rejects all queries'}\"}"
+                == "Query on could not be run due to allocation policies, details: {'RejectAllocationPolicy123': {'can_run': False, 'max_threads': 0, 'explanation': {'reason': 'policy rejects all queries'}}}"
             )
 
     def test_tags_key_column(self) -> None:

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -288,7 +288,7 @@ class TestSnQLApi(BaseApiTest):
             ),
         )
         assert response.status_code == 200
-        allocation_policies = response.json["allocation_policies"]
+        allocation_policies = response.json["quota_allowance"]
         assert allocation_policies["ConcurrentRateLimitAllocationPolicy"]["can_run"]
 
         response = self.post(
@@ -305,8 +305,9 @@ class TestSnQLApi(BaseApiTest):
                 }
             ),
         )
-        allocation_policies = response.json["error"]["quota_allowance"]
+        allocation_policies = response.json["quota_allowance"]
         assert allocation_policies["ConcurrentRateLimitAllocationPolicy"]
+        assert not allocation_policies["ConcurrentRateLimitAllocationPolicy"]["can_run"]
         assert response.status_code == 429
 
     @patch("snuba.settings.RECORD_QUERIES", True)
@@ -1303,7 +1304,7 @@ class TestSnQLApi(BaseApiTest):
             assert response.status_code == 429
             assert (
                 response.json["error"]["message"]
-                == "Query on could not be run due to allocation policies, details: {'RejectAllocationPolicy123': {'can_run': False, 'max_threads': 0, 'explanation': {'reason': 'policy rejects all queries'}}}"
+                == "Query on could not be run due to allocation policies, details: {'RejectAllocationPolicy123': {'can_run': False, 'max_threads': 0, 'explanation': {'reason': 'policy rejects all queries', 'storage_key': 'StorageKey.DOESNTMATTER'}}}"
             )
 
     def test_tags_key_column(self) -> None:

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -258,18 +258,29 @@ def test_db_query_success() -> None:
     assert stats["quota_allowance"] == {
         "BytesScannedWindowAllocationPolicy": {
             "can_run": True,
-            "explanation": {},
+            "explanation": {
+                "storage_key": "StorageKey.ERRORS_RO",
+            },
             "max_threads": 10,
         },
         "ConcurrentRateLimitAllocationPolicy": {
             "can_run": True,
-            "explanation": {"overrides": {}, "reason": "within limit"},
+            "explanation": {
+                "overrides": {},
+                "reason": "within limit",
+                "storage_key": "StorageKey.ERRORS_RO",
+            },
             "max_threads": 10,
         },
         "ReferrerGuardRailPolicy": {
             "can_run": True,
-            "explanation": {},
             "max_threads": 10,
+            "explanation": {
+                "reason": "within limit",
+                "policy": "referrer_guard_rail_policy",
+                "referrer": "something",
+                "storage_key": "StorageKey.ERRORS_RO",
+            },
         },
     }
     assert len(query_metadata_list) == 1
@@ -419,7 +430,10 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
         assert stats["quota_allowance"] == {
             "RejectAllocationPolicy": {
                 "can_run": False,
-                "explanation": {"reason": "policy rejects all queries"},
+                "explanation": {
+                    "reason": "policy rejects all queries",
+                    "storage_key": "StorageKey.DOESNTMATTER",
+                },
                 "max_threads": 0,
             }
         }
@@ -603,12 +617,18 @@ def test_allocation_policy_updates_quota() -> None:
         "CountQueryPolicy": {
             "can_run": False,
             "max_threads": 0,
-            "explanation": {"reason": "can only run 2 queries!"},
+            "explanation": {
+                "reason": "can only run 2 queries!",
+                "storage_key": "StorageKey.DOESNTMATTER",
+            },
         },
         "CountQueryPolicyDuplicate": {
             "can_run": False,
             "max_threads": 0,
-            "explanation": {"reason": "can only run 2 queries!"},
+            "explanation": {
+                "reason": "can only run 2 queries!",
+                "storage_key": "StorageKey.DOESNTMATTER",
+            },
         },
     }
     cause = e.value.__cause__


### PR DESCRIPTION
Context for the task is in [this ticket](https://getsentry.atlassian.net/browse/SNS-2646)

Basically the way we have been aggregating the allocation policy violations and surfacing it to the caller has been bothering me so I did a little cleanup. No longer do we have two similarly named exceptions `AllocationPolicyViolation, AllocationPolicyViolations`. We also now report the same data structure for allocation policy decisions for failed and non-failed queries. 

Bonus: we now have the storage_key in every quota allowance explanation. sometimes it's not immediately obvious which storage the query was rejected for