### PR TITLE
fix(transactions): Select transactions entity when using profiler id

### DIFF
--- a/snuba/query/snql/discover_entity_selection.py
+++ b/snuba/query/snql/discover_entity_selection.py
@@ -117,6 +117,7 @@ TRANSACTIONS_COLUMNS = ColumnSet(
         ("group_ids", Array(UInt(64, Modifiers(nullable=True)))),
         ("app_start_type", String(Modifiers(nullable=True))),
         ("profile_id", UUID(Modifiers(nullable=True))),
+        ("profiler_id", UUID(Modifiers(nullable=True))),
     ]
 )
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -200,6 +200,7 @@ def get_raw_transaction(span_id: str | None = None) -> Mapping[str, Any]:
     primary_hash = md5(unique.encode("utf-8")).hexdigest()
     app_start_type = "warm.prewarmed"
     profile_id = uuid.UUID("046852d2-4483-455c-8c44-f0c8fbf496f9")
+    profiler_id = uuid.UUID("ab90d5a8-0391-4b35-bd78-69d8f8e57469")
 
     return {
         "project_id": PROJECT_ID,
@@ -241,7 +242,10 @@ def get_raw_transaction(span_id: str | None = None) -> Mapping[str, Any]:
                 },
                 "device": {"online": True, "charging": True, "model_id": "Galaxy"},
                 "app": {"start_type": app_start_type},
-                "profile": {"profile_id": profile_id.hex},
+                "profile": {
+                    "profile_id": profile_id.hex,
+                    "profiler_id": profiler_id.hex,
+                },
             },
             "measurements": {
                 "lcp": {"value": 32.129},

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -815,6 +815,39 @@ class TestSnQLApi(BaseApiTest):
         assert len(data) == 1
         assert data[0]["profile_id"] == "046852d24483455c8c44f0c8fbf496f9"
 
+    @pytest.mark.parametrize(
+        "url, entity",
+        [
+            pytest.param("/transactions/snql", "transactions", id="transactions"),
+            pytest.param(
+                "/discover/snql", "discover_transactions", id="discover_transactions"
+            ),
+        ],
+    )
+    def test_profiler_id(self, url: str, entity: str) -> None:
+        response = self.post(
+            url,
+            data=json.dumps(
+                {
+                    "query": f"""
+                    MATCH ({entity})
+                    SELECT profiler_id AS profiler_id
+                    WHERE
+                        finish_ts >= toDateTime('{self.base_time.isoformat()}') AND
+                        finish_ts < toDateTime('{self.next_time.isoformat()}') AND
+                        project_id IN tuple({self.project_id})
+                    LIMIT 10
+                    """,
+                    "tenant_ids": {"referrer": "r", "organization_id": 123},
+                }
+            ),
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)["data"]
+        assert len(data) == 1
+        assert data[0]["profiler_id"] == "ab90d5a803914b35bd7869d8f8e57469"
+
     def test_attribution_tags(self) -> None:
         response = self.post(
             "/events/snql",


### PR DESCRIPTION
When using the profiler_id column, the discover entity selection should default to the transactions entity the same way it does for profile_id.