### PR TITLE
fix(group-attributes): Modify the column type for `group_first_release_id` to bigint

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -400,6 +400,7 @@ class GroupAttributesLoader(DirectoryLoader):
             "0001_group_attributes",
             "0002_add_priority_to_group_attributes",
             "0003_add_first_release_id_to_group_attributes",
+            "0004_fix_group_first_release_id_type",
         ]
 
 

--- a/snuba/snuba_migrations/group_attributes/0004_fix_group_first_release_id_type.py
+++ b/snuba/snuba_migrations/group_attributes/0004_fix_group_first_release_id_type.py
@@ -4,7 +4,7 @@ from snuba.clickhouse.columns import UUID, Column, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
-from snuba.migrations.operations import SqlOperation
+from snuba.migrations.operations import OperationTarget, SqlOperation
 
 
 class Migration(migration.ClickhouseNodeMigration):
@@ -18,6 +18,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 column=Column(
                     "group_first_release_id", UInt(64, Modifiers(nullable=True))
                 ),
+                target=OperationTarget.LOCAL,
             ),
             operations.ModifyColumn(
                 storage_set=StorageSetKey.GROUP_ATTRIBUTES,
@@ -25,6 +26,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 column=Column(
                     "group_first_release_id", UInt(64, Modifiers(nullable=True))
                 ),
+                target=OperationTarget.DISTRIBUTED,
             ),
         ]
 
@@ -32,12 +34,14 @@ class Migration(migration.ClickhouseNodeMigration):
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.GROUP_ATTRIBUTES,
-                table_name="group_attributes_local",
+                table_name="group_attributes_dist",
                 column=Column("group_first_release_id", UUID(Modifiers(nullable=True))),
+                target=OperationTarget.DISTRIBUTED,
             ),
             operations.ModifyColumn(
                 storage_set=StorageSetKey.GROUP_ATTRIBUTES,
-                table_name="group_attributes_dist",
+                table_name="group_attributes_local",
                 column=Column("group_first_release_id", UUID(Modifiers(nullable=True))),
+                target=OperationTarget.LOCAL,
             ),
         ]

--- a/snuba/snuba_migrations/group_attributes/0004_fix_group_first_release_id_type.py
+++ b/snuba/snuba_migrations/group_attributes/0004_fix_group_first_release_id_type.py
@@ -1,10 +1,10 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import UUID, Column
+from snuba.clickhouse.columns import UUID, Column, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
-from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.migrations.operations import SqlOperation
 
 
 class Migration(migration.ClickhouseNodeMigration):

--- a/snuba/snuba_migrations/group_attributes/0004_fix_group_first_release_id_type.py
+++ b/snuba/snuba_migrations/group_attributes/0004_fix_group_first_release_id_type.py
@@ -1,0 +1,43 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import UUID, Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_local",
+                column=Column(
+                    "group_first_release_id", UInt(64, Modifiers(nullable=True))
+                ),
+            ),
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_dist",
+                column=Column(
+                    "group_first_release_id", UInt(64, Modifiers(nullable=True))
+                ),
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_local",
+                column=Column("group_first_release_id", UUID(Modifiers(nullable=True))),
+            ),
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_dist",
+                column=Column("group_first_release_id", UUID(Modifiers(nullable=True))),
+            ),
+        ]


### PR DESCRIPTION
The `group_first_release_id` column was added to GroupAttributes as UUID but release IDs are bigints. The processor and YAML changes must be reverted first in https://github.com/getsentry/snuba/pull/6039 so we can safely update the column type here. The column is not yet in use and has no data.

Will get tests passing once the revert is in.