### PR TITLE
feat(capman): Short circuit allocation policy

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -240,12 +240,37 @@ schema:
     - date
   not_deleted_mandatory_condition: deleted
 allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 1
   - name: ConcurrentRateLimitAllocationPolicy
     args:
       required_tenant_types:
         - organization_id
         - referrer
         - project_id
+  - name: BytesScannedRejectingPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - project_id
+        - referrer
+      default_config_overrides:
+        is_enforced: 1
+  - name: CrossOrgQueryAllocationPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 1
+        is_active: 1
+      cross_org_referrer_limits:
+        getsentry.tasks.backfill_grouping_records:
+          max_threads: 2
+          concurrent_limit: 4
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:
@@ -254,31 +279,6 @@ allocation_policies:
       default_config_overrides:
         throttled_thread_number: 1
         org_limit_bytes_scanned: 10000000
-  - name: ReferrerGuardRailPolicy
-    args:
-      required_tenant_types:
-        - referrer
-      default_config_overrides:
-        is_enforced: 1
-  - name: BytesScannedRejectingPolicy
-    args:
-      required_tenant_types:
-        - organization_id
-        - project_id
-        - referrer
-      default_config_overrides:
-        is_enforced: 0
-  - name: CrossOrgQueryAllocationPolicy
-    args:
-      required_tenant_types:
-        - referrer
-      default_config_overrides:
-        is_enforced: 0
-        is_active: 0
-      cross_org_referrer_limits:
-        getsentry.tasks.backfill_grouping_records:
-          max_threads: 2
-          concurrent_limit: 4
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -249,15 +249,12 @@ allocation_policies:
         - organization_id
         - referrer
         - project_id
-  - name: BytesScannedWindowAllocationPolicy
+  - name: BytesScannedRejectingPolicy
     args:
       required_tenant_types:
         - organization_id
+        - project_id
         - referrer
-      default_config_overrides:
-        is_enforced: 1
-        throttled_thread_number: 1
-        org_limit_bytes_scanned: 10000000
   - name: CrossOrgQueryAllocationPolicy
     args:
       required_tenant_types:
@@ -269,12 +266,15 @@ allocation_policies:
         getsentry.tasks.backfill_grouping_records:
           max_threads: 2
           concurrent_limit: 4
-  - name: BytesScannedRejectingPolicy
+  - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:
         - organization_id
-        - project_id
         - referrer
+      default_config_overrides:
+        is_enforced: 1
+        throttled_thread_number: 1
+        org_limit_bytes_scanned: 10000000
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -237,6 +237,12 @@ schema:
   dist_table_name: errors_dist_ro
   not_deleted_mandatory_condition: deleted
 allocation_policies:
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 1
   - name: ConcurrentRateLimitAllocationPolicy
     args:
       required_tenant_types:
@@ -252,31 +258,23 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 10000000
-  - name: ReferrerGuardRailPolicy
+  - name: CrossOrgQueryAllocationPolicy
     args:
       required_tenant_types:
         - referrer
       default_config_overrides:
         is_enforced: 1
+        is_active: 1
+      cross_org_referrer_limits:
+        getsentry.tasks.backfill_grouping_records:
+          max_threads: 2
+          concurrent_limit: 4
   - name: BytesScannedRejectingPolicy
     args:
       required_tenant_types:
         - organization_id
         - project_id
         - referrer
-      default_config_overrides:
-        is_enforced: 0
-  - name: CrossOrgQueryAllocationPolicy
-    args:
-      required_tenant_types:
-        - referrer
-      default_config_overrides:
-        is_enforced: 0
-        is_active: 0
-      cross_org_referrer_limits:
-        getsentry.tasks.backfill_grouping_records:
-          max_threads: 2
-          concurrent_limit: 4
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -821,6 +821,9 @@ def _apply_allocation_policies_quota(
                     "quota_allowance",
                     quota_allowances[allocation_policy.config_key()],
                 )
+                if not can_run:
+                    break
+
         allowance_dicts = {
             key: quota_allowance.to_dict()
             for key, quota_allowance in quota_allowances.items()

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -592,7 +592,7 @@ def test_allocation_policy_updates_quota() -> None:
             nonlocal queries_run_duplicate
             queries_run_duplicate += 1
 
-    # both policies should error
+    # the first policy will error and short circuit the rest
     query, storage, attribution_info = _build_test_query(
         "count(distinct(project_id))",
         [
@@ -633,19 +633,11 @@ def test_allocation_policy_updates_quota() -> None:
                 "storage_key": "StorageKey.DOESNTMATTER",
             },
         },
-        "CountQueryPolicyDuplicate": {
-            "can_run": False,
-            "max_threads": 0,
-            "explanation": {
-                "reason": "can only run 2 queries!",
-                "storage_key": "StorageKey.DOESNTMATTER",
-            },
-        },
     }
     cause = e.value.__cause__
     assert isinstance(cause, AllocationPolicyViolations)
     assert "CountQueryPolicy" in cause.violations
-    assert "CountQueryPolicyDuplicate" in cause.violations
+    assert "CountQueryPolicyDuplicate" not in cause.violations
 
 
 @pytest.mark.redis_db

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -256,23 +256,8 @@ def test_db_query_success() -> None:
         trace_id="trace_id",
         robust=False,
     )
+
     assert stats["quota_allowance"] == {
-        "BytesScannedWindowAllocationPolicy": {
-            "can_run": True,
-            "explanation": {
-                "storage_key": "StorageKey.ERRORS_RO",
-            },
-            "max_threads": 10,
-        },
-        "ConcurrentRateLimitAllocationPolicy": {
-            "can_run": True,
-            "explanation": {
-                "overrides": {},
-                "reason": "within limit",
-                "storage_key": "StorageKey.ERRORS_RO",
-            },
-            "max_threads": 10,
-        },
         "ReferrerGuardRailPolicy": {
             "can_run": True,
             "max_threads": 10,
@@ -283,17 +268,38 @@ def test_db_query_success() -> None:
                 "storage_key": "StorageKey.ERRORS_RO",
             },
         },
+        "ConcurrentRateLimitAllocationPolicy": {
+            "can_run": True,
+            "max_threads": 10,
+            "explanation": {
+                "reason": "within limit",
+                "overrides": {},
+                "storage_key": "StorageKey.ERRORS_RO",
+            },
+        },
         "BytesScannedRejectingPolicy": {
             "can_run": True,
-            "explanation": {},
             "max_threads": 10,
+            "explanation": {
+                "reason": "within_limit",
+                "storage_key": "StorageKey.ERRORS_RO",
+            },
         },
         "CrossOrgQueryAllocationPolicy": {
             "can_run": True,
-            "explanation": {},
             "max_threads": 10,
+            "explanation": {
+                "reason": "pass_through",
+                "storage_key": "StorageKey.ERRORS_RO",
+            },
+        },
+        "BytesScannedWindowAllocationPolicy": {
+            "can_run": True,
+            "max_threads": 10,
+            "explanation": {"storage_key": "StorageKey.ERRORS_RO"},
         },
     }
+
     assert len(query_metadata_list) == 1
     assert result.extra["stats"] == stats
     assert result.extra["sql"] is not None


### PR DESCRIPTION
Currently, all the policies of a storage run on every request. This can put undue load on redis when we already know the query is rejected. 

If one policy rejects from now on, just don't run any others

Also reorder the policies on errors so that the rejecting ones run first