### PR TITLE
Add additional information to policies

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -25,6 +25,13 @@ CAPMAN_HASH = "capman"
 IS_ACTIVE = "is_active"
 IS_ENFORCED = "is_enforced"
 MAX_THREADS = "max_threads"
+NO_UNITS = "no_units"
+NO_SUGGESTION = "no_suggestion"
+CROSS_ORG_SUGGESTION = "cross org queries do not have limits"
+PASS_THROUGH_REFERRERS_SUGGESTION = (
+    "subscriptions currently do not undergo rate limiting in any way"
+)
+MAX_THRESHOLD = int(1e12)
 
 
 @dataclass(frozen=True)
@@ -96,6 +103,12 @@ class QuotaAllowance:
     # about what caused that action. Not currently well typed
     # because I don't know what exactly should go in it yet
     explanation: dict[str, JsonSerializable]
+    is_throttled: bool
+    throttle_threshold: int
+    rejection_threshold: int
+    quota_used: int
+    quota_unit: str
+    suggestion: str
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -112,6 +125,12 @@ class QuotaAllowance:
             self.can_run == other.can_run
             and self.max_threads == other.max_threads
             and self.explanation == other.explanation
+            and self.is_throttled == other.is_throttled
+            and self.throttle_threshold == other.throttle_threshold
+            and self.rejection_threshold == other.rejection_threshold
+            and self.quota_used == other.quota_used
+            and self.quota_unit == other.quota_unit
+            and self.suggestion == other.suggestion
         )
 
 
@@ -731,11 +750,31 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
     ) -> QuotaAllowance:
         try:
             if not self.is_active:
-                allowance = QuotaAllowance(True, self.max_threads, {})
+                allowance = QuotaAllowance(
+                    can_run=True,
+                    max_threads=self.max_threads,
+                    explanation={},
+                    is_throttled=False,
+                    throttle_threshold=MAX_THRESHOLD,
+                    rejection_threshold=MAX_THRESHOLD,
+                    quota_used=0,
+                    quota_unit=NO_UNITS,
+                    suggestion=NO_SUGGESTION,
+                )
             else:
                 allowance = self._get_quota_allowance(tenant_ids, query_id)
         except InvalidTenantsForAllocationPolicy as e:
-            allowance = QuotaAllowance(False, 0, cast(dict[str, Any], e.to_dict()))
+            allowance = QuotaAllowance(
+                can_run=False,
+                max_threads=0,
+                explanation=cast(dict[str, Any], e.to_dict()),
+                is_throttled=False,
+                throttle_threshold=0,
+                rejection_threshold=0,
+                quota_used=0,
+                quota_unit=NO_UNITS,
+                suggestion=NO_SUGGESTION,
+            )
         except Exception:
             logger.exception(
                 "Allocation policy failed to get quota allowance, this is a bug, fix it"
@@ -759,7 +798,17 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
                 },
             )
         if not self.is_enforced:
-            return QuotaAllowance(True, self.max_threads, {})
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=self.max_threads,
+                explanation={},
+                is_throttled=allowance.is_throttled,
+                throttle_threshold=allowance.throttle_threshold,
+                rejection_threshold=allowance.rejection_threshold,
+                quota_used=allowance.quota_used,
+                quota_unit=allowance.quota_unit,
+                suggestion=allowance.suggestion,
+            )
         # make sure we always know which storage key we rejected a query from
         allowance.explanation["storage_key"] = str(self._storage_key)
         return allowance
