### PR TITLE
feat(devexp): Add required_time_column to storage

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/counters_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters_meta_tag_values.yaml
@@ -29,6 +29,7 @@ schema:
   local_table_name: generic_metric_counters_meta_tag_values_local
   dist_table_name: generic_metric_counters_meta_tag_values_dist
 
+required_time_column: timestamp
 allocation_policies:
   - name: ConcurrentRateLimitAllocationPolicy
     args:

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_meta_tag_values.yaml
@@ -28,7 +28,7 @@ schema:
     ]
   local_table_name: generic_metric_distributions_meta_tag_values_local
   dist_table_name: generic_metric_distributions_meta_tag_values_dist
-
+required_time_column: timestamp
 allocation_policies:
   - name: ConcurrentRateLimitAllocationPolicy
     args:

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_meta_tag_values.yaml
@@ -28,6 +28,8 @@ schema:
     ]
   local_table_name: generic_metric_gauges_meta_tag_values_local
   dist_table_name: generic_metric_gauges_meta_tag_values_dist
+required_time_column: timestamp
+
 
 allocation_policies:
   - name: ConcurrentRateLimitAllocationPolicy

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_meta_tag_values.yaml
@@ -29,6 +29,7 @@ schema:
   local_table_name: generic_metric_sets_meta_tag_values_local
   dist_table_name: generic_metric_sets_meta_tag_values_dist
 
+required_time_column: timestamp
 allocation_policies:
   - name: ConcurrentRateLimitAllocationPolicy
     args:

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -540,6 +540,10 @@ V1_READABLE_STORAGE_SCHEMA = {
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
         "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
         "allocation_policies": STORAGE_ALLOCATION_POLICIES_SCHEMA,
+        "required_time_column": {
+            "type": ["string", "null"],
+            "description": "The name of the required time column specifed in schema",
+        },
     },
     "required": [
         "version",
@@ -570,6 +574,10 @@ V1_WRITABLE_STORAGE_SCHEMA = {
         "writer_options": {
             "type": "object",
             "description": "Extra Clickhouse fields that are used for consumer writes",
+        },
+        "required_time_column": {
+            "type": ["string", "null"],
+            "description": "The name of the required time column specifed in schema",
         },
     },
     "required": [

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -48,6 +48,7 @@ SUBCRIPTION_SCHEDULER_MODE = "subscription_scheduler_mode"
 DLQ_POLICY = "dlq_policy"
 REPLACER_PROCESSOR = "replacer_processor"
 ALLOCATION_POLICIES = "allocation_policies"
+REQUIRED_TIME_COLUMN = "required_time_column"
 
 
 def build_storage_from_config(
@@ -93,6 +94,7 @@ def __build_readable_storage_kwargs(config: dict[str, Any]) -> dict[str, Any]:
         ]
         if ALLOCATION_POLICIES in config
         else [],
+        REQUIRED_TIME_COLUMN: config.get(REQUIRED_TIME_COLUMN, None),
     }
 
 

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -40,10 +40,12 @@ class Storage(ABC):
         storage_set_key: StorageSetKey,
         schema: Schema,
         readiness_state: ReadinessState,
+        required_time_column: Optional[str] = None,
     ):
         self.__storage_set_key = storage_set_key
         self.__schema = schema
         self.__readiness_state = readiness_state
+        self.__required_time_column = required_time_column
 
     def get_storage_set_key(self) -> StorageSetKey:
         return self.__storage_set_key
@@ -56,6 +58,10 @@ class Storage(ABC):
 
     def get_readiness_state(self) -> ReadinessState:
         return self.__readiness_state
+
+    @property
+    def required_time_column(self):
+        return self.__required_time_column
 
 
 class ReadableStorage(Storage):
@@ -126,12 +132,18 @@ class ReadableTableStorage(ReadableStorage):
         query_processors: Optional[Sequence[ClickhouseQueryProcessor]] = None,
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
         allocation_policies: Optional[list[AllocationPolicy]] = None,
