### PR TITLE
feat(spans): Add indexes for tag columns

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -378,6 +378,7 @@ class SpansLoader(DirectoryLoader):
             "0010_spans_add_compression",
             "0011_spans_add_index_on_trace_id",
             "0012_spans_add_index_on_transaction_name",
+            "0013_spans_add_indexes_for_tag_columns",
         ]
 
 

--- a/snuba/snuba_migrations/spans/0013_spans_add_indexes_for_tag_columns.py
+++ b/snuba/snuba_migrations/spans/0013_spans_add_indexes_for_tag_columns.py
@@ -1,0 +1,47 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+table_name_prefix = "spans"
+storage_set = StorageSetKey.SPANS
+indexes = [
+    ("bf_tags_key", "tags.key", "bloom_filter(bloom_filter(0.0))", 1),
+    ("bf_tags_hash_map", "_tags_hash_map", "bloom_filter(0.0)", 1),
+    ("bf_sentry_tags_hash_map", "_sentry_tags_hash_map", "bloom_filter(0.0)", 1),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        ops: Sequence[operations.SqlOperation] = []
+        for index in indexes:
+            index_name, index_expression, index_type, granularity = index
+            ops.append(
+                operations.AddIndex(
+                    storage_set=storage_set,
+                    table_name=f"{table_name_prefix}_local",
+                    index_name=index_name,
+                    index_expression=index_expression,
+                    index_type=index_type,
+                    granularity=granularity,
+                    target=operations.OperationTarget.LOCAL,
+                )
+            )
+        return ops
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        ops: Sequence[operations.SqlOperation] = []
+        for index in indexes:
+            index_name, _, _, _ = index
+            ops.append(
+                operations.DropIndex(
+                    storage_set=storage_set,
+                    table_name=f"{table_name_prefix}_local",
+                    index_name=index_name,
+                    target=operations.OperationTarget.LOCAL,
+                )
+            )
+        return ops

--- a/snuba/snuba_migrations/spans/0013_spans_add_indexes_for_tag_columns.py
+++ b/snuba/snuba_migrations/spans/0013_spans_add_indexes_for_tag_columns.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import List, Sequence
 
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
@@ -16,7 +16,7 @@ class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:
-        ops: Sequence[operations.SqlOperation] = []
+        ops: List[operations.SqlOperation] = []
         for index in indexes:
             index_name, index_expression, index_type, granularity = index
             ops.append(
@@ -33,7 +33,7 @@ class Migration(migration.ClickhouseNodeMigration):
         return ops
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
-        ops: Sequence[operations.SqlOperation] = []
+        ops: List[operations.SqlOperation] = []
         for index in indexes:
             index_name, _, _, _ = index
             ops.append(

--- a/snuba/snuba_migrations/spans/0013_spans_add_indexes_for_tag_columns.py
+++ b/snuba/snuba_migrations/spans/0013_spans_add_indexes_for_tag_columns.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 table_name_prefix = "spans"
 storage_set = StorageSetKey.SPANS
 indexes = [
-    ("bf_tags_key", "tags.key", "bloom_filter(bloom_filter(0.0))", 1),
+    ("bf_tags_key", "tags.key", "bloom_filter(0.0)", 1),
     ("bf_tags_hash_map", "_tags_hash_map", "bloom_filter(0.0)", 1),
     ("bf_sentry_tags_hash_map", "_sentry_tags_hash_map", "bloom_filter(0.0)", 1),
 ]


### PR DESCRIPTION
Searching through the spans dataset is key for the Trace Explorer. We'd like to add indexes to speed search queries on user tags.

We didn't add an index for `sentry_tags.key` since they are mostly the same for all tags (these are specific tags set by Relay for Sentry use).