### PR TITLE
fix(admin): Allow LEFT ARRAY JOIN in the admin tool

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -159,10 +159,11 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
     # Confusingly it will also sometimes lower case ARRAY, so check for both.
     tables_set = set(parsed.tables)
     array_join = None
-    if "ARRAY" in parsed.tables_aliases:
-        array_join = "ARRAY"
-    elif "array" in parsed.tables_aliases:
-        array_join = "array"
+    array_join_keys = ["ARRAY", "array", "LEFT", "left"]
+    for ak in array_join_keys:
+        if ak in parsed.tables_aliases:
+            array_join = ak
+            break
 
     if array_join:
         for v in parsed.tables_aliases.values():

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -36,3 +36,15 @@ def test_allowed_tables_with_array_join() -> None:
             "SELECT * FROM my_table, other_table ARRAY JOIN tags.key AS tag_key, tags.raw_value AS tag_value",
             allowed_tables={"my_table"},
         )
+
+
+def test_allowed_tables_with_left_array_join() -> None:
+    validate_ro_query(
+        "SELECT * FROM my_table LEFT ARRAY JOIN tags.key AS tag_key, tags.raw_value AS tag_value",
+        allowed_tables={"my_table"},
+    )
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query(
+            "SELECT * FROM my_table, other_table LEFT ARRAY JOIN tags.key AS tag_key, tags.raw_value AS tag_value",
+            allowed_tables={"my_table"},
+        )


### PR DESCRIPTION
Change the table validation to also handle the LEFT ARRAY JOIN clause.