### PR TITLE
[CapMan] add throttling to BytesScannedRejectingPolicy

### DIFF
--- a/snuba/query/allocation_policies/bytes_scanned_rejecting_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_rejecting_policy.py
@@ -41,6 +41,8 @@ DEFAULT_OVERRIDE_LIMIT = -1
 PETABYTE = 10**12
 DEFAULT_BYTES_SCANNED_LIMIT = int(1.28 * PETABYTE)
 DEFAULT_TIMEOUT_PENALIZATION = DEFAULT_BYTES_SCANNED_LIMIT // 40
+DEFAULT_BYTES_THROTTLE_DIVIDER = 1
+DEFAULT_THREADS_THROTTLE_DIVIDER = 1
 
 
 class BytesScannedRejectingPolicy(AllocationPolicy):
@@ -90,6 +92,18 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
                 "If a clickhouse query times out, how many bytes does the policy assume the query scanned? Increasing the number increases the penalty for queries that time out",
                 int,
                 DEFAULT_TIMEOUT_PENALIZATION,
+            ),
+            AllocationPolicyConfig(
+                "bytes_throttle_divider",
+                "Divide the scan limit by this number gives the throttling threshold",
+                int,
+                DEFAULT_BYTES_THROTTLE_DIVIDER,
+            ),
+            AllocationPolicyConfig(
+                "threads_throttle_divider",
+                "max threads divided by this number is the number of threads we use to execute queries for a throttled (project_id|organization_id, referrer)",
+                int,
+                DEFAULT_BYTES_THROTTLE_DIVIDER,
             ),
         ]
 
@@ -206,6 +220,24 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
                 },
             )
             return QuotaAllowance(False, self.max_threads, explanation)
+
+        throttle_threshold = max(
+            1, scan_limit // self.get_config_value("bytes_throttle_divider")
+        )
+        if granted_quota.granted < throttle_threshold:
+            self.metrics.increment(
+                "bytes_scanned_queries_throttled",
+                tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
+            )
+            return QuotaAllowance(
+                True,
+                max(
+                    1,
+                    self.max_threads
+                    // self.get_config_value("threads_throttle_divider"),
+                ),
+                {"reason": "within_limit but throttled"},
+            )
         return QuotaAllowance(True, self.max_threads, {"reason": "within_limit"})
 
     def _get_bytes_scanned_in_query(

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -286,7 +286,7 @@ def test_db_query_success() -> None:
             "can_run": True,
             "max_threads": 10,
             "explanation": {
-                "reason": "within_limit",
+                "reason": "within_limit but throttled",
                 "storage_key": "StorageKey.ERRORS_RO",
             },
         },


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2794

The BytesScannedRejectingPolicy prevents a (project_id|organization_id, referrer) combination from sending too many queries by rejecting them once such combination reaches a rejection threshold. I add a throttle threshold so the offending combination will get throttled first before getting rejected. BytesScannedRejectingPolicy will half the threads when the number of bytes scanned goes over 50% of the rejection threshold for that combination. 

Roll out plan: 
In this PR, I set the throttle dividers to 1 so that the rejection threshold and the throttle threshold are the same, so effectively this PR will create the options on Snuba Admin without doing any throttling. Then, within S4S, I will adjust the throttle dividers. With this, I expect to see queries being throttled in DD under the metric concurrent_queries_throttled. I will change the throttle dividers to 0.5 afterwards.