### PR TITLE
fix(gocd): put snuba cmd into $SNUBA_CMD

### DIFF
--- a/gocd/templates/bash/s4s-clickhouse-queries.sh
+++ b/gocd/templates/bash/s4s-clickhouse-queries.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-SNUBA_SERVICE_NAME="query-${SNUBA_CMD_TYPE}-gocd"
-
 if [ "${SNUBA_CMD_TYPE}" == "fetcher" ]
 then
     ARGS="--querylog-host ${QUERYLOG_HOST} --querylog-port ${QUERYLOG_PORT} --window-hours ${WINDOW_HOURS} --tables ${TABLES} --gcs-bucket ${GCS_BUCKET}"
@@ -18,6 +16,7 @@ then
 fi
 
 SNUBA_SERVICE_NAME="query-${SNUBA_CMD_TYPE}-gocd"
+SNUBA_CMD="query-${SNUBA_CMD_TYPE} ${ARGS[@]}"
 
 eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
@@ -29,4 +28,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   "snuba-query-${SNUBA_CMD_TYPE}" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \
-  snuba "query-${SNUBA_CMD_TYPE} ${ARGS[@]}"
+  snuba $SNUBA_CMD


### PR DESCRIPTION
This is to fix the `OSError: [Errno 36] File name too long: '/usr/src/snuba/snuba/cli/query_fetcher... ` error Im seeing in GoCD, this change seemed to work locally for me to call the snuba command correctly, hopefully this works in GoCD too