### PR TITLE
feat(replays): add replay_id column to merged discover table

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -136,6 +136,7 @@ class DiscoverLoader(DirectoryLoader):
             "0005_discover_fix_transaction_name",
             "0006_discover_add_trace_id",
             "0007_discover_add_span_id",
+            "0008_discover_add_replay_id",
         ]
 
 

--- a/snuba/snuba_migrations/discover/0008_discover_add_replay_id.py
+++ b/snuba/snuba_migrations/discover/0008_discover_add_replay_id.py
@@ -1,0 +1,49 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import UUID, Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigrationLegacy):
+    """
+    Add replay_id to merge table
+    """
+
+    blocking = False
+
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column=Column("replay_id", UUID(Modifiers(nullable=True))),
+                after="span_id",
+            ),
+        ]
+
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column_name="replay_id",
+            ),
+        ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("discover_local")
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("discover_local")
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("discover_dist")
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("discover_dist")

--- a/snuba/snuba_migrations/discover/0008_discover_add_replay_id.py
+++ b/snuba/snuba_migrations/discover/0008_discover_add_replay_id.py
@@ -4,46 +4,53 @@ from snuba.clickhouse.columns import UUID, Column
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
 
 
-class Migration(migration.ClickhouseNodeMigrationLegacy):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Add replay_id to merge table
     """
 
     blocking = False
 
-    def __forward_migrations(
-        self, table_name: str
-    ) -> Sequence[operations.SqlOperation]:
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.DISCOVER,
                 table_name=table_name,
                 column=Column("replay_id", UUID(Modifiers(nullable=True))),
                 after="span_id",
-            ),
+                target=target,
+            )
+            for table_name, target in [
+                ("discover_local", OperationTarget.LOCAL),
+                ("discover_dist", OperationTarget.DISTRIBUTED),
+            ]
         ]
 
-    def __backwards_migrations(
-        self, table_name: str
-    ) -> Sequence[operations.SqlOperation]:
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 storage_set=StorageSetKey.DISCOVER,
                 table_name=table_name,
                 column_name="replay_id",
-            ),
+                target=target,
+            )
+            for table_name, target in [
+                ("discover_dist", OperationTarget.DISTRIBUTED),
+                ("discover_local", OperationTarget.LOCAL),
+            ]
         ]
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
-        return self.__forward_migrations("discover_local")
+        return self.forwards_ops()
 
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
-        return self.__backwards_migrations("discover_local")
+        return self.backwards_ops()
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return self.__forward_migrations("discover_dist")
+        return self.forwards_ops()
 
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return self.__backwards_migrations("discover_dist")
+        return self.backwards_ops()


### PR DESCRIPTION
we want to be able to query this field in discover. it exists on both errors and transactions.