### PR TITLE
ref(ch-upgrades): create dist tables functionality

### DIFF
--- a/snuba/cli/query_fetcher.py
+++ b/snuba/cli/query_fetcher.py
@@ -44,19 +44,6 @@ def get_credentials() -> Tuple[str, str]:
     return ("default", "")
 
 
-def get_table_names(connection: ClickhousePool) -> Sequence[str]:
-    name_results = connection.execute("SHOW TABLES").results
-    if not name_results:
-        raise Exception("No tables names found")
-    return [n[0] for n in name_results]
-
-
-def get_table_schema(connection: ClickhousePool, table: str) -> str:
-    return connection.execute(
-        f"SELECT create_table_query FROM system.tables WHERE name = '{table}'"
-    ).results
-
-
 @click.command()
 @click.option(
     "--querylog-host",

--- a/snuba/cli/query_fetcher.py
+++ b/snuba/cli/query_fetcher.py
@@ -156,7 +156,7 @@ def query_fetcher(
     else:
         table_names = [t for t in tables.split(",")]
 
-    def save_table_schema(table) -> None:
+    def save_table_schema(table: str) -> None:
         """
         Fetches the table schema from the same node we are
         fetching the queries from. The schemas may be needed

--- a/snuba/cli/query_fetcher.py
+++ b/snuba/cli/query_fetcher.py
@@ -189,7 +189,7 @@ def query_fetcher(
 
     for table in table_names:
         # we'll use the table schema in the replayer, so
-        # save the create_table_query if not already saved
+        # save the create_table_query
         save_table_schema(table)
         logger.info(f"Running fetcher for {table}...")
         start_time = window_hours_ago_ts

--- a/snuba/cli/query_fetcher.py
+++ b/snuba/cli/query_fetcher.py
@@ -168,8 +168,6 @@ def query_fetcher(
         schemas/table_name.sql
         """
         filename = f"{table}.sql"
-        if uploader.blob_exists(f"schemas/{filename}"):
-            return
         ((schema,),) = connection.execute(
             f"SELECT create_table_query FROM system.tables WHERE name = '{table}'"
         ).results

--- a/snuba/cli/query_replayer.py
+++ b/snuba/cli/query_replayer.py
@@ -70,15 +70,6 @@ def parse_table_name(err: ClickhouseError) -> str:
     return table
 
 
-# Kind of hacky but the saved schemas will have one
-# of these clusters defined
-CLUSTERS = {
-    "snuba-st",
-    "snuba-generic-metrics",
-    "snuba-shared",
-}
-
-
 @click.command()
 @click.option(
     "--clickhouse-host",


### PR DESCRIPTION
Each time we run the series of these pipelines (fetcher, replayer, comparer) we first have to bring up nodes from backups and have our test clusters to work with. Doing the backup will restore the local tables, along with the data, but usually the dist tables are not backed up (if we change our backup process maybe we can change this) but as of now SRE folks would have to manually create the dist tables.

This aims to save the schemas of the dist tables during the fetching process, and when replaying for the first time we should be downloading the schema and using it to create the tables.

I tested this locally with my own gcs bucket 