### PR TITLE
fix(replays): Add ClickHouse query aggregation settings to materialized view

### DIFF
--- a/snuba/datasets/configuration/replays/storages/aggregated.yaml
+++ b/snuba/datasets/configuration/replays/storages/aggregated.yaml
@@ -346,6 +346,11 @@ schema:
   dist_table_name: replays_aggregated_dist
 query_processors:
   - processor: TableRateLimit
+  - processor: ClickhouseSettingsOverride
+    args:
+      settings:
+        max_rows_to_group_by: 1000000
+        group_by_overflow_mode: any
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 allocation_policies:


### PR DESCRIPTION
Without capping the aggregation complexity we run the risk of running out of memory.  This slows the query down significantly.  By applying these optimizations (which are identical to the non-materialized replays dataset) we can significantly improve performance and significantly reduce resource consumption.