### PR TITLE
feat(metrics): add metric_stats use case to generic metrics meta tables

### DIFF
--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -254,7 +254,6 @@ struct CommonMetricFields {
 fn should_record_meta(use_case_id: &str) -> Option<u8> {
     match use_case_id {
         "escalating_issues" => Some(0),
-        "metric_stats" => Some(0),
         _ => Some(1),
     }
 }
@@ -1251,6 +1250,9 @@ mod tests {
 
         let use_case_valid = "spans";
         assert_eq!(should_record_meta(use_case_valid), Some(1));
+
+        let use_case_metric_stats = "metric_stats";
+        assert_eq!(should_record_meta(use_case_metric_stats), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
Enable processing of metrics for the metric_stats use case in order to store metadata for the usecase in the new generic_metrics_*_meta tables that enable quicker querying