### PR TITLE
chore(gocd): Bumping gocd-jsonnet version

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.10.2"
+      "version": "v2.11.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "4ea5baaceaec881adc338e08b235bef4fb325b3e",
-      "sum": "GdmT/ufKbfQw3VnnwSBnDLWkIRhTn4TgT7Y2pzOiwSE="
+      "version": "cfc6f213657cf0b5ced8cb440f7f09c7ad70cb5b",
+      "sum": "NKwcv1k2P5pfv5u3RBPt89sHg6EGPUaPdaw9idC3rgE="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Updating gocd-jsonnet version to move customer-7 to a prod region.
https://github.com/getsentry/gocd-jsonnet/releases/tag/v2.11.0