### PR TITLE
ref(gocd): add comparer pipeline, consolidate script?

### DIFF
--- a/gocd/templates/bash/s4s-clickhouse-queries.sh
+++ b/gocd/templates/bash/s4s-clickhouse-queries.sh
@@ -32,4 +32,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   "snuba-query-${SNUBA_CMD_TYPE}" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \
-  snuba "query-${SNUBA_CMD_TYPE} ${ARGS}"
+  snuba "query-${SNUBA_CMD_TYPE} ${ARGS[@]}"

--- a/gocd/templates/bash/s4s-clickhouse-queries.sh
+++ b/gocd/templates/bash/s4s-clickhouse-queries.sh
@@ -29,6 +29,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
 /devinfra/scripts/k8s/k8s-spawn-job.py \
   --label-selector="service=snuba-${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
+  --try-deployments-and-statefulsets \
   "snuba-query-${SNUBA_CMD_TYPE}" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \

--- a/gocd/templates/bash/s4s-clickhouse-queries.sh
+++ b/gocd/templates/bash/s4s-clickhouse-queries.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+FETCHER_ARGS="--querylog-host ${QUERYLOG_HOST} --querylog-port ${QUERYLOG_PORT} --window-hours ${WINDOW_HOURS} --tables ${TABLES} --gcs-bucket ${GCS_BUCKET}"
+REPLAYER_ARGS="--clickhouse-host ${CLICKHOUSE_HOST} --clickhouse-port ${CLICKHOUSE_PORT}  --gcs-bucket ${GCS_BUCKET}"
+COMPARER_ARGS="--gcs-bucket ${GCS_BUCKET}"
+
+SNUBA_SERVICE_NAME="query-${SNUBA_CMD_TYPE}-gocd"
+
+if [ "${SNUBA_CMD_TYPE}" == "fetcher" ]
+then
+    ARGS=$FETCHER_ARGS
+fi
+
+if [ "${SNUBA_CMD_TYPE}" == "replayer" ]
+then
+    ARGS=$COMPARER_ARGS
+fi
+
+if [ "${SNUBA_CMD_TYPE}" == "comparer" ]
+then
+    ARGS=$REPLAYER_ARGS_ARGS
+fi
+
+SNUBA_SERVICE_NAME="query-${SNUBA_CMD_TYPE}-gocd"
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-spawn-job.py \
+  --label-selector="service=snuba-${SNUBA_SERVICE_NAME}" \
+  --container-name="${SNUBA_SERVICE_NAME}" \
+  "snuba-query-${SNUBA_CMD_TYPE}" \
+  "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- \
+  snuba "query-${SNUBA_CMD_TYPE} ${ARGS}"

--- a/gocd/templates/clickhouse-query-comparer.jsonnet
+++ b/gocd/templates/clickhouse-query-comparer.jsonnet
@@ -1,7 +1,7 @@
 local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
 
 local pipeline_group = 'snuba';
-local pipeline_name = 'clickhouse-query-fetcher';
+local pipeline_name = 'clickhouse-query-comparer';
 
 local generate_compare_job() =
   {

--- a/gocd/templates/clickhouse-query-comparer.jsonnet
+++ b/gocd/templates/clickhouse-query-comparer.jsonnet
@@ -1,0 +1,67 @@
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
+
+local pipeline_group = 'snuba';
+local pipeline_name = 'clickhouse-query-fetcher';
+
+local generate_compare_job() =
+  {
+    environment_variables: {
+      SENTRY_REGION: 's4s',
+      SNUBA_CMD_TYPE: 'comparer',
+    },
+    elastic_profile_id: pipeline_group,
+    tasks: [
+      gocdtasks.script(importstr './bash/s4s-clickhouse-queries.sh'),
+    ],
+  };
+
+local pipeline = {
+  environment_variables: {
+    GOOGLE_CLOUD_PROJECT: 'mattrobenolt-kube',
+    GCS_BUCKET: 'clickhouse-query-comparisons-s4s',
+  },
+  group: pipeline_group,
+  display_order: 100,  // Ensure it's last pipeline in UI
+  lock_behavior: 'unlockWhenFinished',
+  materials: {
+    snuba_repo: {
+      git: 'git@github.com:getsentry/snuba.git',
+      shallow_clone: true,
+      branch: 'master',
+      destination: 'snuba',
+    },
+  },
+  stages: [
+    {
+      'compare-queries': {
+        approval: {
+          type: 'manual',
+        },
+        jobs: {
+          'query-comparer': generate_compare_job(),
+        },
+      },
+    },
+  ],
+};
+
+// We can output two variances of these pipelines.
+if std.extVar('output-files') then
+  // 1. We output each pipeline in a seperate file, this makes debugging easier.
+  {
+    [pipeline_name + '.yaml']: {
+      format_version: 10,
+      pipelines: {
+        [pipeline_name]: pipeline,
+      },
+    },
+  }
+else
+  // 2. Output all pipelines in a single file, needed for validation or passing
+  //    pipelines directly to GoCD.
+  {
+    format_version: 10,
+    pipelines: {
+      [pipeline_name]: pipeline,
+    },
+  }


### PR DESCRIPTION
Tried to make one script that could be used by all three pipelines:
* `fetcher` - https://github.com/getsentry/snuba/pull/5625
* `replayer` - https://github.com/getsentry/snuba/pull/5609
* `comparer`  - This PR includes that pipeline

Also adds `--try-deployments-and-statefulsets` from https://github.com/getsentry/devinfra-deployment-service/pull/534