### PR TITLE
Enables Clickhouse Authorization

### DIFF
--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -108,8 +108,6 @@ pub struct EnvConfig {
     pub record_cogs: bool,
     pub ddm_metrics_sample_rate: f64,
     pub project_stacktrace_blacklist: Vec<u64>,
-    pub clickhouse_user: String,
-    pub clickhouse_password: String,
 }
 
 impl Default for EnvConfig {
@@ -124,8 +122,6 @@ impl Default for EnvConfig {
             record_cogs: false,
             ddm_metrics_sample_rate: 0.0,
             project_stacktrace_blacklist: Vec::new(),
-            clickhouse_user: "default".to_string(),
-            clickhouse_password: "".to_string(),
         }
     }
 }

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -162,8 +162,8 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.storage_config.clickhouse_cluster.database,
             &self.clickhouse_concurrency,
             self.skip_write,
-            &self.env_config.clickhouse_user,
-            &self.env_config.clickhouse_password,
+            &self.storage_config.clickhouse_cluster.user,
+            &self.storage_config.clickhouse_cluster.password,
         );
 
         let accumulator = Arc::new(

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -53,8 +53,6 @@ class EnvConfig:
     record_cogs: bool
     ddm_metrics_sample_rate: float
     project_stacktrace_blacklist: list[int]
-    clickhouse_user: str
-    clickhouse_password: str
 
 
 @dataclass(frozen=True)
@@ -131,8 +129,6 @@ def _resolve_env_config() -> EnvConfig:
     lower_retention_days = settings.LOWER_RETENTION_DAYS
     valid_retention_days = list(settings.VALID_RETENTION_DAYS)
     record_cogs = settings.RECORD_COGS
-    clickhouse_user = str(settings.CLUSTERS[0].get("user"))
-    clickhouse_password = str(settings.CLUSTERS[0].get("password"))
     return EnvConfig(
         sentry_dsn=sentry_dsn,
         dogstatsd_host=dogstatsd_host,
@@ -143,8 +139,6 @@ def _resolve_env_config() -> EnvConfig:
         record_cogs=record_cogs,
         ddm_metrics_sample_rate=ddm_metrics_sample_rate,
         project_stacktrace_blacklist=list(settings.PROJECT_STACKTRACE_BLACKLIST),
-        clickhouse_user=clickhouse_user,
-        clickhouse_password=clickhouse_password,
     )
 
 


### PR DESCRIPTION
https://github.com/getsentry/snuba/issues/5722

Canary: deploy to S4S before rolling out to US SaaS. This shouldn't affect affect production consumers because the default username and password are used.