### PR TITLE
feat: autogenerate add migration ui

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -393,3 +393,4 @@ def generate(
     the commit, PR, and merging.
     """
     autogeneration.generate(storage_path)
+    click.echo("This function is under construction.")

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 
 import click
 
+import snuba.migrations.autogeneration as autogeneration
 from snuba.clusters.cluster import CLUSTERS, ClickhouseNodeType
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.readiness_state import ReadinessState
@@ -378,3 +379,17 @@ def add_node(
         password=password,
         database=database,
     )
+
+
+@migrations.command()
+@click.argument("storage_path", type=str)
+def generate(
+    storage_path: str,
+) -> None:
+    """
+    Given a path to modified storage yaml definition (inside of snuba repo),
+    creates a snuba migration for the given modifications.
+    The migration will be written into the local directory. The user is responsible for making
+    the commit, PR, and merging.
+    """
+    autogeneration.generate(storage_path)

--- a/snuba/migrations/autogeneration/__init__.py
+++ b/snuba/migrations/autogeneration/__init__.py
@@ -1,0 +1,3 @@
+from .main import generate
+
+__all__ = ["generate"]

--- a/snuba/migrations/autogeneration/main.py
+++ b/snuba/migrations/autogeneration/main.py
@@ -1,15 +1,30 @@
 import os
 import subprocess
 
+import requests
+import yaml
 
-def generate(storage_path: str) -> None:
-    repo_path = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"], capture_output=True
-    ).stdout.decode("utf-8")
-    storage_path = os.path.abspath(os.path.expanduser(storage_path))
-    if not storage_path.startswith(repo_path):
-        raise ValueError("Storage path is not in the git repository")
 
-    rel_path = os.path.relpath(storage_path, repo_path)
-    old_storage = ""
-    new_storage = ""
+def generate(local_storage_path: str) -> tuple[str, str]:
+    local_repo_path = (
+        subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True)
+        .stdout.decode("utf-8")
+        .strip()
+    )
+    local_storage_path = os.path.abspath(os.path.expanduser(local_storage_path))
+    if not local_storage_path.startswith(local_repo_path):
+        raise ValueError(
+            f"Storage path '{local_storage_path}' is not in the git repository '{local_repo_path}'"
+        )
+
+    # get local storage
+    rel_storage_path = os.path.relpath(local_storage_path, local_repo_path)
+    with open(os.path.join(local_repo_path, rel_storage_path), "r") as f:
+        new_storage = yaml.safe_load(f)
+
+    # get remote storage
+    REMOTE_SNUBA_REPO = "https://raw.githubusercontent.com/getsentry/snuba/master"
+    res = requests.get(f"{REMOTE_SNUBA_REPO}/{rel_storage_path}")
+    old_storage = yaml.safe_load(res.text)
+
+    return old_storage, new_storage

--- a/snuba/migrations/autogeneration/main.py
+++ b/snuba/migrations/autogeneration/main.py
@@ -7,12 +7,18 @@ import yaml
 
 def generate(local_storage_path: str) -> tuple[str, str]:
     local_repo_path = (
-        subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True)
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], capture_output=True, check=True
+        )
         .stdout.decode("utf-8")
         .strip()
     )
-    print(local_repo_path)
     local_storage_path = os.path.abspath(os.path.expanduser(local_storage_path))
+    # os.path.issubpath()
+    # replace startswith with issubpath
+    # https://docs.python.org/3/library/os.path.html#os.path.commonpath
+    # is there local_storage_path.is_subpath(local_repo_path)
+    # https://docs.python.org/3/library/os.path.html#os.path.relpath
     if not local_storage_path.startswith(local_repo_path):
         raise ValueError(
             f"Storage path '{local_storage_path}' is not in the git repository '{local_repo_path}'"

--- a/snuba/migrations/autogeneration/main.py
+++ b/snuba/migrations/autogeneration/main.py
@@ -14,11 +14,6 @@ def generate(local_storage_path: str) -> tuple[str, str]:
         .strip()
     )
     local_storage_path = os.path.abspath(os.path.expanduser(local_storage_path))
-    # os.path.issubpath()
-    # replace startswith with issubpath
-    # https://docs.python.org/3/library/os.path.html#os.path.commonpath
-    # is there local_storage_path.is_subpath(local_repo_path)
-    # https://docs.python.org/3/library/os.path.html#os.path.relpath
     if not local_storage_path.startswith(local_repo_path):
         raise ValueError(
             f"Storage path '{local_storage_path}' is not in the git repository '{local_repo_path}'"

--- a/snuba/migrations/autogeneration/main.py
+++ b/snuba/migrations/autogeneration/main.py
@@ -11,6 +11,7 @@ def generate(local_storage_path: str) -> tuple[str, str]:
         .stdout.decode("utf-8")
         .strip()
     )
+    print(local_repo_path)
     local_storage_path = os.path.abspath(os.path.expanduser(local_storage_path))
     if not local_storage_path.startswith(local_repo_path):
         raise ValueError(

--- a/snuba/migrations/autogeneration/main.py
+++ b/snuba/migrations/autogeneration/main.py
@@ -1,0 +1,15 @@
+import os
+import subprocess
+
+
+def generate(storage_path: str) -> None:
+    repo_path = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True
+    ).stdout.decode("utf-8")
+    storage_path = os.path.abspath(os.path.expanduser(storage_path))
+    if not storage_path.startswith(repo_path):
+        raise ValueError("Storage path is not in the git repository")
+
+    rel_path = os.path.relpath(storage_path, repo_path)
+    old_storage = ""
+    new_storage = ""

--- a/tests/migrations/test_autogeneration.py
+++ b/tests/migrations/test_autogeneration.py
@@ -14,6 +14,10 @@ def test_basic() -> None:
     os.makedirs(dir)
     try:
         subprocess.run(["git", "init"], cwd=dir, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "me@email.com"], cwd=dir, check=True
+        )
+        subprocess.run(["git", "config", "user.name", "Jane Doe"], cwd=dir, check=True)
         # make a fake storage
         with open(os.path.join(dir, fname), "w") as f:
             f.write("hello world\n")

--- a/tests/migrations/test_autogeneration.py
+++ b/tests/migrations/test_autogeneration.py
@@ -11,7 +11,5 @@ def test_basic() -> None:
 
 
 def test_error() -> None:
-    with pytest.raises(
-        ValueError, match=r"Storage path .* is not in the git repository .*"
-    ):
+    with pytest.raises(ValueError):
         generate("~/hello.txt")

--- a/tests/migrations/test_autogeneration.py
+++ b/tests/migrations/test_autogeneration.py
@@ -1,0 +1,17 @@
+import pytest
+
+from snuba.migrations.autogeneration import generate
+
+
+def test_basic() -> None:
+    old_storage, new_storage = generate(
+        "snuba/datasets/configuration/events/storages/errors.yaml"
+    )
+    assert old_storage, new_storage
+
+
+def test_error() -> None:
+    with pytest.raises(
+        ValueError, match=r"Storage path .* is not in the git repository .*"
+    ):
+        generate("/Users/bloop/hello")

--- a/tests/migrations/test_autogeneration.py
+++ b/tests/migrations/test_autogeneration.py
@@ -14,4 +14,4 @@ def test_error() -> None:
     with pytest.raises(
         ValueError, match=r"Storage path .* is not in the git repository .*"
     ):
-        generate("/Users/bloop/hello")
+        generate("~/hello.txt")

--- a/tests/migrations/test_autogeneration.py
+++ b/tests/migrations/test_autogeneration.py
@@ -1,15 +1,42 @@
-import pytest
+import os
+import subprocess
 
 from snuba.migrations.autogeneration import generate
 
 
 def test_basic() -> None:
-    old_storage, new_storage = generate(
-        "snuba/datasets/configuration/events/storages/errors.yaml"
-    )
-    assert old_storage, new_storage
+    dir = "/tmp/kylesfakerepo987636"
+    fname = "fakestorage.yaml"
 
+    # make a tmp dir with a git repo
+    if os.path.exists(dir):
+        subprocess.run(["rm", "-rf", dir], check=True)
+    os.makedirs(dir)
+    try:
+        subprocess.run(["git", "init"], cwd=dir, check=True)
+        # make a fake storage
+        with open(os.path.join(dir, fname), "w") as f:
+            f.write("hello world\n")
+        subprocess.run(
+            ["git", "add", "."],
+            cwd=dir,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", '"blop"'],
+            cwd=dir,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        if not e.stderr:
+            raise
+        raise ValueError(e.stderr.decode("utf-8")) from e
 
-def test_error() -> None:
-    with pytest.raises(ValueError):
-        generate("~/hello.txt")
+    # update the fake storage
+    with open(os.path.join(dir, fname), "a") as f:
+        f.write("goodbye world")
+
+    # make sure HEAD and curr version looks right
+    old_storage, new_storage = generate(os.path.join(dir, fname))
+    assert old_storage == "hello world\n"
+    assert new_storage == "hello world\ngoodbye world"


### PR DESCRIPTION
This PR is the interface users will use to generate migrations
```
snuba migrations generate path/to/storage
```
the code in this PR:
* get the storage file at that path
* gets the version of it at HEAD

I will use this to send to the diff functions that take the old and new storage as input and generate the actual migration