### PR TITLE
perf(spans): Remove transaction_id from PREWHERE for spans

### DIFF
--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -167,7 +167,7 @@ query_processors:
   - processor: PrewhereProcessor
     args:
       prewhere_candidates:
-        [transaction_id, span_id, trace_id, segment_name]
+        [span_id, trace_id, segment_name]
   - processor: TableRateLimit
   - processor: TupleUnaliaser
 


### PR DESCRIPTION
There is no index on `transaction_id` nor is it part of the table's ORDER BY. Because of this, promoting conditions on the `transaction_id` to the PREWHERE clause actually slows down the query quite significantly.