### PR TITLE
chore: Lower max query size check to 128KiB

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -395,8 +395,8 @@ SLICED_STORAGE_SETS: Mapping[str, int] = {}
 # to slice id
 LOGICAL_PARTITION_MAPPING: Mapping[str, Mapping[int, int]] = {}
 
-# Max query size that can be sent to clickhouse
-MAX_QUERY_SIZE_BYTES = 256 * 1024  # 256 KiB by default
+# From testing, the max query size that can be sent to clickhouse is 131535 bytes (~128.452 KiB)
+MAX_QUERY_SIZE_BYTES = 128 * 1024  # 128 KiB
 
 # The slice configs below are the "SLICED" versions to the equivalent default
 # settings above. For example, "SLICED_KAFKA_TOPIC_MAP" is the "SLICED"


### PR DESCRIPTION
The actual max query size that can be sent to ClickHouse is `131535 bytes`. This is approximately `128.45KiB`. However, snuba has set `MAX_QUERY_SIZE_BYTES` to `256KiB`, As a result, the large queries are incorrectly passing the snuba check and reaching ClickHouse resulting in `ClickHouseError: max query size exceeded`. This PR is responsible for lowering that limit such that snuba catches these errors and returns the proper expection.

More info here: https://www.notion.so/sentry/ClickHouse-max-query-size-exceeded-error-a5851e643b3f435d9dcb1551dbcbbc09