### PR TITLE
fix: snuba admin queries check

### DIFF
--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -156,7 +156,6 @@ class PartCreations(SystemQuery):
         AND table = '{{table}}'
         AND event_time > now() - toIntervalMinute(10)
         and event_type = 'NewPart'
-
     """
 
 

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -79,6 +79,7 @@ def is_query_select(sql_query: str) -> bool:
     """
     Simple validation to ensure query is a select command
     """
+    sql_query = " ".join(sql_query.split())
     match = SYSTEM_QUERY_RE.match(sql_query)
     return True if match else False
 
@@ -87,6 +88,7 @@ def is_query_show(sql_query: str) -> bool:
     """
     Simple validation to ensure query is a show command
     """
+    sql_query = " ".join(sql_query.split())
     match = SHOW_QUERY_RE.match(sql_query)
     return True if match else False
 
@@ -95,6 +97,7 @@ def is_query_describe(sql_query: str) -> bool:
     """
     Simple validation to ensure query is a describe command
     """
+    sql_query = " ".join(sql_query.split())
     match = DESCRIBE_QUERY_RE.match(sql_query)
     return True if match else False
 

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -1,7 +1,7 @@
 import pytest
 
 from snuba.admin.clickhouse.common import InvalidCustomQuery
-from snuba.admin.clickhouse.system_queries import validate_system_query
+from snuba.admin.clickhouse.system_queries import is_query_select, validate_system_query
 
 
 @pytest.mark.parametrize(
@@ -39,3 +39,26 @@ def test_valid_system_query(sql_query: str) -> None:
 def test_invalid_system_query(sql_query: str) -> None:
     with pytest.raises(InvalidCustomQuery):
         validate_system_query(sql_query)
+
+
+select_sql = """
+SELECT
+    table,
+    query,
+    format,
+    query_id,
+    bytes,
+    flush_time,
+    flush_query_id
+FROM
+    system.asynchronous_insert_log
+WHERE
+    status = 'Ok'
+    AND database = 'default'
+    AND flush_time > now() - toIntervalMinute(10)
+ORDER BY table, flush_time
+"""
+
+
+def test_is_query_select():
+    assert is_query_select(select_sql) == True

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -60,5 +60,5 @@ ORDER BY table, flush_time
 """
 
 
-def test_is_query_select():
+def test_is_query_select() -> None:
     assert is_query_select(select_sql) == True


### PR DESCRIPTION
Some queries fail because we don't do `sql_query = " ".join(sql_query.split())` before we match on the regex, I believe this is due to the fact that we explicitly have `\s` in the regex, vs a newline