### PR TITLE
feat(issue-search): Add group_first_release_id to the GroupAttributes table

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -395,6 +395,7 @@ class GroupAttributesLoader(DirectoryLoader):
         return [
             "0001_group_attributes",
             "0002_add_priority_to_group_attributes",
+            "0003_add_first_release_id_to_group_attributes",
         ]
 
 

--- a/snuba/snuba_migrations/group_attributes/0003_add_first_release_id_to_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0003_add_first_release_id_to_group_attributes.py
@@ -1,0 +1,49 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_local",
+                column=Column(
+                    "group_first_release_id", UInt(8, Modifiers(nullable=True))
+                ),
+                target=OperationTarget.LOCAL,
+                after="group_priority",
+            ),
+            operations.AddColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_dist",
+                column=Column(
+                    "group_first_release_id", UInt(8, Modifiers(nullable=True))
+                ),
+                target=OperationTarget.DISTRIBUTED,
+                after="group_priority",
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_dist",
+                column_name="group_first_release_id",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_local",
+                column_name="group_first_release_id",
+                target=OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/group_attributes/0003_add_first_release_id_to_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0003_add_first_release_id_to_group_attributes.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import Column, UUID
+from snuba.clickhouse.columns import UUID, Column
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/snuba_migrations/group_attributes/0003_add_first_release_id_to_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0003_add_first_release_id_to_group_attributes.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import Column, UInt
+from snuba.clickhouse.columns import Column, UUID
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
@@ -16,7 +16,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.GROUP_ATTRIBUTES,
                 table_name="group_attributes_local",
                 column=Column(
-                    "group_first_release_id", UInt(8, Modifiers(nullable=True))
+                    "group_first_release_id",
+                    UUID(Modifiers(nullable=True)),
                 ),
                 target=OperationTarget.LOCAL,
                 after="group_priority",
@@ -25,7 +26,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.GROUP_ATTRIBUTES,
                 table_name="group_attributes_dist",
                 column=Column(
-                    "group_first_release_id", UInt(8, Modifiers(nullable=True))
+                    "group_first_release_id",
+                    UUID(Modifiers(nullable=True)),
                 ),
                 target=OperationTarget.DISTRIBUTED,
                 after="group_priority",


### PR DESCRIPTION
Add a new column, `group_first_release_id` to the GroupAttributes table. This column will be backfilled as part of the issue search improvements, with data from `Group.first_release_id`. 

This column will help speed up searches for `firstRelease`. We'll still handle `firstRelease` queries using Postgres if the query includes the environment. 