### PR TITLE
ref(snuba-deletes): Basic delete API

### DIFF
--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -38,7 +38,7 @@ def format_query(query: FormattableQuery) -> FormattedQuery:
     This is the entry point for any type of query, whether simple or
     composite.
     """
-    if query.is_delete():
+    if isinstance(query, Query) and query.is_delete():
         return FormattedQuery(
             _format_delete_query_content(query, ClickhouseExpressionFormatter)
         )
@@ -156,10 +156,20 @@ def _format_delete_query_content(
                     query.get_from_clause()
                 ),
             ),
+            _format_on_cluster(query, formatter),
             _build_optional_string_node("WHERE", query.get_condition(), formatter),
         ]
         if v is not None
     ]
+
+
+def _format_on_cluster(
+    query: AbstractQuery, formatter: ExpressionVisitor[str]
+) -> StringNode:
+    on_cluster = query.get_on_cluster()
+    if on_cluster:
+        return StringNode(f"ON CLUSTER {on_cluster.accept(formatter)}")
+    return None
 
 
 def _format_select(

--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -80,13 +80,6 @@ class DataSourceFormatter(DataSourceVisitor[FormattedNode, Table]):
         self, data_source: ProcessableQuery[Table]
     ) -> FormattedSubQuery:
         assert isinstance(data_source, Query)
-        if data_source.is_delete():
-            return FormattedSubQuery(
-                _format_delete_query_content(
-                    data_source, self.__expression_formatter_type
-                ),
-            )
-
         return FormattedSubQuery(
             _format_query_content(data_source, self.__expression_formatter_type),
         )

--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -165,7 +165,7 @@ def _format_delete_query_content(
 
 def _format_on_cluster(
     query: AbstractQuery, formatter: ExpressionVisitor[str]
-) -> StringNode:
+) -> Optional[StringNode]:
     on_cluster = query.get_on_cluster()
     if on_cluster:
         return StringNode(f"ON CLUSTER {on_cluster.accept(formatter)}")

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -29,8 +29,10 @@ class Query(AbstractQuery[Table]):
         offset: int = 0,
         totals: bool = False,
         granularity: Optional[int] = None,
+        is_delete: bool = False,
     ) -> None:
         self.__prewhere = prewhere
+        self.__is_delete = is_delete
 
         super().__init__(
             from_clause=from_clause,
@@ -70,3 +72,6 @@ class Query(AbstractQuery[Table]):
 
     def _eq_functions(self) -> Sequence[str]:
         return tuple(super()._eq_functions()) + ("get_prewhere_ast",)
+
+    def is_delete(self) -> bool:
+        return self.__is_delete

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -33,8 +33,6 @@ class Query(AbstractQuery[Table]):
         is_delete: bool = False,
     ) -> None:
         self.__prewhere = prewhere
-        self.__is_delete = is_delete
-        self.__on_cluster = on_cluster
 
         super().__init__(
             from_clause=from_clause,
@@ -49,6 +47,8 @@ class Query(AbstractQuery[Table]):
             offset=offset,
             totals=totals,
             granularity=granularity,
+            on_cluster=on_cluster,
+            is_delete=is_delete,
         )
 
     def _get_expressions_impl(self) -> Iterable[Expression]:
@@ -74,9 +74,3 @@ class Query(AbstractQuery[Table]):
 
     def _eq_functions(self) -> Sequence[str]:
         return tuple(super()._eq_functions()) + ("get_prewhere_ast",)
-
-    def is_delete(self) -> bool:
-        return self.__is_delete
-
-    def get_on_cluster(self) -> Optional[Expression]:
-        return self.__on_cluster

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -29,10 +29,12 @@ class Query(AbstractQuery[Table]):
         offset: int = 0,
         totals: bool = False,
         granularity: Optional[int] = None,
+        on_cluster: Optional[Expression] = None,
         is_delete: bool = False,
     ) -> None:
         self.__prewhere = prewhere
         self.__is_delete = is_delete
+        self.__on_cluster = on_cluster
 
         super().__init__(
             from_clause=from_clause,
@@ -75,3 +77,6 @@ class Query(AbstractQuery[Table]):
 
     def is_delete(self) -> bool:
         return self.__is_delete
+
+    def get_on_cluster(self) -> Optional[Expression]:
+        return self.__on_cluster

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -293,10 +293,10 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         )
 
     def get_deleter(self) -> Reader:
-        print("\n\nDATABSE", self.__database)
         if not self.__deleter:
+            # we need the connection to the storage nodes, not
+            # the distributed nodes
             local_node = self.get_local_nodes()[0]
-            print("local_node", local_node)
             self.__deleter = NativeDriverReader(
                 cache_partition_id=f"{self.__cache_partition_id}_deletes",
                 client=self.get_node_connection(

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -59,6 +59,7 @@ class ClickhouseClientSettings(Enum):
         },
         10000,
     )
+    DELETE = ClickhouseClientSettingsType({"mutations_sync": 1}, None)
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
     QUERY = ClickhouseClientSettingsType({}, None)
     QUERYLOG = ClickhouseClientSettingsType({}, None)
@@ -249,6 +250,7 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         self.__cluster_name = cluster_name
         self.__distributed_cluster_name = distributed_cluster_name
         self.__reader: Optional[Reader] = None
+        self.__deleter: Optional[Reader] = None
         self.__connection_cache = connection_cache
         self.__cache_partition_id = cache_partition_id
         self.__query_settings_prefix = query_settings_prefix
@@ -289,6 +291,20 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
             self.__password,
             self.__database,
         )
+
+    def get_deleter(self) -> Reader:
+        print("\n\nDATABSE", self.__database)
+        if not self.__deleter:
+            local_node = self.get_local_nodes()[0]
+            print("local_node", local_node)
+            self.__deleter = NativeDriverReader(
+                cache_partition_id=f"{self.__cache_partition_id}_deletes",
+                client=self.get_node_connection(
+                    ClickhouseClientSettings.DELETE, local_node
+                ),
+                query_settings_prefix=self.__query_settings_prefix,
+            )
+        return self.__deleter
 
     def get_reader(self) -> Reader:
         if not self.__reader:
@@ -400,9 +416,11 @@ CLUSTERS = [
         storage_sets=cluster["storage_sets"],
         single_node=cluster["single_node"],
         cluster_name=cluster["cluster_name"] if "cluster_name" in cluster else None,
-        distributed_cluster_name=cluster["distributed_cluster_name"]
-        if "distributed_cluster_name" in cluster
-        else None,
+        distributed_cluster_name=(
+            cluster["distributed_cluster_name"]
+            if "distributed_cluster_name" in cluster
+            else None
+        ),
         cache_partition_id=cluster.get("cache_partition_id"),
         query_settings_prefix=cluster.get("query_settings_prefix"),
         max_connections=cluster.get("max_connections", _DEFAULT_MAX_CONNECTIONS),
@@ -446,9 +464,11 @@ def _build_sliced_cluster(cluster: Mapping[str, Any]) -> ClickhouseCluster:
         },
         single_node=cluster["single_node"],
         cluster_name=cluster["cluster_name"] if "cluster_name" in cluster else None,
-        distributed_cluster_name=cluster["distributed_cluster_name"]
-        if "distributed_cluster_name" in cluster
-        else None,
+        distributed_cluster_name=(
+            cluster["distributed_cluster_name"]
+            if "distributed_cluster_name" in cluster
+            else None
+        ),
         cache_partition_id=cluster.get("cache_partition_id"),
         query_settings_prefix=cluster.get("query_settings_prefix"),
     )
@@ -457,9 +477,9 @@ def _build_sliced_cluster(cluster: Mapping[str, Any]) -> ClickhouseCluster:
 _SLICED_STORAGE_SET_CLUSTER_MAP: Dict[Tuple[StorageSetKey, int], ClickhouseCluster] = {}
 
 
-def _get_sliced_storage_set_cluster_map() -> Dict[
-    Tuple[StorageSetKey, int], ClickhouseCluster
-]:
+def _get_sliced_storage_set_cluster_map() -> (
+    Dict[Tuple[StorageSetKey, int], ClickhouseCluster]
+):
     if len(_SLICED_STORAGE_SET_CLUSTER_MAP) == 0:
         for cluster in settings.SLICED_CLUSTERS:
             for storage_set_tuple in cluster["storage_set_slices"]:

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -115,7 +115,7 @@ query_processors:
           trace.trace_id: trace_id
 
 deletion_settings:
-  is_enabled: 0
+  is_enabled: 1
   max_rows_to_delete: 1000
   tables:
     - search_issues_local_v2

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -106,6 +106,8 @@ class Query(DataSource, ABC):
         totals: bool = False,
         granularity: Optional[int] = None,
         experiments: Optional[MutableMapping[str, AnyType]] = None,
+        on_cluster: Optional[Expression] = None,
+        is_delete: bool = False,
     ):
         self.__selected_columns = selected_columns or []
         self.__array_join = array_join
@@ -119,6 +121,8 @@ class Query(DataSource, ABC):
         self.__totals = totals
         self.__granularity = granularity
         self.__experiments = experiments or {}
+        self.__on_cluster = on_cluster
+        self.__is_delete = is_delete
 
     def get_columns(self) -> ColumnSet:
         """
