### PR TITLE
Add additional information to policies

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -764,7 +764,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
                 },
             )
         if not self.is_enforced:
-            return QuotaAllowance(True, self.max_threads, {})
+            return QuotaAllowance(True, self.max_threads, {}, True)
         # make sure we always know which storage key we rejected a query from
         allowance.explanation["storage_key"] = str(self._storage_key)
         return allowance

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -223,12 +223,14 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "pass_through"},
+                is_throttled=False,
             )
         if self.is_cross_org_query(tenant_ids):
             return QuotaAllowance(
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "cross_org"},
+                is_throttled=False,
             )
 
         rate_limit_params, overrides = self._get_rate_limit_params(tenant_ids)
@@ -237,7 +239,10 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
             rate_limit_params,
         )
         return QuotaAllowance(
-            within_rate_limit, self.max_threads, {"reason": why, "overrides": overrides}
+            within_rate_limit,
+            self.max_threads,
+            {"reason": why, "overrides": overrides},
+            False,
         )
 
     def _update_quota_balance(
@@ -250,3 +255,18 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
             return
         rate_limit_params, _ = self._get_rate_limit_params(tenant_ids)
         self._end_query(query_id, rate_limit_params, result_or_error)
+
+    def get_throttle_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_rejection_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_used(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_units(self) -> str:
+        return "No units"
+
+    def get_suggestion(self) -> str:
+        return "No suggestion"

--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -167,6 +167,7 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "pass_through"},
+                is_throttled=False,
             )
 
         concurrent_limit = self._get_concurrent_limit(referrer)
@@ -186,6 +187,7 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
             can_run=can_run,
             max_threads=self._get_max_threads(referrer),
             explanation=decision_explanation,
+            is_throttled=False,
         )
 
     def _update_quota_balance(
@@ -207,3 +209,18 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
             22,
         )
         self._end_query(query_id, rate_limit_params, result_or_error)
