### PR TITLE
ref(snuba-deletes): add DeletionSettings

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -114,6 +114,12 @@ query_processors:
         contexts:
           trace.trace_id: trace_id
 
+deletion_settings:
+  is_enabled: 0
+  max_rows_to_delete: 1000
+  tables:
+    - search_issues_local_v2
+
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -538,6 +538,25 @@ ENTITY_JOIN_RELATIONSHIPS = {
     },
 }
 
+DELETION_SETTINGS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "is_enabled": {
+            "type": "integer",
+        },
+        "tables": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Names of the tables to delete from.",
+        },
+        "max_rows_to_delete": {
+            "type": "integer",
+        },
+    },
+    "required": ["is_enabled", "tables"],
+    "additionalProperties": False,
+}
+
 # Full schemas:
 
 V1_READABLE_STORAGE_SCHEMA = {
@@ -551,6 +570,7 @@ V1_READABLE_STORAGE_SCHEMA = {
         "readiness_state": READINESS_STATE_SCHEMA,
         "schema": SCHEMA_SCHEMA,
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
+        "deletion_settings": DELETION_SETTINGS_SCHEMA,
         "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
         "allocation_policies": STORAGE_ALLOCATION_POLICIES_SCHEMA,
         "required_time_column": {
@@ -581,6 +601,7 @@ V1_WRITABLE_STORAGE_SCHEMA = {
         "schema": SCHEMA_SCHEMA,
         "stream_loader": STREAM_LOADER_SCHEMA,
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
+        "deletion_settings": DELETION_SETTINGS_SCHEMA,
         "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
         "allocation_policies": STORAGE_ALLOCATION_POLICIES_SCHEMA,
         "replacer_processor": STORAGE_REPLACER_PROCESSOR_SCHEMA,

--- a/snuba/datasets/deletion_settings.py
+++ b/snuba/datasets/deletion_settings.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+MAX_ROWS_TO_DELETE_DEFAULT = 1000
+
+
+@dataclass
+class DeletionSettings:
+    is_enabled: int
+    tables: Sequence[str]
+    max_rows_to_delete: int = MAX_ROWS_TO_DELETE_DEFAULT

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -11,6 +11,7 @@ from snuba.clusters.cluster import (
     get_cluster,
 )
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.deletion_settings import DeletionSettings
 from snuba.datasets.readiness_state import ReadinessState
 from snuba.datasets.schemas import Schema
 from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
@@ -130,12 +131,14 @@ class ReadableTableStorage(ReadableStorage):
         schema: Schema,
         readiness_state: ReadinessState,
         query_processors: Optional[Sequence[ClickhouseQueryProcessor]] = None,
+        deletion_settings: Optional[DeletionSettings] = None,
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
         allocation_policies: Optional[list[AllocationPolicy]] = None,
         required_time_column: Optional[str] = None,
     ) -> None:
         self.__storage_key = storage_key
         self.__query_processors = query_processors or []
+        self.__deletion_settings = deletion_settings or DeletionSettings(0, [], 0)
         self.__mandatory_condition_checkers = mandatory_condition_checkers or []
         self.__allocation_policies = allocation_policies or []
         super().__init__(
@@ -157,6 +160,9 @@ class ReadableTableStorage(ReadableStorage):
     def get_allocation_policies(self) -> list[AllocationPolicy]:
         return self.__allocation_policies or super().get_allocation_policies()
 
+    def get_deletion_settings(self) -> DeletionSettings:
+        return self.__deletion_settings
+
 
 class WritableTableStorage(ReadableTableStorage, WritableStorage):
     def __init__(
@@ -170,6 +176,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
         allocation_policies: Optional[list[AllocationPolicy]] = None,
         replacer_processor: Optional[ReplacerProcessor[Any]] = None,
+        deletion_settings: Optional[DeletionSettings] = None,
         writer_options: ClickhouseWriterOptions = None,
         write_format: WriteFormat = WriteFormat.JSON,
         ignore_write_errors: bool = False,
@@ -182,6 +189,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
             schema,
             readiness_state,
             query_processors,
+            deletion_settings,
             mandatory_condition_checkers,
             allocation_policies,
             required_time_column=required_time_column,


### PR DESCRIPTION
**context:**
Embarking on adding (lightweight) deletes to Snuba. The first storage we want to add this to is search issues, since right now you cannot delete via the Sentry application. 

The first step is to add some definitions on the storage that we will use in the delete pipeline (which will be a new endpoint we add later). 

**changes:**
This PR adds some deletion settings that are needed. they are:

* `is_enabled`: whether deletes are enabled for the storage. If no deletion settings are provided in the yaml file, we default to an empty deletion settings state (where `is_enabled` is `0`)
* `tables`: list of tables that we delete from. in some cases there will be more than one table to delete from - as is the case for storages that have a materialized view and where both the local and aggregated tables are queried from the product. In the empty deletion settings state tables is an empty list
* `max_rows_to_delete`: how many rows you can delete in one request. we want some limits to prevent excessive load on clickhouse. defaults to 1000 if deletions are enabled but `max_rows_to_delete` is not specified. in the empty deletion settings state `max_rows_to_delete` is `0`.