### PR TITLE
fix(clickhouse): Remove unecessary logging

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -47,11 +47,7 @@ impl TaskRunner<BytesInsertBatch<HttpBatch>, BytesInsertBatch<()>, anyhow::Error
             let write_start = SystemTime::now();
 
             tracing::debug!("performing write");
-            let did_write = http_batch.finish().await.map_err(RunTaskError::Other)?;
-
-            if did_write {
-                tracing::info!("Inserted {} rows", num_rows);
-            }
+            http_batch.finish().await.map_err(RunTaskError::Other)?;
 
             let write_finish = SystemTime::now();
 


### PR DESCRIPTION
The consumer pod logs are flooded with these logs. Lets remove them so that triaging becomes easier and reduce the footprint of our costs of logging.