### PR TITLE
chore: make snuba co-owners of datasets again

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,16 +2,16 @@
 * @getsentry/owners-snuba
 
 # datasets
-/snuba/datasets/configuration/issues                @getsentry/issues
-/snuba/datasets/configuration/group_attributes      @getsentry/issues
-/snuba/datasets/configuration/groupedmessage        @getsentry/issues
-/snuba/datasets/configuration/groupassignee         @getsentry/issues
-/snuba/datasets/configuration/spans                 @getsentry/performance
-/snuba/datasets/configuration/transactions          @getsentry/performance
-/snuba/datasets/configuration/functions             @getsentry/profiling
-/snuba/datasets/configuration/profiles              @getsentry/profiling
-/snuba/datasets/configuration/replays               @getsentry/replay-backend
-/snuba/datasets/configuration/metrics               @getsentry/telemetry-experience
+/snuba/datasets/configuration/issues                @getsentry/issues @getsentry/owners-snuba
+/snuba/datasets/configuration/group_attributes      @getsentry/issues @getsentry/owners-snuba
+/snuba/datasets/configuration/groupedmessage        @getsentry/issues @getsentry/owners-snuba
+/snuba/datasets/configuration/groupassignee         @getsentry/issues @getsentry/owners-snuba
+/snuba/datasets/configuration/spans                 @getsentry/performance @getsentry/owners-snuba
+/snuba/datasets/configuration/transactions          @getsentry/performance @getsentry/owners-snuba
+/snuba/datasets/configuration/functions             @getsentry/profiling @getsentry/owners-snuba
+/snuba/datasets/configuration/profiles              @getsentry/profiling @getsentry/owners-snuba
+/snuba/datasets/configuration/replays               @getsentry/replay-backend @getsentry/owners-snuba
+/snuba/datasets/configuration/metrics               @getsentry/telemetry-experience @getsentry/owners-snuba
 
 # rust_snuba
 /rust_snuba @getsentry/owners-snuba @getsentry/processing


### PR DESCRIPTION
There was a previous PR that made product teams CODEOWNERS for their snuba datasets. But that PR made it so snuba is no longer codeowners. This PR fixes this to make it so both product teams and snuba own the datasets.