### PR TITLE
gocd: do not create topics on every snuba deployment

### DIFF
--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -12,14 +12,6 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
 /devinfra/scripts/k8s/k8s-spawn-job.py \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
-  "snuba-bootstrap" \
-  "us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
-  -- \
-  snuba bootstrap --force --no-migrate
-
-/devinfra/scripts/k8s/k8s-spawn-job.py \
-  --label-selector="service=${SNUBA_SERVICE_NAME}" \
-  --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate" \
   "us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   -- \


### PR DESCRIPTION
snuba is currently creating topics (even those that are not in production yet) in single tenant on each gocd deployment. snuba shouldn't be managing topics as topicctl is used to do this in all production environments.
