### PR TITLE
chore: new temporary storage set

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -20,6 +20,7 @@ _HARDCODED_STORAGE_SET_KEYS = {
     "GROUP_ATTRIBUTES": "group_attributes",
     "METRICS_SUMMARIES": "metrics_summaries",
     "PROFILE_CHUNKS": "profile_chunks",
+    "SEARCH_ISSUES_TMP": "search_issues_tmp",
 }
 
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -115,6 +115,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "generic_metrics_gauges",
             "metrics_summaries",
             "profile_chunks",
+            "search_issues_tmp",
         },
         "single_node": True,
     },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -35,6 +35,7 @@ CLUSTERS = [
             "generic_metrics_gauges",
             "metrics_summaries",
             "profile_chunks",
+            "search_issues_tmp",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -59,6 +59,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "generic_metrics_gauges",
             "metrics_summaries",
             "profile_chunks",
+            "search_issues_tmp",
         },
         "single_node": False,
         "cluster_name": "storage_cluster",


### PR DESCRIPTION
the purpose of this pr is to create a new storage set.

with the high level goal of enabling the creation of a distributed table on a query node that can access both search_issues and errors.
see https://getsentry.atlassian.net/browse/INF-138

## next step: 
storage set to cluster mapping https://github.com/getsentry/ops/pull/11246

## long term plan for context (optional):
so i will create a new storage set, create a migration on it to create distributed table, and then delete the new storage set


