### PR TITLE
ref(lwdeletes): create parse_and_run_query function

### DIFF
--- a/snuba/admin/production_queries/prod_queries.py
+++ b/snuba/admin/production_queries/prod_queries.py
@@ -22,15 +22,16 @@ def run_snql_query(body: Dict[str, Any], user: str) -> Response:
 
     @audit_log
     def run_query_with_audit(query: str, user: str) -> Response:
-        dataset = get_dataset(body.pop("dataset"))
+        dataset_name = body.pop("dataset")
+        dataset = get_dataset(dataset_name)
         body["dry_run"] = True
-        response = dataset_query(dataset, body, Timer("admin"))
+        response = dataset_query(dataset_name, body, Timer("admin"))
         if response.status_code != 200:
             return response
 
         body["dry_run"] = False
         _validate_projects_in_query(body, dataset)
-        return dataset_query(dataset, body, Timer("admin"))
+        return dataset_query(dataset_name, body, Timer("admin"))
 
     return run_query_with_audit(body["query"], user)
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -58,11 +58,7 @@ from snuba.consumers.dlq import (
     load_instruction,
     store_instruction,
 )
-from snuba.datasets.factory import (
-    InvalidDatasetError,
-    get_dataset,
-    get_enabled_dataset_names,
-)
+from snuba.datasets.factory import InvalidDatasetError, get_enabled_dataset_names
 from snuba.datasets.storages.factory import get_all_storage_keys, get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.migrations.connect import check_for_inactive_replicas
@@ -780,9 +776,9 @@ def snuba_debug() -> Response:
     body = json.loads(request.data)
     body["debug"] = True
     body["dry_run"] = True
+    dataset_name = body.pop("dataset")
     try:
-        dataset = get_dataset(body.pop("dataset"))
-        response = dataset_query(dataset, body, Timer("admin"))
+        response = dataset_query(dataset_name, body, Timer("admin"))
         data = response.get_json()
         assert isinstance(data, dict)
 
@@ -1026,8 +1022,7 @@ def production_snql_query() -> Response:
     body = json.loads(request.data)
     body["tenant_ids"] = {"referrer": request.referrer, "organization_id": ORG_ID}
     try:
