### PR TITLE
ref(gocd): Add a crashloop monitor to deploys

### DIFF
--- a/gocd/templates/bash/s4s-ddog-health-check.sh
+++ b/gocd/templates/bash/s4s-ddog-health-check.sh
@@ -1,1 +1,8 @@
 #!/bin/bash
+
+/devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
+  146517092
+
+
+# Above monitor IDs map to following monitors respectively:
+# Snuba Pods Crashlooping in {{sentry_region.name}}

--- a/gocd/templates/bash/s4s-ddog-health-check.sh
+++ b/gocd/templates/bash/s4s-ddog-health-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
+/devinfra/scripts/checks/datadog/monitor_status.py  \
   146517092
 
 

--- a/gocd/templates/bash/saas-ddog-health-check.sh
+++ b/gocd/templates/bash/saas-ddog-health-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
+/devinfra/scripts/checks/datadog/monitor_status.py  \
   113296727 \
   42722121 \
   146517092

--- a/gocd/templates/bash/saas-ddog-health-check.sh
+++ b/gocd/templates/bash/saas-ddog-health-check.sh
@@ -2,9 +2,11 @@
 
 /devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
   113296727 \
-  42722121
+  42722121 \
+  146517092
 
 
 # Above monitor IDs map to following monitors respectively:
 # Snuba - SLO - High API error rate
 # Snuba - Too many restarts on Snuba pods
+# Snuba Pods Crashlooping in {{sentry_region.name}}


### PR DESCRIPTION
Add a crashloop monitor to the S4S deploy to ensure that the changes at least keep the pods stable.