### PR TITLE
feat(metrics): Create a table for finding meta tag values

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -322,6 +322,8 @@ class GenericMetricsLoader(DirectoryLoader):
             "0030_add_record_meta_column",
             "0031_counters_meta_table",
             "0032_counters_meta_table_mv",
+            "0033_counters_meta_tag_values_table",
+            "0034_counters_meta_tag_values_table_mv",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0033_counters_meta_tag_values_table.py
+++ b/snuba/snuba_migrations/generic_metrics/0033_counters_meta_tag_values_table.py
@@ -1,0 +1,66 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import AggregateFunction, Column, DateTime, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    granularity = "2048"
+    local_table_name = "generic_metric_counters_meta_tag_value_aggregated_local"
+    dist_table_name = "generic_metric_counters_meta_tag_value_aggregated_dist"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+    columns: Sequence[Column[Modifiers]] = [
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("tag_key", UInt(64)),
+        Column("tag_value", String()),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column("count", AggregateFunction("sum", [Float(64)])),
+    ]
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                engine=table_engines.AggregatingMergeTree(
+                    storage_set=self.storage_set_key,
+                    order_by="(project_id, metric_id, tag_key, tag_value, timestamp)",
+                    primary_key="(project_id, metric_id, tag_key, tag_value, timestamp)",
+                    partition_by="(retention_days, toMonday(timestamp))",
+                    settings={"index_granularity": self.granularity},
+                    ttl="timestamp + toIntervalDay(retention_days)",
+                ),
+                columns=self.columns,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.local_table_name, sharding_key=None
+                ),
+                columns=self.columns,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0034_counters_meta_tag_values_table_mv.py
+++ b/snuba/snuba_migrations/generic_metrics/0034_counters_meta_tag_values_table_mv.py
@@ -1,0 +1,65 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import AggregateFunction, Column, DateTime, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_counters_meta_aggregation_mv"
+    dest_table_name = "generic_metric_counters_meta_tag_value_aggregated_local"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("tag_key", UInt(64)),
+        Column("tag_value", String()),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column("count", AggregateFunction("sum", [Float(64)])),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name=self.dest_table_name,
+                target=OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    project_id,
+                    metric_id,
+                    tag_key,
+                    tag_value,
+                    toStartOfWeek(timestamp) as timestamp,
+                    retention_days,
+                    sumState(count_value) as count
+                FROM generic_metric_counters_raw_local
+                ARRAY JOIN
+                    tags.key AS tag_key, tags.raw_value AS tag_value
+                WHERE record_meta = 1
+                GROUP BY
+                    project_id,
+                    metric_id,
+                    tag_key,
+                    tag_value,
+                    timestamp,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=OperationTarget.LOCAL,
+            )
+        ]


### PR DESCRIPTION
In the original meta table, having tag values in a groupUniqArray had very poor
query performance, driven by the slowness in aggregating those data sketches.

Create a new table that can just be used for finding tag values, that stores
the tag values as rows in the table.

This table also deliberately does not have org_id or use_case_id in it. In
theory any query for tag values has a project ID, metric ID and tag key in it.
This means the org ID and use case ID don't provide anything useful.