### PR TITLE
ref: dual-write docker image to artifact registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
       - name: Pull the test image
         id: image_pull
         env:
-          IMAGE_URL: us.gcr.io/sentryio/snuba:${{ github.sha }}
+          IMAGE_URL: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.sha }}
         shell: bash
         run: |
           echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
@@ -455,7 +455,7 @@ jobs:
         shell: bash
         env:
           SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
-          IMAGE_URL: us.gcr.io/sentryio/snuba:${{ github.sha }}
+          IMAGE_URL: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.sha }}
         run: |
           # only login if the password is set
           if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
         "--build-arg",
         "SOURCE_COMMIT=$COMMIT_SHA",
         "--destination=us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA",
+        "--destination=us-central1-docker.pkg.dev/$PROJECT_ID/snuba/image:$COMMIT_SHA",
         "--target=application",
         "-f",
         "./Dockerfile",
@@ -20,10 +21,14 @@ steps:
   # https://github.com/GoogleCloudPlatform/cloud-builders-community/issues/212#issuecomment-1478828752
   - name: docker
     args: [pull, "us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"]
-
+  - name: docker
+    args: [pull, "us-central1-docker.pkg.dev/$PROJECT_ID/snuba/image:$COMMIT_SHA"]
 
 # This is needed for Freight to find matching builds
-images: ['us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
+images: [
+    'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
+    'us-central1-docker.pkg.dev/$PROJECT_ID/snuba/image:$COMMIT_SHA',
+]
 timeout: 2640s
 options:
   # We need more memory for Webpack builds & e2e self-hosted tests


### PR DESCRIPTION
as part of OPS-3966 we're migrating off of deprecated gcr


this is step 1: dual write
step 2: cut over deploy pipelines
step 3: remove dual writing



<!-- Describe your PR here. -->