### PR TITLE
ref(admin): Add a system query for data skipping indexes

### DIFF
--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -134,6 +134,27 @@ class ColumnSizeOnDisk(SystemQuery):
     """
 
 
+class IndexSizeOnDisk(SystemQuery):
+    """
+    Lists the data skipping indexes as well as their sizes on disk. This table has no
+    sense of time, so it's just a snapshot of the current state.
+    """
+
+    sql = """
+    SELECT
+        name,
+        type_full,
+        expr,
+        granularity,
+        formatReadableSize(data_compressed_bytes AS size) AS compressed,
+        formatReadableSize(data_uncompressed_bytes AS usize) AS uncompressed,
+        round(usize / size, 2) AS compr_ratio,
+        marks
+    FROM system.data_skipping_indices
+    WHERE table = '{{table}}'
+    """
+
+
 class PartCreations(SystemQuery):
     """
     New parts created in the last 10 minutes. Replicas have event_type 'DownloadPart',


### PR DESCRIPTION
Add a system query for seeing the size of indexes on disk.

![Screenshot 2024-06-07 at 10 58 23 AM](https://github.com/getsentry/snuba/assets/2727124/3cdc0d43-9fd3-46a0-a870-2205d468eaba)
