### PR TITLE
feat(mql): Support filters and bracket rules in parsing

### DIFF
--- a/snuba/query/mql/parser_supported_join.py
+++ b/snuba/query/mql/parser_supported_join.py
@@ -1224,21 +1224,41 @@ def populate_query_from_mql_context(
         # ensure we correctly join the subqueries. The column names will be the same for all the
         # subqueries, so we just need to map all the table aliases.
 
-        join_clause = query.get_from_clause()
-        assert isinstance(join_clause, JoinClause)
-        base_node_alias = join_clause.right_node.alias
-        other_aliases = [d[1] for d in entity_data if d[1] != base_node_alias]
-        new_conditions = []
-        for other in other_aliases:
-            assert other is not None  # mypy, this should never be None for joins
-            condition = JoinCondition(
-                left=JoinConditionExpression(base_node_alias, "time"),
-                right=JoinConditionExpression(other, "time"),
-            )
-            new_conditions.append(condition)
+        def add_join_keys(join_clause: JoinClause[Any]) -> str:
+            match (join_clause.left_node, join_clause.right_node):
+                case (
+                    IndividualNode(alias=left),
+                    IndividualNode(alias=right),
+                ):
+                    join_clause.keys.append(
+                        JoinCondition(
+                            left=JoinConditionExpression(
+                                table_alias=left, column="time"
+                            ),
+                            right=JoinConditionExpression(
+                                table_alias=right, column="time"
+                            ),
+                        )
+                    )
+                    return right
+                case (
+                    JoinClause() as inner_join_clause,
+                    IndividualNode(alias=right),
+                ):
+                    join_clause.keys.append(
+                        JoinCondition(
+                            left=JoinConditionExpression(
+                                table_alias=add_join_keys(inner_join_clause),
+                                column="time",
+                            ),
+                            right=JoinConditionExpression(
+                                table_alias=right, column="time"
+                            ),
+                        )
+                    )
+                    return right
 
-        conditions = list(join_clause.keys)
-        query.set_from_clause(replace(join_clause, keys=conditions + new_conditions))
+        add_join_keys(join_clause)
 
     limit = limit_value(mql_context)
     offset = offset_value(mql_context)


### PR DESCRIPTION
### Overview

- Distribute join keys from top level JoinClause to each individual JoinClause.
- Adds tests for bracketed formula queries.

### Details

Right now, the query IR that the parser produce for something like
```
  max(`d:transactions/duration@millisecond`)
/ sum(`d:transactions/duration@millisecond`) 
+ avg(`d:transactions/duration@millisecond`)
```

Has a join clause of
```python
join_clause = JoinClause(
    left_node=JoinClause(
        left_node=IndividualNode(
            alias="d2",
        ),
        right_node=IndividualNode(
            alias="d1",
        ),
        keys=[],
    ),
    right_node=IndividualNode(
        alias="d0",
    ),
    keys=[
        JoinCondition(
            left=JoinConditionExpression(table_alias="d1", column="time"),
            right=JoinConditionExpression(table_alias="d0", column="time"),
        ),
       JoinCondition(
            left=JoinConditionExpression(table_alias="d2", column="time"),
            right=JoinConditionExpression(table_alias="d0", column="time"),
        )
    ],
    join_type=JoinType.INNER,
    join_modifier=None,
)
```
But clickhouse does not support joins in the style of
```sql
(
  <subquery>
) AS d2
INNER JOIN
(
    <subquery>
) as d1
INNER JOIN
(
    <subquery>
) AS d0 ON d0.time = d1.time and d1 ON d2.time = d1.time
```
Distributes the join conditions so that the query IR has join key arranged to the proper JoinClause Node
```python
join_clause = JoinClause(
    left_node=JoinClause(
        left_node=IndividualNode(
            alias="d2",
            data_source=from_distributions,
        ),
        right_node=IndividualNode(
            alias="d1",
            data_source=from_distributions,
        ),
        keys=[
            JoinCondition(
                left=JoinConditionExpression(table_alias="d2", column="time"),
                right=JoinConditionExpression(table_alias="d1", column="time"),
            )
        ],
        join_type=JoinType.INNER,
        join_modifier=None,
    ),
    right_node=IndividualNode(
        alias="d0",
        data_source=from_distributions,
    ),
    keys=[
        JoinCondition(
            left=JoinConditionExpression(table_alias="d1", column="time"),
            right=JoinConditionExpression(table_alias="d0", column="time"),
        ),
    ],
    join_type=JoinType.INNER,
    join_modifier=None,
)
```
So that our SQL can look like
```sql
(
    <subquery>
) AS d2
INNER JOIN
(
    <subquery>
) AS d1 ON d2.time = d1.time
INNER JOIN
(
    <subquery>
) AS d0 ON d0.time = d1.time
```
Which clickhouse supports