### PR TITLE
Increase max resolution for jitter from 1min to 15min

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -307,7 +307,7 @@ SUPPORTED_STATES: Set[str] = {
 # We expect to remove them after all storages and migration groups have been migrated.
 READINESS_STATE_FAIL_QUERIES: bool = True
 
-MAX_RESOLUTION_FOR_JITTER = 60
+MAX_RESOLUTION_FOR_JITTER = 900
 
 # These contexts will not be stored in the transactions table
 # Example: {123: {"context1", "context2"}}


### PR DESCRIPTION
## Description
The goal of this PR is to enable the jitter code path here: https://github.com/getsentry/snuba/blob/40d2510c1ab598ba501586688b77189757089cd5/snuba/subscriptions/scheduler.py#L118-L135 for queries with a resolution up to 15minutes.

Here's what the load profile on metric alert subscriptions looks like that we're trying to fix: https://app.datadoghq.com/dashboard/byg-ici-a72/snuba-subscriptions?fromUser=true&fullscreen_end_ts=1714765439441&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1714751039441&fullscreen_widget=3556554584510136&tpl_var_consumer_group%5B0%5D=*&tpl_var_sentry_region%5B0%5D=us&view=spans&from_ts=1714750247173&to_ts=1714764647173&live=true

Technical Spec: https://www.notion.so/sentry/Metric-Alert-Load-Shedding-cba94dd0fa434f3bb56a23f920586eb2