@@ -808,7 +857,15 @@ class PassthroughPolicy(AllocationPolicy):
         self, tenant_ids: dict[str, str | int], query_id: str
     ) -> QuotaAllowance:
         return QuotaAllowance(
-            can_run=True, max_threads=self.max_threads, explanation={}
+            can_run=True,
+            max_threads=self.max_threads,
+            explanation={},
+            is_throttled=False,
+            throttle_threshold=MAX_THRESHOLD,
+            rejection_threshold=MAX_THRESHOLD,
+            quota_used=0,
+            quota_unit=NO_UNITS,
+            suggestion=NO_SUGGESTION,
         )
 
     def _update_quota_balance(

--- a/snuba/query/allocation_policies/bytes_scanned_rejecting_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_rejecting_policy.py
@@ -14,6 +14,10 @@ from sentry_redis_tools.sliding_windows_rate_limiter import (
 
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.query.allocation_policies import (
+    CROSS_ORG_SUGGESTION,
+    MAX_THRESHOLD,
+    NO_SUGGESTION,
+    PASS_THROUGH_REFERRERS_SUGGESTION,
     AllocationPolicy,
     AllocationPolicyConfig,
     InvalidTenantsForAllocationPolicy,
@@ -43,6 +47,8 @@ DEFAULT_BYTES_SCANNED_LIMIT = int(1.28 * PETABYTE)
 DEFAULT_TIMEOUT_PENALIZATION = DEFAULT_BYTES_SCANNED_LIMIT // 40
 DEFAULT_BYTES_THROTTLE_DIVIDER = 2
 DEFAULT_THREADS_THROTTLE_DIVIDER = 2
+QUOTA_UNIT = "bytes"
+SUGGESTION = "scan less bytes"
 
 
 class BytesScannedRejectingPolicy(AllocationPolicy):
@@ -169,6 +175,12 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "cross_org_query"},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=QUOTA_UNIT,
+                suggestion=CROSS_ORG_SUGGESTION,
             )
         (
             customer_tenant_key,
@@ -176,11 +188,24 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
         ) = self._get_customer_tenant_key_and_value(tenant_ids)
         referrer = tenant_ids.get("referrer", "no_referrer")
         if referrer in _PASS_THROUGH_REFERRERS:
-            return QuotaAllowance(True, self.max_threads, {})
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=self.max_threads,
+                explanation={},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=QUOTA_UNIT,
+                suggestion=PASS_THROUGH_REFERRERS_SUGGESTION,
+            )
+
         scan_limit = self.__get_scan_limit(
             customer_tenant_key, customer_tenant_value, referrer
         )
