### PR TITLE
feat(spans): Add an index on segment_name

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -356,6 +356,7 @@ class SpansLoader(DirectoryLoader):
             "0009_spans_add_measure_hashmap",
             "0010_spans_add_compression",
             "0011_spans_add_index_on_trace_id",
+            "0012_spans_add_index_on_transaction_name",
         ]
 
 

--- a/snuba/snuba_migrations/spans/0012_spans_add_index_on_transaction_name.py
+++ b/snuba/snuba_migrations/spans/0012_spans_add_index_on_transaction_name.py
@@ -1,0 +1,34 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+table_name_prefix = "spans"
+column_name = "segment_name"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddIndex(
+                storage_set=StorageSetKey.SPANS,
+                table_name=f"{table_name_prefix}_local",
+                index_name=f"bf_{column_name}",
+                index_expression=column_name,
+                index_type="bloom_filter(0.0)",
+                granularity=1,
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropIndex(
+                StorageSetKey.SPANS,
+                table_name=f"{table_name_prefix}_local",
+                index_name=f"bf_{column_name}",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
We're making queries on the spans dataset involving a whole lot of spans from a specific transaction name. This should help speed up the query.

https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/organization_spans_aggregation.py#L328-L340