### PR TITLE
fix(migrations): Parse precision and timezone from DateTime64

### DIFF
--- a/snuba/migrations/parse_schema.py
+++ b/snuba/migrations/parse_schema.py
@@ -191,7 +191,6 @@ class Visitor(NodeVisitor):  # type: ignore
         ) = visited_children
         if isinstance(precision_timezone_group, list) is False:
             return DateTime64()
-        print(precision_timezone_group, "====================")
         (
             _parenthesis,
             precision,

--- a/snuba/migrations/parse_schema.py
+++ b/snuba/migrations/parse_schema.py
@@ -28,9 +28,10 @@ from snuba.migrations.columns import MigrationModifiers
 grammar = Grammar(
     r"""
     type             = primitive / lowcardinality / agg / nullable / array
-    primitive        = basic_type / uint / float / fixedstring / enum
+    # datetime64 needs to be before basic_type to not be parsed as DateTime
+    primitive        = datetime64 / basic_type / uint / float / fixedstring / enum
     # DateTime must come before Date
-    basic_type       = "DateTime" / "DateTime64" / "Date" / "IPv4" / "IPv6" / "String" / "UUID"
+    basic_type       = "DateTime" / "Date" / "IPv4" / "IPv6" / "String" / "UUID"
     uint             = "UInt" uint_size
     uint_size        = "8" / "16" / "32" / "64"
     float            = "Float" float_size
@@ -55,6 +56,9 @@ grammar = Grammar(
     comma            = ","
     space            = " "
     quote            = "'"
+    datetime64              = "DateTime64" open_paren datetime64_precision (comma space* quote datetime64_timezone quote)? close_paren
+    datetime64_precision    = "3" / "6" / "9"
+    datetime64_timezone     = ~r"[a-zA-Z0-9_/]+"
     """
 )
 
@@ -72,7 +76,6 @@ def merge_modifiers(
 _TYPES: dict[str, type[ColumnType[MigrationModifiers]]] = {
     "Date": Date,
     "DateTime": DateTime,
-    "DateTime64": DateTime64,
     "IPv4": IPv4,
     "IPv6": IPv6,
     "String": String,
@@ -178,6 +181,22 @@ class Visitor(NodeVisitor):  # type: ignore
     ) -> ColumnType[MigrationModifiers]:
         (_arr, _paren, _sp, inner_type, _sp, _paren) = visited_children
         return Array(inner_type)
+
+    def visit_datetime64(
+        self, node: None, visited_children: Iterable[Any]
+    ) -> ColumnType[MigrationModifiers]:
+        (
+            _type,
+            _parenthesis,
+            precision,
+            group,
+            _parenthesis,
+        ) = visited_children
+        if group.children:
+            (_comma, _space, _quote, timezone, _quote) = group
+        else:
+            timezone = None
+        return DateTime64(precision=int(precision.text), timezone=timezone)
 
     def generic_visit(self, node: Node, visited_children: Iterable[Any]) -> Any:
         if isinstance(visited_children, list) and len(visited_children) == 1:

--- a/tests/migrations/test_parse_schema.py
+++ b/tests/migrations/test_parse_schema.py
@@ -9,6 +9,7 @@ from snuba.clickhouse.columns import (
     ColumnType,
     Date,
     DateTime,
+    DateTime64,
     Enum,
     FixedString,
     Float,
@@ -90,6 +91,19 @@ test_data = [
     (
         ("DateTime", "", "", "DoubleDelta, LZ4"),
         (DateTime(Modifiers(codecs=["DoubleDelta", "LZ4"]))),
+    ),
+    # DateTime64
+    (
+        ("DateTime64", "", "", ""),
+        DateTime64(3),
+    ),
+    (
+        ("DateTime64(6)", "", "", ""),
+        DateTime64(6),
+    ),
+    (
+        ("DateTime64(9, 'America/New_York')", "", "", ""),
+        DateTime64(9, "America/New_York"),
     ),
 ]
 


### PR DESCRIPTION
This is a fix to the `DateTime64` type added recently. Schema wasn't being parsed correctly when parsing it from a migration.