### PR TITLE
update CLICKHOUSE_SERVER_MIN_VERSION and CLICKHOUSE_SERVER_MAX_VERSION

### DIFF
--- a/snuba/migrations/clickhouse.py
+++ b/snuba/migrations/clickhouse.py
@@ -1,5 +1,4 @@
-CLICKHOUSE_SERVER_MIN_VERSION = "20.3.5.21"
-# Note only versions up to 21.8.13.1 are currently supported,
-# 23.3.8.22 is enabled for testing purposes in a minimal number of
-# datasets
-CLICKHOUSE_SERVER_MAX_VERSION = "23.3.8.22"
+CLICKHOUSE_SERVER_MIN_VERSION = "21.8.12.29"
+# Note: 21.8.12.29 and 21.8.13.1 are used in self-hosted builds
+# even though SaaS clusters are all on 22.8 or above
+CLICKHOUSE_SERVER_MAX_VERSION = "23.3.19.33"


### PR DESCRIPTION
We have upgraded all ST and SaaS clusters to `22.8`, and are in the process of updating to `23.3`. Self-hosted still uses `21.8.x` so using the minimum version found in https://github.com/getsentry/self-hosted/blob/9e36d2f57a431a236f86a4fcd38125faf7721232/install/detect-platform.sh#L20-L26

Will have to update the `CLICKHOUSE_SERVER_MAX_VERSION` to `23.8` when we get closer to that, I think we can do that after we've upgrade S4S and made sure that was successful 