### PR TITLE
one more auto-offset-reset earliest

### DIFF
--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -55,7 +55,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 )
 @click.option(
     "--auto-offset-reset",
-    default="error",
+    default="earliest",
     type=click.Choice(["error", "earliest", "latest"]),
     help="Kafka consumer auto offset reset.",
 )


### PR DESCRIPTION
same as all the other consumer CLIs which have `earliest` as the default, missed this one earlier