### PR TITLE
fix(spans): Let null domain be null

### DIFF
--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -63,8 +63,7 @@ struct Span {
     action: String,
     deleted: u8,
     description: String,
-    #[serde(default)]
-    domain: String,
+    domain: Option<String>,
     duration: u32,
     end_ms: u16,
     end_timestamp: u64,
@@ -144,7 +143,7 @@ impl TryFrom<FromSpanMessage> for Span {
         Ok(Self {
             action: sentry_tags.get("action").cloned().unwrap_or_default(),
             description: from.description.unwrap_or_default(),
-            domain: sentry_tags.get("domain").cloned().unwrap_or_default(),
+            domain: sentry_tags.get("domain").cloned(),
             duration: from.duration_ms,
             end_ms: (end_timestamp_ms % 1000) as u16,
             end_timestamp: end_timestamp_ms / 1000,
@@ -308,6 +307,7 @@ mod tests {
     #[derive(Debug, Default, Deserialize, Serialize)]
     struct TestSentryTags {
         action: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         domain: Option<String>,
         group: Option<String>,
         #[serde(rename = "http.method")]
@@ -446,5 +446,20 @@ mod tests {
     #[test]
     fn schema() {
         run_schema_type_test::<FromSpanMessage>("snuba-spans", None);
+    }
+
+    #[test]
+    fn test_null_domain() {
+        let mut span = valid_span();
+        span.sentry_tags.domain = Option::None;
+        let data = serde_json::to_vec(&span).unwrap();
+        let payload = KafkaPayload::new(None, None, Some(data));
+        let meta = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: DateTime::from(SystemTime::now()),
+        };
+        process_message(payload, meta, &ProcessorConfig::default())
+            .expect("The message should be processed");
     }
 }

--- a/tests/datasets/test_spans_payloads.py
+++ b/tests/datasets/test_spans_payloads.py
@@ -41,7 +41,7 @@ expected_for_required_fields = {
     "action": "",
     "deleted": 0,
     "description": "",
-    "domain": "",
+    "domain": None,
     "duration": 1234560123,
     "end_ms": 234,
     "end_timestamp": int(


### PR DESCRIPTION
`domain` is a nullable column (https://github.com/getsentry/snuba/blob/master/snuba/snuba_migrations/spans/0001_spans_v1.py#L38) and we'd want to search for empty domain via `!has:span.domain`, `span.domain:""`, which all get turned into `isNull(domain) == 1`, which fails to find the proper spans since we set an empty string by default.

This PR aims to let the `null` value be `null` and not default to an empty string.