### PR TITLE
ref(async-inserts): Add system queries

### DIFF
--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -132,3 +132,92 @@ class ColumnSizeOnDisk(SystemQuery):
         column
     ORDER BY size DESC;
     """
+
+
+class PartCreations(SystemQuery):
+    """
+    New parts created in the last 10 minutes. Replicas have event_type 'DownloadPart',
+    therefore we'll only see the new parts on the node that got the insert
+    """
+
+    sql = """
+    SELECT
+        hostName() AS node_name,
+        event_time,
+        part_name,
+        rows,
+        size_in_bytes AS bytes_on_disk,
+        partition_id,
+        part_type
+    FROM
+        system.part_log
+    WHERE
+        database = 'default'
+        AND table = '{{table}}'
+        AND event_time > now() - toIntervalMinute(10)
+        and event_type = 'NewPart'
+
+    """
+
+
+class AsyncInsertPendingFlushes(SystemQuery):
+    """
+    Current number of aysnc insert queries that are waiting to be flushed
+    """
+
+    # Insert is a keyword that isn't allowed, hence using 'like'
+    sql = """
+    SELECT
+        value as queries
+    FROM system.metrics
+    WHERE metric like 'PendingAsyncInser%'
+    """
+
+
+class AsyncInsertFlushes(SystemQuery):
+    """
+    Async insert queries (flushes) that happened in the last 10 minutes,
+    with a successful status
+    """
+
+    sql = """
+    SELECT
+        table,
+        query,
+        format,
+        query_id,
+        bytes,
+        flush_time,
+        flush_query_id
+    FROM
+        system.asynchronous_insert_log
+    WHERE
+        status = 'Ok'
+        AND database = 'default'
+        AND flush_time > now() - toIntervalMinute(10)
+    ORDER BY table, flush_time
+    """
+
+
+class AsyncInsertFlushErrors(SystemQuery):
+    """
+    Async insert queries that failed within the last 10 minutes
+    """
+
+    sql = """
+    SELECT
+        max(event_time) AS flush,
+        status,
+        exception,
+        any(query_id) AS query_id
+    FROM
+        system.asynchronous_insert_log
+    WHERE
+        database = 'default'
+        AND status <> 'Ok'
+        AND table = '{{table}}'
+        AND flush_time > now() - toIntervalMinute(10)
+    GROUP BY status, exception
+    ORDER BY
+        flush DESC
+    """


### PR DESCRIPTION
These are some very basic queries that we can use (and modify) for our purposes when testing out async inserts. I would have liked to use the more robust queries that I found in https://clickhouse.com/blog/monitoring-asynchronous-data-inserts-in-clickhouse but it was taking too long to easily add these with the way the system queries is built right now.

So for now we have 

* `PartCreations`: This can let us see how many rows/the size each of our new parts has, with async inserts this should be much higher in theory than we have now since it should be buffering multiple inserts. 
* `AsyncInsertPendingFlushes`: This can give us a quick pulse on how many inserts are pending flushing in total
* `AsyncInsertFlushes`: This is like the query log, but for the async insert flush, and can be used in tandem with the query log by looking up the query_id, though this query is for successful inserts flushes
* `AsyncInsertFlushErrors`: Same use as above but specific to failed insert flushes