### PR TITLE
Metrics for replacements DD

### DIFF
--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -215,6 +215,7 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
                 try:
                     projects_to_skip.extend(json.loads(manual_bypass_projects))
                 except Exception as e:
+                    metrics.increment("errors_replacer_process_message_error")
                     logger.exception(e)
             if processed.get_project_id() in projects_to_skip:
                 # For a persistent non rate limited logger

--- a/snuba/replacers/replacements_and_expiry.py
+++ b/snuba/replacers/replacements_and_expiry.py
@@ -50,6 +50,7 @@ def set_config_auto_replacements_bypass_projects(
             tags={},
         )
     except Exception as e:
+        metrics.increment("set_config_auto_replacements_bypass_projects_error")
         logger.exception(e)
 
 
@@ -69,6 +70,7 @@ def _retrieve_projects_from_redis() -> Mapping[int, datetime]:
         )
         return projects
     except Exception as e:
+        metrics.increment("retrieve_projects_from_redis_error")
         logger.exception(e)
         return {}
 

--- a/snuba/replacers/replacements_and_expiry.py
+++ b/snuba/replacers/replacements_and_expiry.py
@@ -13,7 +13,7 @@ from snuba.redis import RedisClientKey, get_redis_client
 from snuba.state import get_int_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
-metrics = MetricsWrapper(environment.metrics, "bucket_timer")
+metrics = MetricsWrapper(environment.metrics, "replacements_and_expiry")
 
 redis_client = get_redis_client(RedisClientKey.REPLACEMENTS_STORE)
 config_auto_replacements_bypass_projects_hash = (
@@ -86,7 +86,7 @@ def get_config_auto_replacements_bypass_projects(
             valid_projects[project_id] = curr_projects[project_id]
     pipeline.execute()
     metrics.timing(
-        "get_config_auto_replacements_bypass_projects",
+        "deleting_expired_projects",
         datetime.now().timestamp() - start.timestamp(),
         tags={},
     )


### PR DESCRIPTION
As part of the roll out plan of automatically skipping offending replacements projects, we want to create a DD dashboard to monitor the following metrics:
- number of projects skipped
- latency of adding skipped projects to redis
- latency of deleting expired projects from redis
- latency of getting skipped projects from redis