### PR TITLE
feat(generic-metrics): Add migrations to allow sampling for counters

### DIFF
--- a/snuba/snuba_migrations/generic_metrics/0052_counters_raw_add_sampling_weight.py
+++ b/snuba/snuba_migrations/generic_metrics/0052_counters_raw_add_sampling_weight.py
@@ -1,0 +1,57 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    local_table_name = "generic_metric_counters_raw_local"
+    dist_table_name = "generic_metric_counters_raw_dist"
+
+    columns: Sequence[tuple[Column[MigrationModifiers], str | None]] = [
+        (
+            Column(
+                "sampling_weight",
+                UInt(64, MigrationModifiers(default=str("1"))),
+            ),
+            None,
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                after=after,
+                target=target,
+            )
+            for column, after in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column, _ in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0052_counters_raw_add_sampling_weight.py
+++ b/snuba/snuba_migrations/generic_metrics/0052_counters_raw_add_sampling_weight.py
@@ -15,13 +15,10 @@ class Migration(migration.ClickhouseNodeMigration):
     local_table_name = "generic_metric_counters_raw_local"
     dist_table_name = "generic_metric_counters_raw_dist"
 
-    columns: Sequence[tuple[Column[MigrationModifiers], str | None]] = [
-        (
-            Column(
-                "sampling_weight",
-                UInt(64, MigrationModifiers(codecs=["ZSTD(1)"], default=str("1"))),
-            ),
-            None,
+    columns: Sequence[Column[MigrationModifiers]] = [
+        Column(
+            "sampling_weight",
+            UInt(64, MigrationModifiers(codecs=["ZSTD(1)"], default=str("1"))),
         ),
     ]
 
@@ -31,10 +28,9 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=self.storage_set_key,
                 table_name=table_name,
                 column=column,
-                after=after,
                 target=target,
             )
-            for column, after in self.columns
+            for column in self.columns
             for table_name, target in [
                 (self.local_table_name, OperationTarget.LOCAL),
                 (self.dist_table_name, OperationTarget.DISTRIBUTED),
@@ -49,7 +45,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 column_name=column.name,
                 target=target,
             )
-            for column, _ in self.columns
+            for column in self.columns
             for table_name, target in [
                 (self.dist_table_name, OperationTarget.DISTRIBUTED),
                 (self.local_table_name, OperationTarget.LOCAL),

--- a/snuba/snuba_migrations/generic_metrics/0052_counters_raw_add_sampling_weight.py
+++ b/snuba/snuba_migrations/generic_metrics/0052_counters_raw_add_sampling_weight.py
@@ -19,7 +19,7 @@ class Migration(migration.ClickhouseNodeMigration):
         (
             Column(
                 "sampling_weight",
-                UInt(64, MigrationModifiers(default=str("1"))),
+                UInt(64, MigrationModifiers(codecs=["ZSTD(1)"], default=str("1"))),
             ),
             None,
         ),

--- a/snuba/snuba_migrations/generic_metrics/0053_counters_aggregated_add_sampling_weight.py
+++ b/snuba/snuba_migrations/generic_metrics/0053_counters_aggregated_add_sampling_weight.py
@@ -1,0 +1,58 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import AggregateFunction, Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    local_table_name = "generic_metric_counters_aggregated_local"
+    dist_table_name = "generic_metric_counters_aggregated_dist"
+
+    columns: Sequence[tuple[Column[MigrationModifiers], str | None]] = [
+        (
+            Column(
+                "value_weighted",
+                AggregateFunction("sum", [Float(64)]),
+            ),
+            "value",
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                after=after,
+                target=target,
+            )
+            for column, after in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column, _ in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0053_counters_aggregated_add_sampling_weight.py
+++ b/snuba/snuba_migrations/generic_metrics/0053_counters_aggregated_add_sampling_weight.py
@@ -20,7 +20,11 @@ class Migration(migration.ClickhouseNodeMigration):
         (
             Column(
                 "value_weighted",
-                AggregateFunction("sum", [Float(64)]),
+                AggregateFunction(
+                    "sum",
+                    [Float(64)],
+                    MigrationModifiers(codecs=["ZSTD(1)"]),
+                ),
             ),
             "value",
         ),

--- a/snuba/snuba_migrations/generic_metrics/0054_counters_mv3.py
+++ b/snuba/snuba_migrations/generic_metrics/0054_counters_mv3.py
@@ -1,0 +1,91 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_counters_aggregation_mv_v3"
+    dest_table_name = "generic_metric_counters_aggregated_local"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("sum", [Float(64)])),
+        Column("value_weighted", AggregateFunction("sum", [Float(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name=self.dest_table_name,
+                target=OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) AS granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    toDateTime(multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1) * intDiv(toUnixTimestamp(timestamp), multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1))) AS timestamp,
+                    least(retention_days, multiIf(granularity = 0, decasecond_retention_days, granularity = 1, min_retention_days, granularity = 2, hr_retention_days, granularity = 3, day_retention_days, 0)) AS retention_days,
+                    sumState(count_value) AS value,
+                    sumState(count_value * sampling_weight) AS value_weighted
+                FROM generic_metric_counters_raw_local
+                WHERE (materialization_version = 3) AND (metric_type = 'counter')
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    timestamp,
+                    granularity,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=OperationTarget.LOCAL,
+            )
+        ]


### PR DESCRIPTION
# Overview

Adds a set of migrations to allow materialization to account for sampled counter values.
Specifically
- Adds a new column that contains `sampling_weight`, i.e. `sampling factor^(-1)`, AKA how many actual row it is worth in the raw table
- Adds a new `value_weighted` column that contains the aggregated sum taking the sampling weight into consideration
- Adds a new materialized view to manifest the columns above.

# Local testing

<details>
  <summary>Click to expand</summary>
  
  ### Run the migrations

```bash
make apply-migrations
```

  ### Insert data into clickhouse, 2 rows, 1 with sample weight at 1, the other with 99
  ```sql

4d5fc6ba4a26 :) insert into generic_metric_counters_raw_local FORMAT JSONColumns \
:-] {
      "use_case_id": ["custom"],
      "org_id": [1],
      "project_id": [1],
      "metric_id": [1],
      "timestamp": [1722378310],
      "retention_days": [90],
      "tags.key": [[1]],
      "tags.indexed_value": [[10]],
      "tags.raw_value": [["c_v_1"]],
      "set_values": [[]],
      "count_value": [1],
      "distribution_values": [[]],
      "metric_type": ["counter"],
      "materialization_version": [3],
      "timeseries_id": [123456],
      "partition": [0],
      "offset": [0],
      "granularities": [[2]],
      "sampling_weight": [1]
    }

INSERT INTO generic_metric_counters_raw_local FORMAT JSONColumns

Query id: 4006be39-0983-4ca7-aeda-c02cd05f4aa1

Ok.

4d5fc6ba4a26 :) insert into generic_metric_counters_raw_local FORMAT JSONColumns
                {
                  "use_case_id": ["custom"],
                  "org_id": [1],
                  "project_id": [1],
                  "metric_id": [1],
                  "timestamp": [1722378310],
                  "retention_days": [90],
                  "tags.key": [[1]],
                  "tags.indexed_value": [[10]],
                  "tags.raw_value": [["c_v_1"]],
                  "set_values": [[]],
                  "count_value": [1],
                  "distribution_values": [[]],
                  "metric_type": ["counter"],
                  "materialization_version": [3],
                  "timeseries_id": [123456],
                  "partition": [0],
                  "offset": [0],
                  "granularities": [[2]],
                  "sampling_weight": [99]
                }

INSERT INTO generic_metric_counters_raw_local FORMAT JSONColumns

Query id: 772c25b5-695e-49fa-9032-c605da0acee9

Ok.
  ```
  ### Query for unbiased values
```sql
SELECT sumMerge(value)
FROM generic_metric_counters_aggregated_local

Query id: 4bdfc292-ab21-468a-a2aa-57b305c02630

┌─sumMerge(value)─┐
│               2 │
└─────────────────┘

1 row in set. Elapsed: 0.005 sec.
```

### Query for biased values
```sql
SELECT sumMerge(value_weighted)
FROM generic_metric_counters_aggregated_local

Query id: a4bc6038-82fa-420e-b0c7-211976a90a98

┌─sumMerge(value_weighted)─┐
│                      100 │
└──────────────────────────┘

1 row in set. Elapsed: 0.005 sec.
```

  ### Insert a row with materialization version = 2
```sql
4d5fc6ba4a26 :) insert into generic_metric_counters_raw_local FORMAT JSONColumns
                {
                  "use_case_id": ["custom"],
                  "org_id": [0],
                  "project_id": [1],
                  "metric_id": [1],
                  "timestamp": [1722378310],
                  "retention_days": [90],
                  "tags.key": [[1]],
                  "tags.indexed_value": [[10]],
                  "tags.raw_value": [["c_v_1"]],
                  "set_values": [[]],
                  "count_value": [1],
                  "distribution_values": [[]],
                  "metric_type": ["counter"],
                  "materialization_version": [2],
                  "timeseries_id": [123456],
                  "partition": [0],
                  "offset": [0],
                  "granularities": [[2]],
                  "sampling_weight": [99]
                }

INSERT INTO generic_metric_counters_raw_local FORMAT JSONColumns

Query id: 7358e4ba-e5d9-4287-a40c-43b93670912b

Ok.

4d5fc6ba4a26 :) select SumMerge(value) from generic_metric_counters_aggregated_local where org_id = 0

SELECT SumMerge(value)
FROM generic_metric_counters_aggregated_local
WHERE org_id = 0

Query id: 6b50eaa2-b20a-41cb-aec2-53e2711d27fa

┌─SumMerge(value)─┐
│               1 │
└─────────────────┘

1 row in set. Elapsed: 0.006 sec.
```
</details>