### PR TITLE
feat(meta): Add record_meta field to counters consumer

### DIFF
--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -213,7 +213,7 @@ impl Parse for CountersRawRow {
         let retention_days = enforce_retention(Some(from.retention_days), &config.env_config);
 
         let mut record_meta: Option<u8> = Some(1);
-        let blacklisted_use_case_ids = vec!["escalating_issues", "metric_stats"];
+        let blacklisted_use_case_ids = ["escalating_issues", "metric_stats"];
         if blacklisted_use_case_ids
             .iter()
             .any(|&u| u == from.use_case_id)

--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -212,14 +212,11 @@ impl Parse for CountersRawRow {
         }
         let retention_days = enforce_retention(Some(from.retention_days), &config.env_config);
 
-        let mut record_meta: Option<u8> = Some(1);
-        let blacklisted_use_case_ids = ["escalating_issues", "metric_stats"];
-        if blacklisted_use_case_ids
-            .iter()
-            .any(|&u| u == from.use_case_id)
-        {
-            record_meta = Some(0);
-        }
+        let record_meta = match from.use_case_id.as_str() {
+            "escalating_issues" => Some(0),
+            "metric_stats" => Some(0),
+            _ => Some(1),
+        };
 
         let common_fields = CommonMetricFields {
             use_case_id: from.use_case_id,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericCountersMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics1.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericCountersMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics1.json.snap
@@ -17,6 +17,7 @@ expression: snapshot_payload
     "min_retention_days": 90,
     "org_id": 1,
     "project_id": 3,
+    "record_meta": 1,
     "retention_days": 90,
     "tags.indexed_value": [
       0,


### PR DESCRIPTION
This field will be used by the materialized view to determine whether the row
should be processed into the meta table.

Depends on https://github.com/getsentry/snuba/pull/5681