### PR TITLE
perm(access) Give telemetry experience team access to cardinality analyzer

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -37,7 +37,8 @@
           "group:team-ingest@sentry.io",
           "group:team-visibility@sentry.io",
           "group:team-performance@sentry.io",
-          "group:team-eng-managers@sentry.io"
+          "group:team-eng-managers@sentry.io",
+          "group:team-telemetry-experience@sentry.io"
       ],
       "role": "roles/CardinalityAnalyzer"
     },


### PR DESCRIPTION
From time to time, while we are debugging some metric issues, it would help a lot knowing which raw data is in the Clickhouse.

Most recent occasion was this morning where we could fix the problem very fast, because the Ingest team had the access to the Cardinality analyzer, and we could see the raw data, it help us eliminate a lot of possible problem causes and quickly locate the real problem.