### PR TITLE
fix(rust): Fix incorrect logging output

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -47,9 +47,9 @@ impl TaskRunner<BytesInsertBatch<HttpBatch>, BytesInsertBatch<()>, anyhow::Error
             let write_start = SystemTime::now();
 
             tracing::debug!("performing write");
-            let skip_write = http_batch.finish().await.map_err(RunTaskError::Other)?;
+            let did_write = http_batch.finish().await.map_err(RunTaskError::Other)?;
 
-            if !skip_write {
+            if did_write {
                 tracing::info!("Inserted {} rows", num_rows);
             }
 


### PR DESCRIPTION
the `finish()` function returns whether the write happened, as such the
logs were messed up.

Fix #5847
