### PR TITLE
ref(ci): update clickhouse versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
       matrix:
         version:
           [
-            "23.3.13.7.altinitystable",
+            "23.3.19.33.altinitystable",
             "23.8.11.29.altinitystable",
           ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,9 +360,8 @@ jobs:
       matrix:
         version:
           [
-            "22.8.15.25.altinitystable",
             "23.3.13.7.altinitystable",
-            "23.8.8.21.altinitystable",
+            "23.8.11.29.altinitystable",
           ]
 
     steps:


### PR DESCRIPTION
We've upgraded our clusters to 23.3 and we use the `23.3.19.33.altinitystable` version https://github.com/getsentry/ops/blob/5d4ce26dd5a0545640bf8a63ef93be4cf10fc05b/salt/pillar/clickhouse/snuba-generic-metrics-distributions.sls#L2

Also we want to use the newer 23.8 version, so I've updated that as well. I have removed 22.8 because we no longer have that running in production 