### PR TITLE
Allows empty `trace_id`

### DIFF
--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -17,7 +17,7 @@ pub fn process_message(
     _config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let payload_json: Value = serde_json::from_slice(&payload_bytes)?;
+    let payload_json: Value = serde_json::from_slice(payload_bytes)?;
     let from: FromQuerylogMessage = payload_json.try_into()?;
 
     let querylog_msg = QuerylogMessage {

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -9,8 +9,6 @@ use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::processors::utils;
-
 use crate::types::{InsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
@@ -19,8 +17,8 @@ pub fn process_message(
     _config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let _: FromQuerylogMessage = utils::from_slice(payload_bytes)?;
-    let from: FromQuerylogMessage = serde_json::from_slice(payload_bytes)?;
+    let payload_json: Value = serde_json::from_slice(&payload_bytes)?;
+    let from: FromQuerylogMessage = payload_json.try_into()?;
 
     let querylog_msg = QuerylogMessage {
         request: from.request,
@@ -170,6 +168,49 @@ struct QueryList {
     duration_ms: Vec<u64>,
 }
 
+impl TryFrom<Value> for FromQuerylogMessage {
+    type Error = anyhow::Error;
+    fn try_from(from: Value) -> anyhow::Result<FromQuerylogMessage> {
+        let request = serde_json::from_value(from["request"].clone())?;
+        let dataset = serde_json::from_value(from["dataset"].clone())?;
+        let projects = serde_json::from_value(from["projects"].clone())?;
+        let organization = serde_json::from_value(from["organization"].clone())?;
+        let status = serde_json::from_value(from["status"].clone())?;
+        let timing = serde_json::from_value(from["timing"].clone())?;
+        let mut query_list = vec![];
+
+        let from_query_list: Vec<Value> =
+            serde_json::from_value(from["query_list"].clone()).unwrap();
+
+        for query in from_query_list {
+            let mut query_trace_id = Uuid::nil();
+            if query["trace_id"] != "" && !query["trace_id"].is_null() {
+                query_trace_id =
+                    Uuid::parse_str(query["trace_id"].to_string().get(1..33).unwrap())?;
+            }
+
+            query_list.push(FromQuery {
+                sql: serde_json::from_value(query["sql"].clone())?,
+                status: serde_json::from_value(query["status"].clone())?,
+                trace_id: query_trace_id,
+                stats: serde_json::from_value(query["stats"].clone())?,
+                profile: serde_json::from_value(query["profile"].clone())?,
+                result_profile: serde_json::from_value(query["result_profile"].clone())?,
+            });
+        }
+
+        Ok(Self {
+            request,
+            dataset,
+            projects,
+            organization,
+            status,
+            timing,
+            query_list,
+        })
+    }
+}
+
 impl TryFrom<Vec<FromQuery>> for QueryList {
     type Error = anyhow::Error;
     fn try_from(from: Vec<FromQuery>) -> anyhow::Result<QueryList> {
@@ -311,6 +352,113 @@ mod tests {
     use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
     use std::time::SystemTime;
+
+    #[test]
+    fn test_querylog_empty_trace_id() {
+        let data = r#"{
+            "request": {
+              "id": "24a78d10a0134f2aa6367ba2a393b504",
+              "body": {
+                "legacy": true,
+                "query": "MATCH (events) SELECT count() AS `count`, min(timestamp) AS `first_seen`, max(timestamp) AS `last_seen` BY tags_key, tags_value WHERE timestamp >= toDateTime('2023-02-08T21:07:12.769001') AND timestamp < toDateTime('2023-02-08T21:12:39.015094') AND project_id IN tuple(1) AND project_id IN tuple(1) AND group_id IN tuple(5) ORDER BY count DESC LIMIT 4 BY tags_key",
+                "dataset": "events",
+                "app_id": "legacy",
+                "parent_api": "/api/0/issues|groups/{issue_id}/tags/"
+              },
+              "referrer": "tagstore.__get_tag_keys_and_top_values",
+              "team": "<unknown>",
+              "feature": "<unknown>",
+              "app_id": "legacy"
+            },
+            "dataset": "events",
+            "entity": "events",
+            "start_timestamp": 1675919232,
+            "end_timestamp": 1675919559,
+            "query_list": [
+              {
+                "sql": "SELECT (tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), tags.key, tags.value)) AS snuba_all_tags), 1) AS _snuba_tags_key), (tupleElement(snuba_all_tags, 2) AS _snuba_tags_value), (count() AS _snuba_count), (min((timestamp AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen) FROM errors_local PREWHERE in((group_id AS _snuba_group_id), tuple(5)) WHERE equals(deleted, 0) AND greaterOrEquals(_snuba_timestamp, toDateTime('2023-02-08T21:07:12', 'Universal')) AND less(_snuba_timestamp, toDateTime('2023-02-08T21:12:39', 'Universal')) AND in((project_id AS _snuba_project_id), tuple(1)) AND in(_snuba_project_id, tuple(1)) GROUP BY _snuba_tags_key, _snuba_tags_value ORDER BY _snuba_count DESC LIMIT 4 BY _snuba_tags_key LIMIT 1000 OFFSET 0",
+                "sql_anonymized": "SELECT (tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), tags.key, tags.value)) AS snuba_all_tags), -1337) AS _snuba_tags_key), (tupleElement(snuba_all_tags, -1337) AS _snuba_tags_value), (count() AS _snuba_count), (min((timestamp AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen) FROM errors_local PREWHERE in((group_id AS _snuba_group_id), tuple(-1337)) WHERE equals(deleted, -1337) AND greaterOrEquals(_snuba_timestamp, toDateTime('2023-02-08T21:07:12', 'Universal')) AND less(_snuba_timestamp, toDateTime('2023-02-08T21:12:39', 'Universal')) AND in((project_id AS _snuba_project_id), tuple(-1337)) AND in(_snuba_project_id, tuple(-1337)) GROUP BY _snuba_tags_key, _snuba_tags_value ORDER BY _snuba_count DESC LIMIT 4 BY _snuba_tags_key LIMIT 1000 OFFSET 0",
+                "start_timestamp": 1675919232,
+                "end_timestamp": 1675919559,
+                "stats": {
+                  "clickhouse_table": "errors_local",
+                  "final": false,
+                  "referrer": "tagstore.__get_tag_keys_and_top_values",
+                  "sample": null,
+                  "table_rate": 0.6,
+                  "table_concurrent": 1,
+                  "project_rate": 0.6333333333333333,
+                  "project_concurrent": 1,
+                  "consistent": false,
+                  "result_rows": 22,
+                  "result_cols": 5,
+                  "query_id": "9079915acbacff0804ed45c72b865024"
+                },
+                "status": "success",
+                "trace_id": "",
+                "profile": {
+                  "time_range": null,
+                  "table": "errors_local",
+                  "all_columns": [
+                    "errors_local.deleted",
+                    "errors_local.group_id",
+                    "errors_local.project_id",
+                    "errors_local.tags.key",
+                    "errors_local.tags.value",
+                    "errors_local.timestamp"
+                  ],
+                  "multi_level_condition": false,
+                  "where_profile": {
+                    "columns": [
+                      "errors_local.deleted",
+                      "errors_local.project_id",
+                      "errors_local.timestamp"
+                    ],
+                    "mapping_cols": []
+                  },
+                  "groupby_cols": ["errors_local.tags.key", "errors_local.tags.value"],
+                  "array_join_cols": ["errors_local.tags.key", "errors_local.tags.value"]
+                },
+                "result_profile": {
+                  "bytes": 1305,
+                  "blocks": 1,
+                  "rows": 22,
+                  "elapsed": 0.009863138198852539
+                },
+                "request_status": "success",
+                "slo": "for"
+              }
+            ],
+            "status": "success",
+            "request_status": "success",
+            "slo": "for",
+            "timing": {
+              "timestamp": 1675890758,
+              "duration_ms": 55,
+              "marks_ms": {
+                "cache_get": 2,
+                "cache_set": 6,
+                "execute": 10,
+                "get_configs": 0,
+                "prepare_query": 15,
+                "rate_limit": 5,
+                "validate_schema": 15
+              },
+              "tags": {}
+            },
+            "projects": [1],
+            "snql_anonymized": "MATCH Entity(events) SELECT tags_key, tags_value, (count() AS count), (min(timestamp) AS first_seen), (max(timestamp) AS last_seen) GROUP BY tags_key, tags_value WHERE greaterOrEquals(timestamp, toDateTime('$S')) AND less(timestamp, toDateTime('$S')) AND in(project_id, tuple(-1337)) AND in(project_id, tuple(-1337)) AND in(group_id, tuple(-1337)) ORDER BY count DESC LIMIT 4 BY tags_key LIMIT 1000 OFFSET 0"
+          }"#;
+
+        let payload = KafkaPayload::new(None, None, Some(data.as_bytes().to_vec()));
+        let meta = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: DateTime::from(SystemTime::now()),
+        };
+        process_message(payload, meta, &ProcessorConfig::default())
+            .expect("The message should be processed");
+    }
 
     #[test]
     fn test_querylog() {

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -316,6 +316,113 @@ mod tests {
     use std::time::SystemTime;
 
     #[test]
+    fn test_querylog_null_trace_id() {
+        let data = r#"{
+            "request": {
+              "id": "24a78d10a0134f2aa6367ba2a393b504",
+              "body": {
+                "legacy": true,
+                "query": "MATCH (events) SELECT count() AS `count`, min(timestamp) AS `first_seen`, max(timestamp) AS `last_seen` BY tags_key, tags_value WHERE timestamp >= toDateTime('2023-02-08T21:07:12.769001') AND timestamp < toDateTime('2023-02-08T21:12:39.015094') AND project_id IN tuple(1) AND project_id IN tuple(1) AND group_id IN tuple(5) ORDER BY count DESC LIMIT 4 BY tags_key",
+                "dataset": "events",
+                "app_id": "legacy",
+                "parent_api": "/api/0/issues|groups/{issue_id}/tags/"
+              },
+              "referrer": "tagstore.__get_tag_keys_and_top_values",
+              "team": "<unknown>",
+              "feature": "<unknown>",
+              "app_id": "legacy"
+            },
+            "dataset": "events",
+            "entity": "events",
+            "start_timestamp": 1675919232,
+            "end_timestamp": 1675919559,
+            "query_list": [
+              {
+                "sql": "SELECT (tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), tags.key, tags.value)) AS snuba_all_tags), 1) AS _snuba_tags_key), (tupleElement(snuba_all_tags, 2) AS _snuba_tags_value), (count() AS _snuba_count), (min((timestamp AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen) FROM errors_local PREWHERE in((group_id AS _snuba_group_id), tuple(5)) WHERE equals(deleted, 0) AND greaterOrEquals(_snuba_timestamp, toDateTime('2023-02-08T21:07:12', 'Universal')) AND less(_snuba_timestamp, toDateTime('2023-02-08T21:12:39', 'Universal')) AND in((project_id AS _snuba_project_id), tuple(1)) AND in(_snuba_project_id, tuple(1)) GROUP BY _snuba_tags_key, _snuba_tags_value ORDER BY _snuba_count DESC LIMIT 4 BY _snuba_tags_key LIMIT 1000 OFFSET 0",
+                "sql_anonymized": "SELECT (tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), tags.key, tags.value)) AS snuba_all_tags), -1337) AS _snuba_tags_key), (tupleElement(snuba_all_tags, -1337) AS _snuba_tags_value), (count() AS _snuba_count), (min((timestamp AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen) FROM errors_local PREWHERE in((group_id AS _snuba_group_id), tuple(-1337)) WHERE equals(deleted, -1337) AND greaterOrEquals(_snuba_timestamp, toDateTime('2023-02-08T21:07:12', 'Universal')) AND less(_snuba_timestamp, toDateTime('2023-02-08T21:12:39', 'Universal')) AND in((project_id AS _snuba_project_id), tuple(-1337)) AND in(_snuba_project_id, tuple(-1337)) GROUP BY _snuba_tags_key, _snuba_tags_value ORDER BY _snuba_count DESC LIMIT 4 BY _snuba_tags_key LIMIT 1000 OFFSET 0",
+                "start_timestamp": 1675919232,
+                "end_timestamp": 1675919559,
+                "stats": {
+                  "clickhouse_table": "errors_local",
+                  "final": false,
+                  "referrer": "tagstore.__get_tag_keys_and_top_values",
+                  "sample": null,
+                  "table_rate": 0.6,
+                  "table_concurrent": 1,
+                  "project_rate": 0.6333333333333333,
+                  "project_concurrent": 1,
+                  "consistent": false,
+                  "result_rows": 22,
+                  "result_cols": 5,
+                  "query_id": "9079915acbacff0804ed45c72b865024"
+                },
+                "status": "success",
+                "trace_id": null,
+                "profile": {
+                  "time_range": null,
+                  "table": "errors_local",
+                  "all_columns": [
+                    "errors_local.deleted",
+                    "errors_local.group_id",
+                    "errors_local.project_id",
+                    "errors_local.tags.key",
+                    "errors_local.tags.value",
+                    "errors_local.timestamp"
+                  ],
+                  "multi_level_condition": false,
+                  "where_profile": {
+                    "columns": [
+                      "errors_local.deleted",
+                      "errors_local.project_id",
+                      "errors_local.timestamp"
+                    ],
+                    "mapping_cols": []
+                  },
+                  "groupby_cols": ["errors_local.tags.key", "errors_local.tags.value"],
+                  "array_join_cols": ["errors_local.tags.key", "errors_local.tags.value"]
+                },
+                "result_profile": {
+                  "bytes": 1305,
+                  "blocks": 1,
+                  "rows": 22,
+                  "elapsed": 0.009863138198852539
+                },
+                "request_status": "success",
+                "slo": "for"
+              }
+            ],
+            "status": "success",
+            "request_status": "success",
+            "slo": "for",
+            "timing": {
+              "timestamp": 1675890758,
+              "duration_ms": 55,
+              "marks_ms": {
+                "cache_get": 2,
+                "cache_set": 6,
+                "execute": 10,
+                "get_configs": 0,
+                "prepare_query": 15,
+                "rate_limit": 5,
+                "validate_schema": 15
+              },
+              "tags": {}
+            },
+            "projects": [1],
+            "snql_anonymized": "MATCH Entity(events) SELECT tags_key, tags_value, (count() AS count), (min(timestamp) AS first_seen), (max(timestamp) AS last_seen) GROUP BY tags_key, tags_value WHERE greaterOrEquals(timestamp, toDateTime('$S')) AND less(timestamp, toDateTime('$S')) AND in(project_id, tuple(-1337)) AND in(project_id, tuple(-1337)) AND in(group_id, tuple(-1337)) ORDER BY count DESC LIMIT 4 BY tags_key LIMIT 1000 OFFSET 0"
+          }"#;
+
+        let payload = KafkaPayload::new(None, None, Some(data.as_bytes().to_vec()));
+        let meta = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: DateTime::from(SystemTime::now()),
+        };
+        process_message(payload, meta, &ProcessorConfig::default())
+            .expect("The message should be processed");
+    }
+
+    #[test]
     fn test_querylog_empty_trace_id() {
         let data = r#"{
             "request": {

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -198,7 +198,7 @@ impl TryFrom<Vec<FromQuery>> for QueryList {
             let mut query_trace_id = Uuid::nil();
             if let Some(q_trace_id) = q.trace_id.as_ref() {
                 if !q_trace_id.is_empty() {
-                    query_trace_id = Uuid::parse_str(&q_trace_id)?;
+                    query_trace_id = Uuid::parse_str(q_trace_id)?;
                 }
             }
             trace_id.push(query_trace_id);

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -198,7 +198,7 @@ impl TryFrom<Vec<FromQuery>> for QueryList {
             let mut query_trace_id = Uuid::nil();
             if let Some(q_trace_id) = q.trace_id.as_ref() {
                 if !q_trace_id.is_empty() {
-                    query_trace_id = Uuid::parse_str(&(q.trace_id.unwrap().to_string()))?;
+                    query_trace_id = Uuid::parse_str(&q_trace_id)?;
                 }
             }
             trace_id.push(query_trace_id);

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -39,10 +39,3 @@ pub struct StringToIntDatetime(
     #[schemars(with = "String")]
     pub u32,
 );
-
-pub fn from_slice<'a, T: Deserialize<'a>>(
-    payload: &'a [u8],
-) -> Result<T, serde_path_to_error::Error<serde_json::Error>> {
-    let jd = &mut serde_json::Deserializer::from_slice(payload);
-    serde_path_to_error::deserialize(jd)
-}

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -440,11 +440,6 @@ SLICED_KAFKA_BROKER_CONFIG: Mapping[Tuple[str, int], Mapping[str, Any]] = {}
 # we save ~2s on startup time
 VALIDATE_DATASET_YAMLS_ON_STARTUP = False
 
-# If an error is encountered while handling a query (for example, if the query is too long),
-# the trace_id is empty or None. This causes parsing errors downstream when a QueryException is
-# written to querylog. The current solution is to populate it with a default trace_id instead
-DEFAULT_EMPTY_TRACE_ID = "00000000-0000-0000-0000-000000000000"
-
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -16,10 +16,7 @@ from sentry_kafka_schemas.schema_types import snuba_queries_v1
 from sentry_sdk import Hub
 from sentry_sdk.api import configure_scope
 
-from snuba import environment
-from snuba import settings
-from snuba import settings as snuba_settings
-from snuba import state
+from snuba import environment, settings, state
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
@@ -506,7 +503,7 @@ def _raw_query(
     timer: Timer,
     # NOTE: This variable is a piece of state which is updated and used outside this function
     stats: MutableMapping[str, Any],
-    trace_id: str = str(uuid.UUID(snuba_settings.DEFAULT_EMPTY_TRACE_ID)),
+    trace_id: Optional[str] = None,
     robust: bool = False,
 ) -> QueryResult:
     """

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import textwrap
-import uuid
 from dataclasses import replace
 from functools import partial
 from math import floor
@@ -339,7 +338,7 @@ def _format_storage_query_and_run(
             stats=stats,
             query_metadata_list=query_metadata.query_list,
             query_settings={},
-            trace_id=str(uuid.UUID(snuba_settings.DEFAULT_EMPTY_TRACE_ID)),
+            trace_id="",
             status=QueryStatus.INVALID_REQUEST,
             request_status=get_request_status(cause),
         )


### PR DESCRIPTION
# fix: Handles empty `trace_id` in payload

[Setting a default `trace_id` upstream](https://github.com/getsentry/snuba/pull/5628) proves to be insufficient to solve the [UUID parsing error](https://sentry.sentry.io/issues/4927370476/?project=300688&query=start%3D2024-02-07T15%3A27%3A00%26end%3D2024-02-07T22%3A23%3A38%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream). It is also not sustainable to find all the places where `trace_id` is set to empty or null since it does not protect against future cases. This pr addresses this issue by adding deserialization logic that populates the query's `trace_id` with `Uuid::nil()` if the payload's `trace_id` is an empty string or null.

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
