### PR TITLE
chore(tech-debt): Add missing column low cardinality processor in Discover

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -463,6 +463,7 @@ query_processors:
         - app_start_type
         - transaction_source
         - version
+        - tags[environment]
 
 
 validate_data_model: error


### PR DESCRIPTION
Some [discover queries](https://sentry.sentry.io/issues/5281216825/events/4d8e33db9f30420e954bb6443471bc19/) are failing as a result of the allocator bug. This is caused by how ClickHouse version 22.8 deals with low cardinality string columns. This PR is responsible for adding `tags[environment]` to the set of columns to be processed by the LowCardinalityProcessor in discover which casts the low cardinality string into a regular (high cardinality) one.