### PR TITLE
ref(card-an): Allow the new meta tables in the cardinality analyzer

### DIFF
--- a/snuba/admin/cardinality_analyzer/cardinality_analyzer.py
+++ b/snuba/admin/cardinality_analyzer/cardinality_analyzer.py
@@ -48,6 +48,8 @@ def run_metrics_query(query: str, user: str) -> ClickhouseResult:
     for mtype in ["counters", "sets", "distributions", "gauges"]:
         meta_tables.add(f"generic_metric_{mtype}_meta_aggregated_dist")
         meta_tables.add(f"generic_metric_{mtype}_meta_tag_value_aggregated_dist")
+        meta_tables.add(f"generic_metric_{mtype}_meta_dist")
+        meta_tables.add(f"generic_metric_{mtype}_meta_tag_values_dist")
 
     validate_ro_query(
         sql_query=query,

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -24,3 +24,15 @@ def test_allowed_tables() -> None:
             "SELECT * FROM my_table, other_table",
             allowed_tables={"my_table"},
         )
+
+
+def test_allowed_tables_with_array_join() -> None:
+    validate_ro_query(
+        "SELECT * FROM my_table ARRAY JOIN tags.key AS tag_key, tags.raw_value AS tag_value",
+        allowed_tables={"my_table"},
+    )
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query(
+            "SELECT * FROM my_table, other_table ARRAY JOIN tags.key AS tag_key, tags.raw_value AS tag_value",
+            allowed_tables={"my_table"},
+        )


### PR DESCRIPTION
Also fix the validation to deal with ARRAY JOIN a little better. It was hard to
test the meta materialized view queries because the validation would choke on
ARRAY JOIN clauses.