### PR TITLE
chore(admin): Allow product tools role to use  snuba-explain tool

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -83,6 +83,7 @@ TOOL_RESOURCES = {
     "production-queries": ToolResource("production-queries"),
     "system-queries": ToolResource("system-queries"),
     "clickhouse-migrations": ToolResource("clickhouse-migrations"),
+    "snuba-explain": ToolResource("snuba-explain"),
     "all": ToolResource("all"),
 }
 
@@ -159,6 +160,7 @@ ROLES = {
                     TOOL_RESOURCES["production-queries"],
                     TOOL_RESOURCES["system-queries"],
                     TOOL_RESOURCES["clickhouse-migrations"],
+                    TOOL_RESOURCES["snuba-explain"],
                 ]
             )
         },

--- a/tests/admin/test_authorization.py
+++ b/tests/admin/test_authorization.py
@@ -34,10 +34,12 @@ def test_product_tools_role(
     response = admin_api.get("/tools")
     assert response.status_code == 200
     data = json.loads(response.data)
+    print(data)
     assert len(data["tools"]) > 0
     assert "snql-to-sql" in data["tools"]
     assert "tracing" in data["tools"]
     assert "system-queries" in data["tools"]
     assert "production-queries" in data["tools"]
     assert "clickhouse-migrations" in data["tools"]
+    assert "snuba-explain" in data["tools"]
     assert "all" not in data["tools"]


### PR DESCRIPTION
Snuba admin users with the `ProductTools` role should be able to access and use snuba-explain tool.