### PR TITLE
ref: Initial refactor to facilitate streaming writes to clickhouse

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2123,7 +2123,6 @@ dependencies = [
  "criterion",
  "ctrlc",
  "futures",
- "futures-channel",
  "hyper 1.2.0",
  "insta",
  "json-schema-diff",
@@ -2145,6 +2144,7 @@ dependencies = [
  "thiserror",
  "tikv-jemallocator",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2816,6 +2816,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap",
  "slab",
  "tokio",
@@ -897,14 +897,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -936,8 +957,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -950,13 +971,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2031,9 +2064,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2090,6 +2123,8 @@ dependencies = [
  "criterion",
  "ctrlc",
  "futures",
+ "futures-channel",
+ "hyper 1.2.0",
  "insta",
  "json-schema-diff",
  "md5",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -48,6 +48,8 @@ adler = "1.0.2"
 schemars = { version = "0.8.16", features = ["uuid1"] }
 json-schema-diff = "0.1.7"
 serde_path_to_error = "0.1.15"
+futures-channel = "0.3.30"
+hyper = "1.2.0"
 
 
 [patch.crates-io]

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -48,8 +48,8 @@ adler = "1.0.2"
 schemars = { version = "0.8.16", features = ["uuid1"] }
 json-schema-diff = "0.1.7"
 serde_path_to_error = "0.1.15"
-futures-channel = "0.3.30"
 hyper = "1.2.0"
+tokio-stream = "0.1.15"
 
 
 [patch.crates-io]

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -105,14 +105,13 @@ impl Batch {
         if !self.current_chunk.is_empty() {
             // XXX: allocating small chunks of memory here and sending it across thread boundaries is
             // not very memory efficient, especially with jemalloc
-            let chunk = mem::replace(&mut self.current_chunk, Vec::new());
+            let chunk = mem::take(&mut self.current_chunk);
             self.sender.as_ref().unwrap().send(Ok(chunk))?;
         }
 
         Ok(())
     }
 
-    #[must_use]
     pub async fn finish(mut self) -> Result<(), anyhow::Error> {
         self.flush_chunk()?;
         // finish stream

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -1,0 +1,132 @@
+use futures_channel::mpsc::{unbounded, UnboundedSender};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, CONNECTION};
+use reqwest::{Client, ClientBuilder};
+use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
+use std::mem;
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+
+const CLICKHOUSE_HTTP_CHUNK_SIZE: usize = 1_000_000;
+
+pub struct BatchFactory {
+    client: Client,
+    url: String,
+    query: String,
+    handle: Handle,
+}
+
+impl BatchFactory {
+    pub fn new(
+        hostname: &str,
+        http_port: u16,
+        table: &str,
+        database: &str,
+        concurrency: &ConcurrencyConfig,
+    ) -> Self {
+        let mut headers = HeaderMap::with_capacity(3);
+        headers.insert(CONNECTION, HeaderValue::from_static("keep-alive"));
+        headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip,deflate"));
+        headers.insert(
+            "X-ClickHouse-Database",
+            HeaderValue::from_str(database).unwrap(),
+        );
+
+        let query_params = "load_balancing=in_order&insert_distributed_sync=1".to_string();
+        let url = format!("http://{hostname}:{http_port}?{query_params}");
+        let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
+
+        let client = ClientBuilder::new()
+            .default_headers(headers)
+            .build()
+            .unwrap();
+
+        BatchFactory {
+            client,
+            url,
+            query,
+            handle: concurrency.handle(),
+        }
+    }
+
+    pub fn new_batch(&self) -> Batch {
+        // this channel is effectively bounded due to max-batch-size and max-batch-time. it is hard
+        // however to enforce any limit locally because it would mean that in the Drop impl of
+        // Batch, the send may block or fail
+        let (sender, receiver) = unbounded();
+
+        let url = self.url.clone();
+        let query = self.query.clone();
+        let client = self.client.clone();
+
+        let result_handle = self.handle.spawn(async move {
+            let res = client
+                .post(&url)
+                .query(&[("query", &query)])
+                .body(reqwest::Body::wrap_stream(receiver))
+                .send()
+                .await?;
+
+            if res.status() != reqwest::StatusCode::OK {
+                anyhow::bail!("error writing to clickhouse: {}", res.text().await?);
+            }
+
+            Ok(())
+        });
+
+        Batch {
+            current_chunk: Vec::new(),
+            sender: Some(sender),
+            result_handle: Some(result_handle),
+        }
+    }
+}
+
+pub struct Batch {
+    current_chunk: Vec<u8>,
+    sender: Option<UnboundedSender<Result<Vec<u8>, anyhow::Error>>>,
+    result_handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
+}
+
+impl Batch {
+    pub fn write_rows(&mut self, rows: &[u8]) -> anyhow::Result<()> {
+        if self.current_chunk.len() > CLICKHOUSE_HTTP_CHUNK_SIZE {
+            self.flush_chunk()?;
+        }
+
+        self.current_chunk.extend(rows);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush_chunk(&mut self) -> anyhow::Result<()> {
+        if !self.current_chunk.is_empty() {
+            // XXX: allocating small chunks of memory here and sending it across thread boundaries is
+            // not very memory efficient, especially with jemalloc
+            let chunk = mem::replace(&mut self.current_chunk, Vec::new());
+            self.sender.as_ref().unwrap().unbounded_send(Ok(chunk))?;
+        }
+
+        Ok(())
+    }
+
+    #[must_use]
+    pub async fn finish(mut self) -> Result<(), anyhow::Error> {
+        self.flush_chunk()?;
+        // finish stream
+        drop(self.sender.take());
+        self.result_handle.take().unwrap().await??;
+        Ok(())
+    }
+}
+
+impl Drop for Batch {
+    fn drop(&mut self) {
+        // in case the batch was not explicitly finished, send an error into the channel to abort
+        // the request
+        if let Some(ref mut sender) = self.sender {
+            let _ = sender.unbounded_send(Err(anyhow::anyhow!(
+                "the batch got dropped without being finished explicitly"
+            )));
+        }
+    }
+}

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -138,33 +138,3 @@ impl ProcessingStrategy<BytesInsertBatch> for ClickhouseWriterStep {
         self.inner.join(timeout)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[tokio::test]
-    async fn it_works() -> Result<(), reqwest::Error> {
-        let client: ClickhouseClient = ClickhouseClient::new(
-            &std::env::var("CLICKHOUSE_HOST").unwrap_or("127.0.0.1".to_string()),
-            8123,
-            "querylog_local",
-            "default",
-        );
-
-        assert!(client.url.contains("load_balancing"));
-        assert!(client.url.contains("insert_distributed_sync"));
-        println!("running test");
-        let res = client.send(b"[]").await;
-        println!("Response status {}", res.unwrap().status());
-        Ok(())
-    }
-
-    #[test]
-    fn chunked_body() {
-        let mut data: Vec<u8> = vec![0; 1_000_000];
-
-        assert_eq!(ClickhouseClient::chunked_body(&data).len(), 1);
-        data.push(0);
-        assert_eq!(ClickhouseClient::chunked_body(&data).len(), 2);
-    }
-}

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, CONNECTION};
-use reqwest::{Client, Response};
 use rust_arroyo::processing::strategies::run_task_in_threads::{
     ConcurrencyConfig, RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
@@ -13,19 +11,20 @@ use rust_arroyo::types::Message;
 use rust_arroyo::{counter, timer};
 
 use crate::config::ClickhouseConfig;
+use crate::strategies::clickhouse::batch::BatchFactory;
 use crate::types::BytesInsertBatch;
 
-const CLICKHOUSE_HTTP_CHUNK_SIZE: usize = 1_000_000;
+mod batch;
 
 struct ClickhouseWriter {
-    client: Arc<ClickhouseClient>,
+    batch_factory: Arc<BatchFactory>,
     skip_write: bool,
 }
 
 impl ClickhouseWriter {
-    pub fn new(client: ClickhouseClient, skip_write: bool) -> Self {
+    pub fn new(batch_factory: BatchFactory, skip_write: bool) -> Self {
         ClickhouseWriter {
-            client: Arc::new(client),
+            batch_factory: Arc::new(batch_factory),
             skip_write,
         }
     }
@@ -37,7 +36,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for Clickhous
         message: Message<BytesInsertBatch>,
     ) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
         let skip_write = self.skip_write;
-        let client = self.client.clone();
+        let mut batch = self.batch_factory.new_batch();
 
         Box::pin(async move {
             let insert_batch = message.payload();
@@ -58,10 +57,11 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for Clickhous
             } else {
                 tracing::debug!("performing write");
 
-                let response = client
-                    .send(insert_batch.encoded_rows())
-                    .await
+                batch
+                    .write_rows(&encoded_rows)
                     .map_err(RunTaskError::Other)?;
+
+                let response = batch.finish().await.map_err(RunTaskError::Other)?;
 
                 tracing::debug!(?response);
                 tracing::info!("Inserted {} rows", insert_batch.len());
@@ -73,10 +73,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for Clickhous
                 timer!("insertions.batch_write_ms", elapsed);
             }
             counter!("insertions.batch_write_msgs", insert_batch.len() as i64);
-            counter!(
-                "insertions.batch_write_bytes",
-                insert_batch.encoded_rows().len() as i64
-            );
+            counter!("insertions.batch_write_bytes", encoded_rows.len() as i64);
             insert_batch.record_message_latency();
 
             Ok(message)
@@ -106,7 +103,7 @@ impl ClickhouseWriterStep {
         let inner = RunTaskInThreads::new(
             next_step,
             Box::new(ClickhouseWriter::new(
-                ClickhouseClient::new(&hostname, http_port, &table, &database),
+                BatchFactory::new(&hostname, http_port, &table, &database, concurrency),
                 skip_write,
             )),
             concurrency,
@@ -139,63 +136,6 @@ impl ProcessingStrategy<BytesInsertBatch> for ClickhouseWriterStep {
 
     fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         self.inner.join(timeout)
-    }
-}
-
-#[derive(Clone)]
-pub struct ClickhouseClient {
-    client: Client,
-    headers: HeaderMap<HeaderValue>,
-    url: String,
-    query: String,
-}
-
-impl ClickhouseClient {
-    pub fn new(hostname: &str, http_port: u16, table: &str, database: &str) -> ClickhouseClient {
-        let mut headers = HeaderMap::with_capacity(3);
-        headers.insert(CONNECTION, HeaderValue::from_static("keep-alive"));
-        headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip,deflate"));
-        headers.insert(
-            "X-ClickHouse-Database",
-            HeaderValue::from_str(database).unwrap(),
-        );
-
-        let query_params = "load_balancing=in_order&insert_distributed_sync=1".to_string();
-        let url = format!("http://{hostname}:{http_port}?{query_params}");
-        let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
-
-        ClickhouseClient {
-            client: Client::new(),
-            headers,
-            url,
-            query,
-        }
-    }
-
-    fn chunked_body(rows: &[u8]) -> Vec<Result<Box<[u8]>, std::io::Error>> {
-        rows.chunks(CLICKHOUSE_HTTP_CHUNK_SIZE)
-            .map(|chunk| Ok(Box::from(chunk)))
-            .collect()
-    }
-
-    pub async fn send(&self, body: &[u8]) -> anyhow::Result<Response> {
-        let chunks = Self::chunked_body(body);
-        let stream = futures::stream::iter(chunks);
-
-        let res = self
-            .client
-            .post(&self.url)
-            .headers(self.headers.clone())
-            .query(&[("query", &self.query)])
-            .body(reqwest::Body::wrap_stream(stream))
-            .send()
-            .await?;
-
-        if res.status() != reqwest::StatusCode::OK {
-            anyhow::bail!("error writing to clickhouse: {}", res.text().await?);
-        }
-
-        Ok(res)
     }
 }
 

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -58,12 +58,11 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for Clickhous
                 tracing::debug!("performing write");
 
                 batch
-                    .write_rows(&encoded_rows)
+                    .write_rows(encoded_rows)
                     .map_err(RunTaskError::Other)?;
 
-                let response = batch.finish().await.map_err(RunTaskError::Other)?;
+                batch.finish().await.map_err(RunTaskError::Other)?;
 
-                tracing::debug!(?response);
                 tracing::info!("Inserted {} rows", insert_batch.len());
             }
 

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -14,7 +14,7 @@ use crate::config::ClickhouseConfig;
 use crate::strategies::clickhouse::batch::BatchFactory;
 use crate::types::BytesInsertBatch;
 
-mod batch;
+pub mod batch;
 
 struct ClickhouseWriter {
     batch_factory: Arc<BatchFactory>,


### PR DESCRIPTION
We want to eventually stop buffering writes to clickhouse, and instead hold one long-running connection for the lifetime of a batch, streaming rows slowly in. This is already how Python works.

This initial refactor creates a new Batch type that holds onto the clickhouse client internally.