### PR TITLE
ref: Rust consumer should not skip writes by default (inc-715)

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -105,7 +105,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     "--skip-write/--no-skip-write",
     "skip_write",
     help="Skip the write to clickhouse",
-    default=True,
+    default=False,
 )
 @click.option(
     "--concurrency",


### PR DESCRIPTION
Previous default was for testing, consumer should not skip writes by default. This matches the default value on the python consumer.