-
+        throttle_threshold = max(
+            1, scan_limit // self.get_config_value("bytes_throttle_divider")
+        )
         timestamp, granted_quotas = _RATE_LIMITER.check_within_quotas(
             [
                 RequestedQuota(
@@ -203,6 +228,7 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
         )
         explanation: dict[str, Any] = {}
         granted_quota = granted_quotas[0]
+        used_quota = scan_limit - granted_quota.granted
         if granted_quota.granted <= 0:
             explanation[
                 "reason"
@@ -219,26 +245,50 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
                     "tenant": f"{customer_tenant_key}__{customer_tenant_value}__{referrer}"
                 },
             )
-            return QuotaAllowance(False, self.max_threads, explanation)
+            return QuotaAllowance(
+                can_run=False,
+                max_threads=self.max_threads,
+                explanation=explanation,
+                is_throttled=True,
+                throttle_threshold=throttle_threshold,
+                rejection_threshold=scan_limit,
+                quota_used=used_quota,
+                quota_unit=QUOTA_UNIT,
+                suggestion=SUGGESTION,
+            )
 
-        throttle_threshold = max(
-            1, scan_limit // self.get_config_value("bytes_throttle_divider")
-        )
         if granted_quota.granted < throttle_threshold:
             self.metrics.increment(
                 "bytes_scanned_queries_throttled",
                 tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
             )
             return QuotaAllowance(
-                True,
-                max(
+                can_run=True,
+                max_threads=max(
                     1,
                     self.max_threads
                     // self.get_config_value("threads_throttle_divider"),
                 ),
-                {"reason": "within_limit but throttled"},
+                explanation={"reason": "within_limit but throttled"},
+                is_throttled=True,
+                throttle_threshold=throttle_threshold,
+                rejection_threshold=scan_limit,
+                quota_used=used_quota,
+                quota_unit=QUOTA_UNIT,
+                suggestion=SUGGESTION,
             )
-        return QuotaAllowance(True, self.max_threads, {"reason": "within_limit"})
+
+        return QuotaAllowance(
+            can_run=True,
+            max_threads=self.max_threads,
+            explanation={"reason": "within_limit"},
+            is_throttled=False,
+            throttle_threshold=throttle_threshold,
+            rejection_threshold=scan_limit,
+            quota_used=used_quota,
+            quota_unit=QUOTA_UNIT,
+            suggestion=NO_SUGGESTION,
+        )
 
     def _get_bytes_scanned_in_query(
         self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -12,6 +12,11 @@ from sentry_redis_tools.sliding_windows_rate_limiter import (
 )
 
 from snuba.query.allocation_policies import (
+    CROSS_ORG_SUGGESTION,
+    MAX_THRESHOLD,
+    NO_SUGGESTION,
+    NO_UNITS,
+    PASS_THROUGH_REFERRERS_SUGGESTION,
     AllocationPolicy,
     AllocationPolicyConfig,
     QueryResultOrError,
@@ -81,6 +86,8 @@ _RATE_LIMITER = RedisSlidingWindowRateLimiter(
 )
 DEFAULT_OVERRIDE_LIMIT = -1
 DEFAULT_BYTES_SCANNED_LIMIT = 10000000
+QUOTA_UNIT = "bytes"
+SUGGESTION = "scan less bytes"
 
 
 class BytesScannedWindowAllocationPolicy(AllocationPolicy):
@@ -133,23 +140,53 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         if not ids_are_valid:
             if self.is_enforced:
                 return QuotaAllowance(
-                    can_run=False, max_threads=0, explanation={"reason": why}
+                    can_run=False,
+                    max_threads=0,
+                    explanation={"reason": why},
+                    is_throttled=False,
+                    throttle_threshold=0,
+                    rejection_threshold=0,
+                    quota_used=0,
+                    quota_unit=NO_UNITS,
+                    suggestion=NO_SUGGESTION,
                 )
         if self.is_cross_org_query(tenant_ids):
             return QuotaAllowance(
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "cross_org_query"},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=QUOTA_UNIT,
+                suggestion=CROSS_ORG_SUGGESTION,
             )
         referrer = tenant_ids.get("referrer", "no_referrer")
         org_id = tenant_ids.get("organization_id", None)
         if referrer in _PASS_THROUGH_REFERRERS:
-            return QuotaAllowance(True, self.max_threads, {})
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=self.max_threads,
+                explanation={},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=QUOTA_UNIT,
+                suggestion=PASS_THROUGH_REFERRERS_SUGGESTION,
+            )
         if referrer in _SINGLE_THREAD_REFERRERS:
             return QuotaAllowance(
                 can_run=True,
                 max_threads=1,
                 explanation={"reason": "low priority referrer"},
+                is_throttled=True,
+                throttle_threshold=0,
+                rejection_threshold=0,
+                quota_used=0,
+                quota_unit=QUOTA_UNIT,
+                suggestion=NO_SUGGESTION,
             )
         if org_id is not None:
             org_limit_bytes_scanned = self.__get_org_limit_bytes_scanned(org_id)
@@ -177,7 +214,9 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             num_threads = self.max_threads
             explanation: dict[str, Any] = {}
             granted_quota = granted_quotas[0]
+            is_throttled = False
             if granted_quota.granted <= 0:
+                is_throttled = True
                 explanation[
                     "reason"
                 ] = f"organization {org_id} is over the bytes scanned limit of {org_limit_bytes_scanned}"
@@ -188,8 +227,28 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
                 if self.is_enforced:
                     num_threads = self.get_config_value("throttled_thread_number")
 
-            return QuotaAllowance(True, num_threads, explanation)
-        return QuotaAllowance(True, self.max_threads, {})
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=num_threads,
+                explanation=explanation,
+                is_throttled=is_throttled,
+                throttle_threshold=org_limit_bytes_scanned,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=org_limit_bytes_scanned - granted_quota.granted,
+                quota_unit=QUOTA_UNIT,
+                suggestion=SUGGESTION,
+            )
+        return QuotaAllowance(
+            can_run=True,
+            max_threads=self.max_threads,
+            explanation={},
+            is_throttled=False,
+            throttle_threshold=MAX_THRESHOLD,
+            rejection_threshold=MAX_THRESHOLD,
+            quota_used=0,
+            quota_unit=QUOTA_UNIT,
+            suggestion=NO_SUGGESTION,
+        )
 
     def _get_bytes_scanned_in_query(
         self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -5,6 +5,8 @@ from typing import Callable, cast
 
 from snuba import state
 from snuba.query.allocation_policies import (
+    CROSS_ORG_SUGGESTION,
+    PASS_THROUGH_REFERRERS_SUGGESTION,
     AllocationPolicy,
     AllocationPolicyConfig,
     AllocationPolicyViolations,
@@ -29,6 +31,11 @@ _PASS_THROUGH_REFERRERS = set(
         "subscriptions_executor",
     ]
 )
+from snuba.query.allocation_policies import MAX_THRESHOLD, NO_SUGGESTION
+
+QUOTA_UNIT = "concurrent_queries"
+SUGGESTION = "scan less concurrent queries"
+import typing
 
 
 class BaseConcurrentRateLimitAllocationPolicy(AllocationPolicy):
@@ -223,21 +230,46 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "pass_through"},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=QUOTA_UNIT,
+                suggestion=PASS_THROUGH_REFERRERS_SUGGESTION,
             )
         if self.is_cross_org_query(tenant_ids):
             return QuotaAllowance(
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "cross_org"},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=QUOTA_UNIT,
+                suggestion=CROSS_ORG_SUGGESTION,
             )
 
         rate_limit_params, overrides = self._get_rate_limit_params(tenant_ids)
