### PR TITLE
fix(gocd): Updating canary checks to happen after the deploy goes out

### DIFF
--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -129,21 +129,13 @@ local deploy_canary_stage(region) =
               timeout: 1200,
               elastic_profile_id: 'snuba',
               environment_variables: {
-                LABEL_SELECTOR: 'service=snuba,is_canary=true',
-              },
-              tasks: [
-                gocdtasks.script(importstr '../bash/deploy.sh'),
-              ],
-            },
-            health_check: {
-              environment_variables: {
                 SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 LABEL_SELECTOR: 'service=snuba,is_canary=true',
               },
-              elastic_profile_id: 'snuba',
               tasks: [
+                gocdtasks.script(importstr '../bash/deploy.sh'),
                 gocdtasks.script(importstr '../bash/canary-ddog-health-check.sh'),
               ],
             },


### PR DESCRIPTION
Noticed a bug in the canary stage of the Snuba deployment pipeline. Since the health check was a job in the same stage as the deployment, it would run in parallel meaning the health check is checking the state before (or as) the deploy goes out rather than after. Combining the deploy and health check jobs into one job with multiple tasks enables them to run sequentially meaning the health check will now run after the deploy goes out.