@@ -236,6 +240,12 @@ class Query(DataSource, ABC):
 
     def get_experiment_value(self, name: str) -> AnyType:
         return self.__experiments.get(name)
+
+    def is_delete(self) -> bool:
+        return self.__is_delete
+
+    def get_on_cluster(self) -> Optional[Expression]:
+        return self.__on_cluster
 
     @abstractmethod
     def _get_expressions_impl(self) -> Iterable[Expression]:
@@ -513,6 +523,8 @@ class ProcessableQuery(Query, ABC, Generic[TSimpleDataSource]):
         offset: int = 0,
         totals: bool = False,
         granularity: Optional[int] = None,
+        is_delete: bool = False,
+        on_cluster: Optional[Expression] = None,
     ):
         super().__init__(
             selected_columns=selected_columns,
@@ -526,6 +538,8 @@ class ProcessableQuery(Query, ABC, Generic[TSimpleDataSource]):
             offset=offset,
             totals=totals,
             granularity=granularity,
+            is_delete=is_delete,
+            on_cluster=on_cluster,
         )
         self.__from_clause = from_clause
 

--- a/snuba/web/converters.py
+++ b/snuba/web/converters.py
@@ -5,8 +5,9 @@ from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity, get_entity_name
 from snuba.datasets.entity import Entity
 from snuba.datasets.factory import get_dataset, get_dataset_name
