### PR TITLE
bytes_scanned_window_policy DD metric

### DIFF
--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -216,6 +216,10 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             granted_quota = granted_quotas[0]
             is_throttled = False
             if granted_quota.granted <= 0:
+                self.metrics.increment(
+                    "bytes_scanned_window_policy_throttle",
+                    tags={"referrer": str(referrer)},
+                )
                 is_throttled = True
                 explanation[
                     "reason"

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -901,6 +901,9 @@ def _apply_allocation_policies_quota(
         _add_quota_info(summary, _THROTTLED_BY, throttle_quota_and_policy)
         stats["quota_allowance"]["summary"] = summary
 
+        if throttle_quota_and_policy is not None:
+            metrics.increment("db_query_throttled_query")
+
         if not can_run:
             raise AllocationPolicyViolations.from_args(stats["quota_allowance"])
         # Before allocation policies were a thing, the query pipeline would apply


### PR DESCRIPTION
In a [previous PR](https://github.com/getsentry/sentry/pull/73442), we emit a Sentry warning and a GCP log for every query throttled by Snuba's capacity management system. However, we quickly realized [a large volume of queries were throttled](https://sentry.sentry.io/issues/5550501231/?project=1&query=&referrer=issue-stream&statsPeriod=24h&stream_index=5).

A potential solution we came up with is to sample the number of throttled queries we emit warnings and logging for, but before this, we realized that every throttled query I manually inspected from GCP logs is throttled by [BytesScannedWindowAllocationPolicy](https://github.com/getsentry/snuba/blob/f8e1456907f046215a3c284b89c91a28d7709191/snuba/query/allocation_policies/bytes_scanned_window_policy.py), a policy we plan on [deprecating anyways](https://www.notion.so/sentry/Increasing-visibility-into-the-Capacity-Management-System-c16b375ed2ee43c19cd2fa163fc93332?pvs=4#185824a1f34b4ff6b31fe1c6ea872aca). A possible explanation of this occurrence is that BytesScannedWindowPolicy does not reject queries - it only throttles them.

We use this PR to answer 2 questions:
1. is almost every throttled query throttled by BytesScannedWindowAllocationPolicy?
2. out of all the queries that go through Snuba's CapMan, how many are throttled?