### PR TITLE
feat(eap): Add attribute key/value lookup table

### DIFF
--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -25,6 +25,7 @@ from snuba.query.matchers import (
     Param,
     String,
 )
+from snuba.utils.constants import ATTRIBUTE_BUCKETS
 
 
 # This is a workaround for a mypy bug, found here: https://github.com/python/mypy/issues/5374
@@ -238,7 +239,7 @@ class SubscriptableHashBucketMapper(SubscriptableReferenceMapper):
     from_column_name: str
     to_col_table: Optional[str]
     to_col_name: str
-    to_num_cols: int
+    to_num_cols: int | None = None
 
     @staticmethod
     def fnv_1a(b: bytes) -> int:
@@ -268,7 +269,8 @@ class SubscriptableHashBucketMapper(SubscriptableReferenceMapper):
         if not isinstance(key.value, str):
             return None
 
-        bucket_idx = self.fnv_1a(key.value.encode("utf-8")) % self.to_num_cols
+        modulo = self.to_num_cols or ATTRIBUTE_BUCKETS
+        bucket_idx = self.fnv_1a(key.value.encode("utf-8")) % modulo
         return SubscriptableReference(
             column=ColumnExpr(
                 None,

--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
@@ -44,14 +44,12 @@ storages:
             from_column_name: attr_str
             to_col_table: null
             to_col_name: attr_str
-            to_num_cols: 20
         - mapper: SubscriptableHashBucketMapper
           args:
             from_column_table: null
             from_column_name: attr_num
             to_col_table: null
             to_col_name: attr_num
-            to_num_cols: 20
 
 storage_selector:
   selector: DefaultQueryStorageSelector

--- a/snuba/snuba_migrations/events_analytics_platform/0002_spans_attributes_mv.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0002_spans_attributes_mv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Sequence
 
 from snuba.clickhouse.columns import AggregateFunction, Column, DateTime, String, UInt
@@ -57,7 +59,7 @@ class Migration(migration.ClickhouseNodeMigration):
     ]
 
     def forwards_ops(self) -> Sequence[SqlOperation]:
-        create_table_ops = [
+        create_table_ops: list[SqlOperation] = [
             operations.CreateTable(
                 storage_set=self.storage_set_key,
                 table_name=self.meta_local_table_name,
@@ -88,7 +90,7 @@ class Migration(migration.ClickhouseNodeMigration):
             ),
         ]
 
-        materialized_view_ops = []
+        materialized_view_ops: list[SqlOperation] = []
         for value_type in self.value_types:
             str_value = "attribute_value" if value_type == "str" else "NULL"
             num_value = "attribute_value" if value_type == "num" else "NULL"
@@ -119,7 +121,7 @@ class Migration(migration.ClickhouseNodeMigration):
         return create_table_ops + materialized_view_ops
 
     def backwards_ops(self) -> Sequence[SqlOperation]:
-        return [
+        ops: Sequence[SqlOperation] = [
             operations.DropTable(
                 storage_set=self.storage_set_key,
                 table_name=self.meta_view_name.format(attribute_type=value_type),
@@ -138,3 +140,4 @@ class Migration(migration.ClickhouseNodeMigration):
                 target=OperationTarget.DISTRIBUTED,
             ),
         ]
+        return ops

--- a/snuba/snuba_migrations/events_analytics_platform/0002_spans_attributes_mv.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0002_spans_attributes_mv.py
@@ -1,0 +1,140 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import AggregateFunction, Column, DateTime, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.constants import ATTRIBUTE_BUCKETS
+from snuba.utils.schemas import Float
+
+META_KEY_QUERY_TEMPLATE = """
+SELECT
+    organization_id,
+    attribute_key,
+    {str_value} AS str_value,
+    {num_value} AS number_value,
+    toMonday(start_timestamp) AS timestamp,
+    retention_days,
+    sumState(cast(1, 'UInt64')) AS count
+FROM eap_spans_local
+LEFT ARRAY JOIN
+    arrayConcat({key_columns}) AS attribute_key,
+    arrayConcat({value_columns}) AS attribute_value
+GROUP BY
+    organization_id,
+    attribute_key,
+    attribute_value,
+    timestamp,
+    retention_days
+"""
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    This migration creates a table meant to store just the attributes seen in a particular org.
+    The table is populated by a separate materialized view for each type of attribute.
+    """
+
+    blocking = False
+    storage_set_key = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+    granularity = "8192"
+
+    value_types = ["str", "num"]
+
+    meta_view_name = "spans_attributes_{attribute_type}_meta_mv"
+    meta_local_table_name = "spans_attributes_meta_local"
+    meta_dist_table_name = "spans_attributes_meta_dist"
+    meta_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("attribute_type", String()),
+        Column("attribute_key", String()),
+        Column("str_value", String(modifiers=Modifiers(nullable=True))),
+        Column("num_value", Float(64, modifiers=Modifiers(nullable=True))),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column("count", AggregateFunction("sum", [UInt(64)])),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        create_table_ops = [
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.meta_local_table_name,
+                engine=table_engines.AggregatingMergeTree(
+                    storage_set=self.storage_set_key,
+                    primary_key="(org_id, attribute_key)",
+                    order_by="(org_id, attribute_key, timestamp)",
+                    partition_by="toMonday(timestamp)",
+                    settings={
+                        "index_granularity": self.granularity,
+                        # Since the partitions contain multiple retention periods, need to ensure
+                        # that rows within partitions are dropped
+                        "ttl_only_drop_parts": 0,
+                    },
+                    ttl="timestamp + toIntervalDay(retention_days)",
+                ),
+                columns=self.meta_table_columns,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.meta_dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.meta_local_table_name, sharding_key=None
+                ),
+                columns=self.meta_table_columns,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+        materialized_view_ops = []
+        for value_type in self.value_types:
+            str_value = "attribute_value" if value_type == "str" else "NULL"
+            num_value = "attribute_value" if value_type == "num" else "NULL"
+
+            key_columns = ",".join(
+                [f"mapKeys(attr_{value_type}_{i})" for i in range(ATTRIBUTE_BUCKETS)]
+            )
+            value_columns = ",".join(
+                [f"mapValues(attr_{value_type}_{i})" for i in range(ATTRIBUTE_BUCKETS)]
+            )
+
+            materialized_view_ops.append(
+                operations.CreateMaterializedView(
+                    storage_set=self.storage_set_key,
+                    view_name=self.meta_view_name.format(attribute_type=value_type),
+                    columns=self.meta_table_columns,
+                    destination_table_name=self.meta_local_table_name,
+                    target=OperationTarget.LOCAL,
+                    query=META_KEY_QUERY_TEMPLATE.format(
+                        str_value=str_value,
+                        num_value=num_value,
+                        key_columns=key_columns,
+                        value_columns=value_columns,
+                    ),
+                ),
+            )
+
+        return create_table_ops + materialized_view_ops
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.meta_view_name.format(attribute_type=value_type),
+                target=OperationTarget.LOCAL,
+            )
+            for value_type in self.value_types
+        ] + [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.meta_local_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.meta_dist_table_name,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]

--- a/snuba/utils/constants.py
+++ b/snuba/utils/constants.py
@@ -7,4 +7,7 @@ NESTED_COL_EXPR_RE = re.compile(r"^([a-zA-Z0-9_\.]+)\[([a-zA-Z0-9_\.:-]+)\]$")
 GRANULARITIES_AVAILABLE = (10, 60, 60 * 60, 24 * 60 * 60)
 
 # Number of EAP Span buckets
+# Changing this column will change Snuba's understanding of how attributes
+# on spans are bucketed into different columns
+# This will affect migrations and querying.
 ATTRIBUTE_BUCKETS = 20

--- a/snuba/utils/constants.py
+++ b/snuba/utils/constants.py
@@ -5,3 +5,6 @@ NESTED_COL_EXPR_RE = re.compile(r"^([a-zA-Z0-9_\.]+)\[([a-zA-Z0-9_\.:-]+)\]$")
 
 #: Metrics granularities for which a materialized view exist, in ascending order
 GRANULARITIES_AVAILABLE = (10, 60, 60 * 60, 24 * 60 * 60)
+
+# Number of EAP Span buckets
+ATTRIBUTE_BUCKETS = 20


### PR DESCRIPTION
Create a table that stores just the attribute keys and values that have been seen by an org. This
can be used for autocomplete or any other validation feature.

The table doesn't have any indexes on it at the moment. It also provides a count, to do simple
ranking if that's useful in the future.