### PR TITLE
ref: deletes api

### DIFF
--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -17,20 +17,36 @@ from snuba.reader import Result
 from snuba.state import get_config
 
 
-def construct_condition(columns: Dict[str, Any]) -> Expression:
-    and_conditions = []
-    for col, values in columns.items():
-        if len(values) == 1:
-            exp = equals(column(col), literal(values[0]))
-        else:
-            literal_values = [literal(v) for v in values]
-            exp = in_cond(
-                column(col), literals_tuple(alias=None, literals=literal_values)
-            )
+def delete_from_storage(
+    storage: WritableTableStorage, columns: Dict[str, Any]
+) -> dict[str, Any]:
+    """
+    Inputs:
+        storage - storage to delete from
+        columns - a mapping from column-name to a list of column values
+            that defines the delete conditions. ex:
+            {
+                "id": [1, 2, 3]
+                "status": ["failed"]
+            }
+            represents
+            DELETE FROM ... WHERE id in (1,2,3) AND status='failed'
 
-        and_conditions.append(exp)
+    Deletes all rows in the given storage, that satisfy the conditions
+    defined in 'columns' input.
+    """
+    if get_config("storage_deletes_enabled", 0):
+        raise Exception("Deletes not enabled")
 
-    return combine_and_conditions(and_conditions)
+    delete_settings = storage.get_deletion_settings()
+    if not delete_settings.is_enabled:
+        raise Exception(f"Deletes not enabled for {storage.get_storage_key().value}")
+
+    payload: dict[str, Any] = {}
+    for table in delete_settings.tables:
+        result = _delete_from_table(storage, table, columns)
+        payload[table] = {**result}
+    return payload
 
 
 def _get_rows_to_delete(
@@ -75,24 +91,7 @@ def _enforce_max_rows(delete_query: Query) -> None:
         )
 
 
-def delete_from_storage(
-    storage: WritableTableStorage, conditions: Dict[str, Any]
-) -> dict[str, Any]:
-    if get_config("storage_deletes_enabled", 0):
-        raise Exception("Deletes not enabled")
-
-    delete_settings = storage.get_deletion_settings()
-    if not delete_settings.is_enabled:
-        raise Exception(f"Deletes not enabled for {storage.get_storage_key().value}")
-
-    payload: dict[str, Any] = {}
-    for table in delete_settings.tables:
-        result = delete_from_table(storage, table, conditions)
-        payload[table] = {**result}
-    return payload
-
-
-def delete_from_table(
+def _delete_from_table(
     storage: WritableTableStorage, table: str, conditions: Dict[str, Any]
 ) -> Result:
     cluster_name = storage.get_cluster().get_clickhouse_cluster_name()
@@ -105,7 +104,7 @@ def delete_from_table(
             # TODO: add allocation policies
             allocation_policies=[],
         ),
-        condition=construct_condition(conditions),
+        condition=_construct_condition(conditions),
         on_cluster=on_cluster,
         is_delete=True,
     )