-from snuba.datasets.storage import Storage, StorageKey
-from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storage import WritableTableStorage
+from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.storage_key import StorageKey
 
 
 class DatasetConverter(BaseConverter):
@@ -26,8 +27,8 @@ class EntityConverter(BaseConverter):
 
 
 class StorageConverter(BaseConverter):
-    def to_python(self, value: str) -> Storage:
-        return get_storage(StorageKey(value))
+    def to_python(self, value: str) -> WritableTableStorage:
+        return get_writable_storage(StorageKey(value))
 
-    def to_url(self, value: Storage) -> str:
+    def to_url(self, value: WritableTableStorage) -> str:
         return value.get_storage_key().value

--- a/snuba/web/converters.py
+++ b/snuba/web/converters.py
@@ -5,6 +5,8 @@ from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity, get_entity_name
 from snuba.datasets.entity import Entity
 from snuba.datasets.factory import get_dataset, get_dataset_name
+from snuba.datasets.storage import Storage, StorageKey
+from snuba.datasets.storages.factory import get_storage
 
 
 class DatasetConverter(BaseConverter):
@@ -21,3 +23,11 @@ class EntityConverter(BaseConverter):
 
     def to_url(self, value: Entity) -> str:
         return get_entity_name(value).value
+
+
+class StorageConverter(BaseConverter):
+    def to_python(self, value: str) -> Storage:
+        return get_storage(StorageKey(value))
+
+    def to_url(self, value: Storage) -> str:
+        return value.get_storage_key().value

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -1,0 +1,36 @@
+from snuba.clickhouse.formatter.query import format_query
+from snuba.clickhouse.query import Query
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query.conditions import combine_and_conditions
+from snuba.query.data_source.simple import Table
+from snuba.query.dsl import column, equals, in_cond, literal, literals_tuple
+
+
+def construct_condition(body):
+    and_conditions = []
+    for col, values in body.get("columns").items():
+        if len(values) == 1:
+            exp = equals(column(col), literal(values[0]))
+        else:
+            literal_values = [literal(v) for v in values]
+            exp = in_cond(column(col), literals_tuple(literal_values))
+
+        and_conditions.append(exp)
+
+    return combine_and_conditions(and_conditions)
+
+
+def delete_query(storage: StorageKey, table: str, body):
+    query = Query(
+        from_clause=Table(
+            table,
+            None,
+            storage_key=storage,
+            allocation_policies=[],
+        ),
+        condition=construct_condition(body),
+        is_delete=True,
+    )
+    formatted_query = format_query(query)
+    # TODO error handling and the lot
+    return storage.get_cluster().get_deleter().execute(formatted_query)

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -21,6 +21,8 @@ def construct_condition(body):
 
 
 def delete_query(storage: StorageKey, table: str, body):
