### PR TITLE
fix(migrations): return limited readiness state for storage set key

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -205,7 +205,10 @@ def get_group_readiness_state_from_storage_set(
     storage_set_key: StorageSetKey,
 ) -> ReadinessState:
     migration_group = _STORAGE_SET_TO_MIGRATION_GROUP_MAPPING[storage_set_key]
-    return _REGISTERED_MIGRATION_GROUPS[migration_group].readiness_state
+    registered_migration_group = _REGISTERED_MIGRATION_GROUPS.get(migration_group, None)
+    if registered_migration_group:
+        return registered_migration_group.readiness_state
+    return ReadinessState.LIMITED
 
 
 def get_group_readiness_state(group: MigrationGroup) -> ReadinessState:


### PR DESCRIPTION
When a migration group is registered in the ops repo and is in the config, it can block deploys because it has not been registered. When this happens just don't run the migration for it and continue on