### PR TITLE
fix: vscode testing ui

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,5 @@
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,
-  "python.testing.unittestEnabled": true,
   "python.testing.pytestArgs": ["tests"]
 }


### PR DESCRIPTION
removes unittest from vscode settings, since we only use pytest, this allows vscode testing ui to work