### PR TITLE
fix(snql) Correctly parse tag columns with an entity alias

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -190,7 +190,7 @@ snql_grammar = Grammar(
     null_literal          = ~r"NULL"i
     subscriptable         = column_name open_square (column_name/tag_name) close_square
     column_name           = ~r"[a-zA-Z_][a-zA-Z0-9_\.:@/]*"
-    tag_column            = "tags" open_square tag_name close_square
+    tag_column            = (entity_alias dot)? "tags" open_square tag_name close_square
     tag_name              = ~r"[^\[\]]*"
     identifier            = backtick ~r"[a-zA-Z_][a-zA-Z0-9_]*" backtick
     function_name         = ~r"[a-zA-Z_][a-zA-Z0-9_]*"
@@ -208,6 +208,7 @@ snql_grammar = Grammar(
     comma                 = ","
     colon                 = ":"
     backtick              = "`"
+    dot                   = "."
 
 """
 )

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1333,6 +1333,38 @@ class TestSnQLApi(BaseApiTest):
 
         assert response.status_code == 200
 
+    def test_tags_column_in_join(self) -> None:
+        response = self.post(
+            "/events/snql",
+            data=json.dumps(
+                {
+                    "dataset": "events",
+                    "query": f"""MATCH (events: events) -[attributes]-> (ga: group_attributes)
+                        SELECT count() AS `count`
+                        BY events.time
+                        WHERE events.timestamp >= toDateTime('{self.base_time.isoformat()}')
+                        AND ifNull(events.tags[service-class], '') != 'devtest'
+                        AND events.timestamp < toDateTime('{self.next_time.isoformat()}')
+                        AND events.project_id IN array({self.project_id})
+                        AND ga.project_id IN array({self.project_id})
+                        AND ga.group_status IN array(0)
+                        AND events.type = 'error'
+                        ORDER BY events.time ASC
+                        LIMIT 10000
+                        GRANULARITY 600""",
+                    "legacy": True,
+                    "app_id": "legacy",
+                    "tenant_ids": {
+                        "organization_id": self.org_id,
+                        "referrer": "join.tag.test",
+                    },
+                    "parent_api": "/api/0/issues|groups/{issue_id}/tags/",
+                }
+            ),
+        )
+
+        assert response.status_code == 200
+
 
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db


### PR DESCRIPTION
If a query had a tag column with an entity alias, e.g. `events.tags[status]`,
the parser would choke and would throw an exception.