### PR TITLE
chore(self-hosted): Remove dependency on snuba-image build step during e2e action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,6 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
 
   self-hosted-end-to-end:
-    needs: [snuba-image]
     runs-on: ubuntu-latest
     timeout-minutes: 25
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
 
   self-hosted-end-to-end:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Snuba


### PR DESCRIPTION
Don't think this is needed, it just needs to wait on `build-on-snuba-pr` image to finish job