### PR TITLE
bug(mql): Fix MQL totals queries

### DIFF
--- a/snuba/query/mql/parser_supported_join.py
+++ b/snuba/query/mql/parser_supported_join.py
@@ -1289,7 +1289,6 @@ def populate_query_from_mql_context(
             assert isinstance(data_source, QueryEntity)
             entity_data.append((data_source.key, alias))
 
-    selected_time_found = False
     for entity_key, table_alias in entity_data:
         time_condition = start_end_time_condition(mql_context, entity_key, table_alias)
         scope_condition = scope_conditions(mql_context, table_alias)
@@ -1307,7 +1306,6 @@ def populate_query_from_mql_context(
             query.set_ast_orderby([orderby])
 
         if selected_time:
-            selected_time_found = True
             query.set_ast_selected_columns(
                 list(query.get_selected_columns()) + [selected_time]
             )
@@ -1318,7 +1316,7 @@ def populate_query_from_mql_context(
             else:
                 query.set_ast_groupby([selected_time.expression])
 
-    if isinstance(query, CompositeQuery) and selected_time_found:
+    if isinstance(query, CompositeQuery):
         # If the query is grouping by time, that needs to be added to the JoinClause keys to
         # ensure we correctly join the subqueries. The column names will be the same for all the
         # subqueries, so we just need to map all the table aliases.

--- a/snuba/query/mql/parser_supported_join.py
+++ b/snuba/query/mql/parser_supported_join.py
@@ -1304,17 +1304,15 @@ def populate_query_from_mql_context(
         query.set_totals(with_totals)
         if orderby:
             query.set_ast_orderby([orderby])
+        query.set_ast_selected_columns(
+            list(query.get_selected_columns()) + [selected_time]
+        )
 
-        if selected_time:
-            query.set_ast_selected_columns(
-                list(query.get_selected_columns()) + [selected_time]
-            )
-
-            groupby = query.get_groupby()
-            if groupby:
-                query.set_ast_groupby(list(groupby) + [selected_time.expression])
-            else:
-                query.set_ast_groupby([selected_time.expression])
+        groupby = query.get_groupby()
+        if groupby:
+            query.set_ast_groupby(list(groupby) + [selected_time.expression])
+        else:
+            query.set_ast_groupby([selected_time.expression])
 
     if isinstance(query, CompositeQuery):
         # If the query is grouping by time, that needs to be added to the JoinClause keys to

--- a/tests/query/parser/test_parser.py
+++ b/tests/query/parser/test_parser.py
@@ -29,15 +29,20 @@ from_distributions = QueryEntity(
     EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
     get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
 )
-time_expression = FunctionCall(
-    "_snuba_time",
-    "toStartOfInterval",
-    (
-        Column("_snuba_timestamp", None, "timestamp"),
-        FunctionCall(None, "toIntervalSecond", (Literal(None, 60),)),
-        Literal(None, "Universal"),
-    ),
-)
+
+
+def time_expression(to_interval_seconds: int | None = 60) -> FunctionCall:
+    return FunctionCall(
+        "_snuba_time",
+        "toStartOfInterval",
+        (
+            Column("_snuba_timestamp", None, "timestamp"),
+            FunctionCall(
+                None, "toIntervalSecond", (Literal(None, to_interval_seconds),)
+            ),
+            Literal(None, "Universal"),
+        ),
+    )
 
 
 def test_mql() -> None:
@@ -77,8 +82,12 @@ def test_mql() -> None:
                     (Column("_snuba_value", None, "value"),),
                 ),
             ),
+            SelectedExpression(
+                "time",
+                time_expression(None),
+            ),
         ],
-        groupby=[],
+        groupby=[time_expression(None)],
         condition=and_cond(
             and_cond(
                 and_cond(
@@ -183,8 +192,12 @@ def test_mql_wildcards() -> None:
                     (Column("_snuba_value", None, "value"),),
                 ),
             ),
+            SelectedExpression(
+                "time",
+                time_expression(None),
+            ),
         ],
-        groupby=[],
+        groupby=[time_expression(None)],
         condition=and_cond(
             and_cond(
                 and_cond(
@@ -287,8 +300,12 @@ def test_mql_negated_wildcards() -> None:
                     (Column("_snuba_value", None, "value"),),
                 ),
             ),
+            SelectedExpression(
+                "time",
+                time_expression(None),
+            ),
         ],
-        groupby=[],
+        groupby=[time_expression(None)],
         condition=and_cond(
             and_cond(
                 and_cond(

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -683,6 +683,117 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         data = json.loads(response.data)
         assert len(data["data"]) == 180, data
 
+    def test_formula_with_totals(self) -> None:
+        query = MetricsQuery(
+            query=Formula(
+                ArithmeticOperator.PLUS.value,
+                [
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="avg",
+                    ),
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="avg",
+                    ),
+                ],
+            ),
+            start=self.start_time,
+            end=self.end_time,
+            rollup=Rollup(interval=None, totals=True, orderby=None, granularity=60),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=self.project_ids,
+                use_case_id=USE_CASE_ID,
+            ),
+            indexer_mappings={
+                "transaction.duration": DISTRIBUTIONS_MRI,
+                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
+                "status_code": resolve_str("status_code"),
+            },
+        )
+
+        response = self.app.post(
+            self.mql_route,
+            data=Request(
+                dataset=DATASET,
+                app_id="test",
+                query=query,
+                flags=Flags(debug=True),
+                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
+            ).serialize_mql(),
+        )
+
+        assert response.status_code == 200, response.data
+        data = json.loads(response.data)
+        assert (
+            data["totals"]["aggregate_value"] == 4.0
+        )  # Should be more than the number of data points
+
+    def test_formula_with_totals_and_interval(self) -> None:
+        query = MetricsQuery(
+            query=Formula(
+                ArithmeticOperator.PLUS.value,
+                [
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="avg",
+                    ),
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="avg",
+                    ),
+                ],
+            ),
+            start=self.start_time,
+            end=self.end_time,
+            rollup=Rollup(interval=60, totals=True, orderby=None, granularity=60),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=self.project_ids,
+                use_case_id=USE_CASE_ID,
+            ),
+            indexer_mappings={
+                "transaction.duration": DISTRIBUTIONS_MRI,
+                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
+                "status_code": resolve_str("status_code"),
+            },
+        )
+
+        response = self.app.post(
+            self.mql_route,
+            data=Request(
+                dataset=DATASET,
+                app_id="test",
+                query=query,
+                flags=Flags(debug=True),
+                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
+            ).serialize_mql(),
+        )
+
+        assert response.status_code == 200, response.data
+        data = json.loads(response.data)
+        assert len(data["data"]) == 180, data
+        assert (
+            data["totals"]["aggregate_value"] == 4.0
+        )  # Should be more than the number of data points
+
     def test_multi_entity_formula(self) -> None:
         query = MetricsQuery(
             query=Formula(


### PR DESCRIPTION
This PR is responsible for fixing MQL formula totals queries. There are two main necessary changes to fix these queries:

* Add time expression to join conditions (`keys`) for totals queries. 
* Whether or not `interval` is provided in the MQL context, the resulting snuba AST (and SQL) should always contain a time expression in the select clause. It is ok for timestamp column to be `NULL`. This timestamp column is necessary for the join conditions to work properly.