### PR TITLE
feat: add product teams to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,9 +7,9 @@
 /snuba/datasets/configuration/issues                @getsentry/issues
 /snuba/datasets/configuration/group_attributes      @getsentry/issues
 /snuba/datasets/configuration/groupassignee         @getsentry/issues
-/snuba/datasets/configuration/sessions              @getsentry/team-starfish @getsentry/performance
-/snuba/datasets/configuration/spans                 @getsentry/team-starfish @getsentry/performance
-/snuba/datasets/configuration/transactions          @getsentry/team-starfish @getsentry/performance
+/snuba/datasets/configuration/sessions              @getsentry/performance
+/snuba/datasets/configuration/spans                 @getsentry/performance
+/snuba/datasets/configuration/transactions          @getsentry/performance
 /snuba/datasets/configuration/functions             @getsentry/profiling
 /snuba/datasets/configuration/profiles              @getsentry/profiling
 /snuba/datasets/configuration/replays               @getsentry/replay-backend
@@ -26,7 +26,6 @@
 # @getsentry/issues
 # @getsentry/performance
 # @getsentry/discover-n-dashboards
-# @getsentry/team-starfish
 # @getsentry/profiling
 # @getsentry/replay-frontend
 # @getsentry/replay-backend

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,40 +1,17 @@
 # Use owners-snuba by default
 * @getsentry/owners-snuba
 
-# Datasets
-/snuba/datasets/configuration/discover              @getsentry/discover-n-dashboards
-/snuba/datasets/configuration/events                @getsentry/issues
+# datasets
 /snuba/datasets/configuration/issues                @getsentry/issues
 /snuba/datasets/configuration/group_attributes      @getsentry/issues
+/snuba/datasets/configuration/groupedmessage        @getsentry/issues
 /snuba/datasets/configuration/groupassignee         @getsentry/issues
-/snuba/datasets/configuration/sessions              @getsentry/performance
 /snuba/datasets/configuration/spans                 @getsentry/performance
 /snuba/datasets/configuration/transactions          @getsentry/performance
 /snuba/datasets/configuration/functions             @getsentry/profiling
 /snuba/datasets/configuration/profiles              @getsentry/profiling
 /snuba/datasets/configuration/replays               @getsentry/replay-backend
-
-/snuba/datasets/configuration/generic_metrics       @getsentry/metrics @getsentry/ddm
-/snuba/datasets/configuration/metrics               @getsentry/metrics @getsentry/ddm
-/snuba/datasets/configuration/groupedmessage
-/snuba/datasets/configuration/outcomes
-/snuba/datasets/configuration/outcomes_raw
-
-# @getsentry/crons
-# @getsentry/hybrid-cloud
-# @getsentry/alerts-notifications
-# @getsentry/issues
-# @getsentry/performance
-# @getsentry/discover-n-dashboards
-# @getsentry/profiling
-# @getsentry/replay-frontend
-# @getsentry/replay-backend
-
-# Integrations:
-# @getsentry/ecosystem
-# @getsentry/product-owners-settings-integrations
-# @getsentry/enterprise
-
+/snuba/datasets/configuration/metrics               @getsentry/telemetry-experience
 
 # rust_snuba
 /rust_snuba @getsentry/owners-snuba @getsentry/processing

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,12 +13,12 @@
 /snuba/datasets/configuration/functions             @getsentry/profiling
 /snuba/datasets/configuration/profiles              @getsentry/profiling
 /snuba/datasets/configuration/replays               @getsentry/replay-backend
-/snuba/datasets/configuration/generic_metrics
+
+/snuba/datasets/configuration/generic_metrics       @getsentry/metrics @getsentry/ddm
+/snuba/datasets/configuration/metrics               @getsentry/metrics @getsentry/ddm
 /snuba/datasets/configuration/groupedmessage
-/snuba/datasets/configuration/metrics
 /snuba/datasets/configuration/outcomes
 /snuba/datasets/configuration/outcomes_raw
-/snuba/datasets/configuration/querylog
 
 # @getsentry/crons
 # @getsentry/hybrid-cloud

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,23 +20,23 @@
 /snuba/datasets/configuration/spans                 @getsentry/team-starfish @getsentry/performance
 /snuba/datasets/configuration/transactions          @getsentry/team-starfish @getsentry/performance
 
