### PR TITLE
ref(async-inserts): allow async inserts as an option

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -97,6 +97,7 @@ fn create_factory(
             broker_config: BrokerConfig::default(),
         },
         stop_at_timestamp: None,
+        async_inserts: false,
     };
     Box::new(factory)
 }

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -57,7 +57,6 @@ fn create_factory(
             user: "test".into(),
             password: "test".into(),
             database: "test".into(),
-            async_inserts: false,
         },
         message_processor: MessageProcessorConfig {
             python_class_name: python_class_name.into(),
@@ -83,6 +82,7 @@ fn create_factory(
         clickhouse_concurrency,
         commitlog_concurrency,
         replacements_concurrency,
+        async_inserts: false,
         python_max_queue_depth: None,
         use_rust_processor: true,
         health_check_file: None,
@@ -97,7 +97,6 @@ fn create_factory(
             broker_config: BrokerConfig::default(),
         },
         stop_at_timestamp: None,
-        async_inserts: false,
     };
     Box::new(factory)
 }

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -57,6 +57,7 @@ fn create_factory(
             user: "test".into(),
             password: "test".into(),
             database: "test".into(),
+            async_inserts: false,
         },
         message_processor: MessageProcessorConfig {
             python_class_name: python_class_name.into(),

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -87,6 +87,7 @@ pub struct ClickhouseConfig {
     pub user: String,
     pub password: String,
     pub database: String,
+    pub async_inserts: bool,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -87,7 +87,6 @@ pub struct ClickhouseConfig {
     pub user: String,
     pub password: String,
     pub database: String,
-    pub async_inserts: bool,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -39,6 +39,7 @@ pub fn consumer(
     python_max_queue_depth: Option<usize>,
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
+    async_inserts: bool,
 ) {
     py.allow_threads(|| {
         consumer_impl(
@@ -53,6 +54,7 @@ pub fn consumer(
             python_max_queue_depth,
             health_check_file,
             stop_at_timestamp,
+            async_inserts,
         )
     });
 }
@@ -70,6 +72,7 @@ pub fn consumer_impl(
     python_max_queue_depth: Option<usize>,
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
+    async_inserts: bool,
 ) -> usize {
     setup_logging();
 
@@ -225,6 +228,7 @@ pub fn consumer_impl(
         physical_topic_name: Topic::new(&consumer_config.raw_topic.physical_topic_name),
         accountant_topic_config: consumer_config.accountant_topic,
         stop_at_timestamp,
+        async_inserts,
     };
 
     let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -36,10 +36,10 @@ pub fn consumer(
     use_rust_processor: bool,
     enforce_schema: bool,
     max_poll_interval_ms: usize,
+    async_inserts: bool,
     python_max_queue_depth: Option<usize>,
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
-    async_inserts: bool,
 ) {
     py.allow_threads(|| {
         consumer_impl(
@@ -51,10 +51,10 @@ pub fn consumer(
             use_rust_processor,
             enforce_schema,
             max_poll_interval_ms,
+            async_inserts,
             python_max_queue_depth,
             health_check_file,
             stop_at_timestamp,
-            async_inserts,
         )
     });
 }
@@ -69,10 +69,10 @@ pub fn consumer_impl(
     use_rust_processor: bool,
     enforce_schema: bool,
     max_poll_interval_ms: usize,
+    async_inserts: bool,
     python_max_queue_depth: Option<usize>,
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
-    async_inserts: bool,
 ) -> usize {
     setup_logging();
 
@@ -218,6 +218,7 @@ pub fn consumer_impl(
         clickhouse_concurrency: ConcurrencyConfig::new(2),
         commitlog_concurrency: ConcurrencyConfig::new(2),
         replacements_concurrency: ConcurrencyConfig::new(4),
+        async_inserts,
         python_max_queue_depth,
         use_rust_processor,
         health_check_file: health_check_file.map(ToOwned::to_owned),
@@ -228,7 +229,6 @@ pub fn consumer_impl(
         physical_topic_name: Topic::new(&consumer_config.raw_topic.physical_topic_name),
         accountant_topic_config: consumer_config.accountant_topic,
         stop_at_timestamp,
-        async_inserts,
     };
 
     let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -45,6 +45,7 @@ pub struct ConsumerStrategyFactory {
     pub clickhouse_concurrency: ConcurrencyConfig,
     pub commitlog_concurrency: ConcurrencyConfig,
     pub replacements_concurrency: ConcurrencyConfig,
+    pub async_inserts: bool,
     pub python_max_queue_depth: Option<usize>,
     pub use_rust_processor: bool,
     pub health_check_file: Option<String>,
@@ -55,7 +56,6 @@ pub struct ConsumerStrategyFactory {
     pub physical_topic_name: Topic,
     pub accountant_topic_config: config::TopicConfig,
     pub stop_at_timestamp: Option<i64>,
-    pub async_inserts: bool,
 }
 
 impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -55,6 +55,7 @@ pub struct ConsumerStrategyFactory {
     pub physical_topic_name: Topic,
     pub accountant_topic_config: config::TopicConfig,
     pub stop_at_timestamp: Option<i64>,
+    pub async_inserts: bool,
 }
 
 impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
@@ -116,7 +117,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.clickhouse_concurrency,
             &self.storage_config.clickhouse_cluster.user,
             &self.storage_config.clickhouse_cluster.password,
-            self.storage_config.clickhouse_cluster.async_inserts,
+            self.async_inserts,
         );
 
         let accumulator = Arc::new(

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -116,6 +116,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.clickhouse_concurrency,
             &self.storage_config.clickhouse_cluster.user,
             &self.storage_config.clickhouse_cluster.password,
+            self.storage_config.clickhouse_cluster.async_inserts,
         );
 
         let accumulator = Arc::new(

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -54,7 +54,7 @@ impl BatchFactory {
         query_params.push_str("load_balancing=in_order&insert_distributed_sync=1");
 
         let async_inserts_allowed = get_str_config("async_inserts_allowed").ok().flatten();
-        if async_inserts == true && async_inserts_allowed == Some(1.to_string()) {
+        if async_inserts && async_inserts_allowed == Some(1.to_string()) {
             query_params.push_str("&async_insert=1&wait_for_async_insert=1");
         }
 

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -53,9 +53,11 @@ impl BatchFactory {
         let mut query_params = String::new();
         query_params.push_str("load_balancing=in_order&insert_distributed_sync=1");
 
-        let async_inserts_allowed = get_str_config("async_inserts_allowed").ok().flatten();
-        if async_inserts && async_inserts_allowed == Some(1.to_string()) {
-            query_params.push_str("&async_insert=1&wait_for_async_insert=1");
+        if async_inserts {
+            let async_inserts_allowed = get_str_config("async_inserts_allowed").ok().flatten();
+            if async_inserts_allowed == Some("1".to_string()) {
+                query_params.push_str("&async_insert=1&wait_for_async_insert=1");
+            }
         }
 
         let url = format!("http://{hostname}:{http_port}?{query_params}");

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -9,6 +9,7 @@ use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::runtime_config::get_str_config;
 use crate::types::RowData;
 
 const CLICKHOUSE_HTTP_CHUNK_SIZE: usize = 1_000_000;
@@ -31,6 +32,7 @@ impl BatchFactory {
         concurrency: &ConcurrencyConfig,
         clickhouse_user: &str,
         clickhouse_password: &str,
+        async_inserts: bool,
     ) -> Self {
         let mut headers = HeaderMap::with_capacity(5);
         headers.insert(CONNECTION, HeaderValue::from_static("keep-alive"));
@@ -48,7 +50,14 @@ impl BatchFactory {
             HeaderValue::from_str(database).unwrap(),
         );
 
-        let query_params = "load_balancing=in_order&insert_distributed_sync=1".to_string();
+        let mut query_params = String::new();
+        query_params.push_str("load_balancing=in_order&insert_distributed_sync=1");
+
+        let async_inserts_allowed = get_str_config("async_inserts_allowed").ok().flatten();
+        if async_inserts == true && async_inserts_allowed == Some(1.to_string()) {
+            query_params.push_str("&async_insert=1&wait_for_async_insert=1");
+        }
+
         let url = format!("http://{hostname}:{http_port}?{query_params}");
         let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
 
@@ -204,6 +213,41 @@ mod tests {
             &concurrency,
             "default",
             "",
+            false,
+        );
+
+        let mut batch = factory.new_batch();
+
+        batch
+            .write_rows(&RowData::from_encoded_rows(vec![
+                br#"{"hello": "world"}"#.to_vec()
+            ]))
+            .unwrap();
+
+        concurrency.handle().block_on(batch.finish()).unwrap();
+
+        mock.assert();
+    }
+
+    #[test]
+    fn test_write_async() {
+        crate::testutils::initialize_python();
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/").body("{\"hello\": \"world\"}\n");
+            then.status(200).body("hi");
+        });
+
+        let concurrency = ConcurrencyConfig::new(1);
+        let factory = BatchFactory::new(
+            &server.host(),
+            server.port(),
+            "testtable",
+            "testdb",
+            &concurrency,
+            "default",
+            "",
+            true,
         );
 
         let mut batch = factory.new_batch();
@@ -236,6 +280,7 @@ mod tests {
             &concurrency,
             "default",
             "",
+            false,
         );
 
         let mut batch = factory.new_batch();
@@ -266,6 +311,7 @@ mod tests {
             &concurrency,
             "default",
             "",
+            false,
         );
 
         let mut batch = factory.new_batch();

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -147,6 +147,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     type=int,
     help="Unix timestamp after which to stop processing messages",
 )
+@click.option(
+    "--async-inserts",
+    is_flag=True,
+    default=False,
+    help="Enable async inserts for ClickHouse",
+)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -173,6 +179,7 @@ def rust_consumer(
     health_check_file: Optional[str],
     enforce_schema: bool,
     stop_at_timestamp: Optional[int],
+    async_inserts: bool,
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -214,6 +221,7 @@ def rust_consumer(
         python_max_queue_depth,
         health_check_file,
         stop_at_timestamp,
+        async_inserts,
     )
 
     sys.exit(exitcode)

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -130,6 +130,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     default=30000,
 )
 @click.option(
+    "--async-inserts",
+    is_flag=True,
+    default=False,
+    help="Enable async inserts for ClickHouse",
+)
+@click.option(
     "--health-check-file",
     default=None,
     type=str,
@@ -146,12 +152,6 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     "--stop-at-timestamp",
     type=int,
     help="Unix timestamp after which to stop processing messages",
-)
-@click.option(
-    "--async-inserts",
-    is_flag=True,
-    default=False,
-    help="Enable async inserts for ClickHouse",
 )
 def rust_consumer(
     *,
@@ -175,11 +175,11 @@ def rust_consumer(
     use_rust_processor: bool,
     group_instance_id: Optional[str],
     max_poll_interval_ms: int,
+    async_inserts: bool,
     python_max_queue_depth: Optional[int],
     health_check_file: Optional[str],
     enforce_schema: bool,
     stop_at_timestamp: Optional[int],
-    async_inserts: bool,
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -218,10 +218,10 @@ def rust_consumer(
         use_rust_processor,
         enforce_schema,
         max_poll_interval_ms,
+        async_inserts,
         python_max_queue_depth,
         health_check_file,
         stop_at_timestamp,
-        async_inserts,
     )
 
     sys.exit(exitcode)


### PR DESCRIPTION
We are going to try out async inserts for specific S4S clusters to test it out and see the impacts of enabling it. This adds a cli arg that we can use to target consumers for specific clusters (e.g. https://github.com/getsentry/ops/pull/10687). I'm also adding a runtime config flag `async_inserts_allowed` so that we can turn it on and off as we test without having to put up code changes. 

When (and if) we move forward to enabling this on more clusters, we won't be able to use the runtime config in the same way since it would turn things on and off across the board, so this is really for testing purposes at this moment

Pre-req for https://github.com/getsentry/ops/pull/10687