### PR TITLE
snuba devserver fix?

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -81,15 +81,17 @@ impl BatchFactory {
             let client = self.client.clone();
 
             let result_handle = self.handle.spawn(async move {
-                let res = client
-                    .post(&url)
-                    .query(&[("query", &query)])
-                    .body(reqwest::Body::wrap_stream(ReceiverStream::new(receiver)))
-                    .send()
-                    .await?;
+                if !receiver.is_empty() && !receiver.is_closed() {
+                    let res = client
+                        .post(&url)
+                        .query(&[("query", &query)])
+                        .body(reqwest::Body::wrap_stream(ReceiverStream::new(receiver)))
+                        .send()
+                        .await?;
 
-                if res.status() != reqwest::StatusCode::OK {
-                    anyhow::bail!("error writing to clickhouse: {}", res.text().await?);
+                    if res.status() != reqwest::StatusCode::OK {
+                        anyhow::bail!("error writing to clickhouse: {}", res.text().await?);
+                    }
                 }
 
                 Ok(())
@@ -216,6 +218,37 @@ mod tests {
         concurrency.handle().block_on(batch.finish()).unwrap();
 
         mock.assert();
+    }
+
+    #[test]
+    fn test_empty_batch() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST).any_request();
+            then.status(200).body("hi");
+        });
+
+        let concurrency = ConcurrencyConfig::new(1);
+        let factory = BatchFactory::new(
+            &server.host(),
+            server.port(),
+            "testtable",
+            "testdb",
+            &concurrency,
+            false,
+            "default",
+            "",
+        );
+
+        let mut batch = factory.new_batch();
+
+        batch
+            .write_rows(&RowData::from_encoded_rows([].to_vec()))
+            .unwrap();
+
+        concurrency.handle().block_on(batch.finish()).unwrap();
+
+        mock.assert_hits(0);
     }
 
     #[test]

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -88,12 +88,6 @@ impl BatchFactory {
                     sleep(Duration::from_millis(800)).await;
                 }
 
-                if receiver.is_closed() && receiver.is_empty() {
-                    // batch is finished and we never had any data to write
-                    // to clickhouse
-                    return Ok(());
-                }
-
                 if !receiver.is_empty() {
                     // only make the request to clickhouse if there is data
                     // being added to the receiver stream from the sender

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -83,7 +83,7 @@ impl BatchFactory {
 
             let result_handle = self.handle.spawn(async move {
                 while receiver.is_empty() && !receiver.is_closed() {
-                    // continously check on the recevier stream, only when it's
+                    // continously check on the receiver stream, only when it's
                     // not empty do we write to clickhouse
                     sleep(Duration::from_millis(800)).await;
                 }
@@ -96,7 +96,7 @@ impl BatchFactory {
 
                 if !receiver.is_empty() {
                     // only make the request to clickhouse if there is data
-                    // being added to the reciever stream from the sender
+                    // being added to the receiver stream from the sender
                     let res = client
                         .post(&url)
                         .query(&[("query", &query)])


### PR DESCRIPTION
We've been seeing some issues with running `snuba devserver` locally and the problem seems to happen when there aren't actually any messages being processed but we still send requests to clickhouse (with `0` as the body).

This change should prevent a request to clickhouse from ever being made if we don't have any rows to write. If the sender doesn't send any messages then the receiver will be empty - which is what we use to check in order to determine when to open the request.
