### PR TITLE
chore(gocd): Update gocd-jsonnet to remove customer-6

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.11.0"
+      "version": "v2.12.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "cfc6f213657cf0b5ced8cb440f7f09c7ad70cb5b",
-      "sum": "NKwcv1k2P5pfv5u3RBPt89sHg6EGPUaPdaw9idC3rgE="
+      "version": "153fcc02aa4d0da06a0b303efc33df96d8877f65",
+      "sum": "kag0gTgr8OUwtb/bfRYyWFpDNaWpW24XWknqpROt0Xw="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Updating gocd-jsonnet library version to remove customer-6 which is no longer used. https://github.com/getsentry/gocd-jsonnet/releases/tag/v2.12.0