### PR TITLE
feat(kafka-control-plane): bump sentry-kafka-schemas and add topic test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.3.4
 sentry-arroyo==2.17.1
-sentry-kafka-schemas==0.1.65
+sentry-kafka-schemas==0.1.67
 sentry-redis-tools==0.3.0
 sentry-relay==0.8.44
 sentry-sdk==1.40.5

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1407,7 +1407,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3006,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "0.1.60"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95883282bfefaed402a8c89c9102f8530b94daa64f598a6ec5f8ae4ae78646ae"
+checksum = "d4121cd942bbb53f176b2f4b101a24fa6aa19c19337d5b21bfc75480440f2aee"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -33,7 +33,7 @@ pyo3 = { version = "0.18.1", features = ["chrono"] }
 reqwest = { version = "0.11.11", features = ["stream"] }
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo" }
 sentry = { version = "0.32.0", features = ["anyhow", "tracing"] }
-sentry-kafka-schemas = "0.1.60"
+sentry-kafka-schemas = "0.1.67"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0"

--- a/tests/utils/streams/test_topics.py
+++ b/tests/utils/streams/test_topics.py
@@ -1,0 +1,30 @@
+import sentry_kafka_schemas
+
+from snuba.utils.streams.topics import Topic
+
+
+def test_valid_topics() -> None:
+    # Ensures that Snuba's topic list matches those registered in sentry-kafka-schemas
+    for topic in Topic:
+        try:
+            sentry_kafka_schemas.get_topic(
+                topic.value
+            )  # Throws an exception if topic not defined
+        except sentry_kafka_schemas.SchemaNotFound:
+            # These topics are not in use but have not yet been removed from snuba's codebase
+            deprecated_topics = (
+                Topic.CDC,
+                Topic.SESSIONS,
+                Topic.SESSIONS_COMMIT_LOG,
+                Topic.SUBSCRIPTION_SCHEDULED_SESSIONS,
+                Topic.DEAD_LETTER_SESSIONS,
+            )
+
+            # TODO: Remove this once these missing topics are added to sentry-kafka-schemas
+            not_yet_defined = (
+                Topic.EVENT_REPLACEMENTS,
+                Topic.ATTRIBUTION,
+            )
+
+            if topic not in deprecated_topics and topic not in not_yet_defined:
+                raise


### PR DESCRIPTION
Validates that all topics are registered in sentry-kafka-schemas as this will be used as the source of truth for creating and managing topics in various environments

