### PR TITLE
feat(group-attributes): Add priority to group attributes table

### DIFF
--- a/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
@@ -9,6 +9,7 @@ schema:
 
     { name: group_status, type: UInt, args: { size: 8 } },
     { name: group_substatus, type: UInt, args: { size: 8, schema_modifiers: [ nullable ] } },
+    { name: group_priority, type: UInt, args: { size: 8, schema_modifiers: [ nullable ] } },
     { name: group_first_seen, type: DateTime },
     { name: group_num_comments, type: UInt, args: { size: 64 } },
 

--- a/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
@@ -16,6 +16,7 @@ schema:
 
       { name: group_status, type: UInt, args: { size: 8 } },
       { name: group_substatus, type: UInt, args: { size: 8, schema_modifiers: [ nullable ] } },
+      { name: group_priority, type: UInt, args: { size: 8, schema_modifiers: [ nullable ] } },
       { name: group_first_seen, type: DateTime },
       { name: group_num_comments, type: UInt, args: { size: 64 } },
 

--- a/snuba/datasets/processors/group_attributes_processor.py
+++ b/snuba/datasets/processors/group_attributes_processor.py
@@ -25,6 +25,7 @@ class GroupAttributesMessageProcessor(DatasetMessageProcessor):
                     "group_id": message["group_id"],
                     "group_status": message["status"],
                     "group_substatus": message["substatus"],
+                    "group_priority": message.get("priority", None),
                     "group_first_seen": datetime.strptime(
                         message["first_seen"], settings.PAYLOAD_DATETIME_FORMAT
                     ),


### PR DESCRIPTION
Non-migration changes to add `group.priority` to the group attributes table.

MIgration PR: #5786