### PR TITLE
the default value of trace_id will be a randomly generated uuid inste…

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -504,7 +504,7 @@ def _raw_query(
     timer: Timer,
     # NOTE: This variable is a piece of state which is updated and used outside this function
     stats: MutableMapping[str, Any],
-    trace_id: Optional[str] = None,
+    trace_id: str = str(uuid.uuid4()),
     robust: bool = False,
 ) -> QueryResult:
     """

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import textwrap
+import uuid
 from dataclasses import replace
 from functools import partial
 from math import floor
@@ -338,7 +339,7 @@ def _format_storage_query_and_run(
             stats=stats,
             query_metadata_list=query_metadata.query_list,
             query_settings={},
-            trace_id="",
+            trace_id=str(uuid.uuid4()),
             status=QueryStatus.INVALID_REQUEST,
             request_status=get_request_status(cause),
         )


### PR DESCRIPTION
…ad of empty string




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
