### PR TITLE
bug(mql): Fix nested totals formulas queries with no group by

### DIFF
--- a/snuba/query/mql/parser_supported_join.py
+++ b/snuba/query/mql/parser_supported_join.py
@@ -1363,8 +1363,12 @@ def populate_query_from_mql_context(
                     JoinClause() as inner_join_clause,
                     IndividualNode(),
                 ):
-                    new_inner_join_clause = add_time_join_keys(inner_join_clause)
-                    join_clause = replace(join_clause, left_node=new_inner_join_clause)
+                    new_inner_join_clause = convert_to_cross_join(inner_join_clause)
+                    join_clause = replace(
+                        join_clause,
+                        left_node=new_inner_join_clause,
+                        join_type=JoinType.CROSS,
+                    )
             return join_clause
 
         # Check if groupby is empty or has a one-sided groupby on the formula

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1010,7 +1010,6 @@ def _qualify_columns(
     from_clause = query.get_from_clause()
     if not isinstance(from_clause, JoinClause):
         return  # We don't qualify columns that have a single source
-
     aliases = set(from_clause.get_alias_node_map().keys())
 
     def transform(exp: Expression) -> Expression:

--- a/tests/query/parser/test_formula_mql_query.py
+++ b/tests/query/parser/test_formula_mql_query.py
@@ -120,6 +120,7 @@ mql_context = {
     },
     "indexer_mappings": {
         "d:transactions/duration@millisecond": 123456,
+        "d:transactions/measurements.fp@millisecond": 789012,
         "status_code": 222222,
         "transaction": 333333,
     },


### PR DESCRIPTION
This PR is responsible for fixing MQL queries with nested formulas (no groupby, with totals). See issue here: https://sentry.sentry.io/issues/5644191888/?project=300688&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=7. When the parser receives a totals formula without a groupby, it automatically converts the join type into a `CROSS JOIN`. This cross join needs to be properly pushed down to all join nodes appropriately.