### PR TITLE
chore: Bump Kafka schema version to 0.1.71

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.3.4
 sentry-arroyo==2.17.1
-sentry-kafka-schemas==0.1.68
+sentry-kafka-schemas==0.1.71
 sentry-redis-tools==0.3.0
 sentry-relay==0.8.44
 sentry-sdk==1.40.5

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3034,9 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "0.1.68"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8faa38578fccf93b0daa5efb07db93e4f6f897cd879304b1b4d6f1ab25437522"
+checksum = "db5d74c530ebdfe25e32b36750d8b89765ce71bbabe90ced721f573013ef4930"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -33,7 +33,7 @@ pyo3 = { version = "0.18.1", features = ["chrono"] }
 reqwest = { version = "0.11.11", features = ["stream"] }
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo" }
 sentry = { version = "0.32.0", features = ["anyhow", "tracing"] }
-sentry-kafka-schemas = "0.1.68"
+sentry-kafka-schemas = "0.1.71"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0"


### PR DESCRIPTION
Bumping this to have support for new commit log and subscriptions scheduled topics
