### PR TITLE
chore(on-call): Remove search-issues and group-attributes from joinable sets

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -93,7 +93,6 @@ JOINABLE_STORAGE_SETS: FrozenSet[FrozenSet[StorageSetKey]] = frozenset(
                 StorageSetKey.GROUP_ATTRIBUTES,
             }
         ),
-        frozenset({StorageSetKey.SEARCH_ISSUES, StorageSetKey.GROUP_ATTRIBUTES}),
     }
 )
 

--- a/tests/datasets/test_group_attributes_join.py
+++ b/tests/datasets/test_group_attributes_join.py
@@ -294,6 +294,9 @@ class TestSearchIssuesGroupAttributes(BaseApiTest):
             },
         }
 
+    @pytest.mark.xfail(
+        reason="The search_issues and group_attributes storage sets are not on the same query node anymore. This should fail since their relationship is no longer in JOINABLE_STORAGE_SETS."
+    )
     def query_search_issues_joined_group_attributes(self):
         query_template = (
             "MATCH (s: search_issues) -[attributes]-> (g: group_attributes) "


### PR DESCRIPTION
The `search_issues` and `group_attributes` datasets no longer share the same query nodes in prod. As a result, ClickHouse is queries are receiving "table does not exist" ClickHouse errors (https://sentry.sentry.io/issues/5219576548/?project=300688&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0). This PR removes them from `JOINABLE_STORAGE_SETS` and makes sure we fail the query before ClickHouse