### PR TITLE
chore(gocd): Removing old config arg

### DIFF
--- a/gocd/templates/snuba.jsonnet
+++ b/gocd/templates/snuba.jsonnet
@@ -15,9 +15,6 @@ local pipedream_config = {
     material_name: 'snuba_repo',
     stage: 'deploy-primary',
     elastic_profile_id: 'snuba',
-    // TODO: Remove this field once a few deploys have completed with the
-    // `pipeline-complete` stage.
-    final_stage: 'deploy-primary',
   },
 
   // Set to true to auto-deploy changes (defaults to true)


### PR DESCRIPTION
This is a no-op change that removes a temporary argument used while transitioning to a different approach for rollbacks a few months back.