### PR TITLE
feat(profiling): Write thread id to transactions table (#6138)

### DIFF
--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -423,8 +423,8 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
 
         # Only top level scalar values within a context are written to the table. `data` is
         # always a dict, so pop it from the context and move some values into the top level.
-        transaction_data = transaction_ctx.pop("data", {})
-        if "thread.id" in transaction_data:
+        transaction_data = transaction_ctx.pop("data", None) or {}
+        if isinstance(transaction_data, dict) and "thread.id" in transaction_data:
             # The thread.id can be either a str/int. Make sure to always convert to a str.
             transaction_ctx["thread_id"] = str(transaction_data["thread.id"])
 

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -421,6 +421,13 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         transaction_ctx.pop("trace_id", None)
         transaction_ctx.pop("span_id", None)
 
+        # Only top level scalar values within a context are written to the table. `data` is
+        # always a dict, so pop it from the context and move some values into the top level.
+        transaction_data = transaction_ctx.pop("data", {})
+        if "thread.id" in transaction_data:
+            # The thread.id can be either a str/int. Make sure to always convert to a str.
+            transaction_ctx["thread_id"] = str(transaction_data["thread.id"])
+
         # The hash and exclusive_time is being stored in the spans columns
         # so there is no need to store it again in the context array.
         transaction_ctx.pop("hash", None)
@@ -432,7 +439,7 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         if app_ctx is not None:
             app_ctx.pop("start_type", None)
 
-        # The profile_id and replay_id are promoted as columns, so no need to store them
+        # The profile_id, profiler_id and replay_id are promoted as columns, so no need to store them
         # again in the context array
         profile_ctx = sanitized_context.get("profile", {})
         profile_ctx.pop("profile_id", None)


### PR DESCRIPTION
In addition to the profiler id, sometimes, we need the thread id to be able to
link to the right thread within the profile.

Fixes SNUBA-595