### PR TITLE
feat(canary): Enable canary health check

### DIFF
--- a/gocd/templates/bash/canary-ddog-health-check.sh
+++ b/gocd/templates/bash/canary-ddog-health-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
+/devinfra/scripts/checks/datadog/monitor_status.py \
   140973101
 
 


### PR DESCRIPTION
This health-check ensures that snuba is able to connect to all clickhouse clusters before continuing down the deployment pipeline. Since it is operating as expected, we can turn this on for real now.