### PR TITLE
fix(metrics): Fix tag value meta materialized view

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -324,6 +324,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0032_counters_meta_table_mv",
             "0033_counters_meta_tag_values_table",
             "0034_counters_meta_tag_values_table_mv",
+            "0035_recreate_counters_meta_tag_value_table_mv",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0035_recreate_counters_meta_tag_value_table_mv.py
+++ b/snuba/snuba_migrations/generic_metrics/0035_recreate_counters_meta_tag_value_table_mv.py
@@ -1,0 +1,65 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import AggregateFunction, Column, DateTime, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_counters_meta_tag_value_aggregation_mv"
+    dest_table_name = "generic_metric_counters_meta_tag_value_aggregated_local"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("tag_key", UInt(64)),
+        Column("tag_value", String()),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column("count", AggregateFunction("sum", [Float(64)])),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name=self.dest_table_name,
+                target=OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    project_id,
+                    metric_id,
+                    tag_key,
+                    tag_value,
+                    toStartOfWeek(timestamp) as timestamp,
+                    retention_days,
+                    sumState(count_value) as count
+                FROM generic_metric_counters_raw_local
+                ARRAY JOIN
+                    tags.key AS tag_key, tags.raw_value AS tag_value
+                WHERE record_meta = 1
+                GROUP BY
+                    project_id,
+                    metric_id,
+                    tag_key,
+                    tag_value,
+                    timestamp,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=OperationTarget.LOCAL,
+            )
+        ]


### PR DESCRIPTION
The original migration used the wrong name for the new view, which caused it to
not be created. Add a new migration with the correct view name.

Since migrations use `IF NOT EXISTS` the previous migration adding the
view was basically a no-op. Nothing was broken, but the view was silently
not created.