### PR TITLE
fix: Disallow column aliases in inner queries of subqueries

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1316,7 +1316,10 @@ def validate_column_aliases_in_subqueries(
     selected_columns = from_clause.get_selected_columns()
     for s in selected_columns:
         if isinstance(s.expression, Column):
-            if s.name != s.expression.column_name:
+            table_name = (
+                s.expression.table_name + "." if s.expression.table_name else ""
+            )
+            if s.name != f"{table_name}{s.expression.column_name}":
                 raise InvalidExpressionException(
                     "aliasing a column in a subquery is not permitted"
                 )


### PR DESCRIPTION
When a column is aliased to something different in the inner subquery, it
breaks how aliasing works at the higher levels. It's also not necessary, since
the column can be referenced directly, and the outer query can alias the
expression however it likes in the results.

Also fixed some typing in the test file.