### PR TITLE
bug(dev-exp): Create copy request object for new pipeline

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -75,6 +75,7 @@ def _run_query_pipeline(
     else:
         if try_new_query_pipeline:
             request_copy = copy.deepcopy(request)
+            compare_clickhouse_query = None
             try:
                 compare_clickhouse_query = EntityProcessingStage().execute(
                     QueryPipelineResult(
@@ -98,7 +99,10 @@ def _run_query_pipeline(
             )
         )
         if try_new_query_pipeline:
-            new_sql = str(compare_clickhouse_query.data)
+            if compare_clickhouse_query:
+                new_sql = str(compare_clickhouse_query.data)
+            else:
+                new_sql = ""
             old_sql = str(clickhouse_query.data)
             if new_sql != old_sql:
                 logger.warning(

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import random
 from typing import Optional
@@ -72,6 +73,7 @@ def _run_query_pipeline(
         )
         clickhouse_query = StorageProcessingStage().execute(clickhouse_query)
     else:
+        request_copy = copy.deepcopy(request)
         clickhouse_query = EntityAndStoragePipelineStage().execute(
             QueryPipelineResult(
                 data=request,
@@ -84,7 +86,7 @@ def _run_query_pipeline(
             try:
                 compare_clickhouse_query = EntityProcessingStage().execute(
                     QueryPipelineResult(
-                        data=request,
+                        data=request_copy,
                         query_settings=request.query_settings,
                         timer=timer,
                         error=None,


### PR DESCRIPTION
When testing the new pipeline, there exist difference between the SQL queries outputted from the old and new pipeline. This the `Request` object is passed into the old pipeline, then is passed into the new pipeline. This is incorrect since the old pipeline mutates this object (specifically the query). This PR is responsible for creating a deep copy of the request object and passing it into the new pipeline so that both inputs to the pipelines are the same.