### PR TITLE
ref: Move to streaming writes in Rust consumer

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -2094,8 +2094,8 @@ dependencies = [
 
 [[package]]
 name = "rust_arroyo"
-version = "2.16.4"
-source = "git+https://github.com/getsentry/arroyo#17dc8fe1af1b320ac483e0ed6110058fb92a98eb"
+version = "2.17.0"
+source = "git+https://github.com/getsentry/arroyo#4a2015c5702855c9484d250deccd50f50059cdd9"
 dependencies = [
  "chrono",
  "coarsetime",

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -119,6 +119,242 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite 2.3.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.2.0",
+ "async-executor",
+ "async-io 2.3.2",
+ "async-lock 3.3.0",
+ "blocking",
+ "futures-lite 2.3.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+dependencies = [
+ "async-lock 3.3.0",
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "parking",
+ "polling 3.5.0",
+ "rustix 0.38.31",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb901c30ebc2fc4ab46395bbfbdba9542c16559d853645d75190c3056caf3bc"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.31",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+dependencies = [
+ "async-io 2.3.2",
+ "async-lock 2.8.0",
+ "atomic-waker",
+ "cfg-if 1.0.0",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.31",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
+name = "async-trait"
+version = "0.1.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +381,17 @@ name = "base64"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
 
 [[package]]
 name = "bincode"
@@ -189,6 +436,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel 2.2.0",
+ "async-lock 3.3.0",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "piper",
+ "tracing",
 ]
 
 [[package]]
@@ -355,6 +618,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +684,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -433,7 +705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -469,6 +741,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -542,6 +820,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +851,15 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "ena"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -598,6 +906,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.2.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +972,15 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -736,6 +1112,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +1219,18 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -941,6 +1357,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.28",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,7 +1407,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1061,12 +1505,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "integer-sqrt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1110,7 +1574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -1128,6 +1592,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1201,16 +1674,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.8.2",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.3",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "libz-sys"
@@ -1229,6 +1759,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1251,6 +1787,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "match_cfg"
@@ -1379,6 +1918,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1607,6 +2152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +2247,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +2282,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1742,6 +2329,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.31",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +2369,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -1999,6 +2622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom 0.2.11",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,6 +2757,7 @@ dependencies = [
  "criterion",
  "ctrlc",
  "futures",
+ "httpmock",
  "hyper 1.2.0",
  "insta",
  "json-schema-diff",
@@ -2173,16 +2808,36 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.12",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -2473,6 +3128,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_tokenstream"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +3219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,6 +3238,16 @@ name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "socket2"
@@ -2596,6 +3277,19 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "thread_local",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
 ]
 
 [[package]]
@@ -2660,10 +3354,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand",
+ "fastrand 2.0.1",
  "redox_syscall",
- "rustix",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2755,6 +3460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,7 +3507,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -3034,6 +3748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,6 +3813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-bag"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,6 +3829,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -57,6 +57,7 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
 
 [dev-dependencies]
 criterion = "0.5.1"
+httpmock = "0.7.0"
 insta = { version = "1.34.0", features = ["json", "redactions"] }
 once_cell = "1.18.0"
 procspawn = { version = "1.0.0", features = ["test-support", "json"] }

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -148,7 +148,6 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
         // Write to clickhouse
         let next_step = Box::new(ClickhouseWriterStep::new(
             next_step,
-            self.skip_write,
             &self.clickhouse_concurrency,
         ));
 
@@ -159,6 +158,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.storage_config.clickhouse_table_name,
             &self.storage_config.clickhouse_cluster.database,
             &self.clickhouse_concurrency,
+            self.skip_write,
         );
 
         let accumulator = Arc::new(

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -32,7 +32,7 @@ use crate::strategies::processor::{
 };
 use crate::strategies::python::PythonTransformStep;
 use crate::strategies::replacements::ProduceReplacements;
-use crate::types::{BytesInsertBatch, CogsData};
+use crate::types::{BytesInsertBatch, CogsData, RowData};
 
 pub struct ConsumerStrategyFactory {
     storage_config: config::StorageConfig,
@@ -162,7 +162,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
         );
 
         let accumulator = Arc::new(
-            |batch: BytesInsertBatch<HttpBatch>, small_batch: BytesInsertBatch| {
+            |batch: BytesInsertBatch<HttpBatch>, small_batch: BytesInsertBatch<RowData>| {
                 batch.merge(small_batch)
             },
         );

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -32,7 +32,7 @@ use crate::strategies::processor::{
 };
 use crate::strategies::python::PythonTransformStep;
 use crate::strategies::replacements::ProduceReplacements;
-use crate::types::BytesInsertBatch;
+use crate::types::{BytesInsertBatch, CogsData};
 
 pub struct ConsumerStrategyFactory {
     storage_config: config::StorageConfig,
@@ -170,7 +170,16 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
         let next_step = Reduce::new(
             next_step,
             accumulator,
-            Arc::new(move || BytesInsertBatch::new2(batch_factory.new_batch())),
+            Arc::new(move || {
+                BytesInsertBatch::new(
+                    batch_factory.new_batch(),
+                    None,
+                    None,
+                    None,
+                    Default::default(),
+                    CogsData::default(),
+                )
+            }),
             self.max_batch_size,
             self.max_batch_time,
             BytesInsertBatch::len,

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -24,7 +24,7 @@ use crate::config;
 use crate::metrics::global_tags::set_global_tag;
 use crate::processors::{self, get_cogs_label};
 use crate::strategies::accountant::RecordCogs;
-use crate::strategies::clickhouse::batch::{Batch, BatchFactory};
+use crate::strategies::clickhouse::batch::{BatchFactory, HttpBatch};
 use crate::strategies::clickhouse::ClickhouseWriterStep;
 use crate::strategies::commit_log::ProduceCommitLog;
 use crate::strategies::processor::{
@@ -162,7 +162,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
         );
 
         let accumulator = Arc::new(
-            |batch: BytesInsertBatch<Batch>, small_batch: BytesInsertBatch| {
+            |batch: BytesInsertBatch<HttpBatch>, small_batch: BytesInsertBatch| {
                 batch.merge(small_batch)
             },
         );

--- a/rust_snuba/src/strategies/accountant.rs
+++ b/rust_snuba/src/strategies/accountant.rs
@@ -51,7 +51,7 @@ impl<N> RecordCogs<N> {
         topic_name: &str,
     ) -> Self
     where
-        N: ProcessingStrategy<BytesInsertBatch> + 'static,
+        N: ProcessingStrategy<BytesInsertBatch<()>> + 'static,
     {
         let accountant = CogsAccountant::new(broker_config, topic_name);
 
@@ -63,9 +63,9 @@ impl<N> RecordCogs<N> {
     }
 }
 
-impl<N> ProcessingStrategy<BytesInsertBatch> for RecordCogs<N>
+impl<N> ProcessingStrategy<BytesInsertBatch<()>> for RecordCogs<N>
 where
-    N: ProcessingStrategy<BytesInsertBatch> + 'static,
+    N: ProcessingStrategy<BytesInsertBatch<()>> + 'static,
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         self.next_step.poll()
@@ -73,8 +73,8 @@ where
 
     fn submit(
         &mut self,
-        message: Message<BytesInsertBatch>,
-    ) -> Result<(), SubmitError<BytesInsertBatch>> {
+        message: Message<BytesInsertBatch<()>>,
+    ) -> Result<(), SubmitError<BytesInsertBatch<()>>> {
         for (app_feature, amount_bytes) in message.payload().cogs_data().data.iter() {
             self.accountant
                 .record_bytes(&self.resource_id, app_feature, *amount_bytes)

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -49,7 +49,7 @@ impl BatchFactory {
         }
     }
 
-    pub fn new_batch(&self) -> Batch {
+    pub fn new_batch(&self) -> HttpBatch {
         // this channel is effectively bounded due to max-batch-size and max-batch-time. it is hard
         // however to enforce any limit locally because it would mean that in the Drop impl of
         // Batch, the send may block or fail
@@ -76,7 +76,7 @@ impl BatchFactory {
             Ok(())
         });
 
-        Batch {
+        HttpBatch {
             current_chunk: Vec::new(),
             num_rows: 0,
             num_bytes: 0,
@@ -86,7 +86,7 @@ impl BatchFactory {
     }
 }
 
-pub struct Batch {
+pub struct HttpBatch {
     current_chunk: Vec<u8>,
     num_rows: usize,
     num_bytes: usize,
@@ -94,7 +94,7 @@ pub struct Batch {
     result_handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
 }
 
-impl Batch {
+impl HttpBatch {
     pub fn num_rows(&self) -> usize {
         self.num_rows
     }
@@ -135,7 +135,7 @@ impl Batch {
     }
 }
 
-impl Drop for Batch {
+impl Drop for HttpBatch {
     fn drop(&mut self) {
         // in case the batch was not explicitly finished, send an error into the channel to abort
         // the request

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -10,7 +10,7 @@ use rust_arroyo::processing::strategies::{
 use rust_arroyo::types::Message;
 use rust_arroyo::{counter, timer};
 
-use crate::strategies::clickhouse::batch::Batch;
+use crate::strategies::clickhouse::batch::HttpBatch;
 use crate::types::BytesInsertBatch;
 
 pub mod batch;
@@ -25,10 +25,12 @@ impl ClickhouseWriter {
     }
 }
 
-impl TaskRunner<BytesInsertBatch<Batch>, BytesInsertBatch<()>, anyhow::Error> for ClickhouseWriter {
+impl TaskRunner<BytesInsertBatch<HttpBatch>, BytesInsertBatch<()>, anyhow::Error>
+    for ClickhouseWriter
+{
     fn get_task(
         &self,
-        message: Message<BytesInsertBatch<Batch>>,
+        message: Message<BytesInsertBatch<HttpBatch>>,
     ) -> RunTaskFunc<BytesInsertBatch<()>, anyhow::Error> {
         let skip_write = self.skip_write;
 
@@ -74,7 +76,7 @@ impl TaskRunner<BytesInsertBatch<Batch>, BytesInsertBatch<()>, anyhow::Error> fo
 }
 
 pub struct ClickhouseWriterStep {
-    inner: RunTaskInThreads<BytesInsertBatch<Batch>, BytesInsertBatch<()>, anyhow::Error>,
+    inner: RunTaskInThreads<BytesInsertBatch<HttpBatch>, BytesInsertBatch<()>, anyhow::Error>,
 }
 
 impl ClickhouseWriterStep {
@@ -93,15 +95,15 @@ impl ClickhouseWriterStep {
     }
 }
 
-impl ProcessingStrategy<BytesInsertBatch<Batch>> for ClickhouseWriterStep {
+impl ProcessingStrategy<BytesInsertBatch<HttpBatch>> for ClickhouseWriterStep {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         self.inner.poll()
     }
 
     fn submit(
         &mut self,
-        message: Message<BytesInsertBatch<Batch>>,
-    ) -> Result<(), SubmitError<BytesInsertBatch<Batch>>> {
+        message: Message<BytesInsertBatch<HttpBatch>>,
+    ) -> Result<(), SubmitError<BytesInsertBatch<HttpBatch>>> {
         self.inner.submit(message)
     }
 

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -200,7 +200,7 @@ impl ProcessingStrategy<BytesInsertBatch<()>> for ProduceCommitLog {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{CogsData, CommitLogEntry, CommitLogOffsets, RowData};
+    use crate::types::{CogsData, CommitLogEntry, CommitLogOffsets};
 
     use super::*;
     use crate::testutils::TestStrategy;
@@ -291,7 +291,7 @@ mod tests {
 
         let payloads = vec![
             BytesInsertBatch::new(
-                RowData::default(),
+                (),
                 Utc::now(),
                 None,
                 None,
@@ -306,7 +306,7 @@ mod tests {
                 CogsData::default(),
             ),
             BytesInsertBatch::new(
-                RowData::default(),
+                (),
                 Utc::now(),
                 None,
                 None,

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -92,11 +92,11 @@ impl ProduceMessage {
     }
 }
 
-impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for ProduceMessage {
+impl TaskRunner<BytesInsertBatch<()>, BytesInsertBatch<()>, anyhow::Error> for ProduceMessage {
     fn get_task(
         &self,
-        message: Message<BytesInsertBatch>,
-    ) -> RunTaskFunc<BytesInsertBatch, anyhow::Error> {
+        message: Message<BytesInsertBatch<()>>,
+    ) -> RunTaskFunc<BytesInsertBatch<()>, anyhow::Error> {
         let producer = self.producer.clone();
         let destination: TopicOrPartition = self.destination.into();
         let topic = self.topic;
@@ -140,7 +140,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch, anyhow::Error> for ProduceMe
 }
 
 pub struct ProduceCommitLog {
-    inner: RunTaskInThreads<BytesInsertBatch, BytesInsertBatch, anyhow::Error>,
+    inner: RunTaskInThreads<BytesInsertBatch<()>, BytesInsertBatch<()>, anyhow::Error>,
 }
 
 impl ProduceCommitLog {
@@ -154,7 +154,7 @@ impl ProduceCommitLog {
         skip_produce: bool,
     ) -> Self
     where
-        N: ProcessingStrategy<BytesInsertBatch> + 'static,
+        N: ProcessingStrategy<BytesInsertBatch<()>> + 'static,
     {
         let inner = RunTaskInThreads::new(
             next_step,
@@ -173,15 +173,15 @@ impl ProduceCommitLog {
     }
 }
 
-impl ProcessingStrategy<BytesInsertBatch> for ProduceCommitLog {
+impl ProcessingStrategy<BytesInsertBatch<()>> for ProduceCommitLog {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         self.inner.poll()
     }
 
     fn submit(
         &mut self,
-        message: Message<BytesInsertBatch>,
-    ) -> Result<(), SubmitError<BytesInsertBatch>> {
+        message: Message<BytesInsertBatch<()>>,
+    ) -> Result<(), SubmitError<BytesInsertBatch<()>>> {
         self.inner.submit(message)
     }
 

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -292,7 +292,7 @@ mod tests {
         let payloads = vec![
             BytesInsertBatch::new(
                 (),
-                Utc::now(),
+                Some(Utc::now()),
                 None,
                 None,
                 CommitLogOffsets(BTreeMap::from([(
@@ -307,7 +307,7 @@ mod tests {
             ),
             BytesInsertBatch::new(
                 (),
-                Utc::now(),
+                Some(Utc::now()),
                 None,
                 None,
                 CommitLogOffsets(BTreeMap::from([

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -16,11 +16,11 @@ use crate::config::ProcessorConfig;
 use crate::processors::{ProcessingFunction, ProcessingFunctionWithReplacements};
 use crate::types::{
     BytesInsertBatch, CommitLogEntry, CommitLogOffsets, InsertBatch, InsertOrReplacement,
-    KafkaMessageMetadata,
+    KafkaMessageMetadata, RowData,
 };
 
 pub fn make_rust_processor(
-    next_step: impl ProcessingStrategy<BytesInsertBatch> + 'static,
+    next_step: impl ProcessingStrategy<BytesInsertBatch<RowData>> + 'static,
     func: ProcessingFunction,
     schema_name: &str,
     enforce_schema: bool,
@@ -34,7 +34,7 @@ pub fn make_rust_processor(
         partition: Partition,
         offset: u64,
         timestamp: DateTime<Utc>,
-    ) -> anyhow::Result<Message<BytesInsertBatch>> {
+    ) -> anyhow::Result<Message<BytesInsertBatch<RowData>>> {
         let payload = BytesInsertBatch::new(
             transformed.rows,
             Some(timestamp),
@@ -73,7 +73,7 @@ pub fn make_rust_processor(
 }
 
 pub fn make_rust_processor_with_replacements(
-    next_step: impl ProcessingStrategy<InsertOrReplacement<BytesInsertBatch>> + 'static,
+    next_step: impl ProcessingStrategy<InsertOrReplacement<BytesInsertBatch<RowData>>> + 'static,
     func: ProcessingFunctionWithReplacements,
     schema_name: &str,
     enforce_schema: bool,
@@ -87,7 +87,7 @@ pub fn make_rust_processor_with_replacements(
         partition: Partition,
         offset: u64,
         timestamp: DateTime<Utc>,
-    ) -> anyhow::Result<Message<InsertOrReplacement<BytesInsertBatch>>> {
+    ) -> anyhow::Result<Message<InsertOrReplacement<BytesInsertBatch<RowData>>>> {
         let payload = match transformed {
             InsertOrReplacement::Insert(transformed) => {
                 InsertOrReplacement::Insert(BytesInsertBatch::new(

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -37,7 +37,7 @@ pub fn make_rust_processor(
     ) -> anyhow::Result<Message<BytesInsertBatch>> {
         let payload = BytesInsertBatch::new(
             transformed.rows,
-            timestamp,
+            Some(timestamp),
             transformed.origin_timestamp,
             transformed.sentry_received_timestamp,
             CommitLogOffsets(BTreeMap::from([(
@@ -92,7 +92,7 @@ pub fn make_rust_processor_with_replacements(
             InsertOrReplacement::Insert(transformed) => {
                 InsertOrReplacement::Insert(BytesInsertBatch::new(
                     transformed.rows,
-                    timestamp,
+                    Some(timestamp),
                     transformed.origin_timestamp,
                     transformed.sentry_received_timestamp,
                     CommitLogOffsets(BTreeMap::from([(

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -86,7 +86,7 @@ impl PythonTransformStep {
 
             let payload = BytesInsertBatch::new(
                 RowData::from_encoded_rows(payload),
-                message_timestamp,
+                Some(message_timestamp),
                 origin_timestamp,
                 sentry_received_timestamp,
                 CommitLogOffsets(commit_log_offsets),

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -23,9 +23,9 @@ type Committable = BTreeMap<(String, u16), u64>;
 type PyReturnValue = (ReturnValue, MessageTimestamp, Committable);
 
 pub struct PythonTransformStep {
-    next_step: Box<dyn ProcessingStrategy<BytesInsertBatch>>,
+    next_step: Box<dyn ProcessingStrategy<BytesInsertBatch<RowData>>>,
     python_strategy: Arc<Mutex<Py<PyAny>>>,
-    transformed_messages: VecDeque<Message<BytesInsertBatch>>,
+    transformed_messages: VecDeque<Message<BytesInsertBatch<RowData>>>,
     commit_request_carried_over: Option<CommitRequest>,
 }
 
@@ -37,7 +37,7 @@ impl PythonTransformStep {
         max_queue_depth: Option<usize>,
     ) -> Result<Self, Error>
     where
-        N: ProcessingStrategy<BytesInsertBatch> + 'static,
+        N: ProcessingStrategy<BytesInsertBatch<RowData>> + 'static,
     {
         env::set_var(
             "RUST_SNUBA_PROCESSOR_MODULE",

--- a/rust_snuba/src/strategies/replacements.rs
+++ b/rust_snuba/src/strategies/replacements.rs
@@ -156,7 +156,7 @@ mod tests {
             .submit(Message::new_any_message(
                 InsertOrReplacement::Insert(BytesInsertBatch::new(
                     RowData::from_rows(row_data).unwrap(),
-                    Utc::now(),
+                    Some(Utc::now()),
                     None,
                     None,
                     CommitLogOffsets::default(),

--- a/rust_snuba/src/strategies/replacements.rs
+++ b/rust_snuba/src/strategies/replacements.rs
@@ -1,5 +1,5 @@
 use crate::strategies::noop::Noop;
-use crate::types::{BytesInsertBatch, InsertOrReplacement};
+use crate::types::{BytesInsertBatch, InsertOrReplacement, RowData};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::Producer;
 use rust_arroyo::processing::strategies::merge_commit_request;
@@ -16,7 +16,7 @@ use std::time::Duration;
 /// Replacements are produced to the replacement topic.
 /// This is  only relevant for the "errors" dataset.
 pub struct ProduceReplacements {
-    next_step: Box<dyn ProcessingStrategy<BytesInsertBatch>>,
+    next_step: Box<dyn ProcessingStrategy<BytesInsertBatch<RowData>>>,
     inner: Box<dyn ProcessingStrategy<KafkaPayload>>,
     skip_produce: bool,
 }
@@ -30,7 +30,7 @@ impl ProduceReplacements {
         skip_produce: bool,
     ) -> Self
     where
-        N: ProcessingStrategy<BytesInsertBatch> + 'static,
+        N: ProcessingStrategy<BytesInsertBatch<RowData>> + 'static,
     {
         let inner: Box<dyn ProcessingStrategy<KafkaPayload>> = match skip_produce {
             false => Box::new(Produce::new(
@@ -50,7 +50,7 @@ impl ProduceReplacements {
     }
 }
 
-impl ProcessingStrategy<InsertOrReplacement<BytesInsertBatch>> for ProduceReplacements {
+impl ProcessingStrategy<InsertOrReplacement<BytesInsertBatch<RowData>>> for ProduceReplacements {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         let _ = self.inner.poll(); // Replacement offsets are not committed
         self.next_step.poll()
@@ -58,8 +58,8 @@ impl ProcessingStrategy<InsertOrReplacement<BytesInsertBatch>> for ProduceReplac
 
     fn submit(
         &mut self,
-        message: Message<InsertOrReplacement<BytesInsertBatch>>,
-    ) -> Result<(), SubmitError<InsertOrReplacement<BytesInsertBatch>>> {
+        message: Message<InsertOrReplacement<BytesInsertBatch<RowData>>>,
+    ) -> Result<(), SubmitError<InsertOrReplacement<BytesInsertBatch<RowData>>>> {
         let payload = message.clone().into_payload();
 
         match payload {

--- a/rust_snuba/src/testutils.rs
+++ b/rust_snuba/src/testutils.rs
@@ -30,24 +30,24 @@ pub fn initialize_python() {
     .unwrap();
 }
 
-pub struct TestStrategy {
-    pub payloads: Vec<BytesInsertBatch>,
+pub struct TestStrategy<R> {
+    pub payloads: Vec<BytesInsertBatch<R>>,
 }
 
-impl TestStrategy {
+impl<R: Send + Sync> TestStrategy<R> {
     pub fn new() -> Self {
         Self { payloads: vec![] }
     }
 }
-impl ProcessingStrategy<BytesInsertBatch> for TestStrategy {
+impl<R: Send + Sync> ProcessingStrategy<BytesInsertBatch<R>> for TestStrategy<R> {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         Ok(None)
     }
     fn submit(
         &mut self,
-        message: Message<BytesInsertBatch>,
-    ) -> Result<(), SubmitError<BytesInsertBatch>> {
-        self.payloads.push(message.payload().clone());
+        message: Message<BytesInsertBatch<R>>,
+    ) -> Result<(), SubmitError<BytesInsertBatch<R>>> {
+        self.payloads.push(message.into_payload());
         Ok(())
     }
     fn close(&mut self) {}

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -259,10 +259,6 @@ impl<R> BytesInsertBatch<R> {
 }
 
 impl BytesInsertBatch {
-    pub fn encoded_rows(&self) -> &[u8] {
-        &self.rows.encoded_rows
-    }
-
     pub fn len(&self) -> usize {
         self.rows.num_rows
     }

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -175,7 +175,7 @@ impl InsertBatch {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct BytesInsertBatch<R = RowData> {
+pub struct BytesInsertBatch<R> {
     rows: R,
 
     /// when the message was inserted into the snuba topic
@@ -258,14 +258,14 @@ impl<R> BytesInsertBatch<R> {
     }
 }
 
-impl BytesInsertBatch {
+impl BytesInsertBatch<RowData> {
     pub fn len(&self) -> usize {
         self.rows.num_rows
     }
 }
 
 impl BytesInsertBatch<HttpBatch> {
-    pub fn merge(mut self, other: BytesInsertBatch) -> Self {
+    pub fn merge(mut self, other: BytesInsertBatch<RowData>) -> Self {
         self.rows
             .write_rows(&other.rows)
             .expect("failed to write rows to channel");

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -200,6 +200,28 @@ pub struct BytesInsertBatch<R = RowData> {
 }
 
 impl<R> BytesInsertBatch<R> {
+    pub fn new(
+        rows: R,
+        message_timestamp: DateTime<Utc>,
+        origin_timestamp: Option<DateTime<Utc>>,
+        sentry_received_timestamp: Option<DateTime<Utc>>,
+        commit_log_offsets: CommitLogOffsets,
+        cogs_data: CogsData,
+    ) -> Self {
+        BytesInsertBatch {
+            rows,
+            message_timestamp: message_timestamp.into(),
+            origin_timestamp: origin_timestamp
+                .map(LatencyRecorder::from)
+                .unwrap_or_default(),
+            sentry_received_timestamp: sentry_received_timestamp
+                .map(LatencyRecorder::from)
+                .unwrap_or_default(),
+            commit_log_offsets,
+            cogs_data,
+        }
+    }
+
     pub fn commit_log_offsets(&self) -> &CommitLogOffsets {
         &self.commit_log_offsets
     }
@@ -235,28 +257,6 @@ impl<R> BytesInsertBatch<R> {
 impl BytesInsertBatch {
     pub fn encoded_rows(&self) -> &[u8] {
         &self.rows.encoded_rows
-    }
-
-    pub fn new(
-        rows: RowData,
-        message_timestamp: DateTime<Utc>,
-        origin_timestamp: Option<DateTime<Utc>>,
-        sentry_received_timestamp: Option<DateTime<Utc>>,
-        commit_log_offsets: CommitLogOffsets,
-        cogs_data: CogsData,
-    ) -> Self {
-        BytesInsertBatch {
-            rows,
-            message_timestamp: message_timestamp.into(),
-            origin_timestamp: origin_timestamp
-                .map(LatencyRecorder::from)
-                .unwrap_or_default(),
-            sentry_received_timestamp: sentry_received_timestamp
-                .map(LatencyRecorder::from)
-                .unwrap_or_default(),
-            commit_log_offsets,
-            cogs_data,
-        }
     }
 
     pub fn len(&self) -> usize {

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -280,7 +280,7 @@ impl BytesInsertBatch<HttpBatch> {
 
     pub fn merge(mut self, other: BytesInsertBatch) -> Self {
         self.rows
-            .write_rows(&other.rows.encoded_rows)
+            .write_rows(&other.rows)
             .expect("failed to write rows to channel");
         self.commit_log_offsets.merge(other.commit_log_offsets);
         self.message_timestamp.merge(other.message_timestamp);

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -1,6 +1,8 @@
 use std::cmp::min;
 use std::collections::BTreeMap;
 
+use crate::strategies::clickhouse::batch::HttpBatch;
+
 use chrono::{DateTime, Utc};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::timer;
@@ -264,8 +266,8 @@ impl BytesInsertBatch {
     }
 }
 
-impl BytesInsertBatch<crate::strategies::clickhouse::batch::Batch> {
-    pub fn new2(rows: crate::strategies::clickhouse::batch::Batch) -> Self {
+impl BytesInsertBatch<HttpBatch> {
+    pub fn new2(rows: HttpBatch) -> Self {
         BytesInsertBatch {
             rows,
             message_timestamp: Default::default(),


### PR DESCRIPTION
Refactor the rust consumer so that from within Reduce, the HTTP request is
opened and rows are directly written into the socket.

This requires splitting up the BytesInsertBatch type as it can be in multiple
"states" depending on the stage of the pipeline. It contains a HttpBatch before
writing to clickhouse, and contains none before committing offsets.

The easiest way that I found is to first make it generic over its internal row
data R, then slowly fixing up all the instances where the generic was missing.

In a future PR I would like to see:

* deleting `InsertBatch` entirely, and replacing all instances with `BytesInsertBatch`
* renaming `BytesInsertBatch` to `InsertBatch`
* splitting up `types.rs` into multiple files
