### PR TITLE
chore(self-hosted): Automatically pick up e2e test action from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
       - name: Checkout Snuba
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@267fab2add9e173029c1e09ecfd82e04688d7c44
+        uses: getsentry/action-self-hosted-e2e-tests@main
         with:
           project_name: snuba
           docker_repo: getsentry/snuba


### PR DESCRIPTION
I've recently updated the self-hosted e2e test action to properly pick up changes on pre-submit after noticing breakage snuck into master from https://github.com/getsentry/relay/pull/3633.

It seems reasonable to pin this to main given that our team has alerting for when this CI check fails on master, and we don't update it frequently. Please let me know if there are any concerns here.

#skip-changelog