### PR TITLE
ref(ch-upgrades): increase window_hours

### DIFF
--- a/snuba/cli/query_fetcher.py
+++ b/snuba/cli/query_fetcher.py
@@ -170,7 +170,7 @@ def query_fetcher(
                 file_saver.save(file_format, queries)
                 files_saved += 1
             else:
-                logger.info(f"No queries for {table}")
+                logger.info(f"No queries for {table} between {start_time} - {end_time}")
             start_time = end_time
 
         logger.info(f"{files_saved} files save for {table}")

--- a/snuba/clickhouse/upgrades/comparisons.py
+++ b/snuba/clickhouse/upgrades/comparisons.py
@@ -137,7 +137,7 @@ class FileManager:
             for row in results:
                 writer.writerow(dataclasses.astuple(row))
 
-        logger.info(f"File {self._full_path(filename)} saved")
+        logger.debug(f"File {self._full_path(filename)} saved")
 
     def _download_from_csv(self, filename: str) -> Sequence[Results]:
         result_type = self._result_type(filename)


### PR DESCRIPTION
we increased the `query_log_ttl` for S4S querylog in https://github.com/getsentry/ops/pull/9562 so I'm increasing the limit for the fetcher to be one week

I also changed the logging a bit cause it will be kind of too much if you are doing multiple tables each for a week - plus I don't think we needed that much logging anyway (can always add back in later)