### PR TITLE
surface CapMan summary in case of AllocationPolicyViolations

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -892,7 +892,9 @@ def _apply_allocation_policies_quota(
             key: quota_allowance.to_dict()
             for key, quota_allowance in quota_allowances.items()
         }
-        stats["quota_allowance"] = allowance_dicts
+        stats["quota_allowance"] = {}
+        stats["quota_allowance"]["details"] = allowance_dicts
+
         summary: dict[str, Any] = {}
         summary["threads_used"] = num_threads
         _add_quota_info(summary, _REJECTED_BY, rejection_quota_and_policy)
@@ -900,7 +902,7 @@ def _apply_allocation_policies_quota(
         stats["quota_allowance"]["summary"] = summary
 
         if not can_run:
-            raise AllocationPolicyViolations.from_args(quota_allowances, summary)
+            raise AllocationPolicyViolations.from_args(stats["quota_allowance"])
         # Before allocation policies were a thing, the query pipeline would apply
         # thread limits in a query processor. That is not necessary if there
         # is an allocation_policy in place but nobody has removed that code yet.

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -900,7 +900,7 @@ def _apply_allocation_policies_quota(
         stats["quota_allowance"]["summary"] = summary
 
         if not can_run:
-            raise AllocationPolicyViolations.from_args(stats["quota_allowance"])
+            raise AllocationPolicyViolations.from_args(quota_allowances, summary)
         # Before allocation policies were a thing, the query pipeline would apply
         # thread limits in a query processor. That is not necessary if there
         # is an allocation_policy in place but nobody has removed that code yet.

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -853,7 +853,7 @@ def _apply_allocation_policies_quota(
     Sets the resource quota in the query_settings object to the minimum of all available
     quota allowances from the given allocation policies.
     """
-    quota_allowances: dict[str, QuotaAllowance] = {}
+    quota_allowances: dict[str, Any] = {}
     can_run = True
     rejection_quota_and_policy = None
     throttle_quota_and_policy = None
@@ -900,7 +900,7 @@ def _apply_allocation_policies_quota(
         stats["quota_allowance"]["summary"] = summary
 
         if not can_run:
-            raise AllocationPolicyViolations.from_args(quota_allowances)
+            raise AllocationPolicyViolations.from_args(stats["quota_allowance"])
         # Before allocation policies were a thing, the query pipeline would apply
         # thread limits in a query processor. That is not necessary if there
         # is an allocation_policy in place but nobody has removed that code yet.

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -418,7 +418,8 @@ def dataset_query(
                 {
                     "error": details,
                     "timing": timer.for_json(),
-                    "quota_allowance": getattr(cause, "quota_allowance", {}),
+                    "quota_allowance": getattr(cause, "quota_allowance", {})
+                    | getattr(cause, "summary", {}),
                     **exception.extra,
                 }
             ),

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -418,8 +418,7 @@ def dataset_query(
                 {
                     "error": details,
                     "timing": timer.for_json(),
-                    "quota_allowance": getattr(cause, "quota_allowance", {})
-                    | getattr(cause, "summary", {}),
+                    "quota_allowance": getattr(cause, "quota_allowance", {}),
                     **exception.extra,
                 }
             ),

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1323,6 +1323,7 @@ class TestSnQLApi(BaseApiTest):
                     "throttled_by": {},
                 },
             }
+
             assert (
                 response.json["error"]["message"]
                 == f"Query on could not be run due to allocation policies, details: {details}"

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1310,7 +1310,18 @@ class TestSnQLApi(BaseApiTest):
                     "quota_used": 0,
                     "quota_unit": NO_UNITS,
                     "suggestion": NO_SUGGESTION,
-                }
+                },
+                "summary": {
+                    "threads_used": 0,
+                    "rejected_by": {
+                        "policy": "RejectAllocationPolicy123",
+                        "quota_used": 0,
+                        "quota_unit": "no_units",
+                        "suggestion": "no_suggestion",
+                        "rejection_threshold": 1000000000000,
+                    },
+                    "throttled_by": {},
+                },
             }
             assert (
                 response.json["error"]["message"]

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -303,7 +303,7 @@ class TestSnQLApi(BaseApiTest):
             ),
         )
         assert response.status_code == 200
-        allocation_policies = response.json["quota_allowance"]
+        allocation_policies = response.json["quota_allowance"]["details"]
         assert allocation_policies["ConcurrentRateLimitAllocationPolicy"]["can_run"]
 
         response = self.post(
@@ -320,7 +320,7 @@ class TestSnQLApi(BaseApiTest):
                 }
             ),
         )
-        allocation_policies = response.json["quota_allowance"]
+        allocation_policies = response.json["quota_allowance"]["details"]
         assert allocation_policies["ConcurrentRateLimitAllocationPolicy"]
         assert not allocation_policies["ConcurrentRateLimitAllocationPolicy"]["can_run"]
         assert response.status_code == 429
@@ -1296,20 +1296,22 @@ class TestSnQLApi(BaseApiTest):
                 ),
             )
             assert response.status_code == 429
-            details = {
-                "RejectAllocationPolicy123": {
-                    "can_run": False,
-                    "max_threads": 0,
-                    "explanation": {
-                        "reason": "policy rejects all queries",
-                        "storage_key": "StorageKey.DOESNTMATTER",
+            info = {
+                "details": {
+                    "RejectAllocationPolicy123": {
+                        "can_run": False,
+                        "max_threads": 0,
+                        "explanation": {
+                            "reason": "policy rejects all queries",
+                            "storage_key": "StorageKey.DOESNTMATTER",
+                        },
+                        "is_throttled": False,
+                        "throttle_threshold": MAX_THRESHOLD,
+                        "rejection_threshold": MAX_THRESHOLD,
+                        "quota_used": 0,
+                        "quota_unit": NO_UNITS,
+                        "suggestion": NO_SUGGESTION,
                     },
-                    "is_throttled": False,
-                    "throttle_threshold": MAX_THRESHOLD,
-                    "rejection_threshold": MAX_THRESHOLD,
-                    "quota_used": 0,
-                    "quota_unit": NO_UNITS,
-                    "suggestion": NO_SUGGESTION,
                 },
                 "summary": {
                     "threads_used": 0,
@@ -1326,7 +1328,7 @@ class TestSnQLApi(BaseApiTest):
 
             assert (
                 response.json["error"]["message"]
-                == f"Query on could not be run due to allocation policies, details: {details}"
+                == f"Query on could not be run due to allocation policies, info: {info}"
             )
 
     def test_tags_key_column(self) -> None:

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -277,75 +277,77 @@ def test_db_query_success() -> None:
                 "throttle_threshold": 1280000000000,
             },
         },
-        "ReferrerGuardRailPolicy": {
-            "can_run": True,
-            "max_threads": 10,
-            "explanation": {
-                "reason": "within limit",
-                "policy": "referrer_guard_rail_policy",
-                "referrer": "something",
-                "storage_key": "StorageKey.ERRORS_RO",
+        "details": {
+            "ReferrerGuardRailPolicy": {
+                "can_run": True,
+                "max_threads": 10,
+                "explanation": {
+                    "reason": "within limit",
+                    "policy": "referrer_guard_rail_policy",
+                    "referrer": "something",
+                    "storage_key": "StorageKey.ERRORS_RO",
+                },
+                "is_throttled": False,
+                "throttle_threshold": 50,
+                "rejection_threshold": 100,
+                "quota_used": 1,
+                "quota_unit": "concurrent_queries",
+                "suggestion": NO_SUGGESTION,
             },
-            "is_throttled": False,
-            "throttle_threshold": 50,
-            "rejection_threshold": 100,
-            "quota_used": 1,
-            "quota_unit": "concurrent_queries",
-            "suggestion": NO_SUGGESTION,
-        },
-        "ConcurrentRateLimitAllocationPolicy": {
-            "can_run": True,
-            "max_threads": 10,
-            "explanation": {
-                "reason": "within limit",
-                "overrides": {},
-                "storage_key": "StorageKey.ERRORS_RO",
+            "ConcurrentRateLimitAllocationPolicy": {
+                "can_run": True,
+                "max_threads": 10,
+                "explanation": {
+                    "reason": "within limit",
+                    "overrides": {},
+                    "storage_key": "StorageKey.ERRORS_RO",
+                },
+                "is_throttled": False,
+                "throttle_threshold": 22,
+                "rejection_threshold": 22,
+                "quota_used": 1,
+                "quota_unit": "concurrent_queries",
+                "suggestion": NO_SUGGESTION,
             },
-            "is_throttled": False,
-            "throttle_threshold": 22,
-            "rejection_threshold": 22,
-            "quota_used": 1,
-            "quota_unit": "concurrent_queries",
-            "suggestion": NO_SUGGESTION,
-        },
-        "BytesScannedRejectingPolicy": {
-            "can_run": True,
-            "max_threads": 5,
-            "explanation": {
-                "reason": "within_limit but throttled",
-                "storage_key": "StorageKey.ERRORS_RO",
+            "BytesScannedRejectingPolicy": {
+                "can_run": True,
+                "max_threads": 5,
+                "explanation": {
+                    "reason": "within_limit but throttled",
+                    "storage_key": "StorageKey.ERRORS_RO",
+                },
+                "is_throttled": True,
+                "throttle_threshold": 1280000000000,
+                "rejection_threshold": 2560000000000,
+                "quota_used": 1560000000000,
+                "quota_unit": "bytes",
+                "suggestion": "scan less bytes",
             },
-            "is_throttled": True,
-            "throttle_threshold": 1280000000000,
-            "rejection_threshold": 2560000000000,
-            "quota_used": 1560000000000,
-            "quota_unit": "bytes",
-            "suggestion": "scan less bytes",
-        },
-        "CrossOrgQueryAllocationPolicy": {
-            "can_run": True,
-            "max_threads": 10,
-            "explanation": {
-                "reason": "pass_through",
-                "storage_key": "StorageKey.ERRORS_RO",
+            "CrossOrgQueryAllocationPolicy": {
+                "can_run": True,
+                "max_threads": 10,
+                "explanation": {
+                    "reason": "pass_through",
+                    "storage_key": "StorageKey.ERRORS_RO",
+                },
+                "is_throttled": False,
+                "throttle_threshold": MAX_THRESHOLD,
+                "rejection_threshold": MAX_THRESHOLD,
+                "quota_used": 0,
+                "quota_unit": NO_UNITS,
+                "suggestion": NO_SUGGESTION,
             },
-            "is_throttled": False,
-            "throttle_threshold": MAX_THRESHOLD,
-            "rejection_threshold": MAX_THRESHOLD,
-            "quota_used": 0,
-            "quota_unit": NO_UNITS,
-            "suggestion": NO_SUGGESTION,
-        },
-        "BytesScannedWindowAllocationPolicy": {
-            "can_run": True,
-            "max_threads": 10,
-            "explanation": {"storage_key": "StorageKey.ERRORS_RO"},
-            "is_throttled": False,
-            "throttle_threshold": 10000000,
-            "rejection_threshold": MAX_THRESHOLD,
-            "quota_used": 0,
-            "quota_unit": "bytes",
-            "suggestion": "scan less bytes",
+            "BytesScannedWindowAllocationPolicy": {
+                "can_run": True,
+                "max_threads": 10,
+                "explanation": {"storage_key": "StorageKey.ERRORS_RO"},
+                "is_throttled": False,
+                "throttle_threshold": 10000000,
+                "rejection_threshold": MAX_THRESHOLD,
+                "quota_used": 0,
+                "quota_unit": "bytes",
+                "suggestion": "scan less bytes",
+            },
         },
     }
 
@@ -517,26 +519,28 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
                     "suggestion": NO_SUGGESTION,
                 },
             },
-            "RejectAllocationPolicy": {
-                "can_run": False,
-                "explanation": {
-                    "reason": "policy rejects all queries",
-                    "storage_key": "StorageKey.DOESNTMATTER",
+            "details": {
+                "RejectAllocationPolicy": {
+                    "can_run": False,
+                    "explanation": {
+                        "reason": "policy rejects all queries",
+                        "storage_key": "StorageKey.DOESNTMATTER",
+                    },
+                    "max_threads": 0,
+                    "is_throttled": True,
+                    "quota_unit": NO_UNITS,
+                    "quota_used": 0,
+                    "rejection_threshold": MAX_THRESHOLD,
+                    "suggestion": NO_SUGGESTION,
+                    "throttle_threshold": MAX_THRESHOLD,
                 },
-                "max_threads": 0,
-                "is_throttled": True,
-                "quota_unit": NO_UNITS,
-                "quota_used": 0,
-                "rejection_threshold": MAX_THRESHOLD,
-                "suggestion": NO_SUGGESTION,
-                "throttle_threshold": MAX_THRESHOLD,
             },
         }
         # extra data contains policy failure information
         assert (
-            excinfo.value.extra["stats"]["quota_allowance"]["RejectAllocationPolicy"][
-                "explanation"
-            ]["reason"]
+            excinfo.value.extra["stats"]["quota_allowance"]["details"][
+                "RejectAllocationPolicy"
+            ]["explanation"]["reason"]
             == "policy rejects all queries"
         )
         assert query_metadata_list[0].request_status.status.value == "rate-limited"
@@ -749,19 +753,21 @@ def test_allocation_policy_updates_quota() -> None:
             },
             "throttled_by": {},
         },
-        "CountQueryPolicy": {
-            "can_run": False,
-            "max_threads": 0,
-            "explanation": {
-                "reason": "can only run 2 queries!",
-                "storage_key": "StorageKey.DOESNTMATTER",
+        "details": {
+            "CountQueryPolicy": {
+                "can_run": False,
+                "max_threads": 0,
+                "explanation": {
+                    "reason": "can only run 2 queries!",
+                    "storage_key": "StorageKey.DOESNTMATTER",
+                },
+                "is_throttled": False,
+                "throttle_threshold": MAX_QUERIES_TO_RUN,
+                "rejection_threshold": MAX_QUERIES_TO_RUN,
+                "quota_used": queries_run,
+                "quota_unit": "queries",
+                "suggestion": "scan less concurrent queries",
             },
-            "is_throttled": False,
-            "throttle_threshold": MAX_QUERIES_TO_RUN,
-            "rejection_threshold": MAX_QUERIES_TO_RUN,
-            "quota_used": queries_run,
-            "quota_unit": "queries",
-            "suggestion": "scan less concurrent queries",
         },
     }
     cause = e.value.__cause__


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2798

Allocation policies are our mechanism for doing traffic management for Snuba queries. On Sentry issues webpage, the [metadata regarding allocation policies](https://github.com/getsentry/snuba/pull/6041) are not surfaced.

<img width="811" alt="Screenshot 2024-06-22 at 8 02 53 PM" src="https://github.com/getsentry/snuba/assets/159840875/f8fbb041-f04f-4afc-a3d2-a44e7f8f7f95">

In this PR, we relay the metadata to Sentry issues webpage so that they are displayed in that same section.