### PR TITLE
fix(spans): Move span id above trace id in the prewhere

### DIFF
--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -165,7 +165,7 @@ query_processors:
   - processor: PrewhereProcessor
     args:
       prewhere_candidates:
-        [transaction_id, trace_id, span_id, segment_name]
+        [transaction_id, span_id, trace_id, segment_name]
   - processor: TableRateLimit
   - processor: TupleUnaliaser
 


### PR DESCRIPTION
- The spans table is ordered by span ids but not trace_id which means that when both are included in a where clause we're producing a slower query since trace_id will go in the prewhere instead of span_id