### PR TITLE
feat(migrations): add discover local

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -136,6 +136,7 @@ class DiscoverLoader(DirectoryLoader):
             "0005_discover_fix_transaction_name",
             "0006_discover_add_trace_id",
             "0007_discover_add_span_id",
+            "0008_discover_fix_new_dist_table",
         ]
 
 

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -136,7 +136,7 @@ class DiscoverLoader(DirectoryLoader):
             "0005_discover_fix_transaction_name",
             "0006_discover_add_trace_id",
             "0007_discover_add_span_id",
-            "0008_discover_fix_new_dist_table",
+            "0008_discover_fix_add_local_table",
         ]
 
 

--- a/snuba/snuba_migrations/discover/0008_discover_fix_add_local_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_add_local_table.py
@@ -51,19 +51,9 @@ columns: List[Column[Modifiers]] = [
 class Migration(migration.ClickhouseNodeMigration):
     blocking = False
     local_table_name = "discover_local"
-    dist_table_name = "discover_dist_new"
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [
-            operations.CreateTable(
-                storage_set=StorageSetKey.DISCOVER,
-                table_name=self.local_table_name,
-                columns=columns,
-                engine=table_engines.Merge(
-                    table_name_regex="^errors_local$|^transactions_local$"
-                ),
-                target=OperationTarget.LOCAL,
-            ),
             operations.CreateTable(
                 storage_set=StorageSetKey.DISCOVER,
                 table_name=self.dist_table_name,
@@ -78,10 +68,4 @@ class Migration(migration.ClickhouseNodeMigration):
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
         # we do not drop the local table because it is created in previous migrations
-        return [
-            operations.DropTable(
-                storage_set=StorageSetKey.DISCOVER,
-                table_name=self.dist_table_name,
-                target=OperationTarget.DISTRIBUTED,
-            )
-        ]
+        return []

--- a/snuba/snuba_migrations/discover/0008_discover_fix_add_local_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_add_local_table.py
@@ -56,13 +56,12 @@ class Migration(migration.ClickhouseNodeMigration):
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.DISCOVER,
-                table_name=self.dist_table_name,
+                table_name=self.local_table_name,
                 columns=columns,
-                engine=table_engines.Distributed(
-                    local_table_name=self.local_table_name,
-                    sharding_key=None,
+                engine=table_engines.Merge(
+                    table_name_regex="^errors_local$|^transactions_local$"
                 ),
-                target=OperationTarget.DISTRIBUTED,
+                target=OperationTarget.LOCAL,
             ),
         ]
 

--- a/snuba/snuba_migrations/discover/0008_discover_fix_new_dist_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_new_dist_table.py
@@ -1,0 +1,91 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import (
+    UUID,
+    Array,
+    Column,
+    DateTime,
+    IPv4,
+    IPv6,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+columns: List[Column[Modifiers]] = [
+    Column("event_id", UUID()),
+    Column("project_id", UInt(64)),
+    Column("type", String(Modifiers(low_cardinality=True))),
+    Column("timestamp", DateTime()),
+    Column("platform", String(Modifiers(low_cardinality=True))),
+    Column("environment", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("release", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("dist", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("transaction_name", String(Modifiers(low_cardinality=True))),
+    Column("message", String()),
+    Column("title", String()),
+    Column("user", String()),
+    Column("user_hash", UInt(64)),
+    Column("user_id", String(Modifiers(nullable=True))),
+    Column("user_name", String(Modifiers(nullable=True))),
+    Column("user_email", String(Modifiers(nullable=True))),
+    Column("ip_address_v4", IPv4(Modifiers(nullable=True))),
+    Column("ip_address_v6", IPv6(Modifiers(nullable=True))),
+    Column("sdk_name", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("sdk_version", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("http_method", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("http_referer", String(Modifiers(nullable=True))),
+    Column("tags", Nested([("key", String()), ("value", String())])),
+    Column("_tags_hash_map", Array(UInt(64))),
+    Column("contexts", Nested([("key", String()), ("value", String())])),
+    Column("span_id", UInt(64, Modifiers(nullable=True))),
+    Column("trace_id", UUID(Modifiers(nullable=True))),
+    Column("deleted", UInt(8)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    local_table_name = "discover_local"
+    dist_table_name = "discover_dist_new"
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=self.local_table_name,
+                columns=columns,
+                engine=table_engines.Merge(
+                    table_name_regex="^errors_local$|^transactions_local$"
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=self.dist_table_name,
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name=self.local_table_name,
+                    sharding_key=None,
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=self.dist_table_name,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=self.local_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/discover/0008_discover_fix_new_dist_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_new_dist_table.py
@@ -77,15 +77,11 @@ class Migration(migration.ClickhouseNodeMigration):
         ]
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        # we do not drop the local table because it is created in previous migrations
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.DISCOVER,
                 table_name=self.dist_table_name,
                 target=OperationTarget.DISTRIBUTED,
-            ),
-            operations.DropTable(
-                storage_set=StorageSetKey.DISCOVER,
-                table_name=self.local_table_name,
-                target=OperationTarget.LOCAL,
-            ),
+            )
         ]


### PR DESCRIPTION
Our migrations in SaaS don't have the discover local table. This causes a mismatch between discover migrations in SaaS and self-hosted/CI. The mismatch prevents us from running any new discover migrations. 

To fix this , this migration adds a `discover_local` table if it doesn't exist to reconcile SaaS with the self-hosted migrations. In SaaS the local table will not be used because we merge the distributed tables directly, but this will allow us to unblock discover migrations.