### PR TITLE
ref(subscriptions): Improve logging by adding metadata field

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -468,8 +468,9 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                     entity = task.task.subscription.data.entity
                     if get_entity_name(entity) == EntityKey.GENERIC_METRICS_GAUGES:
                         logger.warning(
-                            "Skipping malformed subscription query %r in scheduler",
+                            "Skipping malformed subscription query %r with metadata %r in scheduler",
                             task.task.subscription.data.query,
+                            task.task.subscription.data.metadata,
                         )
                         continue
 


### PR DESCRIPTION
The metadata field is where additional `organization` column data should be passed through for generic metrics subscriptions. Add this info to logging so we can better identify the problem at hand. 