### PR TITLE
fix(mql): Fix a bug with scalars in Formulas

### DIFF
--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -181,11 +181,12 @@ class MQLVisitor(NodeVisitor):  # type: ignore
                 "All terms in a formula must have the same groupby"
             )
 
+        groupby = term.groupby if isinstance(term, InitialParseResult) else None
         return InitialParseResult(
             expression=None,
             formula=term_operator,
             parameters=[term, coefficient],
-            groupby=term.groupby,
+            groupby=groupby,
         )
 
     def visit_term(

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -832,3 +832,70 @@ class TestGenericMetricsMQLApi(BaseApiTest):
             ).serialize_mql(),
         )
         assert response.status_code == 200
+
+    def test_formula_filters_with_scalar_formula(self) -> None:
+        query = MetricsQuery(
+            query="sum(d:transactions/duration@millisecond) + (86400 / 3600)",
+            start=self.start_time,
+            end=self.end_time,
+            rollup=Rollup(interval=60, granularity=60, totals=True),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=self.project_ids,
+                use_case_id=USE_CASE_ID,
+            ),
+            indexer_mappings={
+                "transaction.duration": DISTRIBUTIONS_MRI,
+                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
+                "platform": resolve_str("platform"),
+                "ios": resolve_str("ios"),
+            },
+        )
+
+        response = self.app.post(
+            self.mql_route,
+            data=Request(
+                dataset=DATASET,
+                app_id="test",
+                query=query,
+                flags=Flags(debug=True),
+                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
+            ).serialize_mql(),
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)["data"]
+        assert len(data) == 180
+        for row in data:
+            assert row["aggregate_value"] >= 24
+
+    @pytest.mark.xfail(reason="It's not clear if this should be supported or not")
+    def test_scalar_formula(self) -> None:
+        query = MetricsQuery(
+            query="(86400 / 3600)",
+            start=self.start_time,
+            end=self.end_time,
+            rollup=Rollup(interval=60, granularity=60, totals=True),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=self.project_ids,
+                use_case_id=USE_CASE_ID,
+            ),
+            indexer_mappings={
+                "transaction.duration": DISTRIBUTIONS_MRI,
+                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
+                "platform": resolve_str("platform"),
+                "ios": resolve_str("ios"),
+            },
+        )
+
+        response = self.app.post(
+            self.mql_route,
+            data=Request(
+                dataset=DATASET,
+                app_id="test",
+                query=query,
+                flags=Flags(debug=True),
+                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
+            ).serialize_mql(),
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
It is possible for a component of a Formula to be a Formula, and for that
Formula to be made up entirely of scalars (depending on the bracket grouping).
That case was causing an exception to be thrown in parsing.