+    cluster_name = storage.get_cluster().get_clickhouse_cluster_name()
+    on_cluster = literal(cluster_name) if cluster_name else None
     query = Query(
         from_clause=Table(
             table,
@@ -29,6 +31,7 @@ def delete_query(storage: StorageKey, table: str, body):
             allocation_policies=[],
         ),
         condition=construct_condition(body),
+        on_cluster=on_cluster,
         is_delete=True,
     )
     formatted_query = format_query(query)

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -1,33 +1,43 @@
+from typing import Any, Dict
+
+from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.query import format_query
 from snuba.clickhouse.query import Query
-from snuba.datasets.storages.storage_key import StorageKey
+from snuba.datasets.storage import WritableTableStorage
 from snuba.query.conditions import combine_and_conditions
 from snuba.query.data_source.simple import Table
 from snuba.query.dsl import column, equals, in_cond, literal, literals_tuple
+from snuba.query.expressions import Expression
+from snuba.reader import Result
 
 
-def construct_condition(body):
+def construct_condition(body: Dict[str, Any]) -> Expression:
     and_conditions = []
-    for col, values in body.get("columns").items():
+    for col, values in body["columns"].items():
         if len(values) == 1:
             exp = equals(column(col), literal(values[0]))
         else:
             literal_values = [literal(v) for v in values]
-            exp = in_cond(column(col), literals_tuple(literal_values))
+            exp = in_cond(
+                column(col), literals_tuple(alias=None, literals=literal_values)
+            )
 
         and_conditions.append(exp)
 
     return combine_and_conditions(and_conditions)
 
 
