### PR TITLE
ref: separate parse query from build request

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,5 +65,10 @@
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,
-  "python.testing.pytestArgs": ["tests"]
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "mypy-type-checker.args": [
+    "--strict"
+  ]
 }

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -105,7 +105,7 @@ def update_attribution_info(
     return attribution_info
 
 
-def parse_request(
+def parse_api_request(
     body: Dict[str, Any],
     settings_class: Union[Type[HTTPQuerySettings], Type[SubscriptionQuerySettings]],
     schema: RequestSchema,
@@ -196,7 +196,8 @@ def build_request(
                 body, request_parts, referrer, settings_obj, query, snql_anonymized
             )
         except (InvalidJsonRequestException, InvalidQueryException):
-            assert 1 == 0
+            # TODO: remove this before merge
+            assert False
         except Exception as exception:
             request_status = get_request_status(exception)
             record_error_building_request(

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -156,17 +156,13 @@ def parse_api_request(
         )
         span.set_data(
             "snuba_query_raw",
-            textwrap.wrap(repr(request.original_body), 100, break_long_words=False),
+            textwrap.wrap(repr(body), 100, break_long_words=False),
         )
         sentry_sdk.add_breadcrumb(
             category="query_info",
             level="info",
             message="snuba_query_raw",
-            data={
-                "query": textwrap.wrap(
-                    repr(request.original_body), 100, break_long_words=False
-                )
-            },
+            data={"query": textwrap.wrap(repr(body), 100, break_long_words=False)},
         )
         return (request_parts, settings_obj, query, snql_anonymized)
 

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import textwrap
 import uuid
-from typing import Any, Dict, MutableMapping, Optional, Protocol, Tuple, Type, Union
+from typing import Any, Dict, MutableMapping, Optional, Tuple, Type, Union
 
 import sentry_sdk
 
@@ -35,17 +35,6 @@ from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "snuba.validation")
-
-
-class Parser(Protocol):
-    def __call__(
-        self,
-        request_parts: RequestParts,
-        settings: QuerySettings,
-        dataset: Dataset,
-        custom_processing: Optional[CustomProcessors] = ...,
-    ) -> Tuple[Union[Query, CompositeQuery[Entity]], str]:
-        ...
 
 
 def parse_snql_query(
@@ -200,9 +189,6 @@ def build_request(
                 query,
                 snql_anonymized,
             )
-        except (InvalidJsonRequestException, InvalidQueryException):
-            # TODO: remove this before merge
-            assert False
         except Exception as exception:
             request_status = get_request_status(exception)
             record_error_building_request(

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -144,7 +144,6 @@ def parse_api_request(
             )
             raise exception
         except Exception as exception:
-            # TODO: maybe make this log for parse error, maybe fine as is
             request_status = get_request_status(exception)
             record_error_building_request(
                 timer, request_status, referrer, str(type(exception).__name__)

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -156,13 +156,17 @@ def parse_api_request(
         )
         span.set_data(
             "snuba_query_raw",
-            textwrap.wrap(repr(body), 100, break_long_words=False),
+            textwrap.wrap(repr(request.original_body), 100, break_long_words=False),
         )
         sentry_sdk.add_breadcrumb(
             category="query_info",
             level="info",
             message="snuba_query_raw",
-            data={"query": textwrap.wrap(repr(body), 100, break_long_words=False)},
+            data={
+                "query": textwrap.wrap(
+                    repr(request.original_body), 100, break_long_words=False
+                )
+            },
         )
         return (request_parts, settings_obj, query, snql_anonymized)
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -39,7 +39,7 @@ from snuba.query.query_settings import SubscriptionQuerySettings
 from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.schema import RequestSchema
-from snuba.request.validation import build_request, parse_snql_query
+from snuba.request.validation import build_request, parse_api_request
 from snuba.subscriptions.utils import Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -194,19 +194,30 @@ class SubscriptionData:
         if "organization_id" not in tenant_ids:
             # TODO: Subscriptions queries should have an org ID
             tenant_ids["organization_id"] = 1
-
-        request = build_request(
+        request_parts, settings_obj, query, snql_anonymized = parse_api_request(
             {
                 "query": self.query,
                 "tenant_ids": tenant_ids,
             },
-            parse_snql_query,
             SubscriptionQuerySettings,
             schema,
             dataset,
             timer,
             referrer,
-            custom_processing,
+            is_mql=False,
+            custom_processing=custom_processing,
+        )
+        request = build_request(
+            {
+                "query": self.query,
+                "tenant_ids": tenant_ids,
+            },
+            timer,
+            referrer,
+            request_parts,
+            settings_obj,
+            query,
+            snql_anonymized,
         )
         return request
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -213,7 +213,6 @@ class SubscriptionData:
                 "tenant_ids": tenant_ids,
             },
             timer,
-            referrer,
             request_parts,
             settings_obj,
             query,

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -376,7 +376,6 @@ def dataset_query(
     request = build_request(
         body,
         timer,
-        referrer,
         request_parts,
         settings_obj,
         query,

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -50,7 +50,7 @@ from snuba.redis import all_redis_clients
 from snuba.request import Request as SnubaRequest
 from snuba.request.exceptions import InvalidJsonRequestException, JsonDecodeException
 from snuba.request.schema import RequestSchema
-from snuba.request.validation import build_request, parse_mql_query, parse_snql_query
+from snuba.request.validation import build_request, parse_request
 from snuba.state import get_float_config
 from snuba.state.rate_limit import RateLimitExceeded
 from snuba.subscriptions.codecs import SubscriptionDataCodec
@@ -364,9 +364,23 @@ def dataset_query(
     with sentry_sdk.start_span(description="build_schema", op="validate"):
         schema = RequestSchema.build(HTTPQuerySettings, is_mql)
 
-    parse_function = parse_snql_query if not is_mql else parse_mql_query
+    request_parts, settings_obj, query, snql_anonymized = parse_request(
+        body,
+        HTTPQuerySettings,
+        schema,
+        dataset,
+        timer,
+        referrer,
+        is_mql,
+    )
     request = build_request(
-        body, parse_function, HTTPQuerySettings, schema, dataset, timer, referrer
+        body,
+        timer,
+        referrer,
+        request_parts,
+        settings_obj,
+        query,
+        snql_anonymized,
     )
     _get_and_log_referrer(request, body)
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -50,7 +50,7 @@ from snuba.redis import all_redis_clients
 from snuba.request import Request as SnubaRequest
 from snuba.request.exceptions import InvalidJsonRequestException, JsonDecodeException
 from snuba.request.schema import RequestSchema
-from snuba.request.validation import build_request, parse_request
+from snuba.request.validation import build_request, parse_api_request
 from snuba.state import get_float_config
 from snuba.state.rate_limit import RateLimitExceeded
 from snuba.subscriptions.codecs import SubscriptionDataCodec
@@ -364,7 +364,7 @@ def dataset_query(
     with sentry_sdk.start_span(description="build_schema", op="validate"):
         schema = RequestSchema.build(HTTPQuerySettings, is_mql)
 
-    request_parts, settings_obj, query, snql_anonymized = parse_request(
+    request_parts, settings_obj, query, snql_anonymized = parse_api_request(
         body,
         HTTPQuerySettings,
         schema,

--- a/tests/datasets/test_context_promotion.py
+++ b/tests/datasets/test_context_promotion.py
@@ -13,7 +13,7 @@ from snuba.query.expressions import Column, FunctionCall, Literal, NoopVisitor
 from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.reader import Reader
 from snuba.request.schema import RequestSchema
-from snuba.request.validation import build_request, parse_snql_query
+from snuba.request.validation import build_request, parse_api_request
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 
@@ -70,19 +70,21 @@ def test_span_id_promotion(entity_key: str, expected_table_name: str) -> None:
         "turbo": False,
         "consistent": False,
     }
-
     dataset = get_dataset(dataset_name)
-
     schema = RequestSchema.build(HTTPQuerySettings)
-
-    request = build_request(
+    timer = Timer(name="bloop")
+    referrer = "some_referrer"
+    request_parts, settings_obj, query, snql_anonymized = parse_api_request(
         query_body,
-        parse_snql_query,
         HTTPQuerySettings,
         schema,
         dataset,
-        Timer(name="bloop"),
-        "some_referrer",
+        timer,
+        referrer,
+        is_mql=False,
+    )
+    request = build_request(
+        query_body, timer, referrer, request_parts, settings_obj, query, snql_anonymized
     )
     # --------------------------------------------------------------------
 

--- a/tests/datasets/test_context_promotion.py
+++ b/tests/datasets/test_context_promotion.py
@@ -84,7 +84,7 @@ def test_span_id_promotion(entity_key: str, expected_table_name: str) -> None:
         is_mql=False,
     )
     request = build_request(
-        query_body, timer, referrer, request_parts, settings_obj, query, snql_anonymized
+        query_body, timer, request_parts, settings_obj, query, snql_anonymized
     )
     # --------------------------------------------------------------------
 

--- a/tests/datasets/test_nullable_field_casting.py
+++ b/tests/datasets/test_nullable_field_casting.py
@@ -65,7 +65,7 @@ def test_nullable_field_casting(entity: Entity, expected_table_name: str) -> Non
     )
 
     request = build_request(
-        query_body, timer, referrer, request_parts, settings_obj, query, snql_anonymized
+        query_body, timer, request_parts, settings_obj, query, snql_anonymized
     )
     # --------------------------------------------------------------------
 

--- a/tests/datasets/test_nullable_field_casting.py
+++ b/tests/datasets/test_nullable_field_casting.py
@@ -13,7 +13,7 @@ from snuba.query.expressions import Column, FunctionCall, Literal, StringifyVisi
 from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.reader import Reader
 from snuba.request.schema import RequestSchema
-from snuba.request.validation import build_request, parse_snql_query
+from snuba.request.validation import build_request, parse_api_request
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 
@@ -49,19 +49,23 @@ def test_nullable_field_casting(entity: Entity, expected_table_name: str) -> Non
         "turbo": False,
         "consistent": False,
     }
-
     dataset = get_dataset(dataset_name)
-
     schema = RequestSchema.build(HTTPQuerySettings)
+    timer = Timer(name="bloop")
+    referrer = "some_referrer"
 
-    request = build_request(
+    request_parts, settings_obj, query, snql_anonymized = parse_api_request(
         query_body,
-        parse_snql_query,
         HTTPQuerySettings,
         schema,
         dataset,
-        Timer(name="bloop"),
-        "some_referrer",
+        timer,
+        referrer,
+        is_mql=False,
+    )
+
+    request = build_request(
+        query_body, timer, referrer, request_parts, settings_obj, query, snql_anonymized
     )
     # --------------------------------------------------------------------
 

--- a/tests/datasets/test_tags_hashmap.py
+++ b/tests/datasets/test_tags_hashmap.py
@@ -51,7 +51,7 @@ def test_tags_hashmap_optimization() -> None:
         is_mql=False,
     )
     request = build_request(
-        query_body, timer, referrer, request_parts, settings_obj, query, snql_anonymized
+        query_body, timer, request_parts, settings_obj, query, snql_anonymized
     )
     # --------------------------------------------------------------------
 

--- a/tests/datasets/test_tags_hashmap.py
+++ b/tests/datasets/test_tags_hashmap.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import Column, FunctionCall, NoopVisitor
 from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.reader import Reader
 from snuba.request.schema import RequestSchema
-from snuba.request.validation import build_request, parse_snql_query
+from snuba.request.validation import build_request, parse_api_request
 from snuba.utils.metrics.timer import Timer
 
 
@@ -36,19 +36,22 @@ def test_tags_hashmap_optimization() -> None:
         "turbo": False,
         "consistent": False,
     }
-
     dataset = get_dataset(dataset_name)
-
     schema = RequestSchema.build(HTTPQuerySettings)
+    timer = Timer(name="bloop")
+    referrer = "some_referrer"
 
-    request = build_request(
+    request_parts, settings_obj, query, snql_anonymized = parse_api_request(
         query_body,
-        parse_snql_query,
         HTTPQuerySettings,
         schema,
         dataset,
-        Timer(name="bloop"),
-        "some_referrer",
+        timer,
+        referrer,
+        is_mql=False,
+    )
+    request = build_request(
+        query_body, timer, referrer, request_parts, settings_obj, query, snql_anonymized
     )
     # --------------------------------------------------------------------
 

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -69,7 +69,6 @@ def test_build_request(body: Dict[str, Any], condition: Expression) -> None:
     entity = get_entity(EntityKey.EVENTS)
     schema = RequestSchema.build(HTTPQuerySettings)
     timer = Timer("test")
-    referrer = "my_request"
 
     request_parts, settings_obj, query, snql_anonymized = parse_api_request(
         body,
@@ -81,7 +80,7 @@ def test_build_request(body: Dict[str, Any], condition: Expression) -> None:
         is_mql=False,
     )
     request = build_request(
-        body, timer, referrer, request_parts, settings_obj, query, snql_anonymized
+        body, timer, request_parts, settings_obj, query, snql_anonymized
     )
 
     expected_query = Query(
@@ -178,7 +177,6 @@ def test_tenant_ids(
     dataset = get_dataset("events")
     schema = RequestSchema.build(HTTPQuerySettings)
     timer = Timer("test")
-    referrer = "my_request"
 
     request_parts, settings_obj, query, snql_anonymized = parse_api_request(
         request_payload,
@@ -192,7 +190,6 @@ def test_tenant_ids(
     request = build_request(
         request_payload,
         timer,
-        referrer,
         request_parts,
         settings_obj,
         query,


### PR DESCRIPTION
## major changes
`build_request` is now broken into 2 functions that are called sequentially: `parse_api_request` and `build_request`.