### PR TITLE
fix: CH SaaS issues with alias cache

### DIFF
--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -37,10 +37,15 @@ class ExpressionFormatterBase(ExpressionVisitor[str], ABC):
     the visited expression, the return value is the formatted string.
     """
 
-    def __init__(self, parsing_context: Optional[ParsingContext] = None) -> None:
+    def __init__(
+        self,
+        parsing_context: Optional[ParsingContext] = None,
+        include_parsing_context: bool = True,
+    ) -> None:
         self._parsing_context = (
             parsing_context if parsing_context is not None else ParsingContext()
         )
+        self._include_parsing_context = include_parsing_context
 
     def _alias(self, formatted_exp: str, alias: Optional[str]) -> str:
         if not alias:
@@ -53,7 +58,8 @@ class ExpressionFormatterBase(ExpressionVisitor[str], ABC):
             assert ret is not None
             return ret
         else:
-            self._parsing_context.add_alias(alias)
+            if self._include_parsing_context:
+                self._parsing_context.add_alias(alias)
             return f"({formatted_exp} AS {escape_alias(alias)})"
 
     @abstractmethod

--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -97,11 +97,13 @@ def _format_query_content(
     """
     parsing_context = ParsingContext()
     formatter = expression_formatter_type(parsing_context)
+    # Skip the alias cache for select clause
+    select_formatter = expression_formatter_type(None, include_parsing_context=False)
 
     return [
         v
         for v in [
-            _format_select(query, formatter),
+            _format_select(query, select_formatter),
             PaddingNode(
                 "FROM",
                 DataSourceFormatter(expression_formatter_type).visit(

--- a/tests/test_spans_api.py
+++ b/tests/test_spans_api.py
@@ -186,6 +186,27 @@ class TestSpansApi(BaseApiTest):
         assert response.status_code == 200, response.data
         assert data["data"][0]["aggregate"] > 10, data
 
+    def test_alias(self) -> None:
+        """
+        Test aliasing
+        """
+        from_date = (self.base_time - self.skew).isoformat()
+        to_date = (self.base_time + self.skew).isoformat()
+        response = self._post_query(
+            f"""MATCH (spans)
+                SELECT countIf(or(equals(op, 'browser'), equals(op, 'resource.link'))) AS matching_count
+                WHERE project_id = 1
+                AND timestamp >= toDateTime('{from_date}')
+                AND timestamp < toDateTime('{to_date}')
+            """
+        )
+        data = json.loads(response.data)
+        assert response.status_code == 200, response.data
+        assert (
+            "countIf((equals((op AS _snuba_op), 'browser') OR equals((op AS _snuba_op), 'resource.link'))"
+            in data["sql"]
+        )
+
     def test_get_group_sorted_by_exclusive_time(self) -> None:
         """
         Gets details about spans for a given group sorted by exclusive time


### PR DESCRIPTION
**context**
There is a [failing query](https://sentry.sentry.io/issues/5482225833/events/79608ece54624c4d82ffc418c6ca0138/?project=300688&referrer=issue_details.related_trace_issue) on the spans dataset that for some reason fails on SaaS US but not on other regions. 

Snql Query
>```MATCH (spans) SELECT count() AS `count`, trace_id AS `trace`, plus(multiply(toUInt64(tupleElement(max(tuple(end_timestamp, end_ms)), 1)), 1000), tupleElement(max(tuple(end_timestamp, end_ms)), 2)) AS `last_seen`, plus(multiply(toUInt64(tupleElement(min(tuple(start_timestamp, start_ms)), 1)), 1000), countIf(or(equals(op, 'browser'), equals(op, 'resource.link'))) AS `matching_count`, tupleElement(min(tuple(start_timestamp, start_ms)), 2)) AS `first_seen` BY trace_id AS `trace` WHERE ...```

SQL Query
> ``` SELECT (replaceAll(toString(trace_id), '-', '') AS _snuba_trace_id), (count() AS _snuba_count), _snuba_trace_id, (plus(multiply(toUInt64(tupleElement(max(((end_timestamp AS _snuba_end_timestamp), (end_ms AS _snuba_end_ms))), 1)), 1000), tupleElement(max((_snuba_end_timestamp, _snuba_end_ms)), 2)) AS _snuba_last_seen), (plus(multiply(toUInt64(tupleElement(min(((start_timestamp AS _snuba_start_timestamp), (start_ms AS _snuba_start_ms))), 1)), 1000), (countIf((equals((op AS _snuba_op), 'browser') OR equals(_snuba_op, 'resource.link'))) AS _snuba_matching_count), tupleElement(min((_snuba_start_timestamp, _snuba_start_ms)), 2)) AS _snuba_first_seen) FROM spans_local PREWHERE ...``` 

It seems like this causes the issue
`(countIf((equals((op AS _snuba_op), 'browser') OR equals(_snuba_op, 'resource.link')))`

since this is fine
`(countIf((equals((op AS _snuba_op), 'browser') OR equals((op AS _snuba_op), 'resource.link')))`

**solution**
The easiest way I could think to get around this was to ignore the `_parsing_context` (aka the alias cache) in the select clause. It might make queries a little bit more verbose, but I don't think it should cause a problem as we are just leaving in the expanded aliases. 