### PR TITLE
ref(ddm): Add debug queries to cardinality analyzer

### DIFF
--- a/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
+++ b/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
@@ -8,6 +8,7 @@ from snuba.utils.registered_class import RegisteredClass
 # Start index is 9223372036854775808
 METRICS_START_INDEX = 1 << 63
 
+
 # TODO: These enum definitions do not work right now. Most likely because
 # f-string formatting does not work as intended when defining the sql. We hardcode
 # the values in the queries for now.
@@ -64,4 +65,98 @@ class SpanGroupingCardinalitySamples(CardinalityQuery):
     AND (metric_id = 9223372036854776214)
     ORDER BY span.description
     LIMIT 1000
+    """
+
+
+class BucketsByOrgProject(CardinalityQuery):
+    """
+    For a given org/project, find out how many buckets are generated for each granularity.
+    The query asks for which metric type (counters/sets/distributions), the hour window to look back, and the org/project ID.
+
+    Note that gauges uses a different timestamp (rounded_timestamp).
+
+    This also has a totals row at the end.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, count()
+    FROM generic_metric_{{metric_type}}_aggregated_dist
+    WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class BucketsByOrgProjectGauges(CardinalityQuery):
+    """
+    For a given org/project, find out how many buckets are generated for each granularity.
+    This query is for gauges specifically, since it uses timestamps differently.
+    The query asks for the hour window to look back, and the org/project ID.
+
+    This also has a totals row at the end.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, count()
+    FROM generic_metric_gauges_aggregated_dist
+    WHERE rounded_timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class DatapointsByOrgProjectDistributions(CardinalityQuery):
+    """
+    For a given org/project, find out how many datapoints exist for each granularity.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, countMerge(count)
+    FROM generic_metric_distributions_aggregated_dist
+    WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class DatapointsByOrgProjectCounters(CardinalityQuery):
+    """
+    For a given org/project, find out how many datapoints exist for each granularity.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, sumMerge(value)
+    FROM generic_metric_counters_aggregated_dist
+    WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class DatapointsByOrgProjectGauges(CardinalityQuery):
+    """
+    For a given org/project, find out how many datapoints exist for each granularity.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, sumMerge(count)
+    FROM generic_metric_gauges_aggregated_dist
+    WHERE rounded_timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
     """

--- a/snuba/admin/static/table.tsx
+++ b/snuba/admin/static/table.tsx
@@ -3,21 +3,23 @@ import React, { ReactNode, CSSProperties } from "react";
 import { COLORS } from "SnubaAdmin/theme";
 
 type CustomTableStyles = {
-  tableStyle?: CSSProperties,
-  headerStyle?: CSSProperties,
-  thStyle?: CSSProperties,
-  tdStyle?: CSSProperties
-}
+  tableStyle?: CSSProperties;
+  headerStyle?: CSSProperties;
+  thStyle?: CSSProperties;
+  tdStyle?: CSSProperties;
+};
 
 const EMPTY_CUSTOM_STYLES = {
   tableStyle: {},
   headerStyle: {},
   thStyle: {},
   tdStyle: {},
-}
+};
 
-function createCustomTableStyles(styles: Partial<CustomTableStyles> = EMPTY_CUSTOM_STYLES): CustomTableStyles {
-  return {...EMPTY_CUSTOM_STYLES, ...styles};
+function createCustomTableStyles(
+  styles: Partial<CustomTableStyles> = EMPTY_CUSTOM_STYLES
+): CustomTableStyles {
+  return { ...EMPTY_CUSTOM_STYLES, ...styles };
 }
 
 type TableProps = {
@@ -33,10 +35,12 @@ function Table(props: TableProps) {
   const autoColumnWidths = Array(headerData.length).fill(1);
   const notEmptyColumnWidths = columnWidths ?? autoColumnWidths;
   const sumColumnWidths = notEmptyColumnWidths.reduce((acc, i) => acc + i, 0);
-  const customStyles = props.customStyles ? props.customStyles : EMPTY_CUSTOM_STYLES;
+  const customStyles = props.customStyles
+    ? props.customStyles
+    : EMPTY_CUSTOM_STYLES;
   const thisTableStyle = {
-      ...tableStyle,
-      ...customStyles.tableStyle,
+    ...tableStyle,
+    ...customStyles.tableStyle,
   };
   const thisHeaderStyle = {
     ...headerStyle,
@@ -45,12 +49,11 @@ function Table(props: TableProps) {
   const thisThStyle = {
     ...thStyle,
     ...customStyles.thStyle,
-  }
+  };
   const thisTdStyle = {
     ...tdStyle,
     ...customStyles.tdStyle,
-  }
-
+  };
 
   return (
     <table style={thisTableStyle}>
@@ -115,6 +118,7 @@ const tdStyle = {
   padding: 10,
   position: "relative" as const,
   wordBreak: "break-all" as const,
+  "font-family": "monospace" as const,
 };
 
 function EditableTableCell(props: {
@@ -143,4 +147,4 @@ const textAreaStyle = {
   width: "calc(100% - 24px)",
 };
 
-export { Table, EditableTableCell, createCustomTableStyles};
+export { Table, EditableTableCell, createCustomTableStyles };


### PR DESCRIPTION
For the DDM launch, we want a way to analyze the size of the incoming data. Add
two queries to the predefined queries that can give that information (and
provide a useful starting point for more in depth analysis).

Also change the font of table results to be monospace, so it's easier to
compare numbers directly.
