### PR TITLE
Debugging bucket timer

### DIFF
--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -49,6 +49,7 @@ class Counter:
         self.limit = self.counter_window_size * percentage
 
     def __trim_expired_buckets(self, now: datetime) -> None:
+        logger.debug("Entering __trim_expired_buckets method")
         current_minute = floor_minute(now)
         window_start = current_minute - self.counter_window_size
         new_buckets: Buckets = {}
@@ -63,6 +64,7 @@ class Counter:
         start_minute: datetime,
         processing_time: timedelta,
     ) -> None:
+        logger.debug("Entering __add_to_bucket method")
         if start_minute in self.buckets:
             if project_id in self.buckets[start_minute]:
                 self.buckets[start_minute][project_id] += processing_time
@@ -75,6 +77,7 @@ class Counter:
     def record_time_spent(
         self, project_id: int, start: datetime, end: datetime
     ) -> None:
+        logger.debug("Entering record_time_spent method")
         start_minute = floor_minute(start)
         left = start
         right = ceil_minute(start)
@@ -85,27 +88,33 @@ class Counter:
         self.__add_to_bucket(project_id, start_minute, end - left)
 
     def get_projects_exceeding_limit(self) -> List[int]:
+        logger.debug("Entering get_projects_exceeding_limit method")
         now = datetime.now()
         self.__trim_expired_buckets(now)
         project_groups: dict[int, timedelta] = defaultdict(lambda: timedelta(seconds=0))
         logger.debug("self.buckets_size: %s" % len(self.buckets))
         for project_dict in list(self.buckets.values()):
+            logger.debug("project_dict_size: %s" % len(project_dict))
             for project_id, processing_time in project_dict.items():
+                logger.debug(
+                    "project_id: %s, processing_time: %s"
+                    % (project_id, processing_time)
+                )
                 project_groups[project_id] += processing_time
 
-        logger.info("project_groups_size: %s" % len(project_groups))
+        logger.debug("project_groups_size: %s" % len(project_groups))
 
         # Compare the replacement total grouped by project_id with system time limit
         projects_exceeding_time_limit = []
         for project_id, total_processing_time in project_groups.items():
-            logger.info(
+            logger.debug(
                 "project_id: %s, total_processing_time: %s, limit: %s"
                 % (project_id, total_processing_time, self.limit)
             )
             if total_processing_time > self.limit and len(project_groups) > 1:
                 projects_exceeding_time_limit.append(project_id)
 
-        logger.info("projects_exceeding_time_limit: %s", projects_exceeding_time_limit)
+        logger.debug("projects_exceeding_time_limit: %s", projects_exceeding_time_limit)
         metrics.timing(
             "get_projects_exceeding_limit_duration",
             datetime.now().timestamp() - now.timestamp(),

--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -88,6 +88,7 @@ class Counter:
         now = datetime.now()
         self.__trim_expired_buckets(now)
         project_groups: dict[int, timedelta] = defaultdict(lambda: timedelta(seconds=0))
+        logger.debug("self.buckets_size: %s" % len(self.buckets))
         for project_dict in list(self.buckets.values()):
             for project_id, processing_time in project_dict.items():
                 project_groups[project_id] += processing_time


### PR DESCRIPTION
As part of the debugging efforts on why [auto replacements project skipping](https://github.com/getsentry/snuba/pull/5883) isn't working as intended, we have a new hypothesis that the bucket timer algo we depend on isn't working as we expected. More specifically, we noticed (from logging) that [projects_exceeding_limit](https://github.com/getsentry/snuba/blob/76fd1fff03be960a5da216223ed809860fa0fd6b/snuba/replacer.py#L596) logs, but [projects_exceeding_time_limit](https://github.com/getsentry/snuba/blob/76fd1fff03be960a5da216223ed809860fa0fd6b/snuba/utils/bucket_timer.py#L95) does not. We add additional logging to confirm the control flow of our code