-"""
-@getsentry/crons
-@getsentry/hybrid-cloud
-@getsentry/alerts-notifications
-@getsentry/issues
-@getsentry/performance
-@getsentry/discover-n-dashboards
-@getsentry/team-starfish
-@getsentry/profiling
-@getsentry/replay-frontend
-@getsentry/replay-backend
 
-Integrations
-@getsentry/ecosystem
-@getsentry/product-owners-settings-integrations
-@getsentry/enterprise
-"""
+# @getsentry/crons
+# @getsentry/hybrid-cloud
+# @getsentry/alerts-notifications
+# @getsentry/issues
+# @getsentry/performance
+# @getsentry/discover-n-dashboards
+# @getsentry/team-starfish
+# @getsentry/profiling
+# @getsentry/replay-frontend
+# @getsentry/replay-backend
+
+# Integrations:
+# @getsentry/ecosystem
+# @getsentry/product-owners-settings-integrations
+# @getsentry/enterprise
+
 
 # rust_snuba
 /rust_snuba @getsentry/owners-snuba @getsentry/processing

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,43 @@
 # Use owners-snuba by default
 * @getsentry/owners-snuba
 
+# Datasets
+/snuba/datasets/configuration/discover              @getsentry/discover-n-dashboards
+/snuba/datasets/configuration/events                @getsentry/issues
+/snuba/datasets/configuration/functions
+/snuba/datasets/configuration/generic_metrics
+/snuba/datasets/configuration/group_attributes
+/snuba/datasets/configuration/groupassignee
+/snuba/datasets/configuration/groupedmessage
+/snuba/datasets/configuration/issues                @getsentry/issues
+/snuba/datasets/configuration/metrics
+/snuba/datasets/configuration/outcomes
+/snuba/datasets/configuration/outcomes_raw
+/snuba/datasets/configuration/profiles              @getsentry/profiling
+/snuba/datasets/configuration/querylog
+/snuba/datasets/configuration/replays               @getsentry/replay-backend
+/snuba/datasets/configuration/sessions              @getsentry/team-starfish @getsentry/performance
+/snuba/datasets/configuration/spans                 @getsentry/team-starfish @getsentry/performance
+/snuba/datasets/configuration/transactions          @getsentry/team-starfish @getsentry/performance
+
+"""
+@getsentry/crons
+@getsentry/hybrid-cloud
+@getsentry/alerts-notifications
+@getsentry/issues
+@getsentry/performance
+@getsentry/discover-n-dashboards
+@getsentry/team-starfish
+@getsentry/profiling
+@getsentry/replay-frontend
+@getsentry/replay-backend
+
+Integrations
+@getsentry/ecosystem
+@getsentry/product-owners-settings-integrations
+@getsentry/enterprise
+"""
+
 # rust_snuba
 /rust_snuba @getsentry/owners-snuba @getsentry/processing
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,22 +4,21 @@
 # Datasets
 /snuba/datasets/configuration/discover              @getsentry/discover-n-dashboards
 /snuba/datasets/configuration/events                @getsentry/issues
-/snuba/datasets/configuration/functions
-/snuba/datasets/configuration/generic_metrics
-/snuba/datasets/configuration/group_attributes
-/snuba/datasets/configuration/groupassignee
-/snuba/datasets/configuration/groupedmessage
 /snuba/datasets/configuration/issues                @getsentry/issues
-/snuba/datasets/configuration/metrics
-/snuba/datasets/configuration/outcomes
-/snuba/datasets/configuration/outcomes_raw
-/snuba/datasets/configuration/profiles              @getsentry/profiling
-/snuba/datasets/configuration/querylog
-/snuba/datasets/configuration/replays               @getsentry/replay-backend
+/snuba/datasets/configuration/group_attributes      @getsentry/issues
+/snuba/datasets/configuration/groupassignee         @getsentry/issues
 /snuba/datasets/configuration/sessions              @getsentry/team-starfish @getsentry/performance
 /snuba/datasets/configuration/spans                 @getsentry/team-starfish @getsentry/performance
 /snuba/datasets/configuration/transactions          @getsentry/team-starfish @getsentry/performance
-
+/snuba/datasets/configuration/functions             @getsentry/profiling
+/snuba/datasets/configuration/profiles              @getsentry/profiling
+/snuba/datasets/configuration/replays               @getsentry/replay-backend
+/snuba/datasets/configuration/generic_metrics
+/snuba/datasets/configuration/groupedmessage
+/snuba/datasets/configuration/metrics
+/snuba/datasets/configuration/outcomes
+/snuba/datasets/configuration/outcomes_raw
+/snuba/datasets/configuration/querylog
 
 # @getsentry/crons
 # @getsentry/hybrid-cloud


### PR DESCRIPTION
This adds product teams as codeowners to their respective datasets, allowing them to make modifications to their dataset without PR approval from snuba