### PR TITLE
chore: delete SEARCH_ISSUES_TMP storage set

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -21,7 +21,6 @@ _HARDCODED_STORAGE_SET_KEYS = {
     "GROUP_ATTRIBUTES": "group_attributes",
     "METRICS_SUMMARIES": "metrics_summaries",
     "PROFILE_CHUNKS": "profile_chunks",
-    "SEARCH_ISSUES_TMP": "search_issues_tmp",
 }
 
 


### PR DESCRIPTION
This is cleaning up what remains of #6079 . This is cleanup of temporary changes that were done to accomplish https://github.com/getsentry/ops/pull/11385 but can now be deleted. This PR accomplishes step 4 (see below).

## steps
1. ~~delete migrations for SEARCH_ISSUES_TMP~~
2. ~~delete cluster mapping for SEARCH_ISSUES_TMP in snuba~~
3. ~~delete cluster mapping for SEARCH_ISSUES_TMP in ops~~
4. delete SEARCH_ISSUES_TMP storage set in snuba
5. decommission issue-platform-query-node in production


steps 1 and 2 done in https://github.com/getsentry/snuba/pull/6110
step 3 was done in https://github.com/getsentry/ops/pull/11443