### PR TITLE
ref(snuba-deletes): ColumnFilterProcessor will validate all queries to have timestamp

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -135,3 +135,4 @@ deletion_processors:
       column_filters:
         - project_id
         - occurrence_id
+        - client_timestamp

--- a/tests/query/processors/test_column_filter_processor.py
+++ b/tests/query/processors/test_column_filter_processor.py
@@ -13,7 +13,7 @@ from snuba.query.processors.physical.column_filter_processor import (
 from snuba.query.query_settings import HTTPQuerySettings
 
 TABLE = Table("issues", ColumnSet([]), storage_key=StorageKey("issues"))
-VALID_COLUMNS = ["project_id", "occurrence_id"]
+VALID_COLUMNS = ["project_id", "occurrence_id", "client_timestamp"]
 
 test_data = [
     pytest.param(
@@ -22,11 +22,17 @@ test_data = [
             selected_columns=[],
             condition=binary_condition(
                 BooleanFunctions.AND,
-                binary_condition(
-                    "equals", Column(None, None, VALID_COLUMNS[0]), Literal(None, 1)
+                lhs=binary_condition(
+                    "equals", Column(None, None, VALID_COLUMNS[2]), Literal(None, 1)
                 ),
-                binary_condition(
-                    "equals", Column(None, None, VALID_COLUMNS[1]), Literal(None, 1)
+                rhs=binary_condition(
+                    BooleanFunctions.AND,
+                    binary_condition(
+                        "equals", Column(None, None, VALID_COLUMNS[0]), Literal(None, 1)
+                    ),
+                    binary_condition(
+                        "equals", Column(None, None, VALID_COLUMNS[1]), Literal(None, 1)
+                    ),
                 ),
             ),
         ),


### PR DESCRIPTION
Following https://github.com/getsentry/snuba/pull/6120, all lightweight delete queries will be converted to SnQL queries, so the lightweight delete queries are required to have `timestamp`. We add this validation to the `ColumnFilterProcessor`, which makes sure that the columns in the query are exactly the columns listed in the storage definition.

For the issues storage, lightweight deletes will follow this format:
`DELETE FROM search_issues WHERE project_id ... AND occurrence_id ... AND client_timestamp ...`