-def delete_query(storage: StorageKey, table: str, body):
+def delete_query(
+    storage: WritableTableStorage, table: str, body: Dict[str, Any]
+) -> Result:
     cluster_name = storage.get_cluster().get_clickhouse_cluster_name()
     on_cluster = literal(cluster_name) if cluster_name else None
     query = Query(
         from_clause=Table(
             table,
-            None,
-            storage_key=storage,
+            ColumnSet([]),
+            storage_key=storage.get_storage_key(),
+            # TODO: add allocation policies
             allocation_policies=[],
         ),
         condition=construct_condition(body),

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -50,7 +50,7 @@ from snuba.redis import all_redis_clients
 from snuba.request.exceptions import InvalidJsonRequestException, JsonDecodeException
 from snuba.request.schema import RequestSchema
 from snuba.state import get_config
-from snuba.state.rate_limit import RateLimitExceeded
+from snuba.state.rate_limit import RateLimitExceeded, RateLimitParameters, rate_limit
 from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import PartitionId
 from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionDeleter
@@ -295,10 +295,10 @@ def mql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response,
 
 @application.route("/<storage:storage>/", methods=["DELETE"])
 @util.time_request("delete_query")
+@rate_limit(RateLimitParameters("delete", "bucket", None, 1))
 def storage_delete(
     *, storage: WritableTableStorage, timer: Timer
 ) -> Union[Response, str]:
-
     if http_request.method == "DELETE":
 
         check_shutdown({"storage": storage.get_storage_key()})

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -638,7 +638,7 @@ def test_format_clickhouse_specific_query() -> None:
     assert clickhouse_query.get_sql() == expected
 
 
-def test_delete_query():
+def test_delete_query() -> None:
     query = Query(
         Table(
             "my_table",

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -638,6 +638,33 @@ def test_format_clickhouse_specific_query() -> None:
     assert clickhouse_query.get_sql() == expected
 
 
+def test_delete_query():
+    query = Query(
+        Table(
+            "my_table",
+            ColumnSet([]),
+            storage_key=StorageKey("dontmatter"),
+        ),
+        condition=binary_condition(
+            "eq",
+            lhs=Column(None, None, "project_id"),
+            rhs=Literal(None, 1),
+        ),
+        on_cluster=Literal(None, "cluster_name"),
+        is_delete=True,
+    )
+
+    clickhouse_query = format_query(query)
+    expected = (
+        "DELETE "
+        "FROM my_table "
+        "ON CLUSTER 'cluster_name' "
+        "WHERE eq(project_id, 1)"
+    )
+
+    assert clickhouse_query.get_sql() == expected
+
+
 TEST_JOIN = [
     pytest.param(
         JoinClause(

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -161,6 +161,9 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         ]
 
         response = self.delete_query(occurrence_id)
+        data = json.loads(response.data)
+        assert response.status_code == 200, data
+        assert data["search_issues_local_v2"]["data"] == []
 
         # make sure the data got deleted, aka no query results
         response = self.post_query(

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -156,7 +156,9 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         response = self.delete_query(occurrence_id)
         data = json.loads(response.data)
         assert response.status_code == 200, data
-        assert data["search_issues_local_v2"]["data"] == []
+        # TODO: response is different b/n single node and
+        # distributed node, so need to make those consistent
+        # assert data["search_issues_local_v2"]["data"]
 
         # make sure the data got deleted, aka no query results
         response = self.post_query(

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -46,13 +46,6 @@ def base_insert_event(
     )
 
 
-from clickhouse_driver import Client
-
-
-def get_client() -> Client:
-    return Client(host="127.0.0.1", port=9000, database="snuba_test")
-
-
 class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
     @pytest.fixture
     def test_entity(self) -> Union[str, Tuple[str, str]]:
@@ -178,15 +171,6 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         data = json.loads(response.data)
         assert response.status_code == 200, data
         assert data["data"] == []
-
-        client = get_client()
-        # Mutation command should look like the following:
-        # UPDATE _row_exists = 0 WHERE (occurrence_id = 'ebe2b2a0-0cbd-4fe7-806f-6de220656645') AND (project_id = 3)
-        [(cmd,)] = client.execute(
-            "SELECT command FROM system.mutations WHERE database = 'snuba_test' AND table = 'search_issues_local_v2'"
-        )
-
-        assert str(occurrence_id) in cmd
 
     def test_simple_search_query(self) -> None:
         now = datetime.now().replace(minute=0, second=0, microsecond=0)


### PR DESCRIPTION
**context**
This is a simple delete API that allows for deleting data for specific storages that are flagged in, if the runtime config `storage_deletes_enabled` is enabled.

This is not production ready, but rather a way to test out the delete functionality in production, with multi-node clusters. We will be using this to test on search_issues data in S4S only as we iterate. 

**Payload**
This schema may change in the future, and be added to, but the basic structure is a `columns` mapping, which maps the column name to the values you filtering on to delete. This only constructs in or eq expressions, not gte or lte for now.

```json
 {
    "columns": {"occurrence_id": ["4c90c9d3-5a51-4bb7-90f1-913a4b1b758d"], "project_id": [3]},
    "tenant_ids": {"referrer": "api_referrer", "organization_id": 1},
}
```

**What the API has:**
* Killswitch
    * Use `storage_deletes_enabled` to turn off the feature (even if storages are enabled), default is off
* Basic functionality to turn a payload into an AST and formats the query
    * Handles adding ON CLUSTER for multi-node delete queries
* Implements `check_shutdown` which checks to see if any requests come in after shutdown

**What API is missing:**
* Proper validation and error handling
    * This includes the `MaxRowEnforcer` and incorporating the `ColumnFilterProcessor`
    * Error handling needs to also include responses to ON CLUSTER requests which seem to have a different response body
* More unit testing, mostly have tests on the endpoint call