### PR TITLE
feat(capman): Replace BytesScannedWindow policy with BytesScannedRejectingPolicy for spans, replays

### DIFF
--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -190,15 +190,6 @@ allocation_policies:
         - project_id
       default_config_overrides:
         is_enforced: 0
-  - name: BytesScannedWindowAllocationPolicy
-    args:
-      required_tenant_types:
-        - organization_id
-        - referrer
-      default_config_overrides:
-        is_enforced: 1
-        throttled_thread_number: 1
-        org_limit_bytes_scanned: 100000
   - name: ReferrerGuardRailPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -206,3 +206,12 @@ allocation_policies:
       default_config_overrides:
         is_enforced: 0
         is_active: 0
+  - name: BytesScannedRejectingPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - project_id
+        - referrer
+      default_config_overrides:
+        is_active: 0
+        is_enforced: 0

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -115,15 +115,6 @@ allocation_policies:
         - project_id
       default_config_overrides:
         is_enforced: 0
-  - name: BytesScannedWindowAllocationPolicy
-    args:
-      required_tenant_types:
-        - organization_id
-        - referrer
-      default_config_overrides:
-        is_enforced: 1
-        throttled_thread_number: 1
-        org_limit_bytes_scanned: 100000
   - name: ReferrerGuardRailPolicy
     args:
       required_tenant_types:
@@ -131,6 +122,16 @@ allocation_policies:
       default_config_overrides:
         is_enforced: 0
         is_active: 0
+  - name: BytesScannedRejectingPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - project_id
+        - referrer
+      default_config_overrides:
+        is_active: 0
+        is_enforced: 0
+
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: UUIDColumnProcessor


### PR DESCRIPTION
We are facing load issues on spans and replays due to excessive bytes scanned. Add the policy that has been successful on errors in mitigating this load and preventing abusive actors. 

Remove the BytesScannedWindow policy because it has not mitigated these load spikes and the BytesScannedRejectingPolicy also throttles now