### PR TITLE
feat: optimizer rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,7 @@ jobs:
               tests/sentry/event_manager \
               tests/sentry/api/endpoints/test_organization_profiling_functions.py \
               tests/snuba/api/endpoints/test_organization_events_stats_mep.py \
+              tests/sentry/sentry_metrics/querying \
               tests/snuba/test_snql_snuba.py \
               tests/snuba/test_metrics_layer.py \
               -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -155,7 +155,10 @@ def is_not_in_condition_pattern(lhs: Pattern[Expression]) -> FunctionCallPattern
 def binary_condition(
     function_name: str, lhs: Expression, rhs: Expression
 ) -> FunctionCall:
-    return FunctionCall(None, function_name, (lhs, rhs))
+    """This function is deprecated please use snuba.query.dsl.binary_condition"""
+    from snuba.query.dsl import binary_condition as dsl_binary_condition
+
+    return dsl_binary_condition(function_name, lhs, rhs)
 
 
 binary_condition_patterns = {

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -55,6 +55,29 @@ def divide(
     return FunctionCall(alias, "divide", (lhs, rhs))
 
 
+# boolean functions
+def binary_condition(
+    function_name: str, lhs: Expression, rhs: Expression
+) -> FunctionCall:
+    return FunctionCall(None, function_name, (lhs, rhs))
+
+
+def equals(lhs: Expression, rhs: Expression) -> FunctionCall:
+    return binary_condition("equals", lhs, rhs)
+
+
+def and_cond(lhs: FunctionCall, rhs: FunctionCall) -> FunctionCall:
+    return binary_condition("and", lhs, rhs)
+
+
+def or_cond(lhs: FunctionCall, rhs: FunctionCall) -> FunctionCall:
+    return binary_condition("or", lhs, rhs)
+
+
+def in_cond(lhs: Expression, rhs: Expression) -> FunctionCall:
+    return binary_condition("in", lhs, rhs)
+
+
 # aggregate functions
 def count(column: Optional[Column] = None, alias: Optional[str] = None) -> FunctionCall:
     return FunctionCall(alias, "count", (column,) if column else ())

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -39,7 +39,7 @@ from snuba.query.parser.exceptions import ParsingException
 from snuba.query.processors.logical.filter_in_select_optimizer import (
     FilterInSelectOptimizer,
 )
-from snuba.query.query_settings import QuerySettings
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.query.snql.anonymize import format_snql_anonymized
 from snuba.query.snql.parser import (
     MAX_LIMIT,
@@ -1064,19 +1064,12 @@ def quantiles_to_quantile(
     query.transform_expressions(transform)
 
 
-def optimize_filter_in_select(
-    query: CompositeQuery[QueryEntity] | LogicalQuery,
-) -> None:
-    FilterInSelectOptimizer().process_mql_query(query)
-
-
 CustomProcessors = Sequence[
     Callable[[Union[CompositeQuery[QueryEntity], LogicalQuery]], None]
 ]
 
 MQL_POST_PROCESSORS: CustomProcessors = POST_PROCESSORS + [
     quantiles_to_quantile,
-    optimize_filter_in_select,
 ]
 
 
@@ -1115,6 +1108,12 @@ def parse_mql_query(
             MQL_POST_PROCESSORS,
             settings,
         )
+
+    with sentry_sdk.start_span(op="processor", description="filter_in_select_optimize"):
+        if settings is None:
+            FilterInSelectOptimizer().process_query(query, HTTPQuerySettings())
+        else:
+            FilterInSelectOptimizer().process_query(query, settings)
 
     # Custom processing to tweak the AST before validation
     with sentry_sdk.start_span(op="processor", description="custom_processing"):

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -1067,7 +1067,7 @@ def quantiles_to_quantile(
 def optimize_filter_in_select(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
 ) -> None:
-    FilterInSelectOptimizer().process_mql_query2(query)
+    FilterInSelectOptimizer().process_mql_query(query)
 
 
 CustomProcessors = Sequence[

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -1067,7 +1067,7 @@ def quantiles_to_quantile(
 def optimize_filter_in_select(
     query: CompositeQuery[QueryEntity] | LogicalQuery,
 ) -> None:
-    FilterInSelectOptimizer().process_mql_query(query)
+    FilterInSelectOptimizer().process_mql_query2(query)
 
 
 CustomProcessors = Sequence[

--- a/snuba/query/processors/logical/filter_in_select_optimizer.py
+++ b/snuba/query/processors/logical/filter_in_select_optimizer.py
@@ -157,6 +157,6 @@ class FilterInSelectOptimizer:
                 new_condition = deepcopy(func.parameters[1])
             else:
                 new_condition = binary_condition(
-                    "or", deepcopy(func.parameters[1]), new_condition
+                    "or", new_condition, deepcopy(func.parameters[1])
                 )
         return new_condition

--- a/snuba/query/processors/logical/filter_in_select_optimizer.py
+++ b/snuba/query/processors/logical/filter_in_select_optimizer.py
@@ -9,7 +9,6 @@ from snuba.query.expressions import (
     Argument,
     Column,
     CurriedFunctionCall,
-    Expression,
     ExpressionVisitor,
     FunctionCall,
     Lambda,
@@ -19,18 +18,6 @@ from snuba.query.expressions import (
 from snuba.query.logical import Query as LogicalQuery
 from snuba.state import get_int_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
-
-"""
-Domain maps from a property to the specific values that are being filtered for. Ex:
-    sumIf(value, metric_id in [1,2,3])
-        Domain = {metric_id: {1,2,3}}
-    sumIf(value, metric_id=5 and status=200) / sumIf(value, metric_id=5 and status=400)
-        Domain = {
-            metric_id: {5},
-            status: {200, 400}
-        }
-"""
-Domain = dict[Column | SubscriptableReference, set[Literal]]
 
 metrics = MetricsWrapper(environment.metrics, "api")
 
@@ -79,7 +66,8 @@ class FindConditionalAggregateFunctionsVisitor(ExpressionVisitor[None]):
 
 class FilterInSelectOptimizer:
     """
-    This optimizer takes queries that filter in the select clause (via conditional aggregate functions),
+    This optimizer lifts conditions in the select clause into the where clause,
+    this is
     and adds the equivalent conditions to the where clause. Example:
 
         SELECT sumIf(value, metric_id in (1,2,3,4) and status=200)
@@ -92,10 +80,10 @@ class FilterInSelectOptimizer:
         WHERE metric_id in (1,2,3,4) and status=200
     """
 
-    def process_mql_query2(
+    def process_mql_query(
         self, query: LogicalQuery | CompositeQuery[QueryEntity]
     ) -> None:
-        feat_flag = get_int_config("enable_filter_in_select_optimizer", default=0)
+        feat_flag = get_int_config("enable_filter_in_select_optimizer", default=1)
         if feat_flag:
             try:
                 new_condition = self.get_select_filter(query)
@@ -113,7 +101,9 @@ class FilterInSelectOptimizer:
         one condition.
 
         ex: SELECT sumIf(value, metric_id in (1,2,3,4) and status=200),
-                    avgIf(value, metric_id in (11,12) and status=400),
+                   avgIf(value, metric_id in (11,12) and status=400),
+                   ...
+
         returns or((metric_id in (1,2,3,4) and status=200), (metric_id in (11,12) and status=400))
         """
         # find and grab all the conditional aggregate functions
@@ -149,219 +139,3 @@ class FilterInSelectOptimizer:
                     "or", deepcopy(func.parameters[1]), new_condition
                 )
         return new_condition
-
-    def process_mql_query(
-        self, query: LogicalQuery | CompositeQuery[QueryEntity]
-    ) -> None:
-        feat_flag = get_int_config("enable_filter_in_select_optimizer", default=0)
-        if feat_flag:
-            try:
-                domain = self.get_domain_of_mql_query(query)
-            except ValueError:
-                logger.warning(
-                    "Failed getting domain", exc_info=True, extra={"query": query}
-                )
-                domain = {}
-
-            if domain:
-                # add domain to where clause
-                domain_filter = None
-                for key, value in domain.items():
-                    clause = binary_condition(
-                        "in",
-                        key,
-                        FunctionCall(
-                            alias=None,
-                            function_name="array",
-                            parameters=tuple(value),
-                        ),
-                    )
-                    if not domain_filter:
-                        domain_filter = clause
-                    else:
-                        domain_filter = binary_condition(
-                            "and",
-                            domain_filter,
-                            clause,
-                        )
-                assert domain_filter is not None
-                query.add_condition_to_ast(domain_filter)
-                metrics.increment("kyles_optimizer_optimized")
-
-    def get_select_filter_old(
-        self,
-        query: LogicalQuery | CompositeQuery[QueryEntity],
-    ) -> FunctionCall | None:
-        domain = self.get_domain_of_mql_query(query)
-
-        if not domain:
-            return None
-
-        # make the condition
-        domain_filter = None
-        for key, value in domain.items():
-            clause = binary_condition(
-                "in",
-                key,
-                FunctionCall(
-                    alias=None,
-                    function_name="array",
-                    parameters=tuple(value),
-                ),
-            )
-            if not domain_filter:
-                domain_filter = clause
-            else:
-                domain_filter = binary_condition(
-                    "and",
-                    domain_filter,
-                    clause,
-                )
-        return domain_filter
-
-    def get_domain_of_mql_query(
-        self, query: LogicalQuery | CompositeQuery[QueryEntity]
-    ) -> Domain:
-        """
-        This function returns the metric_id domain of the given query.
-        For a definition of metric_id domain, go to definition of the return type of this function ('Domain')
-        """
-        expressions = map(lambda x: x.expression, query.get_selected_columns())
-        target_exp = None
-        for exp in expressions:
-            if self._contains_conditional_aggregate(exp):
-                if target_exp is not None:
-                    raise ValueError(
-                        "Was expecting only 1 select expression to contain condition aggregate but found multiple"
-                    )
-                else:
-                    target_exp = exp
-
-        if target_exp is not None:
-            domains = self._get_conditional_domains(target_exp)
-            if len(domains) == 0:
-                raise ValueError("This shouldnt happen bc there is a target_exp")
-
-            # find the intersect of keys, across the domains of all conditional aggregates
-            key_intersect = set(domains[0].keys())
-            for i in range(1, len(domains)):
-                domain = domains[i]
-                key_intersect = key_intersect.intersection(set(domains[i].keys()))
-
-            # union the domains
-            domain_union: Domain = {}
-            for key in key_intersect:
-                domain_union[key] = set()
-                for domain in domains:
-                    domain_union[key] = domain_union[key].union(domain[key])
-
-            return domain_union
-        else:
-            return {}
-
-    def _contains_conditional_aggregate(self, exp: Expression) -> bool:
-        if isinstance(exp, FunctionCall):
-            if exp.function_name[-2:] == "If":
-                return True
-            for param in exp.parameters:
-                if self._contains_conditional_aggregate(param):
-                    return True
-            return False
-        elif isinstance(exp, CurriedFunctionCall):
-            if exp.internal_function.function_name[-2:] == "If":
-                return True
-            return False
-        else:
-            return False
-
-    def _get_conditional_domains(self, exp: Expression) -> list[Domain]:
-        domains: list[Domain] = []
-        self._get_conditional_domains_helper(exp, domains)
-        return domains
-
-    def _get_conditional_domains_helper(
-        self, exp: Expression, domains: list[Domain]
-    ) -> None:
-        if isinstance(exp, FunctionCall):
-            # add domain of function call
-            if exp.function_name[-2:] == "If":
-                if len(exp.parameters) != 2 or not isinstance(
-                    exp.parameters[1], FunctionCall
-                ):
-                    raise ValueError("unexpected form of function aggregate")
-                domains.append(self._get_domain_of_predicate(exp.parameters[1]))
-            else:
-                for param in exp.parameters:
-                    self._get_conditional_domains_helper(param, domains)
-        elif isinstance(exp, CurriedFunctionCall):
-            # add domain of curried function
-            if exp.internal_function.function_name[-2:] == "If":
-                if len(exp.parameters) != 2 or not isinstance(
-                    exp.parameters[1], FunctionCall
-                ):
-                    raise ValueError("unexpected form of curried function aggregate")
-
-                domains.append(self._get_domain_of_predicate(exp.parameters[1]))
-
-    def _get_domain_of_predicate(self, p: FunctionCall) -> Domain:
-        domain: Domain = {}
-        self._get_domain_of_predicate_helper(p, domain)
-        return domain
-
-    def _get_domain_of_predicate_helper(
-        self,
-        p: FunctionCall,
-        domain: Domain,
-    ) -> None:
-        if p.function_name == "equals":
-            # validate
-            if not len(p.parameters) == 2:
-                raise ValueError("unexpected form of 'equals' function in predicate")
-            lhs = p.parameters[0]
-            rhs = p.parameters[1]
-            if not isinstance(lhs, (Column, SubscriptableReference)) or not isinstance(
-                rhs, Literal
-            ):
-                raise ValueError("unexpected form of 'equals' function in predicate")
-            # if already there throw error, this was to protect against: and(field=1, field=2)
-            if lhs in domain:
-                raise ValueError("lhs of 'equals' was already seen (likely from and)")
-
-            # add it to domain
-            domain[lhs] = {rhs}
-        elif p.function_name == "in":
-            # validate
-            if not len(p.parameters) == 2:
-                raise ValueError("unexpected form of 'in' function in predicate")
-            lhs = p.parameters[0]
-            rhs = p.parameters[1]
-            if not (
-                isinstance(lhs, (Column, SubscriptableReference))
-                and isinstance(rhs, FunctionCall)
-                and rhs.function_name in ("array", "tuple")
-            ):
-                raise ValueError("unexpected form of 'in' function in predicate")
-            # if already there throw error, this was to protect against: and(field=1, field=2)
-            if lhs in domain:
-                raise ValueError("lhs of 'in' was already seen (likely from and)")
-
-            # add it to domain
-            values = set()
-            for e in rhs.parameters:
-                if not isinstance(e, Literal):
-                    raise ValueError(
-                        "expected rhs of 'in' to only contain Literal, but that was not the case"
-                    )
-                values.add(e)
-            domain[lhs] = values
-        elif p.function_name == "and":
-            if not (
-                len(p.parameters) == 2
-                and isinstance(p.parameters[0], FunctionCall)
-                and isinstance(p.parameters[1], FunctionCall)
-            ):
-                raise ValueError("unexpected form of 'and' function in predicate")
-            self._get_domain_of_predicate_helper(p.parameters[0], domain)
-            self._get_domain_of_predicate_helper(p.parameters[1], domain)
-        else:
-            raise ValueError("unexpected form of predicate")

--- a/snuba/query/processors/logical/filter_in_select_optimizer.py
+++ b/snuba/query/processors/logical/filter_in_select_optimizer.py
@@ -73,8 +73,6 @@ class FindConditionalAggregateFunctionsVisitor(
     ) -> list[FunctionCall | CurriedFunctionCall]:
         if exp.internal_function.function_name[-2:] == "If":
             self._matches.append(exp)
-        for param in exp.internal_function.parameters:
-            param.accept(self)
         return self._matches
 
     def visit_argument(self, exp: Argument) -> list[FunctionCall | CurriedFunctionCall]:

--- a/snuba/query/processors/logical/filter_in_select_optimizer.py
+++ b/snuba/query/processors/logical/filter_in_select_optimizer.py
@@ -89,8 +89,12 @@ class FilterInSelectOptimizer:
                 new_condition = self.get_select_filter(query)
                 if new_condition is not None:
                     query.add_condition_to_ast(new_condition)
-            except ValueError:
-                raise
+                    metrics.increment("kyles_optimizer_optimized")
+            except Exception:
+                logger.warning(
+                    "Failed during optimization", exc_info=True, extra={"query": query}
+                )
+                return
 
     def get_select_filter(
         self,

--- a/snuba/query/processors/logical/filter_in_select_optimizer.py
+++ b/snuba/query/processors/logical/filter_in_select_optimizer.py
@@ -1,5 +1,4 @@
 import logging
-from copy import deepcopy
 
 from snuba import environment
 from snuba.query.composite import CompositeQuery
@@ -154,9 +153,9 @@ class FilterInSelectOptimizer:
                 )
 
             if new_condition is None:
-                new_condition = deepcopy(func.parameters[1])
+                new_condition = func.parameters[1]
             else:
                 new_condition = binary_condition(
-                    "or", new_condition, deepcopy(func.parameters[1])
+                    "or", new_condition, func.parameters[1]
                 )
         return new_condition

--- a/tests/query/parser/test_formula_mql_query.py
+++ b/tests/query/parser/test_formula_mql_query.py
@@ -21,6 +21,9 @@ from snuba.query.expressions import (
 )
 from snuba.query.logical import Query
 from snuba.query.mql.parser import parse_mql_query
+from tests.query.processors.test_filter_in_select_optimizer import (
+    expected_optimize_condition,
+)
 
 # Commonly used expressions
 from_distributions = QueryEntity(
@@ -259,7 +262,9 @@ def test_simple_formula() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -304,7 +309,9 @@ def test_simple_formula_with_leading_literals() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -349,7 +356,9 @@ def test_groupby() -> None:
             ),
         ],
         groupby=[tag_column("transaction"), time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -424,7 +433,9 @@ def test_curried_aggregate() -> None:
             ),
         ],
         groupby=[tag_column("transaction"), time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -469,7 +480,9 @@ def test_bracketing_rules() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -533,7 +546,9 @@ def test_formula_filters() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -588,7 +603,9 @@ def test_formula_groupby() -> None:
             ),
         ],
         groupby=[tag_column("transaction"), time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,
@@ -630,7 +647,9 @@ def test_formula_scalar_value() -> None:
             ),
         ],
         groupby=[time_expression],
-        condition=formula_condition,
+        condition=binary_condition(
+            "and", expected_optimize_condition[query_body], formula_condition
+        ),
         order_by=[
             OrderBy(
                 direction=OrderByDirection.ASC,

--- a/tests/query/processors/test_filter_in_select_optimizer.py
+++ b/tests/query/processors/test_filter_in_select_optimizer.py
@@ -1,282 +1,166 @@
-import pytest
+from copy import copy
 
-from snuba.datasets.factory import get_dataset
-from snuba.query.dsl import and_cond, equals, in_cond, or_cond
-from snuba.query.expressions import (
-    Column,
-    FunctionCall,
-    Literal,
-    SubscriptableReference,
-)
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query import SelectedExpression
+from snuba.query.data_source.simple import Entity
+from snuba.query.dsl import and_cond, divide, equals, multiply, or_cond, plus
+from snuba.query.expressions import Column, CurriedFunctionCall, FunctionCall, Literal
 from snuba.query.logical import Query
-from snuba.query.mql.parser import parse_mql_query
 from snuba.query.processors.logical.filter_in_select_optimizer import (
     FilterInSelectOptimizer,
 )
 
-""" CONFIG STUFF THAT DOESNT MATTER MUCH """
 
-generic_metrics = get_dataset(
-    "generic_metrics",
+def _equals(col_name: str, value: str | int) -> FunctionCall:
+    return equals(Column(None, None, col_name), Literal(None, value))
+
+
+def _cond_agg(function_name: str, condition: FunctionCall) -> FunctionCall:
+    return FunctionCall(None, function_name, (Column(None, None, "value"), condition))
+
+
+optimizer = FilterInSelectOptimizer()
+from_entity = Entity(
+    EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+    get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
 )
-mql_context = {
-    "entity": "generic_metrics_distributions",
-    "start": "2023-11-23T18:30:00",
-    "end": "2023-11-23T22:30:00",
-    "rollup": {
-        "granularity": 60,
-        "interval": 60,
-        "with_totals": "False",
-        "orderby": None,
-    },
-    "scope": {
-        "org_ids": [1],
-        "project_ids": [11],
-        "use_case_id": "transactions",
-    },
-    "indexer_mappings": {
-        "d:transactions/duration@millisecond": 123456,
-        "status_code": 222222,
-        "transaction": 333333,
-    },
-    "limit": None,
-    "offset": None,
-}
-assert isinstance(
-    mql_context["indexer_mappings"], dict
-)  # oh mypy, my oh mypy, how you check types
-
-""" TEST CASES """
 
 
-def subscriptable_reference(name: str, key: str) -> SubscriptableReference:
-    """Helper function to build a SubscriptableReference"""
-    return SubscriptableReference(
-        f"_snuba_{name}[{key}]",
-        Column(f"_snuba_{name}", None, name),
-        Literal(None, key),
+def test_simple_query() -> None:
+    input_query = Query(
+        from_clause=from_entity,
+        selected_columns=[
+            SelectedExpression(
+                None,
+                divide(
+                    _cond_agg(
+                        "sumIf",
+                        and_cond(_equals("metric_id", 1), _equals("status_code", 200)),
+                    ),
+                    _cond_agg("sumIf", _equals("metric_id", 1)),
+                ),
+            )
+        ],
     )
-
-
-expected_optimize_condition = {
-    "sum(`d:transactions/duration@millisecond`){status_code:200} / sum(`d:transactions/duration@millisecond`)": or_cond(
-        equals(
-            Column("_snuba_metric_id", None, "metric_id"),
-            Literal(None, 123456),
-        ),
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-    ),
-    "sum(`d:transactions/duration@millisecond`){status_code:200} by transaction / sum(`d:transactions/duration@millisecond`) by transaction": or_cond(
-        equals(
-            Column("_snuba_metric_id", None, "metric_id"),
-            Literal(None, 123456),
-        ),
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-    ),
-    "quantiles(0.5)(`d:transactions/duration@millisecond`){status_code:200} by transaction / sum(`d:transactions/duration@millisecond`) by transaction": or_cond(
-        equals(
-            Column("_snuba_metric_id", None, "metric_id"),
-            Literal(None, 123456),
-        ),
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-    ),
-    "sum(`d:transactions/duration@millisecond`) / ((max(`d:transactions/duration@millisecond`) + avg(`d:transactions/duration@millisecond`)) * min(`d:transactions/duration@millisecond`))": or_cond(
-        equals(
-            Column("_snuba_metric_id", None, "metric_id"),
-            Literal(None, 123456),
-        ),
+    expected_optimized_query = copy(input_query)
+    expected_optimized_query.set_ast_condition(
         or_cond(
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
+            and_cond(_equals("metric_id", 1), _equals("status_code", 200)),
+            _equals("metric_id", 1),
+        )
+    )
+    optimizer.process_mql_query(input_query)
+    assert input_query == expected_optimized_query
+
+
+def test_query_with_curried_function() -> None:
+    input_query = Query(
+        from_clause=from_entity,
+        selected_columns=[
+            SelectedExpression(
+                None,
+                divide(
+                    CurriedFunctionCall(
+                        alias=None,
+                        internal_function=FunctionCall(
+                            None, "quantilesIf", (Literal(None, 0.5),)
+                        ),
+                        parameters=(
+                            Column(None, None, "value"),
+                            and_cond(
+                                _equals("metric_id", 1), _equals("status_code", 200)
+                            ),
+                        ),
+                    ),
+                    _cond_agg("sumIf", _equals("metric_id", 1)),
+                ),
+            )
+        ],
+    )
+    expected_optimized_query = copy(input_query)
+    expected_optimized_query.set_ast_condition(
+        or_cond(
+            and_cond(_equals("metric_id", 1), _equals("status_code", 200)),
+            _equals("metric_id", 1),
+        )
+    )
+    optimizer.process_mql_query(input_query)
+    assert input_query == expected_optimized_query
+
+
+def test_query_with_many_nested_functions() -> None:
+    input_query = Query(
+        from_clause=from_entity,
+        selected_columns=[
+            SelectedExpression(
+                None,
+                divide(
+                    _cond_agg("sumIf", _equals("metric_id", 1)),
+                    multiply(
+                        plus(
+                            _cond_agg("maxIf", _equals("metric_id", 1)),
+                            _cond_agg("avgIf", _equals("metric_id", 1)),
+                        ),
+                        _cond_agg("minIf", _equals("metric_id", 1)),
+                    ),
+                ),
+            )
+        ],
+    )
+    expected_optimized_query = copy(input_query)
+    expected_optimized_query.set_ast_condition(
+        or_cond(
             or_cond(
-                equals(
-                    Column("_snuba_metric_id", None, "metric_id"),
-                    Literal(None, 123456),
-                ),
-                equals(
-                    Column("_snuba_metric_id", None, "metric_id"),
-                    Literal(None, 123456),
-                ),
+                or_cond(_equals("metric_id", 1), _equals("metric_id", 1)),
+                _equals("metric_id", 1),
             ),
-        ),
-    ),
-    "(sum(`d:transactions/duration@millisecond`) / max(`d:transactions/duration@millisecond`)){status_code:200}": or_cond(
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-    ),
-    "(sum(`d:transactions/duration@millisecond`) / max(`d:transactions/duration@millisecond`)){status_code:[400,404,500,501]}": or_cond(
-        and_cond(
-            in_cond(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                FunctionCall(
-                    None,
-                    "tuple",
-                    (
-                        Literal(None, "400"),
-                        Literal(None, "404"),
-                        Literal(None, "500"),
-                        Literal(None, "501"),
-                    ),
-                ),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-        and_cond(
-            in_cond(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                FunctionCall(
-                    None,
-                    "tuple",
-                    (
-                        Literal(None, "400"),
-                        Literal(None, "404"),
-                        Literal(None, "500"),
-                        Literal(None, "501"),
-                    ),
-                ),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-    ),
-    "(sum(`d:transactions/duration@millisecond`) / max(`d:transactions/duration@millisecond`)){status_code:200} by transaction": or_cond(
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-    ),
-    "(sum(`d:transactions/duration@millisecond`) / sum(`d:transactions/duration@millisecond`)) + 100": or_cond(
-        equals(
-            Column("_snuba_metric_id", None, "metric_id"),
-            Literal(None, 123456),
-        ),
-        equals(
-            Column("_snuba_metric_id", None, "metric_id"),
-            Literal(None, 123456),
-        ),
-    ),
-    "sum(`d:transactions/duration@millisecond`) * 1000": equals(
-        Column("_snuba_metric_id", None, "metric_id"),
-        Literal(None, 123456),
-    ),
-    "1 + sum(`d:transactions/duration@millisecond`){status_code:200} / sum(`d:transactions/duration@millisecond`)": or_cond(
-        equals(
-            Column("_snuba_metric_id", None, "metric_id"),
-            Literal(None, 123456),
-        ),
-        and_cond(
-            equals(
-                subscriptable_reference(
-                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
-                ),
-                Literal(None, "200"),
-            ),
-            equals(
-                Column("_snuba_metric_id", None, "metric_id"),
-                Literal(None, 123456),
-            ),
-        ),
-    ),
-}
-
-""" TESTING """
+            _equals("metric_id", 1),
+        )
+    )
+    optimizer.process_mql_query(input_query)
+    assert input_query == expected_optimized_query
 
 
-@pytest.mark.parametrize(
-    "mql_query, expected_condition",
-    expected_optimize_condition.items(),
-)
-def test_condition_generation(mql_query: str, expected_condition: FunctionCall) -> None:
-    logical_query, _ = parse_mql_query(str(mql_query), mql_context, generic_metrics)
-    assert isinstance(logical_query, Query)
+def test_query_with_literal_arithmetic_in_select() -> None:
+    input_query = Query(
+        from_clause=from_entity,
+        selected_columns=[
+            SelectedExpression(
+                None,
+                plus(_cond_agg("sumIf", _equals("metric_id", 1)), Literal(None, 100.0)),
+            )
+        ],
+    )
+    expected_optimized_query = copy(input_query)
+    expected_optimized_query.set_ast_condition(_equals("metric_id", 1))
+    optimizer.process_mql_query(input_query)
+    assert input_query == expected_optimized_query
 
-    opt = FilterInSelectOptimizer()
-    actual = opt.get_select_filter(logical_query)
 
-    assert actual == expected_condition
+def test_query_with_multiple_aggregate_columns() -> None:
+    input_query = Query(
+        from_clause=from_entity,
+        selected_columns=[
+            SelectedExpression(
+                None,
+                plus(_cond_agg("sumIf", _equals("metric_id", 1)), Literal(None, 100.0)),
+            ),
+            SelectedExpression(
+                None,
+                multiply(
+                    _cond_agg("maxIf", _equals("metric_id", 2)),
+                    _cond_agg("avgIf", _equals("metric_id", 2)),
+                ),
+            ),
+        ],
+    )
+    expected_optimized_query = copy(input_query)
+    expected_optimized_query.set_ast_condition(
+        or_cond(
+            or_cond(_equals("metric_id", 1), _equals("metric_id", 2)),
+            _equals("metric_id", 2),
+        )
+    )
+    optimizer.process_mql_query(input_query)
+    assert input_query == expected_optimized_query

--- a/tests/query/processors/test_filter_in_select_optimizer.py
+++ b/tests/query/processors/test_filter_in_select_optimizer.py
@@ -1,7 +1,14 @@
 import pytest
 
 from snuba.datasets.factory import get_dataset
-from snuba.query.expressions import Column, Literal, SubscriptableReference
+from snuba.query.conditions import binary_condition
+from snuba.query.expressions import (
+    Column,
+    Expression,
+    FunctionCall,
+    Literal,
+    SubscriptableReference,
+)
 from snuba.query.logical import Query
 from snuba.query.mql.parser import parse_mql_query
 from snuba.query.processors.logical.filter_in_select_optimizer import (
@@ -38,6 +45,9 @@ mql_context = {
     "limit": None,
     "offset": None,
 }
+assert isinstance(
+    mql_context["indexer_mappings"], dict
+)  # oh mypy, my oh mypy, how you check types
 
 """ TEST CASES """
 
@@ -147,6 +157,239 @@ mql_test_cases: list[tuple[str, dict]] = [
     ),
 ]
 
+
+def equals(lhs: Expression, rhs: Expression) -> FunctionCall:
+    return binary_condition("equals", lhs, rhs)
+
+
+def _and(lhs: FunctionCall, rhs: FunctionCall) -> FunctionCall:
+    return binary_condition("and", lhs, rhs)
+
+
+def _or(lhs: FunctionCall, rhs: FunctionCall) -> FunctionCall:
+    return binary_condition("or", lhs, rhs)
+
+
+def _in(lhs: Expression, rhs: Expression) -> FunctionCall:
+    return binary_condition("in", lhs, rhs)
+
+
+new_mql_test_cases: list[tuple[str, FunctionCall]] = [
+    (
+        "sum(`d:transactions/duration@millisecond`){status_code:200} / sum(`d:transactions/duration@second`)",
+        _or(
+            equals(
+                Column("_snuba_metric_id", None, "metric_id"),
+                Literal(None, 123456),
+            ),
+            _and(
+                equals(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    Literal(None, "200"),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+        ),
+    ),
+    (
+        "sum(`d:transactions/duration@millisecond`){status_code:200} by transaction / sum(`d:transactions/duration@millisecond`) by transaction",
+        _or(
+            equals(
+                Column("_snuba_metric_id", None, "metric_id"),
+                Literal(None, 123456),
+            ),
+            _and(
+                equals(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    Literal(None, "200"),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+        ),
+    ),
+    (
+        "quantiles(0.5)(`d:transactions/duration@millisecond`){status_code:200} by transaction / sum(`d:transactions/duration@millisecond`) by transaction",
+        _or(
+            equals(
+                Column("_snuba_metric_id", None, "metric_id"),
+                Literal(None, 123456),
+            ),
+            _and(
+                equals(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    Literal(None, "200"),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+        ),
+    ),
+    (
+        "sum(`d:transactions/duration@millisecond`) / ((max(`d:transactions/duration@millisecond`) + avg(`d:transactions/duration@millisecond`)) * min(`d:transactions/duration@millisecond`))",
+        _or(
+            equals(
+                Column("_snuba_metric_id", None, "metric_id"),
+                Literal(None, 123456),
+            ),
+            _or(
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+                _or(
+                    equals(
+                        Column("_snuba_metric_id", None, "metric_id"),
+                        Literal(None, 123456),
+                    ),
+                    equals(
+                        Column("_snuba_metric_id", None, "metric_id"),
+                        Literal(None, 123456),
+                    ),
+                ),
+            ),
+        ),
+    ),
+    (
+        "(sum(`d:transactions/duration@millisecond`) / max(`d:transactions/duration@millisecond`)){status_code:200}",
+        _or(
+            _and(
+                equals(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    Literal(None, "200"),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+            _and(
+                equals(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    Literal(None, "200"),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+        ),
+    ),
+    (
+        "(sum(`d:transactions/duration@millisecond`) / max(`d:transactions/duration@millisecond`)){status_code:[400,404,500,501]}",
+        _or(
+            _and(
+                _in(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    FunctionCall(
+                        None,
+                        "array",
+                        (
+                            Literal(None, "400"),
+                            Literal(None, "404"),
+                            Literal(None, "500"),
+                            Literal(None, "501"),
+                        ),
+                    ),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+            _and(
+                _in(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    FunctionCall(
+                        None,
+                        "array",
+                        (
+                            Literal(None, "400"),
+                            Literal(None, "404"),
+                            Literal(None, "500"),
+                            Literal(None, "501"),
+                        ),
+                    ),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+        ),
+    ),
+    (
+        "(sum(`d:transactions/duration@millisecond`) / max(`d:transactions/duration@millisecond`)){status_code:200} by transaction",
+        _or(
+            _and(
+                equals(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    Literal(None, "200"),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+            _and(
+                equals(
+                    subscriptable_reference(
+                        "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                    ),
+                    Literal(None, "200"),
+                ),
+                equals(
+                    Column("_snuba_metric_id", None, "metric_id"),
+                    Literal(None, 123456),
+                ),
+            ),
+        ),
+    ),
+    (
+        "(sum(`d:transactions/duration@millisecond`) / sum(`d:transactions/duration@millisecond`)) + 100",
+        _or(
+            equals(
+                Column("_snuba_metric_id", None, "metric_id"),
+                Literal(None, 123456),
+            ),
+            equals(
+                Column("_snuba_metric_id", None, "metric_id"),
+                Literal(None, 123456),
+            ),
+        ),
+    ),
+    (
+        "sum(`d:transactions/duration@millisecond`) * 1000",
+        equals(
+            Column("_snuba_metric_id", None, "metric_id"),
+            Literal(None, 123456),
+        ),
+    ),
+]
+
 """ TESTING """
 
 optimizer = FilterInSelectOptimizer()
@@ -183,3 +426,17 @@ def test_searcher(mql_query: str, expected_domain: set[int]) -> None:
         selected_expression.expression.accept(v)
         newres = len(v.get_matches()) > 0
         assert newres == oldres
+
+
+@pytest.mark.parametrize(
+    "mql_query, expected_condition",
+    new_mql_test_cases,
+)
+def test_new_pipeline(mql_query: str, expected_condition: FunctionCall) -> None:
+    logical_query, _ = parse_mql_query(str(mql_query), mql_context, generic_metrics)
+    assert isinstance(logical_query, Query)
+
+    opt = FilterInSelectOptimizer()
+    actual = opt.get_select_filter(logical_query)
+    if actual != expected_condition:
+        assert actual != expected_condition

--- a/tests/query/processors/test_filter_in_select_optimizer.py
+++ b/tests/query/processors/test_filter_in_select_optimizer.py
@@ -10,6 +10,7 @@ from snuba.query.logical import Query
 from snuba.query.processors.logical.filter_in_select_optimizer import (
     FilterInSelectOptimizer,
 )
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def _equals(col_name: str, value: str | int) -> FunctionCall:
@@ -25,6 +26,7 @@ from_entity = Entity(
     EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
     get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
 )
+settings = HTTPQuerySettings()
 
 
 def test_simple_query() -> None:
@@ -50,7 +52,7 @@ def test_simple_query() -> None:
             _equals("metric_id", 1),
         )
     )
-    optimizer.process_mql_query(input_query)
+    optimizer.process_query(input_query, settings)
     assert input_query == expected_optimized_query
 
 
@@ -85,7 +87,7 @@ def test_query_with_curried_function() -> None:
             _equals("metric_id", 1),
         )
     )
-    optimizer.process_mql_query(input_query)
+    optimizer.process_query(input_query, settings)
     assert input_query == expected_optimized_query
 
 
@@ -118,7 +120,7 @@ def test_query_with_many_nested_functions() -> None:
             _equals("metric_id", 1),
         )
     )
-    optimizer.process_mql_query(input_query)
+    optimizer.process_query(input_query, settings)
     assert input_query == expected_optimized_query
 
 
@@ -134,7 +136,7 @@ def test_query_with_literal_arithmetic_in_select() -> None:
     )
     expected_optimized_query = copy(input_query)
     expected_optimized_query.set_ast_condition(_equals("metric_id", 1))
-    optimizer.process_mql_query(input_query)
+    optimizer.process_query(input_query, settings)
     assert input_query == expected_optimized_query
 
 
@@ -162,5 +164,5 @@ def test_query_with_multiple_aggregate_columns() -> None:
             _equals("metric_id", 2),
         )
     )
-    optimizer.process_mql_query(input_query)
+    optimizer.process_query(input_query, settings)
     assert input_query == expected_optimized_query

--- a/tests/query/processors/test_filter_in_select_optimizer.py
+++ b/tests/query/processors/test_filter_in_select_optimizer.py
@@ -262,6 +262,24 @@ expected_optimize_condition = {
         Column("_snuba_metric_id", None, "metric_id"),
         Literal(None, 123456),
     ),
+    "1 + sum(`d:transactions/duration@millisecond`){status_code:200} / sum(`d:transactions/duration@millisecond`)": _or(
+        equals(
+            Column("_snuba_metric_id", None, "metric_id"),
+            Literal(None, 123456),
+        ),
+        _and(
+            equals(
+                subscriptable_reference(
+                    "tags_raw", str(mql_context["indexer_mappings"]["status_code"])
+                ),
+                Literal(None, "200"),
+            ),
+            equals(
+                Column("_snuba_metric_id", None, "metric_id"),
+                Literal(None, 123456),
+            ),
+        ),
+    ),
 }
 
 """ TESTING """

--- a/tests/test_metrics_sdk_api.py
+++ b/tests/test_metrics_sdk_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Tuple, Union, cast
 
@@ -359,9 +358,7 @@ class TestGenericMetricsSdkApiCounters(BaseApiTest):
 
         assert response.status_code == 200, data
         rows = data["data"]
-        assert len(rows) >= 180, rows
-
-        assert math.isnan(rows[0]["aggregate_value"])  # division by zero
+        assert len(rows) == 0
 
 
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2669
This PR should get all of riccardos broken tests passing. 

What motivated the rewrite?
* I needed to implement new functionality to get riccardos tests passing
* It was gunna be a lot of work to do
* After talking to enoch we thought of an alternative approach, this turned out to a better solution that would be faster to implement

## Major Changes:
* pretty much full optimizer rewrite
* optimizer feature flag on by default
* fixed breaking integration tests

### heres how it works now:
1. use a visitor to get all the conditional aggregates (ex. sumMergeIf) in the ast
2. `or` all the conditions in these functions, and add this to the where clause.

ex:
```
SELECT sumIf(val, metric_id in [1,2,3] and status=200),
       avgIf(val, metric_id=7), 
       maxIf(val, metric_id=5 and status=400)
WHERE org_id=1
...
```
will generate the following
```
(metric_id in [1,2,3] and status=200) or (metric_id=7) or (metric_id=5 and status=400)
```
and add it to the where clause
```
SELECT sumIf(val, metric_id in [1,2,3] and status=200),
       avgIf(val, metric_id=7), 
       maxIf(val, metric_id=5 and status=400)
WHERE org_id=1 and (
        (metric_id in [1,2,3] and status=200) or (metric_id=7) or (metric_id=5 and status=400)
    )
...
```

