### PR TITLE
fix: move an import that may be causing issue with sentry devservice

### DIFF
--- a/snuba/migrations/autogeneration/main.py
+++ b/snuba/migrations/autogeneration/main.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 from typing import Optional
 
-from black import Mode, format_str  # type: ignore
 from yaml import safe_load
 
 from snuba.clusters.storage_sets import StorageSetKey
@@ -109,6 +108,9 @@ def write_migration(
         raise ValueError(
             f"Error: The migration number {nextnum} was larger than the last migration in the group loader '{group_loader_name}', but the migration already exists"
         )
+
+    from black import Mode, format_str  # type: ignore
+
     with open(newpath, "w") as f:
         f.write(format_str(migration, mode=Mode()))
     return newpath


### PR DESCRIPTION
`sentry devservices up`
```
> Failed to check health: <urlopen error [Errno 61] Connection refused>
  > 'redis' is healthy
  > 'postgres' is healthy
  > 'clickhouse' is healthy
  > Health check for 'snuba' failed, retrying in 10s (attempt 2 of 12)...
  > 'kafka' is healthy
  > Health check for 'snuba' failed, retrying in 10s (attempt 3 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 4 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 5 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 6 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 7 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 8 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 9 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 10 of 12)...
  > Health check for 'snuba' failed, retrying in 10s (attempt 11 of 12)...
```
```
2024-07-08 16:53:38,144 Initializing Snuba...
2024-07-08 16:53:44,015 Generating grammar tables from /usr/local/lib/python3.11/site-packages/blib2to3/Grammar.txt
2024-07-08 16:53:44,102 Writing grammar tables to /home/snuba/.cache/black/22.6.0/Grammar3.11.8.final.0.pickle
2024-07-08 16:53:44,104 Writing failed: [Errno 2] No such file or directory: '/home/snuba/.cache/black/22.6.0/tmpu0ma54zm'
2024-07-08 16:53:44,105 Generating grammar tables from /usr/local/lib/python3.11/site-packages/blib2to3/PatternGrammar.txt
2024-07-08 16:53:44,110 Writing grammar tables to /home/snuba/.cache/black/22.6.0/PatternGrammar3.11.8.final.0.pickle
2024-07-08 16:53:44,111 Writing failed: [Errno 2] No such file or directory: '/home/snuba/.cache/black/22.6.0/tmpjjpl94vi'
2024-07-08 16:53:44,173 Snuba initialization took 6.033616732995142s
```