+        required_time_column: Optional[str] = None,
     ) -> None:
         self.__storage_key = storage_key
         self.__query_processors = query_processors or []
         self.__mandatory_condition_checkers = mandatory_condition_checkers or []
         self.__allocation_policies = allocation_policies or []
-        super().__init__(storage_set_key, schema, readiness_state)
+        super().__init__(
+            storage_set_key,
+            schema,
+            readiness_state,
+            required_time_column=required_time_column,
+        )
 
     def get_storage_key(self) -> StorageKey:
         return self.__storage_key
@@ -161,6 +173,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
         writer_options: ClickhouseWriterOptions = None,
         write_format: WriteFormat = WriteFormat.JSON,
         ignore_write_errors: bool = False,
+        required_time_column: Optional[str] = None,
     ) -> None:
         self.__storage_key = storage_key
         super().__init__(
@@ -171,6 +184,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
             query_processors,
             mandatory_condition_checkers,
             allocation_policies,
+            required_time_column=required_time_column,
         )
         assert isinstance(schema, WritableTableSchema)
         self.__table_writer = TableWriter(

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -60,7 +60,7 @@ class Storage(ABC):
         return self.__readiness_state
 
     @property
-    def required_time_column(self):
+    def required_time_column(self) -> str | None:
         return self.__required_time_column
 
 

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -42,6 +42,8 @@ schema:
   local_table_name: "test"
   dist_table_name: "test"
 
+required_time_column: timestamp
+
 query_processors:
   -
     processor: MappingOptimizer
@@ -100,6 +102,7 @@ allocation_policies:
                 )["group_by_overflow_mode"]
                 == "any"
             )
+            assert storage.required_time_column == "timestamp"
             assert len(policies := storage.get_allocation_policies()) == 2
             assert set([p.config_key() for p in policies]) == {
                 "BytesScannedWindowAllocationPolicy",

--- a/tests/query/snql/test_storage_query.py
+++ b/tests/query/snql/test_storage_query.py
@@ -53,10 +53,10 @@ required_condition = and_cond(
 
 test_cases = [
     pytest.param(
-        f"MATCH STORAGE(metric_summaries) SELECT 4-5, trace_id WHERE {added_condition} GRANULARITY 60",
+        f"MATCH STORAGE(metrics_summaries) SELECT 4-5, trace_id WHERE {added_condition} GRANULARITY 60",
         StorageQuery.from_query(
             Query(
-                QueryStorage(key=StorageKey("metric_summaries")),
+                QueryStorage(key=StorageKey("metrics_summaries")),
                 selected_columns=[
                     SelectedExpression(
                         "4-5",

--- a/tests/query/test_query_validation.py
+++ b/tests/query/test_query_validation.py
@@ -10,6 +10,17 @@ from snuba.query.snql.parser import parse_snql_query
 test_cases = [
     pytest.param(
         """
+        MATCH STORAGE(generic_metrics_counters_meta_tag_values)
+        SELECT event_id
+        WHERE timestamp LIKE 'carbonara'
+        """,
+        ParsingException(
+            "Missing >= condition with a datetime literal on column timestamp for storage generic_metrics_counters_meta_tag_values. Example: timestamp >= toDateTime('2023-05-16 00:00')"
+        ),
+        id="No time condition for storage",
+    ),
+    pytest.param(
+        """
         MATCH (events)
         SELECT event_id
         WHERE timestamp LIKE 'carbonara'
@@ -17,7 +28,7 @@ test_cases = [
         ParsingException(
             "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')"
         ),
-        id="Invalid LIKE param",
+        id="No time condition",
     ),
     pytest.param(
         "MATCH (discover_events) SELECT arrayMap((`x`) -> identity(`y`), sdk_integrations) AS sdks WHERE project_id = 1 AND timestamp >= toDateTime('2021-01-01') AND timestamp < toDateTime('2021-01-02')",


### PR DESCRIPTION
In order to allow storage queries to be validated based on timestamp, we need to know what their timestamp is. Entities already have this so we add this optional field to storages as well.