### PR TITLE
Fix for displaying allocation policies throttled correctly on Snuba Admin production queries UI

### DIFF
--- a/snuba/admin/static/production_queries/index.tsx
+++ b/snuba/admin/static/production_queries/index.tsx
@@ -224,11 +224,11 @@ function renderThrottleStatus(isThrottled: boolean, reasonHeader: string[]) {
       style={{ color: "darkorange", fontFamily: "Arial", fontSize: "medium" }}
     >
       Quota Allowance - Throttled <br />
+      <ol>
       {reasonHeader.map((line, index) => (
-        <ol>
           <li key={index}>{line}</li>
-        </ol>
       ))}
+      </ol>
     </Text>
   ) : (
     <Text style={{ color: "green", fontFamily: "Arial", fontSize: "medium" }}>


### PR DESCRIPTION
In the Snuba Admin Production queries UI allocation policies which are throttled were not shown in an ordered list. 

Fix is added to display correctly.

<img width="1074" alt="Screenshot 2024-06-10 at 1 26 14 PM" src="https://github.com/getsentry/snuba/assets/2090385/8867e8a2-7270-432e-ad3d-403e4de1b181">


