### PR TITLE
fix: parser, bug in pushdown filter 

### DIFF
--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -1,9 +1,27 @@
 from typing import Optional, Sequence
 
-from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.expressions import (
+    Column,
+    Expression,
+    FunctionCall,
+    Literal,
+    SubscriptableReference,
+)
 
 # Add here functions (only stateless stuff) used to make the AST less
 # verbose to build.
+
+
+def snuba_tags_raw(indexer_mapping: int) -> SubscriptableReference:
+    return SubscriptableReference(
+        f"_snuba_tags_raw[{indexer_mapping}]",
+        Column(
+            "_snuba_tags_raw",
+            None,
+            "tags_raw",
+        ),
+        Literal(None, str(indexer_mapping)),
+    )
 
 
 def literals_tuple(alias: Optional[str], literals: Sequence[Literal]) -> FunctionCall:

--- a/tests/query/parser/test_mql_query.py
+++ b/tests/query/parser/test_mql_query.py
@@ -2749,3 +2749,29 @@ def test_invalid_format_expressions_from_mql(
     generic_metrics = get_dataset("generic_metrics")
     with pytest.raises(type(error), match=re.escape(str(error))):
         query, _ = parse_mql_query(query_body, mql_context, generic_metrics)
+
+
+def test_pushdown_error_query():
+    mql = '((avg(d:transactions/duration@millisecond) * 100.0) * 100.0){transaction:"getsentry.tasks.calculate_spike_projections"}'
+    context = {
+        "end": "2024-04-08T06:49:00+00:00",
+        "indexer_mappings": {
+            "d:transactions/duration@millisecond": 9223372036854775909,
+            "transaction": 9223372036854776020,
+        },
+        "limit": 10000,
+        "offset": None,
+        "rollup": {
+            "granularity": 60,
+            "interval": 60,
+            "orderby": None,
+            "with_totals": None,
+        },
+        "scope": {
+            "org_ids": [1],
+            "project_ids": [1],
+            "use_case_id": "'transactions'",
+        },
+        "start": "2024-04-08T05:48:00+00:00",
+    }
+    parse_mql_query(mql, context, get_dataset("generic_metrics"))


### PR DESCRIPTION
The following error was happening during MQL parsing:
https://sentry.sentry.io/issues/5082818756/events/489d5cf1818c4909a985bb0c27ad409c/?project=300688

it was being caused by queries that look like `((avg(d:transactions/millisecond) * 100.0) * 50.0){filter}`
When pushdown_filter is called, it recursively will get called on the `100.0`, which causes `AttributeError: 'float' object has no attribute 'formula'`

In order to fix this, we skip pushdown_filter on anything that isnt an InitialParseResult, this is already done in the code but only for the very top layer of recursion. My fix moves this logic into the recursive case in order to ensure this error wont happen at any layer of recursion.

My fix also adds a test case for the query that previously errored.

related links:
https://www.notion.so/sentry/ddm-parsing-error-880b03749fd04681be77356ea7b65adb