### PR TITLE
fix: wait on system.mutations between hosts during migration execution

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -101,7 +101,7 @@ class SqlOperation(ABC):
             if not is_mutating:
                 return
             elif slept_so_far >= timeout_seconds:
-                raise RuntimeError(
+                raise TimeoutError(
                     f"{conn.host}:{conn.port} not finished mutating after {timeout_seconds} seconds"
                 )
             else:


### PR DESCRIPTION
## changes
Now when migrations are executed, the migration will not move on from 1 host to the next one until `select count(*) from system.mutations where is_done=0` is 0

## testing
Not sure how to do a comprehensive test of this but heres how i tested:

* in the case where no mutation in progress, this works. I successfully ran a normal migration locally.
* in the case of a mutation in progress I wasnt able to directly test, but I tested with is_done=1 to make sure the count(*) results were good (`[(13,)]`) so i think it should work