### PR TITLE
feat(mql): Support parsing simple formulas into JOIN queries

### DIFF
--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -160,15 +160,6 @@ class JoinClause(DataSource, JoinNode[TSimpleDataSource], Generic[TSimpleDataSou
             **self.right_node.get_alias_node_map(),
         }
 
-    def __post_init__(self) -> None:
-        column_set = self.get_columns()
-
-        for condition in self.keys:
-            assert f"{condition.left.table_alias}.{condition.left.column}" in column_set
-            assert (
-                f"{condition.right.table_alias}.{condition.right.column}" in column_set
-            )
-
     def accept(self, visitor: JoinVisitor[TReturn, TSimpleDataSource]) -> TReturn:
         return visitor.visit_join_clause(self)
 

--- a/snuba/query/mql/context_population.py
+++ b/snuba/query/mql/context_population.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from snuba_sdk.metrics_visitors import AGGREGATE_ALIAS
+
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query.conditions import (
+    ConditionFunctions,
+    binary_condition,
+    combine_and_conditions,
+)
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.mql.mql_context import MQLContext
+from snuba.query.parser.exceptions import ParsingException
+from snuba.query.snql.parser import MAX_LIMIT
+from snuba.util import parse_datetime
+from snuba.utils.constants import GRANULARITIES_AVAILABLE
+
+
+def start_end_time_condition(
+    mql_context: MQLContext, entity_key: EntityKey, table_name: str | None = None
+) -> Expression:
+    try:
+        start = parse_datetime(mql_context.start)
+        end = parse_datetime(mql_context.end)
+    except Exception as e:
+        raise ParsingException("Invalid start or end time") from e
+
+    entity = get_entity(entity_key)
+    required_timestamp_column = (
+        entity.required_time_column if entity.required_time_column else "timestamp"
+    )
+    filters = []
+    filters.append(
+        binary_condition(
+            ConditionFunctions.GTE,
+            Column(None, table_name, column_name=required_timestamp_column),
+            Literal(None, value=start),
+        ),
+    )
+    filters.append(
+        binary_condition(
+            ConditionFunctions.LT,
+            Column(None, table_name, column_name=required_timestamp_column),
+            Literal(None, value=end),
+        ),
+    )
+    return combine_and_conditions(filters)
+
+
+def scope_conditions(
+    mql_context: MQLContext, table_name: str | None = None
+) -> Expression:
+    filters = []
+    filters.append(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column(None, table_name, "project_id"),
+            FunctionCall(
+                None,
+                "tuple",
+                tuple(
+                    Literal(None, project_id)
+                    for project_id in mql_context.scope.project_ids
+                ),
+            ),
+        )
+    )
+    filters.append(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column(None, table_name, "org_id"),
+            FunctionCall(
+                None,
+                "tuple",
+                tuple(
+                    Literal(None, int(org_id)) for org_id in mql_context.scope.org_ids
+                ),
+            ),
+        )
+    )
+    filters.append(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, table_name, "use_case_id"),
+            Literal(None, mql_context.scope.use_case_id),
+        )
+    )
+    return combine_and_conditions(filters)
+
+
+def rollup_expressions(
+    mql_context: MQLContext, table_name: str | None = None
+) -> tuple[Expression, bool, OrderBy | None, SelectedExpression | None]:
+    """
+    This function returns four values based on the rollup field in the MQL context:
+    - granularity_condition: an expression that filters the granularity column based on the granularity in the MQL context
+    - with_totals: a boolean indicating whether the query should include totals
+    - orderby: an OrderBy object that specifies the ordering of the results
+    - selected_time: a SelectedExpression for the time column in the time series. If this is a total query, this will be None
+    """
+    rollup = mql_context.rollup
+
+    # Validate/populate granularity
+    if rollup.granularity not in GRANULARITIES_AVAILABLE:
+        raise ParsingException(
+            f"granularity '{rollup.granularity}' is not valid, must be one of {GRANULARITIES_AVAILABLE}"
+        )
+
+    granularity_condition = binary_condition(
+        ConditionFunctions.EQ,
+        Column(None, table_name, "granularity"),
+        Literal(None, rollup.granularity),
+    )
+
+    # Validate totals/orderby
+    if rollup.with_totals is not None and rollup.with_totals not in ("True", "False"):
+        raise ParsingException("with_totals must be a string, either 'True' or 'False'")
+    if rollup.orderby is not None and rollup.orderby not in ("ASC", "DESC"):
+        raise ParsingException("orderby must be either 'ASC' or 'DESC'")
+    if rollup.interval is not None and rollup.orderby is not None:
+        raise ParsingException("orderby is not supported when interval is specified")
+    if rollup.interval and (
+        rollup.interval < GRANULARITIES_AVAILABLE[0]
+        or rollup.interval < rollup.granularity
+    ):
+        raise ParsingException(
+            f"interval {rollup.interval} must be greater than or equal to granularity {rollup.granularity}"
+        )
+
+    with_totals = rollup.with_totals == "True"
+    selected_time = None
+    orderby = None
+    if rollup.interval:
+        # If an interval is specified, then we need to group the time by that interval,
+        # return the time in the select, and order the results by that time.
+        prefix = "" if not table_name else f"{table_name}."
+        time_expression = FunctionCall(
+            f"{prefix}time",
+            "toStartOfInterval",
+            parameters=(
+                Column(None, table_name, "timestamp"),
+                FunctionCall(
+                    None,
+                    "toIntervalSecond",
+                    (Literal(None, rollup.interval),),
+                ),
+                Literal(None, "Universal"),
+            ),
+        )
+        selected_time = SelectedExpression("time", time_expression)
+        orderby = OrderBy(OrderByDirection.ASC, time_expression)
+    elif rollup.orderby is not None:
+        direction = (
+            OrderByDirection.ASC if rollup.orderby == "ASC" else OrderByDirection.DESC
+        )
+        orderby = OrderBy(direction, Column(None, None, AGGREGATE_ALIAS))
+
+    return granularity_condition, with_totals, orderby, selected_time
+
+
+def limit_value(mql_context: MQLContext) -> int:
+    limit = 1000
+    if mql_context.limit:
+        if mql_context.limit > MAX_LIMIT:
+            raise ParsingException(
+                "queries cannot have a limit higher than 10000", should_report=False
+            )
+        limit = mql_context.limit
+
+    return limit
+
+
+def offset_value(mql_context: MQLContext) -> int | None:
+    if mql_context.offset:
+        if mql_context.offset < 0:
+            raise ParsingException("offset must be greater than or equal to 0")
+        return mql_context.offset
+
+    return None

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -88,6 +88,7 @@ class InitialParseResult:
     groupby: list[SelectedExpression] | None = None
     conditions: list[Expression] | None = None
     mri: str | None = None