+
+    def get_throttle_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_rejection_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_used(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_units(self) -> str:
+        return "No units"
+
+    def get_suggestion(self) -> str:
+        return "No suggestion"

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -427,7 +427,7 @@ def test_get_allocation_policy_configs(admin_api: FlaskClient) -> None:
         def _get_quota_allowance(
             self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
-            return QuotaAllowance(True, 1, {})
+            return QuotaAllowance(True, 1, {}, False)
 
         def _update_quota_balance(
             self,
@@ -436,6 +436,21 @@ def test_get_allocation_policy_configs(admin_api: FlaskClient) -> None:
             result_or_error: QueryResultOrError,
         ) -> None:
             pass
+
+        def get_throttle_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+            return -1
+
+        def get_rejection_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+            return -1
+
+        def get_quota_used(self, tenant_ids: dict[str, str | int]) -> int:
+            return -1
+
+        def get_quota_units(self) -> str:
+            return "No units"
+
+        def get_suggestion(self) -> str:
+            return "No suggestion"
 
     def mock_get_policies() -> list[AllocationPolicy]:
         policy = FakePolicy(StorageKey("nothing"), [], {})

--- a/tests/pipeline/test_execution_stage.py
+++ b/tests/pipeline/test_execution_stage.py
@@ -41,7 +41,9 @@ class MockAllocationPolicy(AllocationPolicy):
     def _get_quota_allowance(
         self, tenant_ids: dict[str, str | int], query_id: str
     ) -> QuotaAllowance:
-        return QuotaAllowance(can_run=True, max_threads=1, explanation={})
+        return QuotaAllowance(
+            can_run=True, max_threads=1, explanation={}, is_throttled=False
+        )
 
     def _update_quota_balance(
         self,
@@ -50,6 +52,21 @@ class MockAllocationPolicy(AllocationPolicy):
         result_or_error: QueryResultOrError,
     ) -> None:
         self.did_update = True
+
+    def get_throttle_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_rejection_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_used(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_units(self) -> str:
+        return "No units"
+
+    def get_suggestion(self) -> str:
+        return "No suggestion"
 
 
 def get_fake_metadata() -> SnubaQueryMetadata:

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -60,14 +60,18 @@ class RejectingEverythingAllocationPolicy(PassthroughPolicy):
     def _get_quota_allowance(
         self, tenant_ids: dict[str, str | int], query_id: str
     ) -> QuotaAllowance:
-        return QuotaAllowance(can_run=False, max_threads=10, explanation={})
+        return QuotaAllowance(
+            can_run=False, max_threads=10, explanation={}, is_throttled=False
+        )
 
 
 class ThrottleEverythingAllocationPolicy(PassthroughPolicy):
     def _get_quota_allowance(
         self, tenant_ids: dict[str, str | int], query_id: str
     ) -> QuotaAllowance:
-        return QuotaAllowance(can_run=True, max_threads=1, explanation={})
+        return QuotaAllowance(
+            can_run=True, max_threads=1, explanation={}, is_throttled=True
+        )
 
 
 class BadlyWrittenAllocationPolicy(PassthroughPolicy):
@@ -191,6 +195,21 @@ class SomeParametrizedConfigPolicy(AllocationPolicy):
         self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError
     ) -> None:
         pass
+
+    def get_throttle_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_rejection_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_used(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_units(self) -> str:
+        return "No units"
+
+    def get_suggestion(self) -> str:
+        return "No suggestion"
 
 
 class TestAllocationPolicyLogs(TestCase):

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -40,6 +40,7 @@ class RejectAllocationPolicy123(AllocationPolicy):
             can_run=False,
             max_threads=0,
             explanation={"reason": "policy rejects all queries"},
+            is_throttled=True,
         )
 
     def _update_quota_balance(
@@ -1289,7 +1290,7 @@ class TestSnQLApi(BaseApiTest):
             assert response.status_code == 429
             assert (
                 response.json["error"]["message"]
-                == "Query on could not be run due to allocation policies, details: {'RejectAllocationPolicy123': {'can_run': False, 'max_threads': 0, 'explanation': {'reason': 'policy rejects all queries', 'storage_key': 'StorageKey.DOESNTMATTER'}}}"
+                == "Query on could not be run due to allocation policies, details: {'RejectAllocationPolicy123': {'can_run': False, 'max_threads': 0, 'explanation': {'reason': 'policy rejects all queries', 'storage_key': 'StorageKey.DOESNTMATTER'}, 'is_throttled': False}}"
             )
 
     def test_tags_key_column(self) -> None:

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -40,7 +40,7 @@ class RejectAllocationPolicy123(AllocationPolicy):
             can_run=False,
             max_threads=0,
             explanation={"reason": "policy rejects all queries"},
-            is_throttled=True,
+            is_throttled=False,
         )
 
     def _update_quota_balance(
@@ -50,6 +50,21 @@ class RejectAllocationPolicy123(AllocationPolicy):
         result_or_error: QueryResultOrError,
     ) -> None:
         return
+
+    def get_throttle_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_rejection_threshold(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_used(self, tenant_ids: dict[str, str | int]) -> int:
+        return -1
+
+    def get_quota_units(self) -> str:
+        return "No units"
+
+    def get_suggestion(self) -> str:
+        return "No suggestion"
 
 
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2796

The end goal is to have a payload that looks like the following:
```
"quota_allowance": {
	"summary": {
		"threads_used": 2, # the actual amount of max_threads sent to clickhouse
		"throttled_by": {
			"policy": "BytesScannedRejectingPolicy",
			"throttle_threshold": 800,
			"quota_used": 900,
			"quota_units": "bytes",
			"suggestion": "scan fewer bytes n00b",
		},
		"rejected_by": {},
	}
	# policy details as before
	...
}
```
In order to accomplish this, this PR adds in the relevant information into policy definitions and the `QuotaAllowance` class, and will be followed up by a subsequent PR which will actually update the payload to the above.