-        ret = run_snql_query(body, g.user.email)
-        return ret
+        return run_snql_query(body, g.user.email)
     except InvalidQueryException as exception:
         return Response(
             json.dumps({"error": {"message": str(exception)}}, indent=4),

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -125,14 +125,14 @@ def parse_and_run_query(
     """Top level entrypoint from a raw query body to a query result
 
     Example:
-    request, result = parse_and_run_query(
-        body={
-            "query":"MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE timestamp >= toDateTime('2024-07-17T21:04:34') AND timestamp < toDateTime('2024-07-17T21:10:34')",
-            "tenant_ids":{"organization_id":319976,"referrer":"Group.get_helpful"}
-        },
-        timer=Timer("parse_and_run_query"),
-        is_mql=False,
-    )
+    >>> request, result = parse_and_run_query(
+    >>>     body={
+    >>>         "query":"MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE timestamp >= toDateTime('2024-07-17T21:04:34') AND timestamp < toDateTime('2024-07-17T21:10:34')",
+    >>>         "tenant_ids":{"organization_id":319976,"referrer":"Group.get_helpful"}
+    >>>     },
+    >>>     timer=Timer("parse_and_run_query"),
+    >>>     is_mql=False,
+    >>> )
 
     Optional args:
         dataset_name (str): used mainly for observability purposes

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -122,6 +122,23 @@ def parse_and_run_query(
     dataset_name: Optional[str] = None,
     referrer: Optional[str] = None,
 ) -> tuple[Request, QueryResult]:
+    """Top level entrypoint from a raw query body to a query result
+
+    Example:
+    request, result = parse_and_run_query(
+        body={
+            "query":"MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE timestamp >= toDateTime('2024-07-17T21:04:34') AND timestamp < toDateTime('2024-07-17T21:10:34')",
+            "tenant_ids":{"organization_id":319976,"referrer":"Group.get_helpful"}
+        },
+        timer=Timer("parse_and_run_query"),
+        is_mql=False,
+    )
+
+    Optional args:
+        dataset_name (str): used mainly for observability purposes
+        referrer (str): legacy param, you probably don't need to provide this. It should be in the tenant_ids of the body
+    """
+
     with sentry_sdk.start_span(description="build_schema", op="validate"):
         schema = RequestSchema.build(HTTPQuerySettings, is_mql)
 

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -147,7 +147,6 @@ def parse_and_run_query(
     # "dataset" even though datasets don't define very much. The user is able to provide a dataset_name
     # for that reason. Otherwise they are not useful.
     # EXCEPT FOR DISCOVER which is a whole can of worms, but that's the one place where the dataset is useful for something
-    assert isinstance(dataset_name, str)
     dataset = _get_dataset(dataset_name)
     referrer = referrer or "<unknown>"
     parse_function = parse_snql_query if not is_mql else parse_mql_query

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -285,7 +285,7 @@ def mql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response,
         dataset_name = get_dataset_name(dataset)
         body = parse_request_body(http_request)
         _trace_transaction(dataset_name)
-        return dataset_query(dataset, body, timer, is_mql=True)
+        return dataset_query(dataset_name, body, timer, is_mql=True)
     else:
         assert False, "unexpected fallthrough"
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -40,18 +40,15 @@ from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.factory import get_entity_name
 from snuba.datasets.entity import Entity
 from snuba.datasets.entity_subscriptions.validators import InvalidSubscriptionError
-from snuba.datasets.factory import InvalidDatasetError, get_dataset, get_dataset_name
+from snuba.datasets.factory import InvalidDatasetError, get_dataset_name
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import StorageNotAvailable
 from snuba.query.allocation_policies import AllocationPolicyViolations
 from snuba.query.exceptions import InvalidQueryException, QueryPlanException
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.redis import all_redis_clients
-from snuba.request import Request as SnubaRequest
 from snuba.request.exceptions import InvalidJsonRequestException, JsonDecodeException
 from snuba.request.schema import RequestSchema
-from snuba.request.validation import build_request, parse_mql_query, parse_snql_query
-from snuba.state import get_float_config
 from snuba.state.rate_limit import RateLimitExceeded
 from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import PartitionId
@@ -68,7 +65,7 @@ from snuba.utils.metrics.util import with_span
 from snuba.web import QueryException, QueryTooLongException
 from snuba.web.constants import get_http_status_for_clickhouse_error
 from snuba.web.converters import DatasetConverter, EntityConverter
-from snuba.web.query import run_query
+from snuba.web.query import parse_and_run_query
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
 
 logger = logging.getLogger("snuba.api")
@@ -237,14 +234,16 @@ def parse_request_body(http_request: Request) -> Dict[str, Any]:
             raise JsonDecodeException(str(error)) from error
 
 
-def _trace_transaction(dataset: Dataset) -> None:
+def _trace_transaction(dataset_name: str) -> None:
     with sentry_sdk.configure_scope() as scope:
         if scope.span:
-            scope.span.set_tag("dataset", get_dataset_name(dataset))
+            scope.span.set_tag("dataset", dataset_name)
             scope.span.set_tag("referrer", http_request.referrer)
 
         if scope.transaction:
-            scope.transaction = f"{scope.transaction.name}__{get_dataset_name(dataset)}__{http_request.referrer}"
+            scope.transaction = (
+                f"{scope.transaction.name}__{dataset_name}__{http_request.referrer}"
+            )
 
 
 @application.route("/query", methods=["GET", "POST"])
@@ -254,9 +253,9 @@ def unqualified_query_view(*, timer: Timer) -> Union[Response, str, WerkzeugResp
         return redirect(f"/{settings.DEFAULT_DATASET_NAME}/query", code=302)
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
-        dataset = get_dataset(body.pop("dataset", settings.DEFAULT_DATASET_NAME))
-        _trace_transaction(dataset)
-        return dataset_query(dataset, body, timer)
+        dataset_name = str(body.pop("dataset", settings.DEFAULT_DATASET_NAME))
+        _trace_transaction(dataset_name)
+        return dataset_query(dataset_name, body, timer)
     else:
         assert False, "unexpected fallthrough"
 
@@ -272,8 +271,9 @@ def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response
         )
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
-        _trace_transaction(dataset)
-        return dataset_query(dataset, body, timer)
+        dataset_name = get_dataset_name(dataset)
+        _trace_transaction(dataset_name)
+        return dataset_query(dataset_name, body, timer)
     else:
         assert False, "unexpected fallthrough"
 
@@ -282,8 +282,9 @@ def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response
 @util.time_request("query", {"mql": "true"})
 def mql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response, str]:
     if http_request.method == "POST":
+        dataset_name = get_dataset_name(dataset)
         body = parse_request_body(http_request)
-        _trace_transaction(dataset)
+        _trace_transaction(dataset_name)
         return dataset_query(dataset, body, timer, is_mql=True)
     else:
         assert False, "unexpected fallthrough"
@@ -332,19 +333,9 @@ def dump_payload(payload: MutableMapping[str, Any]) -> str:
         return json.dumps(sanitized_payload, default=str)
 
 
-def _get_and_log_referrer(request: SnubaRequest, body: Dict[str, Any]) -> None:
-    metrics.increment(
-        "just_referrer_count", tags={"referrer": request.attribution_info.referrer}
-    )
-    if random.random() < get_float_config("log-referrer-sample-rate", 0.001):  # type: ignore
-        logger.info(f"Received referrer: {request.attribution_info.referrer}")
-        if request.attribution_info.referrer == "<unknown>":
-            logger.info(f"Received unknown referrer from request: {request}, {body}")
-
-
 @with_span()
 def dataset_query(
-    dataset: Dataset, body: Dict[str, Any], timer: Timer, is_mql: bool = False
+    dataset_name: str, body: Dict[str, Any], timer: Timer, is_mql: bool = False
 ) -> Response:
     assert http_request.method == "POST"
     referrer = http_request.referrer or "<unknown>"  # mypy
@@ -356,22 +347,14 @@ def dataset_query(
     # is detected, and then log everything
     if get_shutdown() or random.random() < 0.05:
         if get_shutdown() or check_down_file_exists():
-            tags = {"dataset": get_dataset_name(dataset)}
+            tags = {"dataset": dataset_name}
             metrics.increment("post.shutdown.query", tags=tags)
             diff = time.time() - (shutdown_time() or 0.0)  # this should never be None
             metrics.timing("post.shutdown.query.delay", diff, tags=tags)
-
-    with sentry_sdk.start_span(description="build_schema", op="validate"):
-        schema = RequestSchema.build(HTTPQuerySettings, is_mql)
-
-    parse_function = parse_snql_query if not is_mql else parse_mql_query
-    request = build_request(
-        body, parse_function, HTTPQuerySettings, schema, dataset, timer, referrer
-    )
-    _get_and_log_referrer(request, body)
-
     try:
-        result = run_query(dataset, request, timer)
+        request, result = parse_and_run_query(
+            body, timer, is_mql, dataset_name, referrer
+        )
         assert result.extra["stats"]
     except InvalidQueryException as exception:
         details: Mapping[str, Any]

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -332,16 +332,6 @@ def test_get_snuba_datasets(admin_api: FlaskClient) -> None:
 
 
 @pytest.mark.redis_db
-def test_snuba_debug_invalid_dataset(admin_api: FlaskClient) -> None:
-    response = admin_api.post(
-        "/snuba_debug", data=json.dumps({"dataset": "", "query": ""})
-    )
-    assert response.status_code == 400
-    data = json.loads(response.data)
-    assert data["error"]["message"] == "dataset '' does not exist"
-
-
-@pytest.mark.redis_db
 def test_snuba_debug_invalid_query(admin_api: FlaskClient) -> None:
     response = admin_api.post(
         "/snuba_debug", data=json.dumps({"dataset": "transactions", "query": ""})

--- a/tests/web/test_parse_and_run_query.py
+++ b/tests/web/test_parse_and_run_query.py
@@ -6,7 +6,7 @@ from snuba.web.query import parse_and_run_query
 
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
-def test_basic() -> None:
+def test_basic_snql() -> None:
     request, result = parse_and_run_query(
         body={
             "query": "MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE timestamp >= toDateTime('2024-07-17T21:04:34') AND timestamp < toDateTime('2024-07-17T21:10:34') AND project_id = 1",
@@ -21,3 +21,45 @@ def test_basic() -> None:
         {"name": "project_id", "type": "UInt64"},
         {"name": "timestamp", "type": "DateTime"},
     ]
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_basic_mql() -> None:
+    # body = {'debug': True, 'query': 'sum(c:transactions/count_per_root_project@none){transaction:"t1"} by (status_code)', 'dataset': 'generic_metrics', 'app_id': 'test', 'tenant_ids': {'referrer': 'tests', 'organization_id': 101}, 'parent_api': '<unknown>', 'mql_context': {'start': '2024-07-16T09:15:00+00:00', 'end': '2024-07-16T15:15:00+00:00', 'rollup': {'orderby': None, 'granularity': 60, 'interval': 60, 'with_totals': None}, 'scope': {'org_ids': [101], 'project_ids': [1, 2], 'use_case_id': 'performance'}, 'indexer_mappings': {'transaction.duration': 'c:transactions/count_per_root_project@none', 'c:transactions/count_per_root_project@none': 1067, 'transaction': 65546, 'status_code': 9223372036854776010}, 'limit': None, 'offset': None}}
+    body = {
+        "query": 'sum(c:transactions/count_per_root_project@none){transaction:"t1"} by (status_code)',
+        "dataset": "generic_metrics",
+        "app_id": "test",
+        "tenant_ids": {"referrer": "tests", "organization_id": 101},
+        "parent_api": "<unknown>",
+        "mql_context": {
+            "start": "2024-07-16T09:15:00+00:00",
+            "end": "2024-07-16T15:15:00+00:00",
+            "rollup": {
+                "orderby": None,
+                "granularity": 60,
+                "interval": 60,
+                "with_totals": None,
+            },
+            "scope": {
+                "org_ids": [101],
+                "project_ids": [1, 2],
+                "use_case_id": "performance",
+            },
+            "indexer_mappings": {
+                "transaction.duration": "c:transactions/count_per_root_project@none",
+                "c:transactions/count_per_root_project@none": 1067,
+                "transaction": 65546,
+                "status_code": 9223372036854776010,
+            },
+            "limit": None,
+            "offset": None,
+        },
+    }
+    request, result = parse_and_run_query(
+        body=body,
+        timer=Timer("parse_and_run_query"),
+        is_mql=True,
+        dataset_name="generic_metrics",
+    )

--- a/tests/web/test_parse_and_run_query.py
+++ b/tests/web/test_parse_and_run_query.py
@@ -1,0 +1,23 @@
+import pytest
+
+from snuba.utils.metrics.timer import Timer
+from snuba.web.query import parse_and_run_query
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_basic():
+    request, result = parse_and_run_query(
+        body={
+            "query": "MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE timestamp >= toDateTime('2024-07-17T21:04:34') AND timestamp < toDateTime('2024-07-17T21:10:34') AND project_id = 1",
+            "tenant_ids": {"organization_id": 319976, "referrer": "Group.get_helpful"},
+        },
+        timer=Timer("parse_and_run_query"),
+        is_mql=False,
+    )
+    assert result.result["meta"] == [
+        {"name": "event_id", "type": "String"},
+        {"name": "group_id", "type": "UInt64"},
+        {"name": "project_id", "type": "UInt64"},
+        {"name": "timestamp", "type": "DateTime"},
+    ]

--- a/tests/web/test_parse_and_run_query.py
+++ b/tests/web/test_parse_and_run_query.py
@@ -6,7 +6,7 @@ from snuba.web.query import parse_and_run_query
 
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
-def test_basic():
+def test_basic() -> None:
     request, result = parse_and_run_query(
         body={
             "query": "MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE timestamp >= toDateTime('2024-07-17T21:04:34') AND timestamp < toDateTime('2024-07-17T21:10:34') AND project_id = 1",


### PR DESCRIPTION
### Context

Lightweight deletes needs to run a query to check how many rows will be affected before actually running the deletes. This requires that the code to run a query is reusable. There is also a disconnect in the codebase between the usefulness of datasets.

The original intent in snuba was that datasets where central to how things were queried. That was never really realized. In SnQL queries, entities or storages are specified directly. There is no functional need for datasets. However, many metrics are tagged with the dataset name and many dashboards use it as filters. This means we can't remove datasets entirely just yet.

### What this PR does

Creates a `parse_and_run_query` function which is the new top level function for running queries from the input JSON payload. It does not concern itself with any HTTP error handling, it just runs the query pipeline. Can be used in a modular way (necessary for lightweight deletes)