### PR TITLE
chore(oncall): Add entity key to subscription scheduler

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -110,6 +110,7 @@ def subscriptions_executor(
 
     metrics_tags = {
         "dataset": dataset_name,
+        "entity": entity_names[0],
     }
 
     if slice_id:


### PR DESCRIPTION
In order to be able to correlate metrics from both scheduler and executor, lets add a tag of entity on the executor. The scheduler already has this tag.