### PR TITLE
chore(gocd): Move de region to be between s4s and us

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.8"
+      "version": "v2.9.1"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "172de74e6347127957707d990f20f3e99c6c1c46",
-      "sum": "pBB9Jio0EnAgB7811tnly/S1B5fz6BeYoi4hQ7KgsHM="
+      "version": "4a103d77466c9c2d24df3fdfc8fc876bdceea135",
+      "sum": "JOy7bA1E50Ycp2gQloaJ9yEeHGArW1GGj8Cq/BM9nx0="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This change moves `de` from a test region that is run separate from the rest of our deploys, to a production region that is run, in this case, after `s4s` and before `us`. Now that `de` officially has customers, it is a good time to move it.