### PR TITLE
fix(22.8) don't use ifnull for cardinality casting

### DIFF
--- a/snuba/query/processors/logical/low_cardinality_processor.py
+++ b/snuba/query/processors/logical/low_cardinality_processor.py
@@ -36,12 +36,8 @@ class LowCardinalityProcessor(LogicalQueryProcessor):
                 exp.alias,
                 "cast",
                 (
-                    FunctionCall(
-                        None,
-                        "ifNull",
-                        (replace(exp, alias=None), Literal(None, "")),
-                    ),
-                    Literal(None, "String"),
+                    replace(exp, alias=None),
+                    Literal(None, "Nullable(String)"),
                 ),
             )
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1455,11 +1455,13 @@ class TestSnQLApi(BaseApiTest):
                         project_id AS `project`,
                         title,
                         event_id AS `id`,
-                        project_id AS `project.name`
+                        project_id AS `project.name`,
+                        platform AS `platform`
                     WHERE timestamp >= toDateTime('{self.base_time.isoformat()}')
                     AND timestamp < toDateTime('{self.next_time.isoformat()}')
                     AND project_id IN array({self.project_id})
                     AND environment IN array('dev', 'prod', 'staging')
+                    AND platform IN tuple('snuba', 'sentry')
                     ORDER BY timestamp DESC LIMIT 51 OFFSET 0""",
                     "legacy": True,
                     "app_id": "legacy",
@@ -1477,6 +1479,8 @@ class TestSnQLApi(BaseApiTest):
         assert (
             "cast(environment, 'Nullable(String)') AS _snuba_environment" in data["sql"]
         )
+        # platform is not nullable but can be cast to nullable
+        assert "cast(platform, 'Nullable(String)') AS _snuba_platform" in data["sql"]
 
 
 @pytest.mark.clickhouse_db

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1431,11 +1431,11 @@ class TestSnQLApi(BaseApiTest):
         assert response.status_code == 200
         data = json.loads(response.data)
         assert (
-            "equals((cast(ifNull(release, ''), 'String') AS _snuba_release), '1123581321345589')"
+            "equals((cast(release, 'Nullable(String)') AS _snuba_release), '1123581321345589')"
             in data["sql"]
         )
         assert (
-            "has(['prod', 'dev'], (cast(ifNull(environment, ''), 'String') AS _snuba_environment))"
+            "has(['prod', 'dev'], (cast(environment, 'Nullable(String)') AS _snuba_environment))"
             in data["sql"]
         )
 
@@ -1475,8 +1475,7 @@ class TestSnQLApi(BaseApiTest):
         assert response.status_code == 200
         data = json.loads(response.data)
         assert (
-            "cast(ifNull(environment, ''), 'String') AS _snuba_environment"
-            in data["sql"]
+            "cast(environment, 'Nullable(String)') AS _snuba_environment" in data["sql"]
         )
 
 


### PR DESCRIPTION
`ifNull` function here doesn't do us any good because sentry actually expects `null` back, cast to a `Nullable(string)` instead