### PR TITLE
support max_bytes_before_external_group_by ClickHouse insert flag

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -98,6 +98,7 @@ fn create_factory(
         },
         stop_at_timestamp: None,
         batch_write_timeout: None,
+        max_bytes_before_external_group_by: None,
     };
     Box::new(factory)
 }

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -20,7 +20,6 @@ pub struct ConsumerConfig {
     pub max_batch_size: usize,
     pub max_batch_time_ms: u64,
     pub env: EnvConfig,
-    pub max_bytes_before_external_group_by: Option<usize>,
 }
 
 pub fn deserialize_broker_config<'de, D>(

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -20,6 +20,7 @@ pub struct ConsumerConfig {
     pub max_batch_size: usize,
     pub max_batch_time_ms: u64,
     pub env: EnvConfig,
+    pub max_bytes_before_external_group_by: Option<usize>,
 }
 
 pub fn deserialize_broker_config<'de, D>(

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -42,6 +42,7 @@ pub fn consumer(
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
     batch_write_timeout_ms: Option<u64>,
+    max_bytes_before_external_group_by: Option<usize>,
 ) {
     py.allow_threads(|| {
         consumer_impl(
@@ -59,6 +60,7 @@ pub fn consumer(
             health_check_file,
             stop_at_timestamp,
             batch_write_timeout_ms,
+            max_bytes_before_external_group_by,
         )
     });
 }
@@ -79,6 +81,7 @@ pub fn consumer_impl(
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
     batch_write_timeout_ms: Option<u64>,
+    max_bytes_before_external_group_by: Option<usize>,
 ) -> usize {
     setup_logging();
 
@@ -247,6 +250,7 @@ pub fn consumer_impl(
         accountant_topic_config: consumer_config.accountant_topic,
         stop_at_timestamp,
         batch_write_timeout,
+        max_bytes_before_external_group_by,
     };
 
     let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -57,6 +57,7 @@ pub struct ConsumerStrategyFactory {
     pub accountant_topic_config: config::TopicConfig,
     pub stop_at_timestamp: Option<i64>,
     pub batch_write_timeout: Option<Duration>,
+    pub max_bytes_before_external_group_by: Option<usize>,
 }
 
 impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
@@ -120,6 +121,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.storage_config.clickhouse_cluster.password,
             self.async_inserts,
             self.batch_write_timeout,
+            self.max_bytes_before_external_group_by,
         );
 
         let accumulator = Arc::new(

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -43,6 +43,7 @@ impl BatchFactory {
         clickhouse_password: &str,
         async_inserts: bool,
         batch_write_timeout: Option<Duration>,
+        max_bytes_before_external_group_by: Option<usize>,
     ) -> Self {
         let mut headers = HeaderMap::with_capacity(5);
         headers.insert(CONNECTION, HeaderValue::from_static("keep-alive"));
@@ -68,6 +69,12 @@ impl BatchFactory {
             if async_inserts_allowed == Some("1".to_string()) {
                 query_params.push_str("&async_insert=1&wait_for_async_insert=1");
             }
+        }
+
+        if max_bytes_before_external_group_by.is_some() {
+            let mut query_segment: String = "&max_bytes_before_external_group_by=".to_owned();
+            query_segment.push_str(&max_bytes_before_external_group_by.unwrap().to_string());
+            query_params.push_str(&query_segment)
         }
 
         let url = format!("http://{hostname}:{http_port}?{query_params}");
@@ -262,6 +269,7 @@ mod tests {
             "",
             false,
             None,
+            None,
         );
 
         let mut batch = factory.new_batch();
@@ -297,6 +305,7 @@ mod tests {
             "",
             true,
             None,
+            None,
         );
 
         let mut batch = factory.new_batch();
@@ -331,6 +340,7 @@ mod tests {
             "",
             false,
             None,
+            None,
         );
 
         let mut batch = factory.new_batch();
@@ -362,6 +372,7 @@ mod tests {
             "default",
             "",
             false,
+            None,
             None,
         );
 
@@ -399,6 +410,7 @@ mod tests {
             // pass in an unreasonably short timeout
             // which prevents the client request from reaching Clickhouse
             Some(Duration::from_millis(0)),
+            None,
         );
 
         let mut batch = factory.new_batch();
@@ -433,6 +445,7 @@ mod tests {
             true,
             // pass in a reasonable timeout
             Some(Duration::from_millis(1000)),
+            None,
         );
 
         let mut batch = factory.new_batch();

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -71,9 +71,9 @@ impl BatchFactory {
             }
         }
 
-        if max_bytes_before_external_group_by.is_some() {
+        if let Some(max_bytes_before_external_group_by) = max_bytes_before_external_group_by {
             let mut query_segment: String = "&max_bytes_before_external_group_by=".to_owned();
-            query_segment.push_str(&max_bytes_before_external_group_by.unwrap().to_string());
+            query_segment.push_str(&max_bytes_before_external_group_by.to_string());
             query_params.push_str(&query_segment)
         }
 

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -164,6 +164,16 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     default=None,
     help="Optional timeout for batch writer client connecting and sending request to Clickhouse",
 )
+@click.option(
+    "--max-bytes-before-external-group-by",
+    is_flag=True,
+    default=False,
+    help="""
+    Allow batching on disk for GROUP BY queries. This is a test mitigation for whether a
+    materialized view is causing OOM on inserts. If successful, this should be set in storage config.
+    If not successful, this option should be removed.
+    """,
+)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -192,7 +202,8 @@ def rust_consumer(
     health_check_file: Optional[str],
     enforce_schema: bool,
     stop_at_timestamp: Optional[int],
-    batch_write_timeout_ms: Optional[int]
+    batch_write_timeout_ms: Optional[int],
+    max_bytes_before_external_group_by: Optional[int]
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -243,6 +254,7 @@ def rust_consumer(
         health_check_file,
         stop_at_timestamp,
         batch_write_timeout_ms,
+        max_bytes_before_external_group_by,
     )
 
     sys.exit(exitcode)

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -166,8 +166,8 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
 )
 @click.option(
     "--max-bytes-before-external-group-by",
-    is_flag=True,
-    default=False,
+    type=int,
+    default=None,
     help="""
     Allow batching on disk for GROUP BY queries. This is a test mitigation for whether a
     materialized view is causing OOM on inserts. If successful, this should be set in storage config.


### PR DESCRIPTION
I'm trying to track down the source of some production errors when writing to generic-metrics-distributions, where ClickHouse is unable to allocate enough memory to handle the execution of the materialized views. The errors look something like:

```
Strategy(error writing to clickhouse: Code: 241. DB::Exception: Received from xxx:9000. DB::Exception: Memory limit (for query) exceeded: would use 9.81 GiB (attempt to allocate chunk of 1073741824 bytes), maximum: 9.31 GiB.: while executing 'ARRAY JOIN granularities :: 10 -> arrayJoin(granularities) UInt8 : 9': while pushing to view default.generic_metric_distributions_aggregation_mv_v3 (63e6c929-c73f-473e-83d5-9f58c48e904a). (MEMORY_LIMIT_EXCEEDED) (version 23.8.11.29.altinitystable (altinity build))


Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::msg
             at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.82/src/error.rs:83:36
   1: rust_snuba::strategies::clickhouse::batch::BatchFactory::new_batch::{{closure}}
             at ./rust_snuba/src/strategies/clickhouse/batch.rs:135:21
   2: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
```

Based on some googling, it seems like https://clickhouse.com/docs/en/sql-reference/statements/select/group-by#group-by-in-external-memory might be a parameter we want to adjust around a bit. Ultimately, this should probably be in storage config, but I think for testing it's easiest if we can adjust via CLI