+    table_alias: str | None = None
 
 
 FormulaParameter = Union[InitialParseResult, int, float]

--- a/snuba/query/mql/parser.py
+++ b/snuba/query/mql/parser.py
@@ -27,6 +27,13 @@ from snuba.query.conditions import (
     binary_condition,
     combine_and_conditions,
 )
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinType,
+)
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.data_source.simple import LogicalDataSource
 from snuba.query.dsl import arrayElement
@@ -41,6 +48,13 @@ from snuba.query.expressions import (
 from snuba.query.indexer.resolver import resolve_mappings
 from snuba.query.logical import EntityQuery
 from snuba.query.logical import Query as LogicalQuery
+from snuba.query.mql.context_population import (
+    limit_value,
+    offset_value,
+    rollup_expressions,
+    scope_conditions,
+    start_end_time_condition,
+)
 from snuba.query.mql.mql_context import MQLContext
 from snuba.query.parser.exceptions import ParsingException
 from snuba.query.processors.logical.filter_in_select_optimizer import (
@@ -70,11 +84,13 @@ logger = logging.getLogger("snuba.mql.parser")
 class InitialParseResult:
     expression: SelectedExpression | None = None
     formula: str | None = None
-    parameters: list[InitialParseResult] | None = None
+    parameters: list[FormulaParameter] | None = None
     groupby: list[SelectedExpression] | None = None
     conditions: list[Expression] | None = None
     mri: str | None = None
 
+
+FormulaParameter = Union[InitialParseResult, int, float]
 
 ARITHMETIC_OPERATORS_MAPPING = {
     "+": "plus",
@@ -93,6 +109,9 @@ class MQLVisitor(NodeVisitor):  # type: ignore
     Builds the arguments for a Snuba AST from the MQL Parsimonious parse tree.
     """
 
+    def __init__(self) -> None:
+        self.alias_count: dict[str, int] = {}
+
     def visit_expression(
         self,
         node: Node,
@@ -104,7 +123,11 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         term, zero_or_more_others = children
         if zero_or_more_others:
             _, term_operator, _, coefficient, *_ = zero_or_more_others[0]
-            return self._visit_formula(term_operator, term, coefficient)
+            return InitialParseResult(
+                expression=None,
+                formula=term_operator,
+                parameters=[term, coefficient],
+            )
         return term
 
     def visit_expr_op(self, node: Node, children: Sequence[Any]) -> Any:
@@ -116,108 +139,6 @@ class MQLVisitor(NodeVisitor):  # type: ignore
     def visit_unary_op(self, node: Node, children: Sequence[Any]) -> Any:
         return UNARY_OPERATORS[node.text]
 
-    def _build_timeseries_formula_param(
-        self, param: InitialParseResult
-    ) -> SelectedExpression:
-        """
-        Timeseries inside a formula need to have three things done to them:
-        1. Add the -If suffix to their aggregate function
-        2. Put all the filters for the timeseries inside the aggregate expression
-        3. Add a metric_id condition to the conditions in the aggregate
-
-        Given an input parse result from `sum(mri){x:y}`, this should output
-        an expression like `sumIf(value, x = y AND metric_id = mri)`.
-        """
-        assert param.expression is not None
-        exp = param.expression.expression
-        assert isinstance(exp, (FunctionCall, CurriedFunctionCall))
-
-        conditions = param.conditions or []
-        metric_id_condition = binary_condition(
-            ConditionFunctions.EQ,
-            Column(None, None, "metric_id"),
-            Literal(None, param.mri),
-        )
-        conditions.append(metric_id_condition)
-        value_column = exp.parameters[0]
-        if isinstance(exp, FunctionCall):
-            return SelectedExpression(
-                None,
-                FunctionCall(
-                    None,
-                    f"{exp.function_name}If",
-                    parameters=(
-                        value_column,
-                        combine_and_conditions(conditions),
-                    ),
-                ),
-            )
-        else:
-            return SelectedExpression(
-                None,
-                CurriedFunctionCall(
-                    None,
-                    FunctionCall(
-                        exp.internal_function.alias,
-                        f"{exp.internal_function.function_name}If",
-                        exp.internal_function.parameters,
-                    ),
-                    (
-                        value_column,
-                        combine_and_conditions(conditions),
-                    ),
-                ),
-            )
-
-    def _visit_formula(
-        self,
-        term_operator: str,
-        operand_1: InitialParseResult,
-        operand_2: InitialParseResult | None = None,
-    ) -> InitialParseResult:
-        # TODO: If the formula has filters/group by, where do those appear?
-
-        # If the parameters of the query are timeseries, extract the expressions from the result
-        if (
-            isinstance(operand_1, InitialParseResult)
-            and operand_1.expression is not None
-        ):
-            operand_1 = replace(
-                operand_1, expression=self._build_timeseries_formula_param(operand_1)
-            )
-        if (
-            operand_2 is not None
-            and isinstance(operand_2, InitialParseResult)
-            and operand_2.expression is not None
-        ):
-            operand_2 = replace(
-                operand_2,
-                expression=self._build_timeseries_formula_param(operand_2),
-            )
-
-        if (
-            operand_2 is not None
-            and isinstance(operand_1, InitialParseResult)
-            and isinstance(operand_2, InitialParseResult)
-            and operand_1.groupby != operand_2.groupby
-        ):
-            raise InvalidQueryException(
-                "All terms in a formula must have the same groupby"
-            )
-
-        groupby = (
-            operand_1.groupby if isinstance(operand_1, InitialParseResult) else None
-        )
-        parameters = [operand_1]
-        if operand_2 is not None:
-            parameters.append(operand_2)
-        return InitialParseResult(
-            expression=None,
-            formula=term_operator,
-            parameters=parameters,
-            groupby=groupby,
-        )
-
     def visit_term(
         self,
         node: Node,
@@ -226,7 +147,15 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         term, zero_or_more_others = children
         if zero_or_more_others:
             _, term_operator, _, unary, *_ = zero_or_more_others[0]
-            return self._visit_formula(term_operator, term, unary)
+            parameters: list[FormulaParameter] = [term]
+            if unary is not None:
+                parameters.append(unary)
+
+            return InitialParseResult(
+                expression=None,
+                formula=term_operator,
+                parameters=parameters,
+            )
 
         return term
 
@@ -236,7 +165,11 @@ class MQLVisitor(NodeVisitor):  # type: ignore
             if isinstance(coefficient, float) or isinstance(coefficient, int):
                 return -coefficient
             elif isinstance(coefficient, InitialParseResult):
-                return self._visit_formula(unary_op[0], coefficient)
+                return InitialParseResult(
+                    expression=None,
+                    formula=unary_op[0],
+                    parameters=[coefficient],
+                )
             else:
                 raise InvalidQueryException(
                     f"Unary expression not supported for type {type(coefficient)}"
@@ -267,50 +200,57 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         ],
     ) -> InitialParseResult:
         target, filters, packed_groupbys, *_ = children
+        new_condition = None
         packed_filters = filters[0][1] if filters else []  # strip braces
         if packed_filters:
             assert isinstance(packed_filters, list)
-            _, filter_expr, *_ = packed_filters[0]
-            if target.formula is not None:
+            _, new_condition, *_ = packed_filters[0]
 
-                def pushdown_filter(n: InitialParseResult) -> None:
-                    assert isinstance(n, InitialParseResult)
-                    if n.formula is not None:
-                        for param in n.parameters or []:
-                            if isinstance(param, InitialParseResult):
-                                # Only push down non-scalar values e.g. sum(mri) / 3600, 3600 will not be pushed down
-                                # TODO: the type definition of InitialParseResult.parameters is inaccurate
-                                pushdown_filter(param)
-                    elif n.expression is not None:
-                        exp = n.expression.expression
-                        assert isinstance(exp, (FunctionCall, CurriedFunctionCall))
-                        exp = replace(
-                            exp,
-                            parameters=(
-                                exp.parameters[0],
-                                binary_condition("and", filter_expr, exp.parameters[1]),
-                            ),
-                        )
-                        n.expression = replace(n.expression, expression=exp)
-                    else:
-                        raise InvalidQueryException("Could not parse formula")
-
-                pushdown_filter(target)
-            else:
-                if target.conditions is not None:
-                    target.conditions = target.conditions + [filter_expr]
-                else:
-                    target.conditions = [filter_expr]
-
+        groupby = None
         if packed_groupbys:
             assert isinstance(packed_groupbys, list)
-            group_by = packed_groupbys[0]
-            if not isinstance(group_by, list):
-                group_by = [group_by]
-            if target.groupby is not None:
-                target.groupby = target.groupby + group_by
+            groupby_val = packed_groupbys[0]
+            groupby = groupby_val if isinstance(groupby_val, list) else [groupby_val]
+
+        if new_condition or groupby:
+            if target.formula is not None:
+                # Push all the filters and groupbys of the formula down to all the leaf nodes
+                # so they get correctly added to their subqueries.
+                def pushdown_values(param: FormulaParameter) -> FormulaParameter:
+                    if not isinstance(param, InitialParseResult):
+                        return param
+                    if param.formula is not None:
+                        parameters = param.parameters or []
+                        for p in parameters:
+                            pushdown_values(p)
+                    elif param.expression is not None:
+                        if new_condition:
+                            param.conditions = (
+                                param.conditions + [new_condition]
+                                if param.conditions
+                                else [new_condition]
+                            )
+                        if groupby:
+                            param.groupby = (
+                                param.groupby + groupby if param.groupby else groupby
+                            )
+                    else:
+                        raise InvalidQueryException("Could not parse formula")
+                    return param
+
+                for param in target.parameters or []:
+                    pushdown_values(param)
             else:
-                target.groupby = group_by
+                if new_condition:
+                    target.conditions = (
+                        target.conditions + [new_condition]
+                        if target.conditions
+                        else [new_condition]
+                    )
+                if groupby:
+                    target.groupby = (
+                        target.groupby + groupby if target.groupby else groupby
+                    )
 
         return target
 
@@ -667,17 +607,25 @@ class MQLVisitor(NodeVisitor):  # type: ignore
         assert isinstance(node.text, str)
         return node.text
 
+    def _generate_table_alias(self, mri: str) -> str:
+        alias = mri[0]
+        suffix = self.alias_count.setdefault(alias, -1) + 1
+        self.alias_count[alias] = suffix
+        return f"{alias}{suffix}"
+
     def visit_quoted_mri(
         self, node: Node, children: Sequence[Any]
     ) -> InitialParseResult:
         assert isinstance(node.text, str)
-        return InitialParseResult(mri=str(node.text[1:-1]))
+        mri = str(node.text[1:-1])
+        return InitialParseResult(mri=mri, table_alias=self._generate_table_alias(mri))
 
     def visit_unquoted_mri(
         self, node: Node, children: Sequence[Any]
     ) -> InitialParseResult:
         assert isinstance(node.text, str)
-        return InitialParseResult(mri=str(node.text))
+        mri = str(node.text)
+        return InitialParseResult(mri=mri, table_alias=self._generate_table_alias(mri))
 
     def visit_quoted_public_name(
         self, node: Node, children: Sequence[Any]
@@ -705,15 +653,17 @@ def parse_mql_query_body(body: str, dataset: Dataset) -> EntityQuery:
     """
     try:
         """
-        Example of parsed tree for:
-        'max(transaction.user{dist:["dist1", "dist2"]}) by transaction',
-
-        InitialParseResult(
-            'public_name': 'transaction.user',
-            'selected_aggregate': [SelectedExpression(name='aggregate_value', expression=sum(value) AS `sum(d:transactions/duration@millisecond)`)],
-            'filters': [in(Column('dist'), tuple('dist1', 'dist2'))],
-            'groupby': [SelectedExpression(name='transaction', Column('transaction')],
-        )
+        Example MQL:
+            'max(transaction.duration{dist:["dist1", "dist2"]}) by transaction'
+        After visiting the parse tree, it becomes:
+            InitialParseResult(
+                'expression': SelectedExpression(name='aggregate_value', expression=sum(value) AS `sum(d:transactions/duration@millisecond)`),
+                'formula': None,
+                'parameters': None,
+                'groupby': [SelectedExpression(name='transaction', Column('transaction')],
+                'conditions': [in(Column('dist'), tuple('dist1', 'dist2'))],
+                'mri': 'd:transactions/duration@millisecond'
+            )
         """
         try:
             exp_tree = MQL_GRAMMAR.parse(body)
@@ -746,96 +696,9 @@ def parse_mql_query_body(body: str, dataset: Dataset) -> EntityQuery:
             )
 
         if parsed.formula:
-
-            def extract_expression(param: InitialParseResult | Any) -> Expression:
-                if not isinstance(param, InitialParseResult):
-                    return Literal(None, param)
-                elif param.expression is not None:
-                    return param.expression.expression
-                elif param.formula:
-                    parameters = param.parameters or []
-                    return FunctionCall(
-                        None,
-                        param.formula,
-                        tuple(extract_expression(p) for p in parameters),
-                    )
-                else:
-                    raise InvalidQueryException("Could not parse formula")
-
-            parameters = parsed.parameters or []
-            selected_columns = [
-                SelectedExpression(
-                    name=AGGREGATE_ALIAS,
-                    expression=FunctionCall(
-                        alias=AGGREGATE_ALIAS,
-                        function_name=parsed.formula,
-                        parameters=tuple(extract_expression(p) for p in parameters),
-                    ),
-                )
-            ]
-            if parsed.groupby:
-                selected_columns.extend(parsed.groupby)
-            groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
-
-            def extract_mri(param: InitialParseResult | Any) -> str:
-                if isinstance(param, InitialParseResult):
-                    if param.mri:
-                        return param.mri
-                    elif param.formula:
-                        for p in param.parameters or []:
-                            try:
-                                mri = extract_mri(p)
-                                if mri:
-                                    return mri
-                            except ParsingException:
-                                pass
-
-                raise ParsingException("formula does not contain any MRIs")
-
-            mri = extract_mri(parsed)  # Only works for single type formulas
-            entity_key = select_entity(mri, dataset)
-
-            query = LogicalQuery(
-                from_clause=QueryEntity(
-                    key=entity_key, schema=get_entity(entity_key).get_data_model()
-                ),
-                selected_columns=selected_columns,
-                groupby=groupby,
-            )
-        if parsed.expression:
-            selected_columns = [parsed.expression]
-            if parsed.groupby:
-                selected_columns.extend(parsed.groupby)
-            groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
-
-            metric_value = parsed.mri
-            if not metric_value:
-                raise ParsingException("no MRI specified in MQL query")
-
-            conditions: list[Expression] = [
-                binary_condition(
-                    ConditionFunctions.EQ,
-                    Column(None, None, "metric_id"),
-                    Literal(None, metric_value),
-                )
-            ]
-            if parsed.conditions:
-                conditions.extend(parsed.conditions)
-
-            final_conditions = (
-                combine_and_conditions(conditions) if conditions else None
-            )
-
-            entity_key = select_entity(metric_value, dataset)
-
-            query = LogicalQuery(
-                from_clause=QueryEntity(
-                    key=entity_key, schema=get_entity(entity_key).get_data_model()
-                ),
-                selected_columns=selected_columns,
-                condition=final_conditions,
-                groupby=groupby,
-            )
+            query = convert_formula_to_query(parsed, dataset)
+        else:
+            query = convert_timeseries_to_query(parsed, dataset)
     except Exception as e:
         raise e
     return EntityQuery.from_query(query)
@@ -853,6 +716,275 @@ GENERIC_ENTITIES = {
     "s": EntityKey.GENERIC_METRICS_SETS,
     "g": EntityKey.GENERIC_METRICS_GAUGES,
 }
+
+
+def build_formula_query_from_clause(
+    parsed: InitialParseResult, dataset: Dataset
+) -> tuple[LogicalQuery | CompositeQuery[QueryEntity], list[InitialParseResult]]:
+    def find_all_leaf_nodes(tree: FormulaParameter) -> list[InitialParseResult] | None:
+        if isinstance(tree, InitialParseResult) and tree.formula is None:
+            return [tree]
+        elif isinstance(tree, InitialParseResult) and tree.formula is not None:
+            nodes = []
+            for p in tree.parameters or []:
+                found = find_all_leaf_nodes(p)
+                if found:
+                    nodes.extend(found)
+            return nodes
+        else:
+            return None
+
+    join_nodes = find_all_leaf_nodes(parsed)
+    if join_nodes is None:
+        raise InvalidQueryException("Could not parse formula")
+
+    # We use the group by for the ON conditions, so make sure they are all the same
+    groupbys = join_nodes[0].groupby
+    if not all(node.groupby == groupbys for node in join_nodes):
+        raise InvalidQueryException("All terms in a formula must have the same groupby")
+
+    entity_keys = [select_entity(node.mri or "", dataset) for node in join_nodes]
+    if len(entity_keys) == 1:
+        # The query only has a single aggregation, so it's not necessary to build a join clause
+        # across entities.
+        entity_key = entity_keys.pop()
+        return (
+            LogicalQuery(
+                from_clause=QueryEntity(
+                    entity_key, get_entity(entity_key).get_data_model()
+                )
+            ),
+            join_nodes,
+        )
+
+    # Used to cache query entities to avoid building multiple times
+    entities: dict[EntityKey, QueryEntity] = {}
+
+    def build_node(node: InitialParseResult) -> IndividualNode[QueryEntity]:
+        if not node.mri:
+            raise InvalidQueryException("No MRI found")
+        if not node.table_alias:
+            raise InvalidQueryException(f"No table alias found for MRI {node.mri}")
+
+        entity_key = select_entity(node.mri, dataset)
+        data_source = entities.setdefault(
+            entity_key, QueryEntity(entity_key, get_entity(entity_key).get_data_model())
+        )
+        return IndividualNode(node.table_alias, data_source)
+
+    # Build the JoinClause recursively, joining each node to the previous node.
+    # Note one thing: this assumes that each node has the same group by, which is enforced earlier.
+    first_node = build_node(join_nodes[0])
+
+    def build_join_clause(
+        prev_node: IndividualNode[QueryEntity], nodes: list[InitialParseResult]
+    ) -> JoinClause[QueryEntity]:
+        if not nodes:
+            raise InvalidQueryException("Invalid join clause in formula query")
+
+        node = nodes[0]
+        if not node.table_alias:
+            raise InvalidQueryException("Invalid table alias in formula query")
+        lhs = build_node(node)
+
+        conditions = []
+        for groupby in node.groupby or []:
+            column = groupby.expression
+            assert isinstance(column, Column)
+            conditions.append(
+                JoinCondition(
+                    left=JoinConditionExpression(lhs.alias, column.column_name),
+                    right=JoinConditionExpression(prev_node.alias, column.column_name),
+                )
+            )
+
+        left_side = build_join_clause(lhs, nodes[1:]) if len(nodes) > 1 else lhs
+        return JoinClause(
+            left_node=left_side,
+            right_node=prev_node,
+            keys=conditions,
+            join_type=JoinType.INNER,
+        )
+
+    join_clause = build_join_clause(first_node, join_nodes[1:])
+    return (
+        CompositeQuery(
+            from_clause=join_clause,
+        ),
+        join_nodes,
+    )
+
+
+def convert_formula_to_query(
+    parsed: InitialParseResult, dataset: Dataset
+) -> LogicalQuery | CompositeQuery[QueryEntity]:
+    """
+    Look up all the referenced entities, and create a JoinClause for each of the entities
+    referenced in the formula. Then map the correct table to each of the expressions in the formula.
+    E.g. sum(d:transactions/duration) / sum(c:transactions/duration_ms) will produce a JoinClause
+    with (d: generic_metrics_distributions) -[counters]-> (c: generic_metrics_counters)
+    Most formulas do not operate on multiple entities, but they get the same treatment as if they
+    did in order to keep consistency. In that case the table is joined on itself.
+    If a formula has only a single MRI and some scalars e.g. sum(d:transactions/duration) + 1, then
+    there's no need for a JoinClause, and this returns a simple LogicalQuery.
+    """
+    if parsed.formula is None:
+        raise InvalidQueryException("Parsed formula has no formula name specified")
+
+    query, nodes = build_formula_query_from_clause(parsed, dataset)
+
+    def alias_wrap(alias: str | None) -> str | None:
+        return None if isinstance(query, LogicalQuery) else alias
+
+    # Build SelectedExpression from root tree
+    # When going through the selected expressions, populate the table aliases
+    def extract_expression(param: InitialParseResult | Any) -> Expression:
+        if not isinstance(param, InitialParseResult):
+            return Literal(None, param)
+        elif param.expression is not None:
+            aggregate_function = param.expression.expression
+            assert isinstance(aggregate_function, (FunctionCall, CurriedFunctionCall))
+            # Metrics aggregates operate on a column
+            column = aggregate_function.parameters[0]
+            assert isinstance(column, Column)
+            return replace(
+                aggregate_function,
+                parameters=(replace(column, table_name=alias_wrap(param.table_alias)),),
+                alias=None,
+            )
+        elif param.formula:
+            parameters = param.parameters or []
+            return FunctionCall(
+                None,
+                param.formula,
+                tuple(extract_expression(p) for p in parameters),
+            )
+        else:
+            raise InvalidQueryException(
+                "Could not build selected expression for formula"
+            )
+
+    parameters = parsed.parameters or []
+    selected_columns = [
+        SelectedExpression(
+            name=AGGREGATE_ALIAS,
+            expression=FunctionCall(
+                alias=AGGREGATE_ALIAS,
+                function_name=parsed.formula,
+                parameters=tuple(extract_expression(p) for p in parameters),
+            ),
+        )
+    ]
+
+    # The groupbys are pushed down to all the nodes of the query. Add them to the groupby of the query
+    groupby = []
+    for leaf_node in nodes:
+        if leaf_node.groupby:
+            for group_exp in leaf_node.groupby:
+                if isinstance(group_exp.expression, Column):
+                    aliased_groupby = replace(
+                        group_exp,
+                        expression=replace(
+                            group_exp.expression,
+                            table_name=alias_wrap(leaf_node.table_alias),
+                        ),
+                    )
+                    selected_columns.append(aliased_groupby)
+                    groupby.append(aliased_groupby.expression)
+
+    if groupby:
+        query.set_ast_groupby(groupby)
+
+    query.set_ast_selected_columns(selected_columns)
+
+    # Go through all the conditions, populate the conditions with the table alias, add them to the query conditions
+    # also needs the metric ID conditions added
+    def extract_filters(param: InitialParseResult | Any) -> list[FunctionCall]:
+        if not isinstance(param, InitialParseResult):
+            return []
+        elif param.expression is not None:
+            conditions = []
+            for c in param.conditions or []:
+                assert isinstance(c, FunctionCall)
+                lhs = c.parameters[0]
+                if isinstance(lhs, Column):
+                    conditions.append(
+                        replace(
+                            c,
+                            parameters=tuple(
+                                [
+                                    replace(
+                                        lhs, table_name=alias_wrap(param.table_alias)
+                                    ),
+                                    *c.parameters[1:],
+                                ]
+                            ),
+                        )
+                    )
+
+            conditions.append(
+                binary_condition(
+                    "equals",
+                    Column(None, alias_wrap(param.table_alias), "metric_id"),
+                    Literal(None, param.mri),
+                )
+            )
+            return conditions
+        elif param.formula:
+            conditions = []
+            for p in param.parameters or []:
+                conditions.extend(extract_filters(p))
+            return conditions
+        else:
+            raise InvalidQueryException("Could not extract valid filters for formula")
+
+    conditions = []
+    for p in parsed.parameters or []:
+        conditions.extend(extract_filters(p))
+
+    query.add_condition_to_ast(combine_and_conditions(conditions))
+
+    return query
+
+
+def convert_timeseries_to_query(
+    parsed: InitialParseResult, dataset: Dataset
+) -> LogicalQuery:
+    if parsed.expression is None:
+        raise InvalidQueryException("Parsed expression has no expression specified")
+
+    selected_columns = [parsed.expression]
+    if parsed.groupby:
+        selected_columns.extend(parsed.groupby)
+    groupby = [g.expression for g in parsed.groupby] if parsed.groupby else None
+
+    metric_value = parsed.mri
+    if not metric_value:
+        raise ParsingException("no MRI specified in MQL query")
+
+    conditions: list[Expression] = [
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "metric_id"),
+            Literal(None, metric_value),
+        )
+    ]
+    if parsed.conditions:
+        conditions.extend(parsed.conditions)
+
+    final_conditions = combine_and_conditions(conditions) if conditions else None
+
+    entity_key = select_entity(metric_value, dataset)
+
+    query = LogicalQuery(
+        from_clause=QueryEntity(
+            key=entity_key, schema=get_entity(entity_key).get_data_model()
+        ),
+        selected_columns=selected_columns,
+        condition=final_conditions,
+        groupby=groupby,
+    )
+    return query
 
 
 def select_entity(mri: str, dataset: Dataset) -> EntityKey:
@@ -1035,13 +1167,75 @@ def populate_query_from_mql_context(
     query: EntityQuery, mql_context_dict: dict[str, Any]
 ) -> tuple[EntityQuery, MQLContext]:
     mql_context = MQLContext.from_dict(mql_context_dict)
-    entity_key = query.get_from_clause().key
 
-    populate_start_end_time(query, mql_context, entity_key)
-    populate_scope(query, mql_context)
-    populate_rollup(query, mql_context)
-    populate_limit(query, mql_context)
-    populate_offset(query, mql_context)
+    # List of entity key/alias tuples
+    entity_data: list[tuple[EntityKey, str | None]] = []
+    if isinstance(query, LogicalQuery):
+        entity_data.append((query.get_from_clause().key, None))
+    elif isinstance(query, CompositeQuery):
+        join_clause = query.get_from_clause()
+        assert isinstance(join_clause, JoinClause)
+
+        alias_node_map = join_clause.get_alias_node_map()
+        for alias, node in alias_node_map.items():
+            data_source = node.data_source
+            assert isinstance(data_source, QueryEntity)
+            entity_data.append((data_source.key, alias))
+
+    selected_time_found = False
+    for entity_key, table_alias in entity_data:
+        time_condition = start_end_time_condition(mql_context, entity_key, table_alias)
+        scope_condition = scope_conditions(mql_context, table_alias)
+        granularity_condition, with_totals, orderby, selected_time = rollup_expressions(
+            mql_context, table_alias
+        )
+
+        context_condition = combine_and_conditions(
+            [time_condition, scope_condition, granularity_condition]
+        )
+        query.add_condition_to_ast(context_condition)
+
+        query.set_totals(with_totals)
+        if orderby:
+            query.set_ast_orderby([orderby])
+
+        if selected_time:
+            selected_time_found = True
+            query.set_ast_selected_columns(
+                list(query.get_selected_columns()) + [selected_time]
+            )
+
+            groupby = query.get_groupby()
+            if groupby:
+                query.set_ast_groupby(list(groupby) + [selected_time.expression])
+            else:
+                query.set_ast_groupby([selected_time.expression])
+
+    if isinstance(query, CompositeQuery) and selected_time_found:
+        # If the query is grouping by time, that needs to be added to the JoinClause keys to
+        # ensure we correctly join the subqueries. The column names will be the same for all the
+        # subqueries, so we just need to map all the table aliases.
+
+        join_clause = query.get_from_clause()
+        assert isinstance(join_clause, JoinClause)
+        base_node_alias = join_clause.right_node.alias
+        other_aliases = [d[1] for d in entity_data if d[1] != base_node_alias]
+        new_conditions = []
+        for other in other_aliases:
+            assert other is not None  # mypy, this should never be None for joins
+            condition = JoinCondition(
+                left=JoinConditionExpression(base_node_alias, "time"),
+                right=JoinConditionExpression(other, "time"),
+            )
+            new_conditions.append(condition)
+
+        conditions = list(join_clause.keys)
+        query.set_from_clause(replace(join_clause, keys=conditions + new_conditions))
+
+    limit = limit_value(mql_context)
+    offset = offset_value(mql_context)
+    query.set_limit(limit)
+    query.set_offset(offset) if offset else None
 
     return query, mql_context
 