-        _, within_rate_limit, why = self._is_within_rate_limit(
+        rate_limit_stats, within_rate_limit, why = self._is_within_rate_limit(
             query_id,
             rate_limit_params,
         )
+
+        if within_rate_limit:
+            suggestion = NO_SUGGESTION
+        else:
+            suggestion = SUGGESTION
         return QuotaAllowance(
-            within_rate_limit, self.max_threads, {"reason": why, "overrides": overrides}
+            can_run=within_rate_limit,
+            max_threads=self.max_threads,
+            explanation={"reason": why, "overrides": overrides},
+            is_throttled=False,
+            throttle_threshold=typing.cast(int, rate_limit_params.concurrent_limit),
+            rejection_threshold=typing.cast(int, rate_limit_params.concurrent_limit),
+            quota_used=rate_limit_stats.concurrent,
+            quota_unit=QUOTA_UNIT,
+            suggestion=suggestion,
         )
 
     def _update_quota_balance(

--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -27,6 +27,11 @@ logger = logging.getLogger("snuba.query.allocation_policy_cross_org")
 _RATE_LIMIT_NAME = "concurrent_limit_policy"
 _UNREGISTERED_REFERRER_MAX_THREADS = 1
 _UNREGISTERED_REFERRER_CONCURRENT_QUERIES = 1
+from snuba.query.allocation_policies import MAX_THRESHOLD, NO_SUGGESTION, NO_UNITS
+
+QUOTA_UNIT = "concurrent_queries"
+SUGGESTION = "scan less concurrent queries"
+import typing
 
 
 class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
@@ -167,13 +172,19 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
                 can_run=True,
                 max_threads=self.max_threads,
                 explanation={"reason": "pass_through"},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=NO_UNITS,
+                suggestion=NO_SUGGESTION,
             )
 
         concurrent_limit = self._get_concurrent_limit(referrer)
         rate_limit_params = RateLimitParameters(
             self.rate_limit_name, referrer, None, concurrent_limit
         )
-        _, can_run, explanation = self._is_within_rate_limit(
+        rate_limit_stats, can_run, explanation = self._is_within_rate_limit(
             query_id,
             rate_limit_params,
         )
@@ -182,10 +193,21 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
             decision_explanation[
                 "cross_org_query"
             ] = f"This referrer is not registered for the current storage {self._storage_key.value}, if you want to increase its limits, register it in the yaml of the CrossOrgQueryAllocationPolicy"
+
+        if can_run:
+            suggestion = NO_SUGGESTION
+        else:
+            suggestion = SUGGESTION
         return QuotaAllowance(
             can_run=can_run,
             max_threads=self._get_max_threads(referrer),
             explanation=decision_explanation,
+            is_throttled=False,
+            throttle_threshold=typing.cast(int, rate_limit_params.concurrent_limit),
+            rejection_threshold=typing.cast(int, rate_limit_params.concurrent_limit),
+            quota_used=rate_limit_stats.concurrent,
+            quota_unit=QUOTA_UNIT,
+            suggestion=suggestion,
         )
 
     def _update_quota_balance(

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -12,6 +12,9 @@ from snuba.admin.auth import USER_HEADER_KEY
 from snuba.datasets.factory import get_enabled_dataset_names
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.allocation_policies import (
+    MAX_THRESHOLD,
+    NO_SUGGESTION,
+    NO_UNITS,
     AllocationPolicy,
     AllocationPolicyConfig,
     QueryResultOrError,
@@ -427,7 +430,17 @@ def test_get_allocation_policy_configs(admin_api: FlaskClient) -> None:
         def _get_quota_allowance(
             self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
-            return QuotaAllowance(True, 1, {})
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=1,
+                explanation={},
+                is_throttled=False,
+                rejection_threshold=MAX_THRESHOLD,
+                throttle_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=NO_UNITS,
+                suggestion=NO_SUGGESTION,
+            )
 
         def _update_quota_balance(
             self,

--- a/tests/pipeline/test_execution_stage.py
+++ b/tests/pipeline/test_execution_stage.py
@@ -11,6 +11,9 @@ from snuba.pipeline.query_pipeline import QueryPipelineResult
 from snuba.pipeline.stages.query_execution import ExecutionStage
 from snuba.query import SelectedExpression
 from snuba.query.allocation_policies import (
+    MAX_THRESHOLD,
+    NO_SUGGESTION,
+    NO_UNITS,
     AllocationPolicy,
     AllocationPolicyConfig,
     QueryResultOrError,
@@ -41,7 +44,17 @@ class MockAllocationPolicy(AllocationPolicy):
     def _get_quota_allowance(
         self, tenant_ids: dict[str, str | int], query_id: str
     ) -> QuotaAllowance:
-        return QuotaAllowance(can_run=True, max_threads=1, explanation={})
+        return QuotaAllowance(
+            can_run=True,
+            max_threads=1,
+            explanation={},
+            is_throttled=False,
+            throttle_threshold=MAX_THRESHOLD,
+            rejection_threshold=MAX_THRESHOLD,
+            quota_used=0,
+            quota_unit=NO_UNITS,
+            suggestion=NO_SUGGESTION,
+        )
 
     def _update_quota_balance(
         self,

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -8,6 +8,9 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.allocation_policies import (
     CAPMAN_HASH,
     DEFAULT_PASSTHROUGH_POLICY,
+    MAX_THRESHOLD,
+    NO_SUGGESTION,
+    NO_UNITS,
     AllocationPolicy,
     AllocationPolicyConfig,
     InvalidPolicyConfig,
@@ -60,14 +63,34 @@ class RejectingEverythingAllocationPolicy(PassthroughPolicy):
     def _get_quota_allowance(
         self, tenant_ids: dict[str, str | int], query_id: str
     ) -> QuotaAllowance:
-        return QuotaAllowance(can_run=False, max_threads=10, explanation={})
+        return QuotaAllowance(
+            can_run=False,
+            max_threads=10,
+            explanation={},
+            is_throttled=True,
+            throttle_threshold=MAX_THRESHOLD,
+            rejection_threshold=MAX_THRESHOLD,
+            quota_used=0,
+            quota_unit=NO_UNITS,
+            suggestion=NO_SUGGESTION,
+        )
 
 
 class ThrottleEverythingAllocationPolicy(PassthroughPolicy):
     def _get_quota_allowance(
         self, tenant_ids: dict[str, str | int], query_id: str
     ) -> QuotaAllowance:
-        return QuotaAllowance(can_run=True, max_threads=1, explanation={})
+        return QuotaAllowance(
+            can_run=True,
+            max_threads=1,
+            explanation={},
+            is_throttled=True,
+            throttle_threshold=MAX_THRESHOLD,
+            rejection_threshold=MAX_THRESHOLD,
+            quota_used=0,
+            quota_unit=NO_UNITS,
+            suggestion=NO_SUGGESTION,
+        )
 
 
 class BadlyWrittenAllocationPolicy(PassthroughPolicy):


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2796

Allocation policies are our mechanism for doing traffic management for Snuba queries. Currently, the result of applying allocation policies in the internal API is simply accept/reject/throttle. In this PR, we are updating existing allocation policies to return additional metadata, most importantly to distinguish between queries that are accepted, rejected, or throttled.

Next steps: surface these new metadata fields in the [external API](https://getsentry.atlassian.net/browse/SNS-2797)
When all changes are finished, we should have a payload for Sentry that looks like:

```
"quota_allowance": {
	"summary": {
		"threads_used": 2, # the actual amount of max_threads sent to clickhouse
		"throttled_by": {
			"policy": "BytesScannedRejectingPolicy",
			"throttle_threshold": 800,
			"quota_used": 900,
			"quota_units": "bytes",
			"suggestion": "scan fewer bytes n00b",
		},
		"rejected_by": {},
	}
	# policy details as before
	...
}
```