### PR TITLE
fix: fix mypy --strict vscode 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,7 +57,6 @@
   },
 
   "python.linting.mypyEnabled": true,
-  "python.linting.mypyArgs": ["--strict"],
   "python.linting.flake8Enabled": true,
   "python.formatting.provider": "black",
   // https://github.com/DonJayamanne/pythonVSCode/issues/992
@@ -65,5 +64,6 @@
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,
-  "python.testing.pytestArgs": ["tests"]
+  "python.testing.pytestArgs": ["tests"],
+  "mypy-type-checker.args": ["--strict"]
 }


### PR DESCRIPTION
what is currently in the settings file `"python.linting.mypyArgs": ["--strict"]` is depricated and doesnt actually do anything. I updated this to the proper way.