@@ -114,3 +113,19 @@ def delete_from_table(
     formatted_query = format_query(query)
     # TODO error handling and the lot
     return storage.get_cluster().get_deleter().execute(formatted_query)
+
+
+def _construct_condition(columns: Dict[str, Any]) -> Expression:
+    and_conditions = []
+    for col, values in columns.items():
+        if len(values) == 1:
+            exp = equals(column(col), literal(values[0]))
+        else:
+            literal_values = [literal(v) for v in values]
+            exp = in_cond(
+                column(col), literals_tuple(alias=None, literals=literal_values)
+            )
+
+        and_conditions.append(exp)
+
+    return combine_and_conditions(and_conditions)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -336,7 +336,6 @@ def storage_delete(
         try:
             payload = delete_from_storage(storage, columns)
         except Exception as error:
-            # TODO: better error handling
             logger.warning("Failed query", exc_info=error)
             return make_response(jsonify({"error": error}), 500)
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -312,7 +312,7 @@ def storage_delete(
         body = parse_request_body(http_request)
         try:
             """
-            conditions is a key value mapping
+            columns is a key value mapping
             of storage-column-name to a list of values
             ex:
             {
@@ -322,7 +322,7 @@ def storage_delete(
             which represents
             WHERE id in (1,2,3) AND status='failed'
             """
-            conditions = body["conditions"]
+            columns = body["columns"]
         except Exception:
             return make_response(
                 jsonify(
@@ -334,7 +334,7 @@ def storage_delete(
             )
 
         try:
-            payload = delete_from_storage(storage, conditions)
+            payload = delete_from_storage(storage, columns)
         except Exception as error:
             # TODO: better error handling
             logger.warning("Failed query", exc_info=error)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -326,9 +326,7 @@ def storage_delete(
         except Exception:
             return make_response(
                 jsonify(
-                    {
-                        "error": "required input 'conditions' not present in body of request"
-                    }
+                    {"error": "required input 'columns' not present in body of request"}
                 ),
                 400,
             )

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -174,6 +174,23 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         assert response.status_code == 200, data
         assert data["data"] == []
 
+    def test_bad_delete(self) -> None:
+        res = self.app.delete(
+            "/search_issues/",
+            data=json.dumps(
+                {
+                    "debug": True,
+                    "tenant_ids": {"referrer": "test", "organization_id": 1},
+                }
+            ),
+            headers={"referer": "test"},
+        )
+        assert int(res.status_code / 100) == 4  # 400 status code
+        assert (
+            res.get_json()["error"]
+            == "required input 'columns' not present in body of request"
+        )
+
     def test_simple_search_query(self) -> None:
         now = datetime.now().replace(minute=0, second=0, microsecond=0)
 

--- a/tests/web/test_max_rows_enforcer.py
+++ b/tests/web/test_max_rows_enforcer.py
@@ -15,7 +15,7 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.data_source.simple import Table
 from snuba.query.exceptions import TooManyDeleteRowsException
 from snuba.state import set_config
-from snuba.web.delete_query import _enforce_max_rows, construct_condition
+from snuba.web.delete_query import _construct_condition, _enforce_max_rows
 from tests.base import BaseApiTest
 from tests.datasets.configuration.utils import ConfigurationTest
 from tests.helpers import write_unprocessed_events
@@ -45,7 +45,7 @@ class TestMaxRowsEnforcer(SimpleAPITest, BaseApiTest, ConfigurationTest):
             "debug": True,
             "tenant_ids": {"referrer": "test", "organization_id": 1},
         }
-        condition = construct_condition(body)
+        condition = _construct_condition(body)
         self.query = Query(
             from_clause=from_clause,
             condition=condition,


### PR DESCRIPTION
## major changes
1. extract the logic that was inside of `views.py:storage_delete` and put it into a new function `delete_query.py:delete_from_storage`. 
Now whats in views.py is basically just responsible for handling the http request stuff, and the actual logic for deletes happens in `delete_from_storage`. This way my snuba admin UI can call `delete_from_storage` as its interface. The motivation for this change can be best described by a summary of my conversations with Evan and Filippo:

> **Filippo & Evan**: The api-endpoint-view-function (`storage_delete`) should be as lightweight as possible, only responsible for parsing the http request inputs and then passing them along to another function that actually handles the logic.

> **Kyle:** But why does it have to be this way? Can't I just use api endpoint itself as the interface that I send the snuba admin requests to. Then the internals don't matter.

> **Filippo & Evan:** You shouldn't use the api endpoint as the interface for snuba admin requests.

> **Evan:** What if we wanted to do deletes with RPC instead of http? What if we wanted to do them within python instead of http? The view function is only responsible for the transit layer, http, the actual logic of deletes is de-coupled and follows a separate interface. This way whether we want to use http, RPC, or python function call, its more flexible.

> **Kyle**: Oh, i see now.

2. change `body` input to `columns`
The previously defined input for our delete interface was `body` which was an arbitrary key-value mapping. I found this to be unclear on what the expected/required input is. I changed this to be the `columns` object which I think clarifies a bit what is required by the caller.

this change is part of [SNS-2827](https://getsentry.atlassian.net/browse/SNS-2827?atlOrigin=eyJpIjoiMzYxMjNmMGMxMjAxNDM2ZGFjZjAzM2ZjMWY1NTVhZGQiLCJwIjoiaiJ9)

[SNS-2827]: https://getsentry.atlassian.net/browse/SNS-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