### PR TITLE
dev(rate-limits): up concurrent rate limit for similarity backfill

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -264,8 +264,8 @@ allocation_policies:
         is_active: 1
       cross_org_referrer_limits:
         getsentry.tasks.backfill_grouping_records:
-          max_threads: 2
-          concurrent_limit: 4
+          max_threads: 10
+          concurrent_limit: 20
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -264,7 +264,7 @@ allocation_policies:
         is_active: 1
       cross_org_referrer_limits:
         getsentry.tasks.backfill_grouping_records:
-          max_threads: 10
+          max_threads: 5
           concurrent_limit: 20
   - name: BytesScannedWindowAllocationPolicy
     args:


### PR DESCRIPTION
we are simply doing point queries, so should be able to do a bit more concurrently without issues.