### PR TITLE
fix: Remove `message` from the prewhere processor

### DIFF
--- a/snuba/datasets/configuration/discover/storages/discover.yaml
+++ b/snuba/datasets/configuration/discover/storages/discover.yaml
@@ -127,7 +127,6 @@ query_processors:
       prewhere_candidates:
         - event_id
         - release
-        - message
         - transaction_name
         - environment
         - project_id


### PR DESCRIPTION
This column actually causes an error in some queries when it is added to the
prewhere. `DB::Exception: Storage Merge doesn't support PREWHERE for message.`

Remove it for now and it can be revisited in the future if necessary.