--- a/snuba/query/mql/parser_supported_join.py
+++ b/snuba/query/mql/parser_supported_join.py
@@ -95,6 +95,7 @@ class InitialParseResult:
     groupby: list[SelectedExpression] | None = None
     conditions: list[Expression] | None = None
     mri: str | None = None
+    table_alias: str | None = None
 
 
 FormulaParameter = Union[InitialParseResult, int, float]
@@ -1278,7 +1279,7 @@ MQL_POST_PROCESSORS: CustomProcessors = POST_PROCESSORS + [
 ]
 
 
-def parse_mql_query(
+def parse_mql_query_new(
     body: str,
     mql_context_dict: dict[str, Any],
     dataset: Dataset,

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -70,7 +70,7 @@ def parse_subscriptables(
         key_name = match[2]
         return SubscriptableReference(
             alias=exp.column_name,
-            column=Column(None, None, col_name),
+            column=Column(None, exp.table_name, col_name),
             key=Literal(None, key_name),
         )
 

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1017,6 +1017,9 @@ def _qualify_columns(
         if not isinstance(exp, Column):
             return exp
 
+        if exp.table_name is not None:
+            return exp  # Table name is already qualified
+
         parts = exp.column_name.split(".", 1)
         if len(parts) != 2 or parts[0] not in aliases:
             raise ParsingException(

--- a/tests/query/data_source/test_join.py
+++ b/tests/query/data_source/test_join.py
@@ -1,5 +1,3 @@
-import pytest
-
 from snuba.clickhouse.columns import UUID, Any, ColumnSet, String, UInt
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.query import SelectedExpression
@@ -58,19 +56,6 @@ def test_simple_join() -> None:
     assert "err.event_id" in joined_cols
     assert "groups.id" in joined_cols
     assert "groups.message" in joined_cols
-
-    with pytest.raises(AssertionError):
-        JoinClause(
-            left_node=node_err,
-            right_node=node_group,
-            keys=[
-                JoinCondition(
-                    left=JoinConditionExpression("err", "missing_col"),
-                    right=JoinConditionExpression("groups", "another_missing_col"),
-                )
-            ],
-            join_type=JoinType.INNER,
-        )
 
 
 def test_complex_joins() -> None:

--- a/tests/query/parser/test_formula_mql_query.py
+++ b/tests/query/parser/test_formula_mql_query.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.factory import get_dataset
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query.composite import CompositeQuery
+from snuba.query.conditions import binary_condition, combine_and_conditions
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinType,
+)
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.dsl import divide, literals_tuple
+from snuba.query.expressions import (
+    Column,
+    FunctionCall,
+    Literal,
+    SubscriptableReference,
+)
+from snuba.query.mql.parser_supported_join import parse_mql_query_new
+
+# Commonly used expressions
+from_distributions = QueryEntity(
+    EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+    get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
+)
+
+
+def time_expression(table_alias: str | None = None) -> FunctionCall:
+    alias_prefix = f"{table_alias}." if table_alias else ""
+    return FunctionCall(
+        f"_snuba_{alias_prefix}time",
+        "toStartOfInterval",
+        (
+            Column("_snuba_timestamp", table_alias, "timestamp"),
+            FunctionCall(None, "toIntervalSecond", (Literal(None, 60),)),
+            Literal(None, "Universal"),
+        ),
+    )
+
+
+def condition(table_alias: str | None = None) -> list[FunctionCall]:
+    conditions = [
+        binary_condition(
+            "greaterOrEquals",
+            Column("_snuba_timestamp", table_alias, "timestamp"),
+            Literal(None, datetime(2023, 11, 23, 18, 30)),
+        ),
+        binary_condition(
+            "less",
+            Column("_snuba_timestamp", table_alias, "timestamp"),
+            Literal(None, datetime(2023, 11, 23, 22, 30)),
+        ),
+        binary_condition(
+            "in",
+            Column("_snuba_project_id", table_alias, "project_id"),
+            literals_tuple(None, [Literal(alias=None, value=11)]),
+        ),
+        binary_condition(
+            "in",
+            Column("_snuba_org_id", table_alias, "org_id"),
+            literals_tuple(None, [Literal(alias=None, value=1)]),
+        ),
+        binary_condition(
+            "equals",
+            Column("_snuba_use_case_id", table_alias, "use_case_id"),
+            Literal(None, value="transactions"),
+        ),
+        binary_condition(
+            "equals",
+            Column("_snuba_granularity", table_alias, "granularity"),
+            Literal(None, value=60),
+        ),
+    ]
+
+    return conditions
+
+
+mql_context = {
+    "entity": "generic_metrics_distributions",
+    "start": "2023-11-23T18:30:00",
+    "end": "2023-11-23T22:30:00",
+    "rollup": {
+        "granularity": 60,
+        "interval": 60,
+        "with_totals": "False",
+        "orderby": None,
+    },
+    "scope": {
+        "org_ids": [1],
+        "project_ids": [11],
+        "use_case_id": "transactions",
+    },
+    "indexer_mappings": {
+        "d:transactions/duration@millisecond": 123456,
+        "status_code": 222222,
+        "transaction": 333333,
+    },
+    "limit": None,
+    "offset": None,
+}
+
+
+def timeseries(
+    agg: str, metric_id: int, condition: FunctionCall | None = None
+) -> FunctionCall:
+    metric_condition = FunctionCall(
+        None,
+        "equals",
+        (
+            Column(
+                "_snuba_metric_id",
+                None,
+                "metric_id",
+            ),
+            Literal(None, metric_id),
+        ),
+    )
+    if condition:
+        metric_condition = FunctionCall(
+            None,
+            "and",
+            (
+                condition,
+                metric_condition,
+            ),
+        )
+
+    return FunctionCall(
+        None,
+        agg,
+        (
+            Column("_snuba_value", None, "value"),
+            metric_condition,
+        ),
+    )
+
+
+def metric_id_condition(metric_id: int, table_alias: str | None = None) -> FunctionCall:
+    return FunctionCall(
+        None,
+        "equals",
+        (
+            Column("_snuba_metric_id", table_alias, "metric_id"),
+            Literal(None, metric_id),
+        ),
+    )
+
+
+def tag_column(tag: str, table_alias: str | None = None) -> SubscriptableReference:
+    tag_val = mql_context.get("indexer_mappings").get(tag)  # type: ignore
+    return SubscriptableReference(
+        alias=f"_snuba_tags_raw[{tag_val}]",
+        column=Column(
+            alias="_snuba_tags_raw",
+            table_name=table_alias,
+            column_name="tags_raw",
+        ),
+        key=Literal(alias=None, value=f"{tag_val}"),
+    )
+
+
+def test_simple_formula() -> None:
+    query_body = "sum(`d:transactions/duration@millisecond`){status_code:200} / sum(`d:transactions/duration@millisecond`)"
+
+    expected_selected = SelectedExpression(
+        "aggregate_value",
+        divide(
+            FunctionCall(
+                None,
+                "sum",
+                (Column("_snuba_value", "d0", "value"),),
+            ),
+            FunctionCall(
+                None,
+                "sum",
+                (Column("_snuba_value", "d1", "value"),),
+            ),
+            "_snuba_aggregate_value",
+        ),
+    )
+
+    join_clause = JoinClause(
+        left_node=IndividualNode(
+            alias="d1",
+            data_source=from_distributions,
+        ),
+        right_node=IndividualNode(
+            alias="d0",
+            data_source=from_distributions,
+        ),
+        keys=[
+            JoinCondition(
+                left=JoinConditionExpression(table_alias="d0", column="time"),
+                right=JoinConditionExpression(table_alias="d1", column="time"),
+            )
+        ],
+        join_type=JoinType.INNER,
+        join_modifier=None,
+    )
+
+    tag_condition = binary_condition(
+        "equals", tag_column("status_code", "d0"), Literal(None, "200")
+    )
+    metric_condition1 = metric_id_condition(123456, "d0")
+    metric_condition2 = metric_id_condition(123456, "d1")
+    formula_condition = combine_and_conditions(
+        condition("d0")
+        + condition("d1")
+        + [tag_condition, metric_condition1, metric_condition2]
+    )
+
+    expected = CompositeQuery(
+        from_clause=join_clause,
+        selected_columns=[
+            expected_selected,
+            SelectedExpression(
+                "time",
+                time_expression("d1"),
+            ),
+            SelectedExpression(
+                "time",
+                time_expression("d0"),
+            ),
+        ],
+        groupby=[time_expression("d1"), time_expression("d0")],
+        condition=formula_condition,
+        order_by=[
+            OrderBy(
+                direction=OrderByDirection.ASC,
+                expression=time_expression("d0"),
+            ),
+        ],
+        limit=1000,
+        offset=0,
+    )
+
+    generic_metrics = get_dataset(
+        "generic_metrics",
+    )
+    query = parse_mql_query_new(str(query_body), mql_context, generic_metrics)
+    eq, reason = query.equals(expected)
+    assert eq, reason


### PR DESCRIPTION
### Overview
Most of this code was adapted from: https://github.com/getsentry/snuba/pull/5717. This PR contains the fundamental changes for supporting parsing simple formulas into the appropriate `CompositeQuery` object that contains a `JoinClause`. Note that this CompositeQuery is not executable yet as we still need to add metric subquery generator support. This PR only focuses on the parsing stage, and eventually, we can iteratively add support down the query pipeline. To accomplish this, a new parser file, `parser_supported_join.py`, was created to isolate between the parsing stages. This allows us to iterate on the new MQL parser without affecting the current formula queries. Later, when the parser supports all formulas to JOINs (filters, brackets, groupbys, arbitrary functions, etc.), we can feature flag cut the queries over from the old parser to the new one. Then, delete the old parser.


### Testing
See `tests/query/parser/test_formula_mql_query.py`.