### PR TITLE
fix: dlq-consumer should default to auto-offset-reset earliest

### DIFF
--- a/snuba/cli/dlq_consumer.py
+++ b/snuba/cli/dlq_consumer.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--auto-offset-reset",
-    default="error",
+    default="earliest",
     type=click.Choice(["error", "earliest", "latest"]),
     help="Kafka consumer auto offset reset.",
 )


### PR DESCRIPTION
same as https://github.com/getsentry/snuba/pull/5753 and https://github.com/getsentry/snuba/pull/5772 and every other consumer at sentry now

