### PR TITLE
fix(ci/cd): Remove broken monitor check

### DIFF
--- a/gocd/templates/bash/s4s-ddog-health-check.sh
+++ b/gocd/templates/bash/s4s-ddog-health-check.sh
@@ -1,4 +1,1 @@
 #!/bin/bash
-
-/devinfra/scripts/checks/datadog/monitor_status.py \
-  130641272


### PR DESCRIPTION
The monitor that this was using no longer exists, which is causing the CD
pipeline to fail.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
