### PR TITLE
feat(snuba-deletes): DeleteRequest object

### DIFF
--- a/snuba/request/__init__.py
+++ b/snuba/request/__init__.py
@@ -21,3 +21,9 @@ class Request:
     @property
     def referrer(self) -> str:
         return self.attribution_info.referrer
+
+
+@dataclass(frozen=True)
+class DeleteRequest:
+    storage: str
+    where_clause: str


### PR DESCRIPTION
In order to support lightweight deletes in Snuba, we will accept `DELETE` queries. Since they are much simpler than the other types of queries Snuba supports, we figured it'd be easier to have a separate `DeleteRequest` object to work off of.