### PR TITLE
bug(mql): Fix MQL formula queries with totals and no groupby

### DIFF
--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -20,7 +20,12 @@ from snuba.clickhouse.query import Query
 from snuba.query import ProcessableQuery
 from snuba.query import Query as AbstractQuery
 from snuba.query.composite import CompositeQuery
-from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinType,
+    JoinVisitor,
+)
 from snuba.query.data_source.simple import Table
 from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.expressions import Expression, ExpressionVisitor
@@ -234,6 +239,14 @@ class JoinFormatter(JoinVisitor[FormattedNode, Table]):
     def visit_join_clause(self, node: JoinClause[Table]) -> FormattedNode:
         join_type = f"{node.join_type.value} " if node.join_type else ""
         modifier = f"{node.join_modifier.value} " if node.join_modifier else ""
+        if node.join_type == JoinType.CROSS:
+            return SequenceNode(
+                [
+                    node.left_node.accept(self),
+                    StringNode(f"{modifier}{join_type}JOIN"),
+                    node.right_node.accept(self),
+                ]
+            )
         return SequenceNode(
             [
                 node.left_node.accept(self),

--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -25,6 +25,7 @@ from snuba.utils.schemas import Column, ColumnSet, SchemaModifiers, WildcardColu
 class JoinType(Enum):
     INNER = "INNER"
     LEFT = "LEFT"
+    CROSS = "CROSS"
 
 
 class JoinModifier(Enum):

--- a/snuba/query/formatters/tracing.py
+++ b/snuba/query/formatters/tracing.py
@@ -140,15 +140,6 @@ class TracingQueryFormatter(
         return [f"{self.visit(node.data_source)} AS `{node.alias}`"]
 
     def visit_join_clause(self, node: JoinClause[SimpleDataSource]) -> List[str]:
-        # There is only one of these in the on clause (I think)
-        on_list = []
-        for c in node.keys:
-            on_list.append(
-                [
-                    f"{c.left.table_alias}.{c.left.column}",
-                    f"{c.right.table_alias}.{c.right.column}",
-                ]
-            )
         if node.join_type == JoinType.CROSS:
             return [
                 *_indent_str_list(node.left_node.accept(self), 1),

--- a/snuba/query/formatters/tracing.py
+++ b/snuba/query/formatters/tracing.py
@@ -2,7 +2,12 @@ from typing import Any, List, Mapping, Sequence, Union
 
 from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
-from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinType,
+    JoinVisitor,
+)
 from snuba.query.data_source.simple import SimpleDataSource
 from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.expressions import StringifyVisitor
@@ -136,21 +141,35 @@ class TracingQueryFormatter(
 
     def visit_join_clause(self, node: JoinClause[SimpleDataSource]) -> List[str]:
         # There is only one of these in the on clause (I think)
-        on_list = [
-            [
-                f"{c.left.table_alias}.{c.left.column}",
-                f"{c.right.table_alias}.{c.right.column}",
+        on_list = []
+        for c in node.keys:
+            on_list.append(
+                [
+                    f"{c.left.table_alias}.{c.left.column}",
+                    f"{c.right.table_alias}.{c.right.column}",
+                ]
+            )
+        if node.join_type == JoinType.CROSS:
+            return [
+                *_indent_str_list(node.left_node.accept(self), 1),
+                f"{node.join_type.name.upper()} JOIN",
+                *_indent_str_list(node.right_node.accept(self), 1),
             ]
-            for c in node.keys
-        ][0]
-
-        return [
-            *_indent_str_list(node.left_node.accept(self), 1),
-            f"{node.join_type.name.upper()} JOIN",
-            *_indent_str_list(node.right_node.accept(self), 1),
-            "ON",
-            *_indent_str_list(
-                on_list,
-                1,
-            ),
-        ]
+        else:
+            on_list = [
+                [
+                    f"{c.left.table_alias}.{c.left.column}",
+                    f"{c.right.table_alias}.{c.right.column}",
+                ]
+                for c in node.keys
+            ][0]
+            return [
+                *_indent_str_list(node.left_node.accept(self), 1),
+                f"{node.join_type.name.upper()} JOIN",
+                *_indent_str_list(node.right_node.accept(self), 1),
+                "ON",
+                *_indent_str_list(
+                    on_list,
+                    1,
+                ),
+            ]

--- a/snuba/query/joins/metrics_subquery_generator.py
+++ b/snuba/query/joins/metrics_subquery_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import Generator, Mapping
 
 from snuba.query import ProcessableQuery, SelectedExpression
@@ -260,17 +259,5 @@ def generate_metrics_subqueries(query: CompositeQuery[Entity]) -> None:
 
     # Since groupbys are pushed down, we don't need them in the outer query.
     query.set_ast_groupby([])
-
-    query.set_ast_orderby(
-        [
-            replace(
-                orderby,
-                expression=_process_root(
-                    orderby.expression, subqueries, alias_generator
-                ),
-            )
-            for orderby in query.get_orderby()
-        ]
-    )
 
     query.set_from_clause(SubqueriesReplacer(subqueries).visit_join_clause(from_clause))

--- a/snuba/query/joins/metrics_subquery_generator.py
+++ b/snuba/query/joins/metrics_subquery_generator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import Generator, Mapping
 
 from snuba.query import ProcessableQuery, SelectedExpression
@@ -257,17 +256,8 @@ def generate_metrics_subqueries(query: CompositeQuery[Entity]) -> None:
 
     for e in query.get_groupby():
         _process_root_groupby(query, e, subqueries, alias_generator)
+
+    # Since groupbys are pushed down, we don't need them in the outer query.
     query.set_ast_groupby([])
 
-    query.set_ast_orderby(
-        [
-            replace(
-                orderby,
-                expression=_process_root(
-                    orderby.expression, subqueries, alias_generator
-                ),
-            )
-            for orderby in query.get_orderby()
-        ]
-    )
     query.set_from_clause(SubqueriesReplacer(subqueries).visit_join_clause(from_clause))

--- a/snuba/query/joins/metrics_subquery_generator.py
+++ b/snuba/query/joins/metrics_subquery_generator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Generator, Mapping
 
 from snuba.query import ProcessableQuery, SelectedExpression
@@ -259,5 +260,17 @@ def generate_metrics_subqueries(query: CompositeQuery[Entity]) -> None:
 
     # Since groupbys are pushed down, we don't need them in the outer query.
     query.set_ast_groupby([])
+
+    query.set_ast_orderby(
+        [
+            replace(
+                orderby,
+                expression=_process_root(
+                    orderby.expression, subqueries, alias_generator
+                ),
+            )
+            for orderby in query.get_orderby()
+        ]
+    )
 
     query.set_from_clause(SubqueriesReplacer(subqueries).visit_join_clause(from_clause))

--- a/snuba/query/mql/context_population.py
+++ b/snuba/query/mql/context_population.py
@@ -114,10 +114,6 @@ def rollup_expressions(
         Literal(None, rollup.granularity),
     )
 
-    # Validate interval/totals
-    if rollup.interval is None and rollup.with_totals in (None, "False"):
-        raise ParsingException("Rollup must have at least one of interval or totals")
-
     # Validate totals/orderby
     if rollup.with_totals is not None and rollup.with_totals not in ("True", "False"):
         raise ParsingException("with_totals must be a string, either 'True' or 'False'")

--- a/snuba/query/mql/context_population.py
+++ b/snuba/query/mql/context_population.py
@@ -152,7 +152,7 @@ def rollup_expressions(
         )
         selected_time = SelectedExpression("time", time_expression)
         orderby = OrderBy(OrderByDirection.ASC, time_expression)
-    elif rollup.orderby and not with_totals:
+    elif rollup.orderby is not None:
         direction = (
             OrderByDirection.ASC if rollup.orderby == "ASC" else OrderByDirection.DESC
         )

--- a/snuba/query/mql/context_population.py
+++ b/snuba/query/mql/context_population.py
@@ -92,7 +92,7 @@ def scope_conditions(
 
 def rollup_expressions(
     mql_context: MQLContext, table_name: str | None = None
-) -> tuple[Expression, bool, OrderBy | None, SelectedExpression]:
+) -> tuple[Expression, bool, OrderBy | None, SelectedExpression | None]:
     """
     This function returns four values based on the rollup field in the MQL context:
     - granularity_condition: an expression that filters the granularity column based on the granularity in the MQL context

--- a/snuba/query/mql/context_population.py
+++ b/snuba/query/mql/context_population.py
@@ -114,6 +114,12 @@ def rollup_expressions(
         Literal(None, rollup.granularity),
     )
 
+    # Validate totals/interval
+    if rollup.interval is None and rollup.with_totals in (None, "False"):
+        raise ParsingException(
+            "either interval or with_totals must be specified in rollup"
+        )
+
     # Validate totals/orderby
     if rollup.with_totals is not None and rollup.with_totals not in ("True", "False"):
         raise ParsingException("with_totals must be a string, either 'True' or 'False'")

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -760,7 +760,6 @@ def db_query(
         evolves it can be changed. The inconsistency was consciously chosen for expediency and to have
         allocation policy be applied at the top level of the db_query process
     """
-
     allocation_policies = _get_allocation_policies(clickhouse_query)
     query_id = uuid.uuid4().hex
     result = None

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -760,6 +760,7 @@ def db_query(
         evolves it can be changed. The inconsistency was consciously chosen for expediency and to have
         allocation policy be applied at the top level of the db_query process
     """
+
     allocation_policies = _get_allocation_policies(clickhouse_query)
     query_id = uuid.uuid4().hex
     result = None

--- a/tests/query/joins/test_metrics_subqueries.py
+++ b/tests/query/joins/test_metrics_subqueries.py
@@ -193,7 +193,12 @@ def test_subquery_generator_metrics() -> None:
     expected_outer_query_orderby = [
         OrderBy(
             direction=OrderByDirection.ASC,
-            expression=column("_snuba_d0.time", "d0", "_snuba_d0.time"),
+            expression=f.toStartOfInterval(
+                column("timestamp", "d0", "_snuba_timestamp"),
+                f.toIntervalSecond(literal(60)),
+                literal("Universal"),
+                alias="_snuba_d0.time",
+            ),
         )
     ]
     assert original_query.get_orderby() == expected_outer_query_orderby

--- a/tests/query/parser/test_parser.py
+++ b/tests/query/parser/test_parser.py
@@ -18,7 +18,7 @@ from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import NestedColumn, and_cond, column, in_cond, literal
-from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.expressions import Column, FunctionCall
 from snuba.query.logical import Query
 from snuba.query.mql.parser_supported_join import parse_mql_query_new
 from snuba.query.snql.parser import parse_snql_query
@@ -29,20 +29,6 @@ from_distributions = QueryEntity(
     EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
     get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS).get_data_model(),
 )
-
-
-def time_expression(to_interval_seconds: int | None = 60) -> FunctionCall:
-    return FunctionCall(
-        "_snuba_time",
-        "toStartOfInterval",
-        (
-            Column("_snuba_timestamp", None, "timestamp"),
-            FunctionCall(
-                None, "toIntervalSecond", (Literal(None, to_interval_seconds),)
-            ),
-            Literal(None, "Universal"),
-        ),
-    )
 
 
 def test_mql() -> None:
@@ -82,12 +68,8 @@ def test_mql() -> None:
                     (Column("_snuba_value", None, "value"),),
                 ),
             ),
-            SelectedExpression(
-                "time",
-                time_expression(None),
-            ),
         ],
-        groupby=[time_expression(None)],
+        groupby=[],
         condition=and_cond(
             and_cond(
                 and_cond(
@@ -192,12 +174,8 @@ def test_mql_wildcards() -> None:
                     (Column("_snuba_value", None, "value"),),
                 ),
             ),
-            SelectedExpression(
-                "time",
-                time_expression(None),
-            ),
         ],
-        groupby=[time_expression(None)],
+        groupby=[],
         condition=and_cond(
             and_cond(
                 and_cond(
@@ -300,12 +278,8 @@ def test_mql_negated_wildcards() -> None:
                     (Column("_snuba_value", None, "value"),),
                 ),
             ),
-            SelectedExpression(
-                "time",
-                time_expression(None),
-            ),
         ],
-        groupby=[time_expression(None)],
+        groupby=[],
         condition=and_cond(
             and_cond(
                 and_cond(

--- a/tests/query/parser/test_parser.py
+++ b/tests/query/parser/test_parser.py
@@ -40,7 +40,7 @@ def test_mql() -> None:
             "orderby": "ASC",
             "granularity": 60,
             "interval": None,
-            "with_totals": None,
+            "with_totals": "True",
         },
         "scope": {
             "org_ids": [1],
@@ -130,6 +130,7 @@ def test_mql() -> None:
                 ),
             ),
         ],
+        totals=True,
         limit=1000,
     )
     actual = parse_mql_query_new(mql, context, get_dataset("generic_metrics"))
@@ -146,7 +147,7 @@ def test_mql_wildcards() -> None:
             "orderby": "ASC",
             "granularity": 60,
             "interval": None,
-            "with_totals": None,
+            "with_totals": "True",
         },
         "scope": {
             "org_ids": [1],
@@ -235,6 +236,7 @@ def test_mql_wildcards() -> None:
             ),
         ],
         limit=1000,
+        totals=True,
     )
     actual = parse_mql_query_new(mql, context, get_dataset("generic_metrics"))
     eq, reason = actual.equals(expected)
@@ -250,7 +252,7 @@ def test_mql_negated_wildcards() -> None:
             "orderby": "ASC",
             "granularity": 60,
             "interval": None,
-            "with_totals": None,
+            "with_totals": "True",
         },
         "scope": {
             "org_ids": [1],
@@ -339,6 +341,7 @@ def test_mql_negated_wildcards() -> None:
             ),
         ],
         limit=1000,
+        totals=True,
     )
     actual = parse_mql_query_new(mql, context, get_dataset("generic_metrics"))
     eq, reason = actual.equals(expected)
@@ -474,7 +477,7 @@ def test_recursion_error() -> None:
             "orderby": "ASC",
             "granularity": 60,
             "interval": None,
-            "with_totals": None,
+            "with_totals": "True",
         },
         "scope": {
             "org_ids": [1],

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -1272,3 +1272,61 @@ class TestGenericMetricsMQLApi(BaseApiTest):
             ).serialize_mql(),
         )
         assert response.status_code == 200
+
+    def test_formula_with_totals_and_orderby(self) -> None:
+        query = MetricsQuery(
+            query=Formula(
+                ArithmeticOperator.PLUS.value,
+                [
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="avg",
+                    ),
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="avg",
+                    ),
+                ],
+            ),
+            start=self.start_time,
+            end=self.end_time,
+            rollup=Rollup(
+                interval=None, totals=True, orderby=Direction.DESC, granularity=60
+            ),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=self.project_ids,
+                use_case_id=USE_CASE_ID,
+            ),
+            indexer_mappings={
+                "transaction.duration": DISTRIBUTIONS_MRI,
+                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
+                "status_code": resolve_str("status_code"),
+            },
+        )
+
+        response = self.app.post(
+            self.mql_route,
+            data=Request(
+                dataset=DATASET,
+                app_id="test",
+                query=query,
+                flags=Flags(debug=True),
+                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
+            ).serialize_mql(),
+        )
+
+        assert response.status_code == 200, response.data
+        data = json.loads(response.data)
+        print(data)
+        assert (
+            data["totals"]["aggregate_value"] == 4.0
+        )  # Should be more than the number of data points

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -281,7 +281,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         assert rows[0]["aggregate_value"] > 0
         assert rows[0]["status_code"] == "200"
 
-    def test_groupby_with_interval_with_totals(self) -> None:
+    def test_interval_with_totals(self) -> None:
         query = MetricsQuery(
             query=Timeseries(
                 metric=Metric(
@@ -330,6 +330,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         assert response.status_code == 200
         rows = data["data"]
         assert len(rows) == 180, rows
+
         assert rows[0]["aggregate_value"] > 0
         assert rows[0]["status_code"] == "200"
         assert (
@@ -682,7 +683,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         data = json.loads(response.data)
         assert len(data["data"]) == 180, data
 
-    def test_formula_no_groupby_with_interval_totals(self) -> None:
+    def test_formula_with_totals(self) -> None:
         query = MetricsQuery(
             query=Formula(
                 ArithmeticOperator.PLUS.value,
@@ -693,7 +694,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
                             DISTRIBUTIONS_MRI,
                             DISTRIBUTIONS.metric_id,
                         ),
-                        aggregate="sum",
+                        aggregate="avg",
                     ),
                     Timeseries(
                         metric=Metric(
@@ -701,63 +702,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
                             DISTRIBUTIONS_MRI,
                             DISTRIBUTIONS.metric_id,
                         ),
-                        aggregate="sum",
-                    ),
-                ],
-            ),
-            start=self.start_time,
-            end=self.end_time,
-            rollup=Rollup(interval=60, totals=True, orderby=None, granularity=60),
-            scope=MetricsScope(
-                org_ids=[self.org_id],
-                project_ids=self.project_ids,
-                use_case_id=USE_CASE_ID,
-            ),
-            indexer_mappings={
-                "transaction.duration": DISTRIBUTIONS_MRI,
-                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
-                "status_code": resolve_str("status_code"),
-            },
-        )
-
-        response = self.app.post(
-            self.mql_route,
-            data=Request(
-                dataset=DATASET,
-                app_id="test",
-                query=query,
-                flags=Flags(debug=True),
-                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
-            ).serialize_mql(),
-        )
-
-        assert response.status_code == 200, response.data
-        data = json.loads(response.data)
-        assert len(data["data"]) == 180
-        assert (
-            data["totals"]["aggregate_value"] > 180.0
-        )  # Should be more than the number of data points
-
-    def test_formula_no_groupby_no_interval_with_totals(self) -> None:
-        query = MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.PLUS.value,
-                [
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
-                    ),
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
+                        aggregate="avg",
                     ),
                 ],
             ),
@@ -790,177 +735,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         assert response.status_code == 200, response.data
         data = json.loads(response.data)
         assert (
-            data["totals"]["aggregate_value"] > 180.0
-        )  # Should be more than the number of data points
-
-    def test_formula_no_groupby_with_interval_no_totals(self) -> None:
-        query = MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.PLUS.value,
-                [
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="avg",
-                    ),
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="avg",
-                    ),
-                ],
-            ),
-            start=self.start_time,
-            end=self.end_time,
-            rollup=Rollup(interval=60, totals=False, orderby=None, granularity=60),
-            scope=MetricsScope(
-                org_ids=[self.org_id],
-                project_ids=self.project_ids,
-                use_case_id=USE_CASE_ID,
-            ),
-            indexer_mappings={
-                "transaction.duration": DISTRIBUTIONS_MRI,
-                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
-                "status_code": resolve_str("status_code"),
-            },
-        )
-
-        response = self.app.post(
-            self.mql_route,
-            data=Request(
-                dataset=DATASET,
-                app_id="test",
-                query=query,
-                flags=Flags(debug=True),
-                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
-            ).serialize_mql(),
-        )
-
-        assert response.status_code == 200, response.data
-        data = json.loads(response.data)
-        assert len(data["data"]) == 180, data
-
-    def test_formula_with_groupby_no_internval_with_totals(self) -> None:
-        query = MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.PLUS.value,
-                [
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                ],
-            ),
-            start=self.start_time,
-            end=self.end_time,
-            rollup=Rollup(interval=None, totals=True, orderby=None, granularity=60),
-            scope=MetricsScope(
-                org_ids=[self.org_id],
-                project_ids=self.project_ids,
-                use_case_id=USE_CASE_ID,
-            ),
-            indexer_mappings={
-                "transaction.duration": DISTRIBUTIONS_MRI,
-                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
-                "status_code": resolve_str("status_code"),
-                "transaction": resolve_str("transaction"),
-            },
-        )
-
-        response = self.app.post(
-            self.mql_route,
-            data=Request(
-                dataset=DATASET,
-                app_id="test",
-                query=query,
-                flags=Flags(debug=True),
-                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
-            ).serialize_mql(),
-        )
-
-        assert response.status_code == 200, response.data
-        data = json.loads(response.data)
-        assert len(data["data"]) == 1
-        assert (
-            data["totals"]["aggregate_value"] > 180.0
-        )  # Should be more than the number of data points
-
-    def test_formula_onesided_groupby_with_interval_with_totals(self) -> None:
-        query = MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.PLUS.value,
-                [
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
-                    ),
-                ],
-            ),
-            start=self.start_time,
-            end=self.end_time,
-            rollup=Rollup(interval=60, totals=True, orderby=None, granularity=60),
-            scope=MetricsScope(
-                org_ids=[self.org_id],
-                project_ids=self.project_ids,
-                use_case_id=USE_CASE_ID,
-            ),
-            indexer_mappings={
-                "transaction.duration": DISTRIBUTIONS_MRI,
-                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
-                "status_code": resolve_str("status_code"),
-                "transaction": resolve_str("transaction"),
-            },
-        )
-
-        response = self.app.post(
-            self.mql_route,
-            data=Request(
-                dataset=DATASET,
-                app_id="test",
-                query=query,
-                flags=Flags(debug=True),
-                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
-            ).serialize_mql(),
-        )
-
-        assert response.status_code == 200, response.data
-        data = json.loads(response.data)
-        assert len(data["data"]) == 180
-        assert (
-            data["totals"]["aggregate_value"] > 180.0
+            data["totals"]["aggregate_value"] == 4.0
         )  # Should be more than the number of data points
 
     def test_formula_with_totals_and_interval(self) -> None:
@@ -1497,61 +1272,3 @@ class TestGenericMetricsMQLApi(BaseApiTest):
             ).serialize_mql(),
         )
         assert response.status_code == 200
-
-    def test_orderby(self) -> None:
-        query = MetricsQuery(
-            query=Formula(
-                ArithmeticOperator.PLUS.value,
-                [
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                    Timeseries(
-                        metric=Metric(
-                            "transaction.duration",
-                            DISTRIBUTIONS_MRI,
-                            DISTRIBUTIONS.metric_id,
-                        ),
-                        aggregate="sum",
-                        groupby=[Column("transaction")],
-                    ),
-                ],
-            ),
-            start=self.start_time,
-            end=self.end_time,
-            rollup=Rollup(
-                interval=None, totals=True, orderby=Direction.DESC, granularity=60
-            ),
-            scope=MetricsScope(
-                org_ids=[self.org_id],
-                project_ids=self.project_ids,
-                use_case_id=USE_CASE_ID,
-            ),
-            indexer_mappings={
-                "transaction.duration": DISTRIBUTIONS_MRI,
-                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
-                "status_code": resolve_str("status_code"),
-                "transaction": resolve_str("transaction"),
-            },
-        )
-
-        response = self.app.post(
-            self.mql_route,
-            data=Request(
-                dataset=DATASET,
-                app_id="test",
-                query=query,
-                flags=Flags(debug=True),
-                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
-            ).serialize_mql(),
-        )
-
-        assert response.status_code == 200, response.data
-        data = json.loads(response.data)
-        print(data)

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -1497,3 +1497,61 @@ class TestGenericMetricsMQLApi(BaseApiTest):
             ).serialize_mql(),
         )
         assert response.status_code == 200
+
+    def test_orderby(self) -> None:
+        query = MetricsQuery(
+            query=Formula(
+                ArithmeticOperator.PLUS.value,
+                [
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="sum",
+                        groupby=[Column("transaction")],
+                    ),
+                    Timeseries(
+                        metric=Metric(
+                            "transaction.duration",
+                            DISTRIBUTIONS_MRI,
+                            DISTRIBUTIONS.metric_id,
+                        ),
+                        aggregate="sum",
+                        groupby=[Column("transaction")],
+                    ),
+                ],
+            ),
+            start=self.start_time,
+            end=self.end_time,
+            rollup=Rollup(
+                interval=None, totals=True, orderby=Direction.DESC, granularity=60
+            ),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=self.project_ids,
+                use_case_id=USE_CASE_ID,
+            ),
+            indexer_mappings={
+                "transaction.duration": DISTRIBUTIONS_MRI,
+                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
+                "status_code": resolve_str("status_code"),
+                "transaction": resolve_str("transaction"),
+            },
+        )
+
+        response = self.app.post(
+            self.mql_route,
+            data=Request(
+                dataset=DATASET,
+                app_id="test",
+                query=query,
+                flags=Flags(debug=True),
+                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
+            ).serialize_mql(),
+        )
+
+        assert response.status_code == 200, response.data
+        data = json.loads(response.data)
+        print(data)


### PR DESCRIPTION
### Overview
This PR is responsible for fixing formula totals queries, formulas with an orderby, and one-sided groupby formulas. The main changes/fixes in code include:

* Revert back to adding the time expression to the SELECT clause when an interval is provided.
* Only add time expression in join conditions if interval is provided.
* Support formula queries with no groupby, no interval, and with totals. When no groupby and no interval are provided in a formula query, the subqueries will return a single value. As a result, there are no columns to join by. A `CROSS JOIN` is used to to obtain a results in the outer query to perform its given mathematical operation.
* Support one-sided group bys (time spent percentage use-case)

### Testing
See added unit tests in `tests/test_metrics_mql_api.py` for supported queries.