### PR TITLE
chore(self-hosted): Mark e2e test check as required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,8 +429,6 @@ jobs:
     needs: [snuba-image]
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    # temporary, remove once we are confident the action is working
-    continue-on-error: true
 
     steps:
       - name: Checkout Snuba


### PR DESCRIPTION
It's been in CI for a week and looks stable. I've checked on every failure in the past week and it is not due to flakiness, it's from image build failure so it looks like we should be good to go to get this required.