### PR TITLE
fix: update filter in select optimizer

### DIFF
--- a/snuba/query/processors/logical/filter_in_select_optimizer.py
+++ b/snuba/query/processors/logical/filter_in_select_optimizer.py
@@ -1,3 +1,5 @@
+import sentry_sdk
+
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
@@ -43,11 +45,12 @@ class FilterInSelectOptimizer:
     def process_mql_query(
         self, query: LogicalQuery | CompositeQuery[QueryEntity]
     ) -> None:
-        feat_flag = get_int_config("enable_filter_in_select_optimizer", default=0)
+        feat_flag = get_int_config("enable_filter_in_select_optimizer", default=1)
         if feat_flag:
             try:
                 domain = self.get_domain_of_mql_query(query)
-            except ValueError:
+            except ValueError as err:
+                sentry_sdk.capture_exception(err)
                 domain = {}
 
             if domain:

--- a/tests/query/parser/test_formula_mql_query.py
+++ b/tests/query/parser/test_formula_mql_query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from datetime import datetime
 
 import pytest
@@ -233,6 +234,25 @@ def tag_column(tag: str) -> SubscriptableReference:
     )
 
 
+def in_clause(lhs: Column | SubscriptableReference, rhs: Iterable):
+    return binary_condition(
+        "in",
+        lhs,
+        FunctionCall(
+            alias=None,
+            function_name="array",
+            parameters=tuple(rhs),
+        ),
+    )
+
+
+def metric_id_in(mids: set[int]) -> FunctionCall:
+    return in_clause(
+        Column("_snuba_metric_id", None, "metric_id"),
+        map(lambda x: Literal(None, x), mids),
+    )
+
+
 def test_simple_formula() -> None:
     query_body = "sum(`d:transactions/duration@millisecond`){status_code:200} / sum(`d:transactions/duration@millisecond`)"
     expected_selected = SelectedExpression(
@@ -259,7 +279,7 @@ def test_simple_formula() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -304,7 +324,7 @@ def test_simple_formula_with_leading_literals() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -349,7 +369,7 @@ def test_groupby() -> None:
             ),
         ],
         groupby=[tag_column("transaction"), time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -424,7 +444,7 @@ def test_curried_aggregate() -> None:
             ),
         ],
         groupby=[tag_column("transaction"), time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -469,7 +489,7 @@ def test_bracketing_rules() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -533,7 +553,15 @@ def test_formula_filters() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and",
+            metric_id_in({123456}),
+            binary_condition(
+                "and",
+                in_clause(tag_column("status_code"), [Literal(None, "200")]),
+                formula_condition,
+            ),
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -588,7 +616,15 @@ def test_formula_groupby() -> None:
             ),
         ],
         groupby=[tag_column("transaction"), time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and",
+            metric_id_in({123456}),
+            binary_condition(
+                "and",
+                in_clause(tag_column("status_code"), [Literal(None, "200")]),
+                formula_condition,
+            ),
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -630,7 +666,7 @@ def test_formula_scalar_value() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -679,7 +715,7 @@ def test_arbitrary_functions() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -728,7 +764,7 @@ def test_arbitrary_functions_with_formula() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition("and", metric_id_in({123456}), formula_condition),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,

--- a/tests/query/processors/test_filter_in_select_optimizer.py
+++ b/tests/query/processors/test_filter_in_select_optimizer.py
@@ -33,6 +33,7 @@ mql_context = {
         "d:transactions/duration@second": 123457,
         "status_code": 222222,
         "transaction": 333333,
+        "platform": 444444,
     },
     "limit": None,
     "offset": None,
@@ -136,6 +137,17 @@ mql_test_cases: list[tuple[str, dict]] = [
             },
         },
     ),
+    (
+        '(sum(d:transactions/duration@millisecond){transaction:"/hello"} by (platform) * 1000000.0)',
+        {
+            Column("_snuba_metric_id", None, "metric_id"): {
+                Literal(None, 123456),
+            },
+            subscriptable_reference("tags_raw", "333333"): {
+                Literal(None, "/hello"),
+            },
+        },
+    ),
 ]
 
 """ TESTING """
@@ -151,6 +163,4 @@ def test_get_domain_of_mql(mql_query: str, expected_domain: set[int]) -> None:
     logical_query, _ = parse_mql_query(str(mql_query), mql_context, generic_metrics)
     assert isinstance(logical_query, Query)
     res = optimizer.get_domain_of_mql_query(logical_query)
-    if res != expected_domain:
-        raise
     assert res == expected_domain


### PR DESCRIPTION
this relates to #5610
* feature flag defaults to on
* sentry capture_exception in the case of internal optimizer error (includes unsupported optimization form)
* added a test

update:
* modify test_mql_formula_queries to pass with the new optimizer
* extract domain -> condition conversion to its own method