### PR TITLE
fix(22.8) Cast LowCardinality string columns to String

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -448,6 +448,22 @@ query_processors:
       time_parse_columns:
         - timestamp
   - processor: BasicFunctionsProcessor
+  - processor: LowCardinalityProcessor
+    args:
+      columns:
+        - transaction_name
+        - transaction_op
+        - platform
+        - environment
+        - release
+        - dist
+        - sdk_name
+        - sdk_version
+        - http_method
+        - type
+        - app_start_type
+        - transaction_source
+        - version
 
 
 validate_data_model: error

--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -458,7 +458,6 @@ query_processors:
         - release
         - dist
         - sdk_name
-        - sdk_version
         - http_method
         - type
         - app_start_type

--- a/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
@@ -338,7 +338,6 @@ query_processors:
         - release
         - dist
         - sdk_name
-        - sdk_version
         - http_method
         - type
         - app_start_type

--- a/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
@@ -328,6 +328,21 @@ query_processors:
   - processor: ApdexProcessor
   - processor: FailureRateProcessor
   - processor: ConditionSimplifierProcessor
+  - processor: LowCardinalityProcessor
+    args:
+      columns:
+        - transaction_name
+        - transaction_op
+        - platform
+        - environment
+        - release
+        - dist
+        - sdk_name
+        - sdk_version
+        - http_method
+        - type
+        - app_start_type
+        - transaction_source
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -360,6 +360,13 @@ query_processors:
     { processor: ApdexProcessor },
     { processor: FailureRateProcessor },
     { processor: ConditionSimplifierProcessor },
+    {
+      processor: LowCardinalityProcessor,
+      args:
+        {
+          columns: [transaction_name, transaction_op, platform, environment, release, dist, sdk_name, sdk_version, http_method, type, app_start_type, transaction_source],
+        },
+    },
   ]
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -364,7 +364,7 @@ query_processors:
       processor: LowCardinalityProcessor,
       args:
         {
-          columns: [transaction_name, transaction_op, platform, environment, release, dist, sdk_name, sdk_version, http_method, type, app_start_type, transaction_source],
+          columns: [transaction_name, transaction_op, platform, environment, release, dist, sdk_name, http_method, type, app_start_type, transaction_source],
         },
     },
   ]

--- a/snuba/query/processors/logical/low_cardinality_processor.py
+++ b/snuba/query/processors/logical/low_cardinality_processor.py
@@ -1,0 +1,49 @@
+from snuba import state
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.logical import Query
+from snuba.query.processors.logical import LogicalQueryProcessor
+from snuba.query.query_settings import QuerySettings
+
+
+class LowCardinalityProcessor(LogicalQueryProcessor):
+    """
+    22.8 has some problems when dealing with low cardinality string columns,
+    where the actual values in production are high cardinality. For example, in some
+    datasets `release` is a LowCardinality(String), but in practice it has a high cardinality.
+
+    This processor will fetch all the LowCardinality columns in the Entity, and wrap them in
+    `cast(ifNull(column, ''), 'String')` which strips the LowCardinality property and avoids
+    the error in 22.8
+
+    Which columns to use is hardcoded in, because whether or not a column is low cardinality
+    is not necessarily exposed in the schema definitions.
+    """
+
+    def __init__(self, columns: list[str]) -> None:
+        self.low_card_columns = set(columns)
+
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
+        def transform_expressions(exp: Expression) -> Expression:
+            if (
+                not isinstance(exp, Column)
+                or exp.column_name not in self.low_card_columns
+            ):
+                return exp
+
+            return FunctionCall(
+                None,
+                "cast",
+                (
+                    FunctionCall(
+                        None,
+                        "ifNull",
+                        (exp, Literal(None, "")),
+                    ),
+                    Literal(None, "String"),
+                ),
+            )
+
+        if state.get_int_config("use.low.cardinality.processor", 1) == 0:
+            return
+
+        query.transform_expressions(transform_expressions)

--- a/snuba/query/processors/logical/low_cardinality_processor.py
+++ b/snuba/query/processors/logical/low_cardinality_processor.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from snuba import state
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
@@ -31,13 +33,13 @@ class LowCardinalityProcessor(LogicalQueryProcessor):
                 return exp
 
             return FunctionCall(
-                None,
+                exp.alias,
                 "cast",
                 (
                     FunctionCall(
                         None,
                         "ifNull",
-                        (exp, Literal(None, "")),
+                        (replace(exp, alias=None), Literal(None, "")),
                     ),
                     Literal(None, "String"),
                 ),

--- a/tests/datasets/test_nullable_field_casting.py
+++ b/tests/datasets/test_nullable_field_casting.py
@@ -79,7 +79,6 @@ def test_nullable_field_casting(entity: Entity, expected_table_name: str) -> Non
                 super().__init__()
 
             def visit_function_call(self, exp: FunctionCall) -> str:
-                print(exp)
                 if (
                     exp.function_name == "cast"
                     and exp.alias == "_snuba_sdk_version"

--- a/tests/datasets/test_nullable_field_casting.py
+++ b/tests/datasets/test_nullable_field_casting.py
@@ -79,6 +79,7 @@ def test_nullable_field_casting(entity: Entity, expected_table_name: str) -> Non
                 super().__init__()
 
             def visit_function_call(self, exp: FunctionCall) -> str:
+                print(exp)
                 if (
                     exp.function_name == "cast"
                     and exp.alias == "_snuba_sdk_version"

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -237,7 +237,7 @@ test_data = [
     pytest.param(
         """
         MATCH (transactions)
-        SELECT platform
+        SELECT sdk_version
         WHERE tags_key IN tuple('t1', 't2')
             AND finish_ts >= toDateTime('2021-01-01T00:00:00')
             AND finish_ts < toDateTime('2021-01-02T00:00:00')
@@ -247,8 +247,8 @@ test_data = [
             None,
             selected_columns=[
                 SelectedExpression(
-                    name="platform",
-                    expression=Column("_snuba_platform", None, "platform"),
+                    name="sdk_version",
+                    expression=Column("_snuba_sdk_version", None, "sdk_version"),
                 )
             ],
             condition=with_required(

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1431,11 +1431,11 @@ class TestSnQLApi(BaseApiTest):
         assert response.status_code == 200
         data = json.loads(response.data)
         assert (
-            "equals(cast(ifNull((release AS _snuba_release), ''), 'String'), '1123581321345589')"
+            "equals((cast(ifNull(release, ''), 'String') AS _snuba_release), '1123581321345589')"
             in data["sql"]
         )
         assert (
-            "has(['prod', 'dev'], cast(ifNull((environment AS _snuba_environment), ''), 'String'))"
+            "has(['prod', 'dev'], (cast(ifNull(environment, ''), 'String') AS _snuba_environment))"
             in data["sql"]
         )
 
@@ -1475,7 +1475,7 @@ class TestSnQLApi(BaseApiTest):
         assert response.status_code == 200
         data = json.loads(response.data)
         assert (
-            "cast(ifNull((environment AS _snuba_environment), ''), 'String')"
+            "cast(ifNull(environment, ''), 'String') AS _snuba_environment"
             in data["sql"]
         )
 


### PR DESCRIPTION
In 22.8, if a LowCardinality(String) is queried, and it actually is not low
cardinality, it can cause an error in Clickhouse. To be safe, cast all
LowCardinality columns to regular String to avoid causing this issue.

So far this is only impacting Discover + transactions, so limit the change
there. This might decrease query performance for other queries, since
all LowCardinality strings will be treated as String.