### PR TITLE
chore: create tests for each API pipeline stage

### DIFF
--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -5,11 +5,22 @@ from snuba.query.expressions import (
     Expression,
     FunctionCall,
     Literal,
+    OptionalScalarType,
     SubscriptableReference,
 )
 
 # Add here functions (only stateless stuff) used to make the AST less
 # verbose to build.
+
+
+def column(
+    column_name, table_name: str | None = None, alias: str | None = None
+) -> Column:
+    return Column(alias, table_name, column_name)
+
+
+def literal(value: OptionalScalarType, alias: str | None = None) -> Literal:
+    return Literal(alias, value)
 
 
 def snuba_tags_raw(indexer_mapping: int) -> SubscriptableReference:

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -14,7 +14,7 @@ from snuba.query.expressions import (
 
 
 def column(
-    column_name, table_name: str | None = None, alias: str | None = None
+    column_name: str, table_name: str | None = None, alias: str | None = None
 ) -> Column:
     return Column(alias, table_name, column_name)
 

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -95,8 +95,20 @@ def equals(lhs: Expression, rhs: Expression) -> FunctionCall:
     return binary_condition("equals", lhs, rhs)
 
 
-def and_cond(lhs: FunctionCall, rhs: FunctionCall) -> FunctionCall:
-    return binary_condition("and", lhs, rhs)
+def and_cond(lhs: FunctionCall, rhs: FunctionCall, *args: FunctionCall) -> FunctionCall:
+    """
+    if only lhs and rhs are given, return and(lhs, rhs)
+    otherwise (more than 2 conditions are given), returns and(lhs, and(rhs, and(...)))
+    """
+    if len(args) == 0:
+        return binary_condition("and", lhs, rhs)
+
+    sofar = args[len(args) - 1]
+    for i in range(len(args) - 2, -1, -1):
+        sofar = binary_condition("and", args[i], sofar)
+    sofar = binary_condition("and", rhs, sofar)
+    sofar = binary_condition("and", lhs, sofar)
+    return sofar
 
 
 def or_cond(lhs: FunctionCall, rhs: FunctionCall) -> FunctionCall:

--- a/tests/pipeline/test_entity_processing_stage.py
+++ b/tests/pipeline/test_entity_processing_stage.py
@@ -43,7 +43,7 @@ class NoopQueryProcessor(LogicalQueryProcessor):
         query.add_condition_to_ast(equals(literal(1), literal(1)))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()  # (scope="module")
 def mock_storage() -> Generator[ReadableTableStorage, None, None]:
     # setup
     storkey = StorageKey("mockstorage")
@@ -71,7 +71,7 @@ def mock_storage() -> Generator[ReadableTableStorage, None, None]:
     del _STORAGE_SET_CLUSTER_MAP[storage.get_storage_set_key()]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()  # (scope="module")
 def mock_entity(
     mock_storage: ReadableTableStorage,
 ) -> Generator[PluggableEntity, None, None]:

--- a/tests/pipeline/test_entity_processing_stage.py
+++ b/tests/pipeline/test_entity_processing_stage.py
@@ -1,0 +1,102 @@
+from datetime import datetime
+
+from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.clickhouse.query import Query
+from snuba.datasets.factory import get_dataset
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.pipeline.query_pipeline import QueryPipelineResult
+from snuba.pipeline.stages.query_processing import EntityProcessingStage
+from snuba.query import SelectedExpression
+from snuba.query.dsl import and_cond, binary_condition, column, equals, literal
+from snuba.query.expressions import Column, FunctionCall
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.query.snql.parser import parse_snql_query
+from snuba.request import Request
+from snuba.utils.metrics.timer import Timer
+
+
+def test_basic():
+    query_body = {
+        "query": (
+            "MATCH (metrics_distributions) "
+            "SELECT avg(granularity) "
+            "WHERE "
+            "timestamp >= toDateTime('2021-05-17 19:42:01') AND "
+            "timestamp < toDateTime('2021-05-17 23:42:01') AND "
+            "org_id = 1 AND "
+            "project_id = 1"
+        ),
+    }
+    metrics_dataset = get_dataset("metrics")
+    query, _ = parse_snql_query(query_body["query"], metrics_dataset)
+    query_settings = HTTPQuerySettings()
+    timer = Timer("test")
+    request = request = Request(
+        id="",
+        original_body=query_body,
+        query=query,
+        snql_anonymized="",
+        query_settings=query_settings,
+        attribution_info=AttributionInfo(
+            get_app_id("blah"), {"tenant_type": "tenant_id"}, "blah", None, None, None
+        ),
+    )
+    res = EntityProcessingStage().execute(
+        QueryPipelineResult(
+            data=request,
+            query_settings=request.query_settings,
+            timer=timer,
+            error=None,
+        )
+    )
+    assert res.data and not res.error
+    assert res.query_settings == query_settings and res.timer == timer
+    assert isinstance(res.data, Query)
+    actual = res.data
+    assert (
+        actual.get_arrayjoin() is None
+        and actual.get_prewhere_ast() is None
+        and actual.get_groupby() == []
+        and actual.get_having() is None
+        and actual.get_orderby() == []
+        and actual.get_limitby() is None
+        and actual.get_offset() == 0
+        and not actual.has_totals()
+        and actual.get_granularity() is None
+        and actual.get_limit() == 1000
+    )
+    assert actual.get_from_clause().storage_key == StorageKey.METRICS_DISTRIBUTIONS
+    expected_selected = [
+        SelectedExpression(
+            "avg(granularity)",
+            FunctionCall(
+                "_snuba_avg(granularity)",
+                "avg",
+                (Column("_snuba_granularity", None, "granularity"),),
+            ),
+        )
+    ]
+    assert actual.get_selected_columns() == expected_selected
+    expected_cond = and_cond(
+        equals(column("granularity"), literal(60)),
+        and_cond(
+            binary_condition(
+                "greaterOrEquals",
+                column("timestamp", alias="_snuba_timestamp"),
+                literal(datetime(2021, 5, 17, 19, 42, 1)),
+            ),
+            and_cond(
+                binary_condition(
+                    "less",
+                    column("timestamp", alias="_snuba_timestamp"),
+                    literal(datetime(2021, 5, 17, 23, 42, 1)),
+                ),
+                and_cond(
+                    equals(column("org_id", alias="_snuba_org_id"), literal(1)),
+                    equals(column("project_id", alias="_snuba_project_id"), literal(1)),
+                ),
+            ),
+        ),
+    )
+    assert actual.get_condition() == expected_cond

--- a/tests/pipeline/test_entity_processing_stage.py
+++ b/tests/pipeline/test_entity_processing_stage.py
@@ -1,3 +1,7 @@
+from collections.abc import Generator
+
+import pytest
+
 from snuba.attribution import get_app_id
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.columns import ColumnSet
@@ -21,7 +25,8 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
 from snuba.query.dsl import and_cond, column, equals, literal
 from snuba.query.logical import Query as LogicalQuery
-from snuba.query.query_settings import HTTPQuerySettings
+from snuba.query.processors.logical import LogicalQueryProcessor
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.query.snql.parser import parse_snql_query_initial
 from snuba.request import Request
 from snuba.utils.metrics.timer import Timer
@@ -31,44 +36,68 @@ from snuba.utils.schemas import DateTime, UInt
 """
 Create a fake storage and entity, put the entity in global definitions
 """
-entkey = EntityKey("mock_entity")
-storkey = StorageKey("mockstorage")
-storsetkey = StorageSetKey("mockstorageset")
-colset = ColumnSet(
-    [
-        ColumnSchema("org_id", UInt(64)),
-        ColumnSchema("project_id", UInt(64)),
-        ColumnSchema("timestamp", DateTime()),
-    ]
-)
-storage = ReadableTableStorage(
-    storage_key=storkey,
-    storage_set_key=storsetkey,
-    schema=TableSchema(
-        columns=colset,
-        local_table_name=f"{storkey.value}_local",
-        dist_table_name=f"{storkey.value}_dist",
+
+
+class NoopQueryProcessor(LogicalQueryProcessor):
+    def process_query(self, query: LogicalQuery, query_settings: QuerySettings) -> None:
+        query.add_condition_to_ast(equals(literal(1), literal(1)))
+
+
+@pytest.fixture(scope="module")
+def mock_storage() -> Generator[ReadableTableStorage, None, None]:
+    # setup
+    storkey = StorageKey("mockstorage")
+    storsetkey = StorageSetKey("mockstorageset")
+    storage = ReadableTableStorage(
+        storage_key=storkey,
         storage_set_key=storsetkey,
-    ),
-    readiness_state=ReadinessState.COMPLETE,
-)
-_STORAGE_SET_CLUSTER_MAP[storage.get_storage_set_key()] = CLUSTERS[0]
-entity = PluggableEntity(
-    entity_key=entkey,
-    storages=[EntityStorageConnection(storage, TranslationMappers())],
-    query_processors=[],
-    columns=colset.columns,
-    validators=[],
-    required_time_column="timestamp",
-    storage_selector=DefaultQueryStorageSelector(),
-)
-override_entity_map(entkey, entity)
+        schema=TableSchema(
+            columns=ColumnSet(
+                [
+                    ColumnSchema("org_id", UInt(64)),
+                    ColumnSchema("project_id", UInt(64)),
+                    ColumnSchema("timestamp", DateTime()),
+                ]
+            ),
+            local_table_name=f"{storkey.value}_local",
+            dist_table_name=f"{storkey.value}_dist",
+            storage_set_key=storsetkey,
+        ),
+        readiness_state=ReadinessState.COMPLETE,
+    )
+    _STORAGE_SET_CLUSTER_MAP[storage.get_storage_set_key()] = CLUSTERS[0]
+    yield storage
+    # teardown
+    del _STORAGE_SET_CLUSTER_MAP[storage.get_storage_set_key()]
 
 
-def test_basic() -> None:
+@pytest.fixture(scope="module")
+def mock_entity(
+    mock_storage: ReadableTableStorage,
+) -> Generator[PluggableEntity, None, None]:
+    # setup
+    entkey = EntityKey("mock_entity")
+    entity = PluggableEntity(
+        entity_key=entkey,
+        storages=[EntityStorageConnection(mock_storage, TranslationMappers())],
+        query_processors=[NoopQueryProcessor()],
+        columns=mock_storage.get_schema().get_columns().columns,
+        validators=[],
+        required_time_column="timestamp",
+        storage_selector=DefaultQueryStorageSelector(),
+    )
+    override_entity_map(entkey, entity)
+    yield entity
+    # teardown
+    reset_entity_factory()
+
+
+def test_basic(
+    mock_storage: ReadableTableStorage, mock_entity: PluggableEntity
+) -> None:
     query_body = {
         "query": (
-            f"MATCH ({entkey.value}) "
+            f"MATCH ({mock_entity.entity_key.value}) "
             "SELECT timestamp "
             "WHERE "
             "org_id = 1 AND "
@@ -89,23 +118,24 @@ def test_basic() -> None:
             get_app_id("blah"), {"tenant_type": "tenant_id"}, "blah", None, None, None
         ),
     )
-    schema = storage.get_schema()
+    schema = mock_storage.get_schema()
     assert isinstance(schema, TableSchema)
     expected = QueryPipelineResult(
         data=Query(
             from_clause=Table(
                 table_name=schema.get_table_name(),
-                schema=storage.get_schema().get_columns(),
-                storage_key=storkey,
-                allocation_policies=storage.get_allocation_policies(),
+                schema=mock_storage.get_schema().get_columns(),
+                storage_key=mock_storage.get_storage_key(),
+                allocation_policies=mock_storage.get_allocation_policies(),
                 final=logical_query.get_final(),
                 sampling_rate=logical_query.get_sample(),
-                mandatory_conditions=storage.get_schema()
+                mandatory_conditions=mock_storage.get_schema()
                 .get_data_source()
                 .get_mandatory_conditions(),
             ),
             selected_columns=[SelectedExpression("timestamp", column("timestamp"))],
             condition=and_cond(
+                equals(literal(1), literal(1)),
                 equals(column("org_id"), literal(1)),
                 equals(column("project_id"), literal(1)),
             ),
@@ -124,4 +154,3 @@ def test_basic() -> None:
         )
     )
     assert actual == expected
-    reset_entity_factory()

--- a/tests/pipeline/test_entity_processing_stage.py
+++ b/tests/pipeline/test_entity_processing_stage.py
@@ -1,48 +1,117 @@
-from datetime import datetime
-
 from snuba.attribution import get_app_id
 from snuba.attribution.attribution_info import AttributionInfo
+from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
-from snuba.datasets.factory import get_dataset
+from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
+from snuba.clusters.cluster import _STORAGE_SET_CLUSTER_MAP, CLUSTERS
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import override_entity_map, reset_entity_factory
+from snuba.datasets.entities.storage_selectors.selector import (
+    DefaultQueryStorageSelector,
+)
+from snuba.datasets.pluggable_entity import PluggableEntity
+from snuba.datasets.readiness_state import ReadinessState
+from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storage import EntityStorageConnection, ReadableTableStorage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.pipeline.query_pipeline import QueryPipelineResult
 from snuba.pipeline.stages.query_processing import EntityProcessingStage
 from snuba.query import SelectedExpression
-from snuba.query.dsl import and_cond, binary_condition, column, equals, literal
-from snuba.query.expressions import Column, FunctionCall
+from snuba.query.data_source.simple import Table
+from snuba.query.dsl import and_cond, column, equals, literal
 from snuba.query.query_settings import HTTPQuerySettings
-from snuba.query.snql.parser import parse_snql_query
+from snuba.query.snql.parser import parse_snql_query_initial
 from snuba.request import Request
 from snuba.utils.metrics.timer import Timer
+from snuba.utils.schemas import Column as ColumnSchema
+from snuba.utils.schemas import DateTime, UInt
+
+"""
+Create a fake storage and entity, put the entity in global definitions
+"""
+entkey = EntityKey("mock_entity")
+storkey = StorageKey("mockstorage")
+storsetkey = StorageSetKey("mockstorageset")
+colset = ColumnSet(
+    [
+        ColumnSchema("org_id", UInt(64)),
+        ColumnSchema("project_id", UInt(64)),
+        ColumnSchema("timestamp", DateTime()),
+    ]
+)
+storage = ReadableTableStorage(
+    storage_key=storkey,
+    storage_set_key=storsetkey,
+    schema=TableSchema(
+        columns=colset,
+        local_table_name=f"{storkey.value}_local",
+        dist_table_name=f"{storkey.value}_dist",
+        storage_set_key=storsetkey,
+    ),
+    readiness_state=ReadinessState.COMPLETE,
+)
+_STORAGE_SET_CLUSTER_MAP[storage.get_storage_set_key()] = CLUSTERS[0]
+entity = PluggableEntity(
+    entity_key=entkey,
+    storages=[EntityStorageConnection(storage, TranslationMappers())],
+    query_processors=[],
+    columns=colset.columns,
+    validators=[],
+    required_time_column="timestamp",
+    storage_selector=DefaultQueryStorageSelector(),
+)
+override_entity_map(entkey, entity)
 
 
 def test_basic():
     query_body = {
         "query": (
-            "MATCH (metrics_distributions) "
-            "SELECT avg(granularity) "
+            f"MATCH ({entkey.value}) "
+            "SELECT timestamp "
             "WHERE "
-            "timestamp >= toDateTime('2021-05-17 19:42:01') AND "
-            "timestamp < toDateTime('2021-05-17 23:42:01') AND "
             "org_id = 1 AND "
             "project_id = 1"
         ),
     }
-    metrics_dataset = get_dataset("metrics")
-    query, _ = parse_snql_query(query_body["query"], metrics_dataset)
+    logical_query = parse_snql_query_initial(query_body["query"])
     query_settings = HTTPQuerySettings()
     timer = Timer("test")
-    request = request = Request(
+    request = Request(
         id="",
         original_body=query_body,
-        query=query,
+        query=logical_query,
         snql_anonymized="",
         query_settings=query_settings,
         attribution_info=AttributionInfo(
             get_app_id("blah"), {"tenant_type": "tenant_id"}, "blah", None, None, None
         ),
     )
-    res = EntityProcessingStage().execute(
+    schema = storage.get_schema()
+    assert isinstance(schema, TableSchema)
+    expected = QueryPipelineResult(
+        data=Query(
+            from_clause=Table(
+                table_name=schema.get_table_name(),
+                schema=storage.get_schema().get_columns(),
+                storage_key=storkey,
+                allocation_policies=storage.get_allocation_policies(),
+                final=logical_query.get_final(),
+                sampling_rate=logical_query.get_sample(),
+                mandatory_conditions=storage.get_mandatory_condition_checkers(),
+            ),
+            selected_columns=[SelectedExpression("timestamp", column("timestamp"))],
+            condition=and_cond(
+                equals(column("org_id"), literal(1)),
+                equals(column("project_id"), literal(1)),
+            ),
+            limit=1000,
+        ),
+        query_settings=query_settings,
+        timer=timer,
+        error=None,
+    )
+    actual = EntityProcessingStage().execute(
         QueryPipelineResult(
             data=request,
             query_settings=request.query_settings,
@@ -50,53 +119,5 @@ def test_basic():
             error=None,
         )
     )
-    assert res.data and not res.error
-    assert res.query_settings == query_settings and res.timer == timer
-    assert isinstance(res.data, Query)
-    actual = res.data
-    assert (
-        actual.get_arrayjoin() is None
-        and actual.get_prewhere_ast() is None
-        and actual.get_groupby() == []
-        and actual.get_having() is None
-        and actual.get_orderby() == []
-        and actual.get_limitby() is None
-        and actual.get_offset() == 0
-        and not actual.has_totals()
-        and actual.get_granularity() is None
-        and actual.get_limit() == 1000
-    )
-    assert actual.get_from_clause().storage_key == StorageKey.METRICS_DISTRIBUTIONS
-    expected_selected = [
-        SelectedExpression(
-            "avg(granularity)",
-            FunctionCall(
-                "_snuba_avg(granularity)",
-                "avg",
-                (Column("_snuba_granularity", None, "granularity"),),
-            ),
-        )
-    ]
-    assert actual.get_selected_columns() == expected_selected
-    expected_cond = and_cond(
-        equals(column("granularity"), literal(60)),
-        and_cond(
-            binary_condition(
-                "greaterOrEquals",
-                column("timestamp", alias="_snuba_timestamp"),
-                literal(datetime(2021, 5, 17, 19, 42, 1)),
-            ),
-            and_cond(
-                binary_condition(
-                    "less",
-                    column("timestamp", alias="_snuba_timestamp"),
-                    literal(datetime(2021, 5, 17, 23, 42, 1)),
-                ),
-                and_cond(
-                    equals(column("org_id", alias="_snuba_org_id"), literal(1)),
-                    equals(column("project_id", alias="_snuba_project_id"), literal(1)),
-                ),
-            ),
-        ),
-    )
-    assert actual.get_condition() == expected_cond
+    assert actual == expected
+    reset_entity_factory()

--- a/tests/pipeline/test_execution_stage.py
+++ b/tests/pipeline/test_execution_stage.py
@@ -22,7 +22,12 @@ from snuba.query.dsl import and_cond, column, equals, literal
 from snuba.query.expressions import Column, FunctionCall
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.query_settings import HTTPQuerySettings
-from snuba.querylog.query_metadata import SnubaQueryMetadata
+from snuba.querylog.query_metadata import (
+    SLO,
+    QueryStatus,
+    RequestStatus,
+    SnubaQueryMetadata,
+)
 from snuba.request import Request
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.schemas import UUID, String, UInt
@@ -143,6 +148,13 @@ def test_basic(ch_query: Query) -> None:
     assert isinstance(policy, MockAllocationPolicy) and policy.did_update
     q = settings.get_resource_quota()
     assert q and q.max_threads == 1
+    # metadata
+    assert (
+        metadata.request_status == RequestStatus.SUCCESS
+        and metadata.status == QueryStatus.SUCCESS
+        and metadata.slo == SLO.FOR
+        and len(metadata.query_list) == 1
+    )
 
 
 @pytest.mark.clickhouse_db

--- a/tests/pipeline/test_execution_stage.py
+++ b/tests/pipeline/test_execution_stage.py
@@ -96,3 +96,9 @@ def test_basic():
         and len(res.data.result["data"]) == 1
         and "avg(granularity)" in res.data.result["data"][0]
     )
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_dry_run():
+    pass

--- a/tests/pipeline/test_execution_stage.py
+++ b/tests/pipeline/test_execution_stage.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+
+import pytest
+
+from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.pipeline.query_pipeline import QueryPipelineResult
+from snuba.pipeline.stages.query_execution import ExecutionStage
+from snuba.query import SelectedExpression
+from snuba.query.data_source.simple import Table
+from snuba.query.dsl import and_cond, binary_condition, column, equals, literal
+from snuba.query.expressions import Column, FunctionCall
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.querylog.query_metadata import SnubaQueryMetadata
+from snuba.request import Request
+from snuba.utils.metrics.timer import Timer
+from snuba.utils.schemas import DateTime, UInt
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_basic():
+    attinfo = AttributionInfo(
+        get_app_id("blah"), {"tenant_type": "tenant_id"}, "blah", None, None, None
+    )
+    settings = HTTPQuerySettings()
+    timer = Timer("test")
+    ch_query = Query(
+        from_clause=Table(
+            "metrics_distributions_v2_local",
+            ColumnSet(
+                [
+                    ("org_id", UInt(64)),
+                    ("project_id", UInt(64)),
+                    ("timestamp", DateTime()),
+                    ("granularity", UInt(32)),
+                ]
+            ),
+            storage_key=StorageKey.METRICS_DISTRIBUTIONS,
+        ),
+        selected_columns=[
+            SelectedExpression(
+                "avg(granularity)",
+                FunctionCall(
+                    "_snuba_avg(granularity)",
+                    "avg",
+                    (Column("_snuba_granularity", None, "granularity"),),
+                ),
+            )
+        ],
+        condition=and_cond(
+            equals(column("granularity"), literal(60)),
+            and_cond(
+                binary_condition(
+                    "greaterOrEquals",
+                    column("timestamp", alias="_snuba_timestamp"),
+                    literal(datetime(2021, 5, 17, 19, 42, 1)),
+                ),
+                and_cond(
+                    binary_condition(
+                        "less",
+                        column("timestamp", alias="_snuba_timestamp"),
+                        literal(datetime(2021, 5, 17, 23, 42, 1)),
+                    ),
+                    and_cond(
+                        equals(column("org_id", alias="_snuba_org_id"), literal(1)),
+                        equals(
+                            column("project_id", alias="_snuba_project_id"), literal(1)
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        limit=1000,
+    )
+    res = ExecutionStage(
+        attinfo,
+        query_metadata=SnubaQueryMetadata(
+            Request("", {}, ch_query, settings, attinfo, ""),
+            "blah",
+            timer,
+        ),
+    ).execute(
+        QueryPipelineResult(
+            data=ch_query,
+            query_settings=settings,
+            timer=timer,
+            error=None,
+        )
+    )
+    assert (
+        res.data
+        and len(res.data.result["data"]) == 1
+        and "avg(granularity)" in res.data.result["data"][0]
+    )

--- a/tests/pipeline/test_storage_processing_stage.py
+++ b/tests/pipeline/test_storage_processing_stage.py
@@ -1,0 +1,88 @@
+from copy import deepcopy
+from datetime import datetime
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.pipeline.query_pipeline import QueryPipelineResult
+from snuba.pipeline.stages.query_processing import StorageProcessingStage
+from snuba.query import SelectedExpression
+from snuba.query.data_source.simple import Table
+from snuba.query.dsl import and_cond, binary_condition, column, equals, literal
+from snuba.query.expressions import Column, FunctionCall
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.utils.metrics.timer import Timer
+
+
+def test_basic():
+    ch_query = Query(
+        from_clause=Table(
+            "metrics_distributions_v2_local",
+            ColumnSet([]),
+            storage_key=StorageKey.METRICS_DISTRIBUTIONS,
+        ),
+        selected_columns=[
+            SelectedExpression(
+                "avg(granularity)",
+                FunctionCall(
+                    "_snuba_avg(granularity)",
+                    "avg",
+                    (Column("_snuba_granularity", None, "granularity"),),
+                ),
+            )
+        ],
+        condition=and_cond(
+            equals(column("granularity"), literal(60)),
+            and_cond(
+                binary_condition(
+                    "greaterOrEquals",
+                    column("timestamp", alias="_snuba_timestamp"),
+                    literal(datetime(2021, 5, 17, 19, 42, 1)),
+                ),
+                and_cond(
+                    binary_condition(
+                        "less",
+                        column("timestamp", alias="_snuba_timestamp"),
+                        literal(datetime(2021, 5, 17, 23, 42, 1)),
+                    ),
+                    and_cond(
+                        equals(column("org_id", alias="_snuba_org_id"), literal(1)),
+                        equals(
+                            column("project_id", alias="_snuba_project_id"), literal(1)
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        limit=1000,
+    )
+    timer = Timer("test")
+    settings = HTTPQuerySettings()
+
+    res = StorageProcessingStage().execute(
+        QueryPipelineResult(
+            data=deepcopy(ch_query),
+            query_settings=settings,
+            timer=timer,
+            error=None,
+        )
+    )
+    assert res.data == Query(
+        from_clause=res.data.get_from_clause(),
+        selected_columns=ch_query.get_selected_columns(),
+        array_join=ch_query.get_arrayjoin(),
+        condition=ch_query.get_condition(),
+        prewhere=ch_query.get_prewhere_ast(),
+        groupby=ch_query.get_groupby(),
+        having=ch_query.get_having(),
+        order_by=ch_query.get_orderby(),
+        limitby=ch_query.get_limitby(),
+        limit=ch_query.get_limit(),
+        offset=ch_query.get_offset(),
+        totals=ch_query.has_totals(),
+        granularity=ch_query.get_granularity(),
+    )
+    assert res.data.get_from_clause() != ch_query.get_from_clause()
+    assert res.data.get_from_clause().table_name == "metrics_distributions_v2_local"
+    assert res.data.get_from_clause().storage_key == StorageKey.METRICS_DISTRIBUTIONS
+    assert len(res.data.get_from_clause().schema.columns) > 0

--- a/tests/pipeline/test_storage_processing_stage.py
+++ b/tests/pipeline/test_storage_processing_stage.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
 from snuba.clusters.cluster import _STORAGE_SET_CLUSTER_MAP, CLUSTERS
@@ -12,6 +10,7 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.pipeline.query_pipeline import QueryPipelineResult
 from snuba.pipeline.stages.query_processing import StorageProcessingStage
 from snuba.query.data_source.simple import Table
+from snuba.query.dsl import equals, literal
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.utils.metrics.timer import Timer
@@ -19,15 +18,10 @@ from snuba.utils.metrics.timer import Timer
 
 class MockQueryProcessor(ClickhouseQueryProcessor):
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
-        return
+        query.add_condition_to_ast(equals(literal(1), literal(1)))
 
 
 # Create a fake storage and add it to global storages and clusters
-mock_processors = [
-    MockQueryProcessor(),
-    MockQueryProcessor(),
-    MockQueryProcessor(),
-]
 mock_storage = ReadableTableStorage(
     storage_key=StorageKey("mockstorage"),
     storage_set_key=StorageSetKey("mockstorageset"),
@@ -38,7 +32,7 @@ mock_storage = ReadableTableStorage(
         storage_set_key=StorageSetKey("mockstorageset"),
     ),
     readiness_state=ReadinessState.COMPLETE,
-    query_processors=mock_processors,
+    query_processors=[MockQueryProcessor()],
     mandatory_condition_checkers=[],
     allocation_policies=[],
 )
@@ -47,38 +41,37 @@ _STORAGE_SET_CLUSTER_MAP[mock_storage.get_storage_set_key()] = CLUSTERS[0]
 
 
 def test_basic():
-    for f in mock_processors:
-        f.process_query = MagicMock()
-
-    ch_query = Query(
-        from_clause=Table(
-            "dontmatter",
-            ColumnSet([]),
-            storage_key=mock_storage.get_storage_key(),
+    theinput = QueryPipelineResult(
+        data=Query(
+            from_clause=Table(
+                "dontmatter",
+                ColumnSet([]),
+                storage_key=mock_storage.get_storage_key(),
+            ),
+            selected_columns=[],
+            condition=None,
         ),
-        selected_columns=[],
-        condition=None,
+        timer=Timer("test"),
+        query_settings=HTTPQuerySettings(),
+        error=None,
     )
-    timer = Timer("test")
-    settings = HTTPQuerySettings()
-    res = StorageProcessingStage().execute(
-        QueryPipelineResult(
-            data=ch_query,
-            query_settings=settings,
-            timer=timer,
-            error=None,
-        )
+    expected = QueryPipelineResult(
+        data=Query(
+            from_clause=Table(
+                table_name=mock_storage.get_schema().get_table_name(),
+                schema=mock_storage.get_schema().get_columns(),
+                storage_key=mock_storage.get_storage_key(),
+                allocation_policies=mock_storage.get_allocation_policies(),
+                final=theinput.data.get_from_clause().final,
+                sampling_rate=theinput.data.get_from_clause().sampling_rate,
+                mandatory_conditions=mock_storage.get_mandatory_condition_checkers(),
+            ),
+            selected_columns=[],
+            condition=equals(literal(1), literal(1)),
+        ),
+        timer=theinput.timer,
+        query_settings=theinput.query_settings,
+        error=None,
     )
-
-    assert res.data
-    fc = ch_query.get_from_clause()
-    assert (
-        fc
-        and fc.table_name == mock_storage.get_schema().get_table_name()
-        and fc.schema == mock_storage.get_schema().get_columns()
-        and fc.storage_key == mock_storage.get_storage_key()
-        and fc.allocation_policies == mock_storage.get_allocation_policies()
-        and fc.mandatory_conditions == mock_storage.get_mandatory_condition_checkers()
-    )
-    for f in mock_processors:
-        f.process_query.assert_called_with(ch_query, settings)
+    actual = StorageProcessingStage().execute(theinput)
+    assert actual == expected

--- a/tests/pipeline/test_storage_processing_stage.py
+++ b/tests/pipeline/test_storage_processing_stage.py
@@ -40,38 +40,46 @@ get_config_built_storages()[mock_storage.get_storage_key()] = mock_storage
 _STORAGE_SET_CLUSTER_MAP[mock_storage.get_storage_set_key()] = CLUSTERS[0]
 
 
-def test_basic():
-    theinput = QueryPipelineResult(
-        data=Query(
-            from_clause=Table(
-                "dontmatter",
-                ColumnSet([]),
-                storage_key=mock_storage.get_storage_key(),
-            ),
-            selected_columns=[],
-            condition=None,
+def test_basic() -> None:
+    query = Query(
+        from_clause=Table(
+            "dontmatter",
+            ColumnSet([]),
+            storage_key=mock_storage.get_storage_key(),
         ),
-        timer=Timer("test"),
-        query_settings=HTTPQuerySettings(),
-        error=None,
+        selected_columns=[],
+        condition=None,
     )
+    timer = Timer("test")
+    settings = HTTPQuerySettings()
+    schema = mock_storage.get_schema()
+    assert isinstance(schema, TableSchema)
     expected = QueryPipelineResult(
         data=Query(
             from_clause=Table(
-                table_name=mock_storage.get_schema().get_table_name(),
+                table_name=schema.get_table_name(),
                 schema=mock_storage.get_schema().get_columns(),
                 storage_key=mock_storage.get_storage_key(),
                 allocation_policies=mock_storage.get_allocation_policies(),
-                final=theinput.data.get_from_clause().final,
-                sampling_rate=theinput.data.get_from_clause().sampling_rate,
-                mandatory_conditions=mock_storage.get_mandatory_condition_checkers(),
+                final=query.get_from_clause().final,
+                sampling_rate=query.get_from_clause().sampling_rate,
+                mandatory_conditions=mock_storage.get_schema()
+                .get_data_source()
+                .get_mandatory_conditions(),
             ),
             selected_columns=[],
             condition=equals(literal(1), literal(1)),
         ),
-        timer=theinput.timer,
-        query_settings=theinput.query_settings,
+        timer=timer,
+        query_settings=settings,
         error=None,
     )
-    actual = StorageProcessingStage().execute(theinput)
+    actual = StorageProcessingStage().execute(
+        QueryPipelineResult(
+            data=query,
+            timer=timer,
+            query_settings=settings,
+            error=None,
+        )
+    )
     assert actual == expected


### PR DESCRIPTION
Added a general case test for `EntityProcessingStage`, `StorageProcessingStage`, and `ExecutionStage`.

I decided not to test `EntityAndStoragePipelineStage` since it will be phased out soon.