### PR TITLE
feat(profiling): Add profiler id column to transactions

### DIFF
--- a/snuba/snuba_migrations/transactions/0023_add_profiler_id_column.py
+++ b/snuba/snuba_migrations/transactions/0023_add_profiler_id_column.py
@@ -1,0 +1,40 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import UUID, Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name=table_name,
+                column=Column("profiler_id", UUID(Modifiers(nullable=True))),
+                after="profile_id",
+                target=target,
+            )
+            for table_name, target in [
+                ("transactions_local", OperationTarget.LOCAL),
+                ("transactions_dist", OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name=table_name,
+                column_name="profiler_id",
+                target=target,
+            )
+            for table_name, target in [
+                ("transactions_dist", OperationTarget.DISTRIBUTED),
+                ("transactions_local", OperationTarget.LOCAL),
+            ]
+        ]


### PR DESCRIPTION
For continuous profiling, the profile context will contain a new value `profiler_id`, not to be confused with `profile_id`. A `profiler_id` is set on the transaction's profile context when the continuous profiler is enabled. This is a separate value from the existing `profile_id` because we need to be able to distinguish if the transaction is associated with a transaction based profile or a continuous profile and load the profile from the correct place.