### PR TITLE
bug(mql): Remove Add Equivalent Conditions Processor from MQL Pipeline

### DIFF
--- a/snuba/pipeline/composite_entity_processing.py
+++ b/snuba/pipeline/composite_entity_processing.py
@@ -23,13 +23,16 @@ def translate_composite_query(
     """
     Converts a logical composite query to a physical composite query.
     """
-    add_equivalent_conditions(query)
-    _generate_subqueries(query)
+    _pre_entity_query_processing(query)
     physical_query = _translate_logical_composite_query(query, query_settings)
     return physical_query
 
 
-def _generate_subqueries(query: CompositeQuery[Entity]) -> None:
+def _pre_entity_query_processing(query: CompositeQuery[Entity]) -> None:
+    """
+    Depending on the type of query, this function will execute the necessary
+    entity query processings functions to prepare the query for translation.
+    """
     from_clause = query.get_from_clause()
     is_gen_metrics_join_query = True
     if isinstance(from_clause, JoinClause):
@@ -46,6 +49,7 @@ def _generate_subqueries(query: CompositeQuery[Entity]) -> None:
     if is_gen_metrics_join_query:
         generate_metrics_subqueries(query)
     else:
+        add_equivalent_conditions(query)
         generate_subqueries(query)
 
 

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -50,6 +50,7 @@ SHARED_TAGS_1 = {
 
 SHARED_TAGS_2 = {
     "transaction": "t2",
+    "status_code": "400",
 }
 
 # This is stored this way since that's how it's encoded in the message
@@ -284,7 +285,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         assert len(rows) == 180, rows
 
         assert rows[0]["aggregate_value"] > 0
-        assert rows[0]["status_code"] == "200"
+        assert rows[0]["status_code"] == "200" or rows[0]["status_code"] == "400"
 
     def test_interval_with_totals(self) -> None:
         query = MetricsQuery(
@@ -337,7 +338,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         assert len(rows) == 180, rows
 
         assert rows[0]["aggregate_value"] > 0
-        assert rows[0]["status_code"] == "200"
+        assert rows[0]["status_code"] == "200" or rows[0]["status_code"] == "400"
         assert (
             data["totals"]["aggregate_value"] > 180
         )  # Should be more than the number of data points
@@ -386,7 +387,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         assert len(rows) == 360, rows
 
         assert rows[0]["aggregate_value"] > 0
-        assert rows[0]["status_code"] == "200"
+        assert rows[0]["status_code"] == "200" or rows[0]["status_code"] == "400"
         assert data["totals"]["aggregate_value"] == 2.0
 
     def test_total_orderby_functions(self) -> None:
@@ -434,7 +435,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         assert len(rows) == 1, rows
 
         assert rows[0]["aggregate_value"] == 4.0
-        assert rows[0]["status_code"] == "200"
+        assert rows[0]["status_code"] == "200" or rows[0]["status_code"] == "400"
 
     def test_dots_in_mri_names(self) -> None:
         query = MetricsQuery(

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -1564,7 +1564,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
         )  # Should be more than the number of data points
         assert response.status_code == 200
 
-    def test_formula_filters_with_scalar(self) -> None:
+    def test_simple_formula_filters_with_scalar(self) -> None:
         query = MetricsQuery(
             query=Formula(
                 function_name="divide",
@@ -1579,9 +1579,9 @@ class TestGenericMetricsMQLApi(BaseApiTest):
                 ],
                 filters=[
                     Condition(
-                        lhs=Column(name="platform"),
+                        lhs=Column(name="transaction"),
                         op=Op.EQ,
-                        rhs="ios",
+                        rhs="t1",
                     )
                 ],
             ),
@@ -1596,8 +1596,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
             indexer_mappings={
                 "transaction.duration": DISTRIBUTIONS_MRI,
                 DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
-                "platform": resolve_str("platform"),
-                "ios": resolve_str("ios"),
+                "transaction": resolve_str("transaction"),
             },
         )
 
@@ -1611,6 +1610,70 @@ class TestGenericMetricsMQLApi(BaseApiTest):
                 tenant_ids={"referrer": "tests", "organization_id": self.org_id},
             ).serialize_mql(),
         )
+        assert response.status_code == 200
+
+    def test_complex_formula_filters_with_scalar(self) -> None:
+        query = MetricsQuery(
+            query=Formula(
+                function_name="multiply",
+                parameters=[
+                    Formula(
+                        function_name="divide",
+                        parameters=[
+                            Timeseries(
+                                metric=Metric(
+                                    mri=DISTRIBUTIONS_MRI,
+                                ),
+                                aggregate="sum",
+                                filters=[Condition(Column("transaction"), Op.EQ, "t2")],
+                            ),
+                            Timeseries(
+                                metric=Metric(
+                                    mri=DISTRIBUTIONS_MRI,
+                                ),
+                                aggregate="sum",
+                                filters=[
+                                    Condition(
+                                        Column("transaction"),
+                                        Op.EQ,
+                                        "t1",
+                                    )
+                                ],
+                            ),
+                        ],
+                    ),
+                    100.0,
+                ],
+            ),
+            start=self.start_time,
+            end=self.end_time,
+            rollup=Rollup(interval=60, granularity=60, totals=None),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=self.project_ids,
+                use_case_id=USE_CASE_ID,
+            ),
+            indexer_mappings={
+                "transaction.duration": DISTRIBUTIONS_MRI,
+                DISTRIBUTIONS_MRI: DISTRIBUTIONS.metric_id,
+                "transaction": resolve_str("transaction"),
+                "status_code": resolve_str("status_code"),
+            },
+        )
+
+        response = self.app.post(
+            self.mql_route,
+            data=Request(
+                dataset=DATASET,
+                app_id="test",
+                query=query,
+                flags=Flags(debug=True),
+                tenant_ids={"referrer": "tests", "organization_id": self.org_id},
+            ).serialize_mql(),
+        )
+        data = json.loads(response.data)
+        assert len(data["data"]) == 180
+
         assert response.status_code == 200
 
     def test_formula_filters_with_scalar_formula(self) -> None:


### PR DESCRIPTION
This PR is responsible for fixing queries with similar tag key filters but different tag values. To do this, the `add_equivalent_conditions` processor was removed from the MQL entity processing pipeline. 

This processor is responsible for finding conditions in a join query on columns that are semantically equivalent in the another entity in the join and adds the same condition on the equivalent column. For example, in a join between events and groupedmessage, if there is a condition on events.project_id, it would replicate the same condition on groupedmessage.project_id as this is a semantically equivalent column in order to optimize the clickhouse scan. This processor is not necessary for MQL as all relevant conditions are already added during parsing. 

More specifically, this fixes the query described in this [issue](https://github.com/getsentry/sentry/issues/75142) as formulas with same tag keys filters in each expression are no longer replicated in each subquery. 