### PR TITLE
feat(group-attributes): Add new column for group first release

### DIFF
--- a/snuba/snuba_migrations/group_attributes/0004_add_new_first_release_column_to_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0004_add_new_first_release_column_to_group_attributes.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_local",
+                column=Column(
+                    "group_first_release",
+                    UInt(64, Modifiers(nullable=True)),
+                ),
+                target=OperationTarget.LOCAL,
+                after="group_priority",
+            ),
+            operations.AddColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_dist",
+                column=Column(
+                    "group_first_release",
+                    UInt(64, Modifiers(nullable=True)),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+                after="group_priority",
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_dist",
+                column_name="group_first_release",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_local",
+                column_name="group_first_release",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
Add a new column with a different name for the Group.first_release field to the GroupAttributes table.

Un-revert of https://github.com/getsentry/snuba/pull/6055