### PR TITLE
allow one replacement project to be skipped

### DIFF
--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -112,7 +112,10 @@ class Counter:
                 % (project_id, total_processing_time, self.limit)
             )
             if total_processing_time > self.limit and (
-                len(project_groups) > 1 or get_int_config("s4s_replacements_testing")
+                len(project_groups) > 1
+                or get_int_config(
+                    "allows_skipping_single_project_replacements", default=0
+                )
             ):
                 projects_exceeding_time_limit.append(project_id)
 

--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -111,7 +111,9 @@ class Counter:
                 "project_id: %s, total_processing_time: %s, limit: %s"
                 % (project_id, total_processing_time, self.limit)
             )
-            if total_processing_time > self.limit and len(project_groups) > 1:
+            if total_processing_time > self.limit and (
+                len(project_groups) > 1 or get_int_config("s4s_replacements_testing")
+            ):
                 projects_exceeding_time_limit.append(project_id)
 
         logger.debug("projects_exceeding_time_limit: %s", projects_exceeding_time_limit)


### PR DESCRIPTION
In the current replacements set up, if a project takes up more time processing replacements than what the threshold allows, it actually won't be skipped if it's the only project that exists. The intention was that it's fine for the single existing project to use up the entire replacements processing budget. Thus, when we are testing within S4S, even if we are going over the testing threshold (which is 0), we are not adding sentry-for-sentry to the list of projects to skip, since it's the only project that exists.

This PR uses another runtime config, `s4s_replacements_testing`, so that if it's true, we allow the single existing project to be skipped as long as it exceeds the threshold (0).

This is for S4S testing only and will be removed
