### PR TITLE
fix(ratelimits) up rate limit for events for backfill as well

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -269,8 +269,8 @@ allocation_policies:
         is_active: 1
       cross_org_referrer_limits:
         getsentry.tasks.backfill_grouping_records:
-          max_threads: 2
-          concurrent_limit: 4
+          max_threads: 5
+          concurrent_limit: 20
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:


### PR DESCRIPTION
in this PR https://github.com/getsentry/snuba/pull/6064 we upped the rate limit for this referrer, but need to do it on the events dataet as well. i'm not actually sure how the errors_ro gets hit, but it seems our query in prod hits events.

