### PR TITLE
fix(eap-spans): Add sync to the downwards migration, mark dataset experimental

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
@@ -6,7 +6,7 @@ storage:
   key: eap_spans
   set_key: events_analytics_platform
 
-readiness_state: partial
+readiness_state: experimental
 
 schema:
   columns:

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -206,7 +206,7 @@ class DropTable(SqlOperation):
         storage_set: StorageSetKey,
         table_name: str,
         target: OperationTarget = OperationTarget.UNSET,
-        sync=False,
+        sync: bool = False,
     ) -> None:
         super().__init__(storage_set, target=target)
         self.table_name = table_name

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -206,12 +206,17 @@ class DropTable(SqlOperation):
         storage_set: StorageSetKey,
         table_name: str,
         target: OperationTarget = OperationTarget.UNSET,
+        sync=False,
     ) -> None:
         super().__init__(storage_set, target=target)
         self.table_name = table_name
+        self.sync = sync
 
     def format_sql(self) -> str:
-        return f"DROP TABLE IF EXISTS {self.table_name};"
+        sql = f"DROP TABLE IF EXISTS {self.table_name}"
+        if self.sync:
+            sql = f"{sql} SYNC"
+        return f"{sql};"
 
 
 class TruncateTable(SqlOperation):

--- a/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
@@ -127,10 +127,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     order_by="(organization_id, _sort_timestamp, trace_id, span_id)",
                     sign_column="sign",
                     partition_by="(toMonday(_sort_timestamp))",
-                    settings={
-                        "index_granularity": "8192",
-                        "storage_policy": "'multidisk'",
-                    },
+                    settings={"index_granularity": "8192"},
                     storage_set=storage_set_name,
                     ttl="_sort_timestamp + toIntervalDay(retention_days)",
                 ),

--- a/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
@@ -129,7 +129,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     partition_by="(toMonday(_sort_timestamp))",
                     settings={
                         "index_granularity": "8192",
-                        "storage_policy": "multidisk",
+                        "storage_policy": "'multidisk'",
                     },
                     storage_set=storage_set_name,
                     ttl="_sort_timestamp + toIntervalDay(retention_days)",

--- a/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
@@ -161,10 +161,12 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=storage_set_name,
                 table_name=local_table_name,
                 target=OperationTarget.LOCAL,
+                sync=True,
             ),
             operations.DropTable(
                 storage_set=storage_set_name,
                 table_name=dist_table_name,
                 target=OperationTarget.DISTRIBUTED,
+                sync=True,
             ),
         ]

--- a/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0001_spans.py
@@ -1,4 +1,3 @@
-from os import environ
 from typing import List, Sequence
 
 from snuba.clusters.storage_sets import StorageSetKey
@@ -118,10 +117,6 @@ class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
     def forwards_ops(self) -> Sequence[SqlOperation]:
-        settings = {"index_granularity": "8192"}
-        if environ.get("SENTRY_REGION") in ["de", "us"]:
-            settings["storage_policy"] = "multidisk"
-
         res: List[SqlOperation] = [
             operations.CreateTable(
                 storage_set=storage_set_name,
@@ -132,7 +127,10 @@ class Migration(migration.ClickhouseNodeMigration):
                     order_by="(organization_id, _sort_timestamp, trace_id, span_id)",
                     sign_column="sign",
                     partition_by="(toMonday(_sort_timestamp))",
-                    settings=settings,
+                    settings={
+                        "index_granularity": "8192",
+                        "storage_policy": "multidisk",
+                    },
                     storage_set=storage_set_name,
                     ttl="_sort_timestamp + toIntervalDay(retention_days)",
                 ),

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -114,6 +114,13 @@ def test_drop_table() -> None:
     )
 
 
+def test_drop_table_with_sync() -> None:
+    assert (
+        DropTable(StorageSetKey.EVENTS, "test_table", sync=True).format_sql()
+        == "DROP TABLE IF EXISTS test_table SYNC;"
+    )
+
+
 def test_truncate_table() -> None:
     assert (
         TruncateTable(StorageSetKey.EVENTS, "test_table").format_sql()


### PR DESCRIPTION
We didn't configure the table the right way to take advantage of the storage policy `multidisk` we defined. We need to drop the table to re-create it.

This PR will turn the `events_analytics_platform` dataset into an experimental dataset and use the `SYNC` option to drop the table immediately and avoid problems with Zookeeper keeping some data by default for DR.

From https://clickhouse.com/docs/en/sql-reference/statements/drop
```
If the SYNC modifier is specified, the entity is dropped without delay.
```

We will set the default disk policy to `multidisk` on clusters that need it.

Plan to deploy this would be:
- Set the readiness state for eap_spans to experimental
- Deploy this change to every environment

Then, in `de` then `us`:
- Truncate the `eap_spans_local` table if there's data (so we can drop it)
- Run the reverse migration
- Change the default disk policy to `multidisk`
- Run the forward migration