### PR TITLE
fix(events-analytics-platform): Fix sharding key, clickhouse does not like u128

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
@@ -139,7 +139,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 engine=table_engines.Distributed(
                     local_table_name=local_table_name,
-                    sharding_key="reinterpretAsUInt128(trace_id)",
+                    sharding_key="cityHash64(reinterpretAsUInt128(trace_id))",  # sharding keys must be at most 64 bits
                 ),
                 target=OperationTarget.DISTRIBUTED,
             ),


### PR DESCRIPTION
This works locally at least:

```
8a035ef769f1 :) select cityHash64(reinterpretAsUInt128('550e8400-e29b-41d4-a716-446655440000'::UUID));

SELECT cityHash64(reinterpretAsUInt128(CAST('550e8400-e29b-41d4-a716-446655440000', 'UUID')))

 7067610571742207507
```
