### PR TITLE
fix(mql): Handle leading literal in mql formula

### DIFF
--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -737,14 +737,18 @@ def parse_mql_query_body(body: str, dataset: Dataset) -> LogicalQuery:
                 selected_columns.extend(parsed.groupby)
             groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
 
-            def extract_mri(param: InitialParseResult) -> str:
-                if param.mri:
-                    return param.mri
-                elif param.formula:
-                    for p in param.parameters or []:
-                        mri = extract_mri(p)
-                        if mri:
-                            return mri
+            def extract_mri(param: InitialParseResult | Any) -> str:
+                if isinstance(param, InitialParseResult):
+                    if param.mri:
+                        return param.mri
+                    elif param.formula:
+                        for p in param.parameters or []:
+                            try:
+                                mri = extract_mri(p)
+                                if mri:
+                                    return mri
+                            except ParsingException:
+                                pass
 
                 raise ParsingException("formula does not contain any MRIs")
 


### PR DESCRIPTION
When there's a leading literal in the mql formula, we are unable to extract the MRI from it and error. This should be handled and continue trying the next term in the formula for the MRI.

Fixes SNUBA-4H3