### PR TITLE
feat(gocd): Add snuba API canary health check

### DIFF
--- a/gocd/templates/bash/canary-ddog-health-check.sh
+++ b/gocd/templates/bash/canary-ddog-health-check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
+  140973101
+
+
+# Above monitor IDs 140973101 map to following monitors:
+# Snuba API Health Check is Failing

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -135,6 +135,18 @@ local deploy_canary_stage(region) =
                 gocdtasks.script(importstr '../bash/deploy.sh'),
               ],
             },
+            health_check: {
+              environment_variables: {
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
+                DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
+                DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
+                LABEL_SELECTOR: 'service=snuba,is_canary=true',
+              },
+              elastic_profile_id: 'snuba',
+              tasks: [
+                gocdtasks.script(importstr '../bash/canary-ddog-health-check.sh'),
+              ],
+            },
           },
         },
       },


### PR DESCRIPTION
### Overview
Now that we deploy snuba API canary in GoCD, we can validate that snuba is able to connect to all the appropriate ClickHouse clusters before deploying to SaaS. As we continue to make snuba more self-serve, this safeguard can help product developers stop bad deploys (incorrect storage names, wrong table names, etc.) from going out to production. Additionally, this check would stop developers from prematurely enabling a storage (via readiness_state), before the necessary migrations are executed and tables are created.

### Expected Behaviour
This is currently set to `dry_run=true` and should not stop deploys even if check fails. We should be able to see this new check in GoCD UI.