### PR TITLE
feat(replays): Set platform as empty string if platform is not provided

### DIFF
--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -53,7 +53,7 @@ pub fn deserialize_message(
                 event_hash: click.event_hash,
                 offset,
                 partition,
-                platform: "javascript".to_string(),
+                platform: "".to_string(),
                 project_id: replay_message.project_id,
                 replay_id: replay_message.replay_id,
                 retention_days: replay_message.retention_days,
@@ -134,7 +134,7 @@ pub fn deserialize_message(
                 os_name: event.contexts.os.name.unwrap_or_default(),
                 os_version: event.contexts.os.version.unwrap_or_default(),
                 partition,
-                platform: event.platform.unwrap_or("javascript".to_string()),
+                platform: event.platform.unwrap_or("".to_string()),
                 project_id: replay_message.project_id,
                 release: event.release.unwrap_or_default(),
                 replay_id: event.replay_id,
@@ -181,7 +181,7 @@ pub fn deserialize_message(
                 info_id: event.info_id.unwrap_or_default(),
                 offset,
                 partition,
-                platform: "javascript".to_string(),
+                platform: "".to_string(),
                 project_id: replay_message.project_id,
                 replay_id: replay_message.replay_id,
                 retention_days: replay_message.retention_days,
@@ -197,7 +197,7 @@ pub fn deserialize_message(
                 event_hash: Uuid::from_u64_pair(0, event.viewed_by_id),
                 offset,
                 partition,
-                platform: "javascript".to_string(),
+                platform: "".to_string(),
                 project_id: replay_message.project_id,
                 replay_id: replay_message.replay_id,
                 retention_days: replay_message.retention_days,
@@ -699,7 +699,7 @@ mod tests {
         assert_eq!(replay_row.ip_address_v4, None);
         assert_eq!(replay_row.ip_address_v6, None);
         assert_eq!(replay_row.is_archived, 0);
-        assert_eq!(replay_row.platform, "javascript".to_string());
+        assert_eq!(replay_row.platform, "".to_string());
         assert_eq!(replay_row.project_id, 1);
         assert_eq!(replay_row.replay_start_timestamp, None);
         assert_eq!(replay_row.retention_days, 30);
@@ -825,7 +825,7 @@ mod tests {
         assert_eq!(replay_row.ip_address_v4, None);
         assert_eq!(replay_row.ip_address_v6, None);
         assert_eq!(replay_row.is_archived, 0);
-        assert_eq!(replay_row.platform, "javascript".to_string());
+        assert_eq!(replay_row.platform, "".to_string());
         assert_eq!(replay_row.replay_start_timestamp, None);
         assert_eq!(replay_row.session_sample_rate, -1.0);
         assert_eq!(replay_row.title, None);
@@ -920,7 +920,7 @@ mod tests {
         assert_eq!(replay_row.ip_address_v4, None);
         assert_eq!(replay_row.ip_address_v6, None);
         assert_eq!(replay_row.is_archived, 0);
-        assert_eq!(replay_row.platform, "javascript".to_string());
+        assert_eq!(replay_row.platform, "".to_string());
         assert_eq!(replay_row.replay_start_timestamp, None);
         assert_eq!(replay_row.session_sample_rate, -1.0);
         assert_eq!(replay_row.title, None);
@@ -1003,7 +1003,7 @@ mod tests {
         assert_eq!(replay_row.info_id, Uuid::nil());
         assert_eq!(replay_row.ip_address_v4, None);
         assert_eq!(replay_row.ip_address_v6, None);
-        assert_eq!(replay_row.platform, "javascript".to_string());
+        assert_eq!(replay_row.platform, "".to_string());
         assert_eq!(replay_row.replay_start_timestamp, None);
         assert_eq!(replay_row.session_sample_rate, -1.0);
         assert_eq!(replay_row.title, None);
@@ -1079,7 +1079,7 @@ mod tests {
         assert_eq!(&replay_row.os_name, "");
         assert_eq!(&replay_row.os_version, "");
         assert_eq!(replay_row.partition, 0);
-        assert_eq!(replay_row.platform, "javascript".to_string()); // ?
+        assert_eq!(replay_row.platform, "".to_string());
         assert_eq!(&replay_row.release, "");
         assert_eq!(replay_row.replay_start_timestamp, None);
         assert_eq!(&replay_row.replay_type, "");

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__archive.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__archive.json.snap
@@ -40,7 +40,7 @@ expression: snapshot_payload
     "os_name": "",
     "os_version": "",
     "partition": 0,
-    "platform": "javascript",
+    "platform": "",
     "project_id": 1,
     "release": "",
     "replay_id": "834f314c-aae5-4030-a1b0-dc52b202f24a",

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__click-serialized.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__click-serialized.json.snap
@@ -43,7 +43,7 @@ expression: snapshot_payload
     "os_name": "",
     "os_version": "",
     "partition": 0,
-    "platform": "javascript",
+    "platform": "",
     "project_id": 1,
     "release": "",
     "replay_id": "834f314c-aae5-4030-a1b0-dc52b202f24a",

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__click.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__click.json.snap
@@ -43,7 +43,7 @@ expression: snapshot_payload
     "os_name": "",
     "os_version": "",
     "partition": 0,
-    "platform": "javascript",
+    "platform": "",
     "project_id": 1,
     "release": "",
     "replay_id": "834f314c-aae5-4030-a1b0-dc52b202f24a",

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__event-link.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__event-link.json.snap
@@ -40,7 +40,7 @@ expression: snapshot_payload
     "os_name": "",
     "os_version": "",
     "partition": 0,
-    "platform": "javascript",
+    "platform": "",
     "project_id": 1,
     "release": "",
     "replay_id": "834f314c-aae5-4030-a1b0-dc52b202f24a",

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__viewed.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@ingest-replay-events-ReplaysProcessor-ingest-replay-events__1__viewed.json.snap
@@ -40,7 +40,7 @@ expression: snapshot_payload
     "os_name": "",
     "os_version": "",
     "partition": 0,
-    "platform": "javascript",
+    "platform": "",
     "project_id": 1,
     "release": "",
     "replay_id": "834f314c-aae5-4030-a1b0-dc52b202f24a",

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -387,7 +387,7 @@ class TestReplaysProcessor:
         assert received["error_sample_rate"] == -1.0
         assert received["session_sample_rate"] == -1.0
 
-        assert received["platform"] == "javascript"
+        assert received["platform"] == ""
         assert received["replay_type"] == ""
         assert received["dist"] == ""
         assert received["user_name"] == ""
@@ -529,7 +529,7 @@ class TestReplaysActionProcessor:
         assert row["trace_ids"] == []
         assert row["error_ids"] == []
         assert row["urls"] == []
-        assert row["platform"] == "javascript"
+        assert row["platform"] == ""
         assert row["user"] == ""
         assert row["sdk_name"] == ""
         assert row["sdk_version"] == ""


### PR DESCRIPTION
Previously it was set to `javascript` as that was the only platform replay was available on.  With the addition of mobile replays this is no longer true.  The query in `sentry` already uses the `anyIf` operator and filters out empty values.

Related: https://github.com/getsentry/sentry/issues/74074