### PR TITLE
fix(capman): emit the bytes scanned metric from db_query

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -851,6 +851,10 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
     ) -> None:
         pass
 
+    @property
+    def storage_key(self) -> StorageKey:
+        return self._storage_key
+
 
 class PassthroughPolicy(AllocationPolicy):
     def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -285,13 +285,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             return
         if bytes_scanned == 0:
             return
-        # we emitted both kinds of bytes scanned in _get_bytes_scanned_in_query however
-        # this metric shows what is actually being used to enforce the policy
-        self.metrics.increment(
-            "bytes_scanned",
-            bytes_scanned,
-            tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
-        )
         if "organization_id" in tenant_ids:
             org_limit_bytes_scanned = self.__get_org_limit_bytes_scanned(
                 tenant_ids.get("organization_id")

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -686,7 +686,7 @@ def _record_bytes_scanned(result_or_error: QueryResultOrError, attribution_info:
     custom_metrics = MetricsWrapper(environment.metrics, "allocation_policy")
 
     if result_or_error.query_result:
-        progress_bytes_scanned = cast(int, result_or_error.query_result.result.get("profile", {}).get("progress_bytes", None))  # type: ignore
+        progress_bytes_scanned = cast(int, result_or_error.query_result.result.get("profile", {}).get("progress_bytes", 0))  # type: ignore
         custom_metrics.increment(
             "bytes_scanned",
             progress_bytes_scanned,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -687,7 +687,7 @@ def _record_bytes_scanned(
     attribution_info: AttributionInfo,
     dataset_name: str,
     storage_key: StorageKey,
-):
+) -> None:
     custom_metrics = MetricsWrapper(environment.metrics, "allocation_policy")
 
     if result_or_error.query_result:

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -277,7 +277,7 @@ def test_db_record_bytes_scanned() -> None:
     assert len(metrics) == 1
     assert metrics[0].tags == {
         "referrer": attribution_info.referrer,
-        "dataset_name": dataset_name,
+        "dataset": dataset_name,
         "storage_key": storage_key.value,
     }
 


### PR DESCRIPTION
closes https://getsentry.atlassian.net/browse/SNS-2812

Right now the bytes_scanned metric that is used in our [customer dashboard](https://app.datadoghq.com/dashboard/tjn-nwy-wwf/snuba-customer-dashboard?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1719517147379&to_ts=1719524347379&live=true) and our [API abuse dashboard](https://app.datadoghq.com/dashboard/u66-3d3-a27/snuba-api-abuse) is emitted from the BytesScannedWindowAllocationPolicy ([code](https://github.com/getsentry/snuba/blob/master/snuba/query/allocation_policies/bytes_scanned_window_policy.py#L290-L294))

There is a [plan](https://www.notion.so/sentry/Increasing-visibility-into-the-Capacity-Management-System-c16b375ed2ee43c19cd2fa163fc93332) to deprecate the BytesScannedWindowPolicy and it already does not exist on replays and spans.

This breaks that dashboard.

This metric should be emitted independently of any policy at a higher level (e.g. db_query)