### PR TITLE
chore(admin): Remove starfish group from iam policy

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -34,7 +34,6 @@
     },
     {
       "members": [
-          "group:team-starfish@sentry.io",
           "group:team-ingest@sentry.io",
           "group:team-visibility@sentry.io",
           "group:team-performance@sentry.io",


### PR DESCRIPTION
We should remove `team-starfish` from the snuba admin iam policy since it no longer exists: https://github.com/getsentry/security-as-code/pull/645. This is causing [auth errors in admin](https://sentry.sentry.io/issues/4739270573/?project=300688&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=2.).