### PR TITLE
fix(capman): make allocation policies work with joins

### DIFF
--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -162,7 +162,6 @@ class JoinClause(DataSource, JoinNode[TSimpleDataSource], Generic[TSimpleDataSou
 
     def __post_init__(self) -> None:
         column_set = self.get_columns()
-
         for condition in self.keys:
             assert f"{condition.left.table_alias}.{condition.left.column}" in column_set
             assert (

--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -162,6 +162,7 @@ class JoinClause(DataSource, JoinNode[TSimpleDataSource], Generic[TSimpleDataSou
 
     def __post_init__(self) -> None:
         column_set = self.get_columns()
+
         for condition in self.keys:
             assert f"{condition.left.table_alias}.{condition.left.column}" in column_set
             assert (

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -628,7 +628,9 @@ def _raw_query(
         )
 
 
-def _get_allocation_policies(query: Query | CompositeQuery[Table]):
+def _get_allocation_policies(
+    query: Query | CompositeQuery[Table],
+) -> list[AllocationPolicy]:
     collector = _PolicyCollector()
     collector.visit(query)
     return collector.policies

--- a/tests/datasets/test_cdc_events.py
+++ b/tests/datasets/test_cdc_events.py
@@ -130,10 +130,12 @@ class TestCdcEvents(BaseApiTest):
                         "btime": self.base_time,
                         "ntime": self.next_time,
                     },
+                    "tenant_ids": {"organization_id": 1, "referrer": "abcd"},
                 }
             ),
         )
         data = json.loads(response.data)
+
         assert response.status_code == 200
         assert len(data["data"]) == expected_rows, data
 
@@ -169,6 +171,7 @@ class TestCdcEvents(BaseApiTest):
                         "btime": self.base_time,
                         "ntime": self.next_time,
                     },
+                    "tenant_ids": {"organization_id": 1, "referrer": "abcd"},
                 }
             ),
         )

--- a/tests/datasets/test_cdc_events.py
+++ b/tests/datasets/test_cdc_events.py
@@ -136,7 +136,7 @@ class TestCdcEvents(BaseApiTest):
         )
         data = json.loads(response.data)
 
-        assert response.status_code == 200
+        assert response.status_code == 200, data
         assert len(data["data"]) == expected_rows, data
 
     @pytest.mark.clickhouse_db
@@ -176,5 +176,5 @@ class TestCdcEvents(BaseApiTest):
             ),
         )
         data = json.loads(response.data)
-        assert response.status_code == 200
+        assert response.status_code == 200, data
         assert len(data["data"]) == expected_rows, data

