### PR TITLE
feat(devexp): add a default subscriptable mapper to the storage stage

### DIFF
--- a/snuba/datasets/configuration/spans/entities/metrics_summaries.yaml
+++ b/snuba/datasets/configuration/spans/entities/metrics_summaries.yaml
@@ -42,16 +42,6 @@ schema:
 storages:
   - storage: metrics_summaries
     is_writable: true
-    translation_mappers:
-      subscriptables:
-        - mapper: SubscriptableMapper
-          args:
-            from_column_table: null
-            from_column_name: tags
-            to_nested_col_table: null
-            to_nested_col_name: tags
-            value_subcolumn_name: value
-            nullable: false
 
 storage_selector:
   selector: DefaultQueryStorageSelector

--- a/snuba/pipeline/stages/query_processing.py
+++ b/snuba/pipeline/stages/query_processing.py
@@ -46,7 +46,7 @@ class StorageProcessingStage(
 ):
     def _apply_default_subscriptable_mapping(
         self, query: ClickhouseQuery | CompositeQuery[Table]
-    ):
+    ) -> None:
         query.transform_expressions(transform_subscriptables)
 
     def _process_data(

--- a/snuba/pipeline/stages/query_processing.py
+++ b/snuba/pipeline/stages/query_processing.py
@@ -1,3 +1,4 @@
+from snuba import state
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.plans.entity_processing import run_entity_processing_executor
 from snuba.datasets.plans.entity_validation import run_entity_validators
@@ -47,7 +48,8 @@ class StorageProcessingStage(
     def _apply_default_subscriptable_mapping(
         self, query: ClickhouseQuery | CompositeQuery[Table]
     ) -> None:
-        query.transform_expressions(transform_subscriptables)
+        if state.get_config("apply_default_subscriptable_mapping", 1):
+            query.transform_expressions(transform_subscriptables)
 
     def _process_data(
         self, pipe_input: QueryPipelineData[ClickhouseQuery | CompositeQuery[Table]]

--- a/snuba/pipeline/stages/query_processing.py
+++ b/snuba/pipeline/stages/query_processing.py
@@ -4,6 +4,7 @@ from snuba.datasets.plans.entity_validation import run_entity_validators
 from snuba.datasets.plans.storage_processing import (
     apply_storage_processors,
     build_best_plan,
+    transform_subscriptables,
 )
 from snuba.pipeline.composite_entity_processing import translate_composite_query
 from snuba.pipeline.composite_storage_processing import (
@@ -43,9 +44,15 @@ class StorageProcessingStage(
         ClickhouseQuery | CompositeQuery[Table],
     ]
 ):
+    def _apply_default_subscriptable_mapping(
+        self, query: ClickhouseQuery | CompositeQuery[Table]
+    ):
+        query.transform_expressions(transform_subscriptables)
+
     def _process_data(
         self, pipe_input: QueryPipelineData[ClickhouseQuery | CompositeQuery[Table]]
     ) -> ClickhouseQuery | CompositeQuery[Table]:
+        self._apply_default_subscriptable_mapping(pipe_input.data)
         if isinstance(pipe_input.data, ClickhouseQuery):
             query_plan = build_best_plan(pipe_input.data, pipe_input.query_settings, [])
             return apply_storage_processors(query_plan, pipe_input.query_settings)

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -38,14 +38,18 @@ class _FunctionCall:
     def __init__(self, name: str) -> None:
         self.name = name
 
-    def __call__(self, *args: Expression | OptionalScalarType, **kwargs: str):
+    def _arg_to_literal_expr(self, arg: Expression | OptionalScalarType) -> Expression:
+        if isinstance(arg, Expression):
+            return arg
+        return Literal(None, arg)
+
+    def __call__(
+        self, *args: Expression | OptionalScalarType, **kwargs: str
+    ) -> FunctionCall:
         alias = kwargs.pop("alias", None)
         if kwargs:
             raise ValueError(f"Unsuppored dsl kwargs: {kwargs}")
-        transformed_args = [
-            Literal(None, arg) if isinstance(arg, OptionalScalarType) else arg
-            for arg in args
-        ]
+        transformed_args = [self._arg_to_literal_expr(arg) for arg in args]
         return FunctionCall(alias, self.name, tuple(transformed_args))
 
 

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -13,6 +13,47 @@ from snuba.query.expressions import (
 # verbose to build.
 
 
+class NestedColumn:
+    """Usage:
+    tags = NestedColumn("tags")
+    assert tags["some_key"] == SubscriptableReference(
+        "_snuba_tags[some_key]",
+        Column("_snuba_tags"), None, "tags"),
+        Literal(None, "some_key")
+    )
+    """
+
+    def __init__(self, column_name: str) -> None:
+        self.column_name = column_name
+
+    def __getitem__(self, key: str) -> SubscriptableReference:
+        return SubscriptableReference(
+            f"_snuba_{self.column_name}[{key}]",
+            Column(f"_snuba_{self.column_name}", None, self.column_name),
+            Literal(None, key),
+        )
+
+
+class _FunctionCall:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __call__(self, *args: Expression | OptionalScalarType, **kwargs: str):
+        alias = kwargs.pop("alias", None)
+        if kwargs:
+            raise ValueError(f"Unsuppored dsl kwargs: {kwargs}")
+        transformed_args = [
+            Literal(None, arg) if isinstance(arg, OptionalScalarType) else arg
+            for arg in args
+        ]
+        return FunctionCall(alias, self.name, tuple(transformed_args))
+
+
+class Functions:
+    def __getattr__(self, name: str) -> _FunctionCall:
+        return _FunctionCall(name)
+
+
 def column(
     column_name: str, table_name: str | None = None, alias: str | None = None
 ) -> Column:
@@ -21,18 +62,6 @@ def column(
 
 def literal(value: OptionalScalarType, alias: str | None = None) -> Literal:
     return Literal(alias, value)
-
-
-def snuba_tags_raw(indexer_mapping: int) -> SubscriptableReference:
-    return SubscriptableReference(
-        f"_snuba_tags_raw[{indexer_mapping}]",
-        Column(
-            "_snuba_tags_raw",
-            None,
-            "tags_raw",
-        ),
-        Literal(None, str(indexer_mapping)),
-    )
 
 
 def literals_tuple(alias: Optional[str], literals: Sequence[Literal]) -> FunctionCall:

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -53,9 +53,20 @@ class _FunctionCall:
         return FunctionCall(alias, self.name, tuple(transformed_args))
 
 
-class Functions:
+class _Functions:
     def __getattr__(self, name: str) -> _FunctionCall:
         return _FunctionCall(name)
+
+
+"""
+Usage:
+
+from snuba.query.dsl import Functions as f
+assert f.equals(1, 1, alias="eq") == FunctionCall(
+    "eq", "equals" (Literal(None, 1), Literal(None, 1))
+)
+"""
+Functions = _Functions()
 
 
 def column(

--- a/tests/pipeline/test_storage_processing_stage.py
+++ b/tests/pipeline/test_storage_processing_stage.py
@@ -106,7 +106,7 @@ def test_basic(mock_storage: ReadableTableStorage) -> None:
     assert actual == expected
 
 
-def test_default_subscriptable(mock_storage: ReadableTableStorage):
+def test_default_subscriptable(mock_storage: ReadableTableStorage) -> None:
     query = Query(
         from_clause=Table(
             "dontmatter",

--- a/tests/pipeline/test_storage_processing_stage.py
+++ b/tests/pipeline/test_storage_processing_stage.py
@@ -18,13 +18,13 @@ from snuba.pipeline.query_pipeline import QueryPipelineResult
 from snuba.pipeline.stages.query_processing import StorageProcessingStage
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
-from snuba.query.dsl import Functions, NestedColumn, column, equals, literal
+from snuba.query.dsl import Functions as f
+from snuba.query.dsl import NestedColumn, column, equals, literal
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.utils.metrics.timer import Timer
 
 tags = NestedColumn("tags")
-f = Functions()
 
 
 class NoopCHQueryProcessor(ClickhouseQueryProcessor):


### PR DESCRIPTION
In order to make storage queries work with nested columns, we need to build in default processing of queries that have expressions like:

`tags[something] = 'blah'`

this PR implements this feature. It also removes the SubscriptableMapper for metric_summaries to show that it's no longer necessary

Also add some syntactic sugar to the DSL to make the tests look nicer