### PR TITLE
fix(docs): remove make command that no longer exists

### DIFF
--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -28,7 +28,6 @@ clone this repo into your workspace::
 These commands set up the Python virtual environment::
 
     cd snuba
-    make pyenv-setup
     python -m venv .venv
     source .venv/bin/activate
     pip install --upgrade pip==22.2.2


### PR DESCRIPTION
When setting up my Snuba dev environment locally, I noticed that the make command in the docs no longer exists and has no specific replacement that I am aware of.