### PR TITLE
fix(cd): deploy fails from ci timeout

### DIFF
--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 /devinfra/scripts/checks/githubactions/checkruns.py \
+  --timeout-mins 60 \
   getsentry/snuba \
   ${GO_REVISION_SNUBA_REPO} \
   "Tests and code coverage (test)" \


### PR DESCRIPTION
this bug was meant to be fixed by #5834 but wasnt actually, this PR should actually fix it now.