### PR TITLE
chore(on-call): Add CrossOrgQueryAllocationPolicy to errors

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -275,6 +275,10 @@ allocation_policies:
       default_config_overrides:
         is_enforced: 0
         is_active: 0
+      cross_org_referrer_limits:
+        getsentry.tasks.backfill_grouping_records:
+          max_threads: 2
+          concurrent_limit: 4
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor

--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -268,6 +268,13 @@ allocation_policies:
         - referrer
       default_config_overrides:
         is_enforced: 0
+  - name: CrossOrgQueryAllocationPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -273,6 +273,10 @@ allocation_policies:
       default_config_overrides:
         is_enforced: 0
         is_active: 0
+      cross_org_referrer_limits:
+        getsentry.tasks.backfill_grouping_records:
+          max_threads: 2
+          concurrent_limit: 4
 
 
 query_processors:

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -266,6 +266,13 @@ allocation_policies:
         - referrer
       default_config_overrides:
         is_enforced: 0
+  - name: CrossOrgQueryAllocationPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
 
 
 query_processors:

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -502,7 +502,7 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
         assert response.status_code == 200
 
         # three policies
-        assert response.json is not None and len(response.json) == 4
+        assert response.json is not None and len(response.json) == 5
         policy_configs = response.json
         bytes_scanned_policy = [
             policy
@@ -542,7 +542,7 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
 
         response = admin_api.get("/allocation_policy_configs/errors")
         assert response.status_code == 200
-        assert response.json is not None and len(response.json) == 4
+        assert response.json is not None and len(response.json) == 5
         assert {
             "default": -1,
             "description": "Number of bytes a specific org can scan in a 10 minute "

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -288,6 +288,11 @@ def test_db_query_success() -> None:
             "explanation": {},
             "max_threads": 10,
         },
+        "CrossOrgQueryAllocationPolicy": {
+            "can_run": True,
+            "explanation": {},
+            "max_threads": 10,
+        },
     }
     assert len(query_metadata_list) == 1
     assert result.extra["stats"] == stats


### PR DESCRIPTION
This PR is responsible for adding the CrossOrgQueryAllocationPolicy to errors in order to give us better control over referrers that run across all orgs (e.g.: [backfill seer grouping records script](https://github.com/getsentry/sentry/pull/68466)). 