### PR TITLE
feat(group-attributes): Add an inner join relationship for search_issues and group_attributes

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -204,3 +204,9 @@ join_relationships:
     columns:
       - [project_id, project_id]
       - [group_id, group_id]
+  attributes_inner:
+    rhs_entity: group_attributes
+    join_type: inner
+    columns:
+      - [project_id, project_id]
+      - [group_id, group_id]


### PR DESCRIPTION
Add an inner join relationship for the `search_issues` dataset with the `group_attributes` to support inner join queries on issue search. 

Similar join relationship defined for the events table [here](https://github.com/getsentry/snuba/blob/22f3d4d199f845f468a1b56c7a55c497551d5e31/snuba/datasets/configuration/events/entities/events.yaml#L489).