--- a/tests/datasets/test_group_attributes_join.py
+++ b/tests/datasets/test_group_attributes_join.py
@@ -120,8 +120,8 @@ class TestEventsGroupAttributes(BaseApiTest):
         query = parse_snql_query(str(query_body), get_dataset("events"))
         attribution_info = AttributionInfo(
             app_id=AppID(key=""),
-            tenant_ids={},
-            referrer="",
+            tenant_ids={"organization_id": 1234, "referrer": "abcd"},
+            referrer="abcd",
             team=None,
             feature=None,
             parent_api=None,
@@ -158,7 +158,13 @@ class TestEventsGroupAttributes(BaseApiTest):
 
         return self.app.post(
             "/events/snql",
-            data=json.dumps({"dataset": "events", "query": query_body}),
+            data=json.dumps(
+                {
+                    "dataset": "events",
+                    "query": query_body,
+                    "tenant_ids": attribution_info.tenant_ids,
+                }
+            ),
         )
 
     def query_events_inner_joined_group_attributes(self):
@@ -191,8 +197,8 @@ class TestEventsGroupAttributes(BaseApiTest):
         query = parse_snql_query(str(query_body), get_dataset("events"))
         attribution_info = AttributionInfo(
             app_id=AppID(key=""),
-            tenant_ids={},
-            referrer="",
+            tenant_ids={"organization_id": 1234, "referrer": "abcd"},
+            referrer="abcd",
             team=None,
             feature=None,
             parent_api=None,
@@ -229,7 +235,13 @@ class TestEventsGroupAttributes(BaseApiTest):
 
         return self.app.post(
             "/events/snql",
-            data=json.dumps({"dataset": "events", "query": query_body}),
+            data=json.dumps(
+                {
+                    "dataset": "events",
+                    "query": query_body,
+                    "tenant_ids": attribution_info.tenant_ids,
+                }
+            ),
         )
 
     @pytest.mark.clickhouse_db
@@ -237,7 +249,7 @@ class TestEventsGroupAttributes(BaseApiTest):
     def test_group_attributes_join(self) -> None:
         response = self.query_events_inner_joined_group_attributes()
         data = json.loads(response.data)
-        assert response.status_code == 200
+        assert response.status_code == 200, data
         assert (
             data["data"][0].items()
             == {
@@ -276,7 +288,7 @@ class TestEventsGroupAttributes(BaseApiTest):
     def test_group_attributes_inner_join(self) -> None:
         response = self.query_events_joined_group_attributes()
         data = json.loads(response.data)
-        assert response.status_code == 200
+        assert response.status_code == 200, data
         assert (
             data["data"][0].items()
             == {
@@ -466,8 +478,8 @@ class TestSearchIssuesGroupAttributes(BaseApiTest):
         query = parse_snql_query(str(query_body), get_dataset("search_issues"))
         attribution_info = AttributionInfo(
             app_id=AppID(key=""),
-            tenant_ids={},
-            referrer="",
+            tenant_ids={"organization_id": 1234, "referrer": "abcd"},
+            referrer="abcd",
             team=None,
             feature=None,
             parent_api=None,
@@ -511,7 +523,13 @@ class TestSearchIssuesGroupAttributes(BaseApiTest):
 
         return self.app.post(
             "/search_issues/snql",
-            data=json.dumps({"dataset": "search_issues", "query": query_body}),
+            data=json.dumps(
+                {
+                    "dataset": "search_issues",
+                    "query": query_body,
+                    "tenant_ids": attribution_info.tenant_ids,
+                }
+            ),
         )
 
     @pytest.mark.clickhouse_db

--- a/tests/web/test__get_allocation_policy.py
+++ b/tests/web/test__get_allocation_policy.py
@@ -24,7 +24,7 @@ from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.web.db_query import _get_allocation_policies
 
 
-class PermissiveJoinClause(JoinClause):
+class PermissiveJoinClause(JoinClause[Table]):
     def __post_init__(self) -> None:
         """JoinClause verifies that the join clause is references
         valid columns, these tests do not care about columns"""

--- a/tests/web/test__get_allocation_policy.py
+++ b/tests/web/test__get_allocation_policy.py
@@ -2,42 +2,53 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Union
-from unittest import mock
 
 import pytest
 
+from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
-from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query import SelectedExpression
-from snuba.query.allocation_policies import (
-    DEFAULT_PASSTHROUGH_POLICY,
-    AllocationPolicy,
-    PassthroughPolicy,
-)
+from snuba.query.allocation_policies import AllocationPolicy, PassthroughPolicy
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import ConditionFunctions, binary_condition
-from snuba.query.data_source.join import JoinClause
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinType,
+)
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.web.db_query import _get_allocation_policies
 
-events_storage = get_entity(EntityKey.EVENTS).get_writable_storage()
-assert events_storage is not None
-events_table_name = events_storage.get_table_writer().get_schema().get_table_name()
+
+class PermissiveJoinClause(JoinClause):
+    def __post_init__(self) -> None:
+        """JoinClause verifies that the join clause is references
+        valid columns, these tests do not care about columns"""
+        pass
 
 
 events_table = Table(
-    events_table_name,
-    events_storage.get_schema().get_columns(),
+    "errors",
+    ColumnSet([]),
     allocation_policies=[PassthroughPolicy(StorageKey("flimflam"), [], {})],
-    storage_key=events_storage.get_storage_key(),
+    storage_key=StorageKey("errors"),
     final=False,
     sampling_rate=None,
-    mandatory_conditions=events_storage.get_schema()
-    .get_data_source()
-    .get_mandatory_conditions(),
+    mandatory_conditions=[],
+)
+
+groups_table = Table(
+    "groups",
+    ColumnSet([]),
+    allocation_policies=[PassthroughPolicy(StorageKey("jimjam"), [], {})],
+    storage_key=StorageKey("groups"),
+    final=False,
+    sampling_rate=None,
+    mandatory_conditions=[],
 )
 
 composite_query = CompositeQuery(
@@ -62,21 +73,20 @@ composite_query = CompositeQuery(
 )
 
 
-class BadJoinClause(JoinClause[Table]):
-    # the join clause functionality is not supported,
-    # doesn't matter that the join clause is not valid
-    # if we support join clauses + allocation_policies
-    # we can remove this
-    def __post_init__(self) -> None:
-        pass
-
-
 join_query = CompositeQuery(
-    from_clause=BadJoinClause(
-        left_node=mock.Mock(),
-        right_node=mock.Mock(),
-        keys=[mock.Mock()],
-        join_type=mock.Mock(),
+    from_clause=PermissiveJoinClause(
+        left_node=IndividualNode(alias="err", data_source=events_table),
+        right_node=IndividualNode(
+            alias="groups",
+            data_source=groups_table,
+        ),
+        keys=[
+            JoinCondition(
+                left=JoinConditionExpression("err", "group_id"),
+                right=JoinConditionExpression("groups", "id"),
+            )
+        ],
+        join_type=JoinType.INNER,
     ),
     selected_columns=[],
 )
@@ -107,8 +117,11 @@ join_query = CompositeQuery(
         ),
         pytest.param(
             join_query,
-            [DEFAULT_PASSTHROUGH_POLICY],
-            id="Joins just pass through (this is a hack)",
+            [
+                PassthroughPolicy(StorageKey("flimflam"), [], {}),
+                PassthroughPolicy(StorageKey("jimjam"), [], {}),
+            ],
+            id="all allocation policies from joins are put together",
         ),
         pytest.param(
             ClickhouseQuery(


### PR DESCRIPTION
Queries using joins have up to this point not been subject to allocation policies. making them an abuse vector. Now that we have join queries serving in production, put the protection on them