### PR TITLE
perf(replays): increase num of max threads used for queries

### DIFF
--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -174,6 +174,7 @@ query_processors:
       settings:
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
+        max_threads: 16
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 stream_loader:


### PR DESCRIPTION
We observed from using the snuba clickhouse tracing tool (so amazing), that increasing max threads can help out query speed quite a bit for our larger orgs. From looking at this [dashboard](https://app.datadoghq.com/dashboard/mb4-iya-qa7/clickhouse?fromUser=false&refresh_mode=sliding&tpl_var_host%5B0%5D=%2A&tpl_var_scope%5B0%5D=role%3Asnuba-replays-query%2A&view=spans&from_ts=1710527589629&to_ts=1710529389629&live=true), we have plenty of resources available on our cluster, so lets try increasing this to 16 to see if it helps with performance. 