### PR TITLE
chore(snuba): remove reference to make pyenv-setup in contributing docs

### DIFF
--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -28,7 +28,6 @@ clone this repo into your workspace::
 These commands set up the Python virtual environment::
 
     cd snuba
-    make pyenv-setup
     python -m venv .venv
     source .venv/bin/activate
     pip install --upgrade pip==22.2.2


### PR DESCRIPTION
The docs contain a reference to make pyenv-setup, which is not contained in the makefile anymore, and therefore does not work or have value. As far as I could tell, omitting that call works as well, as long as pyenv is setup correctly.