### PR TITLE
fix(snuba-admin): Add quotes around ColumnSizeOnDisk's table value

### DIFF
--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -126,7 +126,7 @@ class ColumnSizeOnDisk(SystemQuery):
         sum(rows) rows_cnt,
         round(usize / rows_cnt, 2) avg_row_size
     FROM system.parts_columns
-    WHERE (active = 1) AND (table = {{table}})
+    WHERE (active = 1) AND (table = '{{table}}')
     GROUP BY
         table,
         column


### PR DESCRIPTION
I notice it was missing and I believe is the intention is to set one table name only.