### PR TITLE
fix: LowCardinality column bug w/ aliases

### DIFF
--- a/snuba/datasets/configuration/spans/entities/spans.yaml
+++ b/snuba/datasets/configuration/spans/entities/spans.yaml
@@ -155,6 +155,10 @@ query_processors:
         - end_timestamp
         - timestamp
   - processor: BasicFunctionsProcessor
+  - processor: LowCardinalityProcessor
+    args:
+      columns:
+        - op
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -171,10 +171,6 @@ query_processors:
         [span_id, trace_id, segment_name]
   - processor: TableRateLimit
   - processor: TupleUnaliaser
-  - processor: LowCardinalityProcessor
-    args:
-      columns:
-        - op
 
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -171,6 +171,10 @@ query_processors:
         [span_id, trace_id, segment_name]
   - processor: TableRateLimit
   - processor: TupleUnaliaser
+  - processor: LowCardinalityProcessor
+    args:
+      columns:
+        - op
 
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer


### PR DESCRIPTION
Initial context in https://github.com/getsentry/snuba/pull/6107 Okie it might be the `LowCardinality` column not actually being low cardinality.

Casting the column seems to make it work 
>
```
SELECT
  countIf(
    equals((cast(op, 'String') AS _snuba_op), 'browser')
    OR equals(_snuba_op, 'resource.link')
  ) AS _snuba_matching_count
FROM spans_dist...
```
