### PR TITLE
feat(generic-metrics): Add migrations to allow sampling for gauges

### DIFF
--- a/snuba/snuba_migrations/generic_metrics/0055_gauges_raw_add_sampling_weight.py
+++ b/snuba/snuba_migrations/generic_metrics/0055_gauges_raw_add_sampling_weight.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    local_table_name = "generic_metric_gauges_raw_local"
+    dist_table_name = "generic_metric_gauges_raw_dist"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_GAUGES
+
+    columns: Sequence[Column[MigrationModifiers]] = [
+        Column(
+            "sampling_weight",
+            UInt(64, MigrationModifiers(codecs=["ZSTD(1)"], default=str("1"))),
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                target=target,
+            )
+            for column in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0056_gauges_aggregated_add_weighted_columns.py
+++ b/snuba/snuba_migrations/generic_metrics/0056_gauges_aggregated_add_weighted_columns.py
@@ -1,0 +1,71 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import AggregateFunction, Float, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    local_table_name = "generic_metric_gauges_aggregated_local"
+    dist_table_name = "generic_metric_gauges_aggregated_dist"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_GAUGES
+
+    columns: Sequence[tuple[Column[MigrationModifiers], str | None]] = [
+        (
+            Column(
+                "sum_weighted",
+                AggregateFunction(
+                    "sum",
+                    [Float(64)],
+                    MigrationModifiers(codecs=["ZSTD(1)"]),
+                ),
+            ),
+            "sum",
+        ),
+        (
+            Column(
+                "count_weighted",
+                AggregateFunction(
+                    "sum",
+                    [UInt(64)],
+                    MigrationModifiers(codecs=["ZSTD(1)"]),
+                ),
+            ),
+            "count",
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                after=after,
+                target=target,
+            )
+            for column, after in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column, _ in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0057_gauges_mv3.py
+++ b/snuba/snuba_migrations/generic_metrics/0057_gauges_mv3.py
@@ -1,0 +1,97 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, DateTime, Nested, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_gauges_aggregation_mv3"
+    dest_table_name = "generic_metric_gauges_aggregated_local"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_GAUGES
+
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_GAUGES
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name=self.dest_table_name,
+                target=OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) as granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    maxState(timestamp as raw_timestamp) as last_timestamp,
+                    toDateTime(multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
+                      intDiv(toUnixTimestamp(raw_timestamp),
+                             multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as rounded_timestamp,
+                    least(retention_days,
+                        multiIf(granularity=0,decasecond_retention_days,
+                                granularity=1,min_retention_days,
+                                granularity=2,hr_retention_days,
+                                granularity=3,day_retention_days,
+                                0)) as retention_days,
+                    minState(arrayJoin(gauges_values.min)) as min,
+                    maxState(arrayJoin(gauges_values.max)) as max,
+                    sumState(arrayJoin(gauges_values.sum)) as sum,
+                    sumState(sampling_weight * arrayJoin(gauges_values.sum)) AS sum_weighted,
+                    sumState(arrayJoin(gauges_values.count)) as count,
+                    sumState(sampling_weight * arrayJoin(gauges_values.count)) AS count_weighted,
+                    argMaxState(arrayJoin(gauges_values.last), raw_timestamp) as last
+                FROM generic_metric_gauges_raw_local
+                WHERE materialization_version = 3
+                  AND metric_type = 'gauge'
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    raw_timestamp,
+                    granularity,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=OperationTarget.LOCAL,
+            )
+        ]


### PR DESCRIPTION
# Overview

This PR is responsible for adding a set of migrations to allow materialization to account for sampled gauges values.
More specifically:
- Add a new `sampling_weight`, i.e. `sampling factor^(-1)` column to the gauges raw table 
- Add new `sum_weighted` and `count_weighted` columns that contains the aggregated function which takes the sampling weight into consideration
- Adds new materialized view to manifest the columns above.

# Local testing

<details>
  <summary>Click to expand</summary>
  
  ### Run the migrations

```bash
make apply-migrations
```

  ### Insert data into clickhouse, 2 rows, 1 with sample weight at 1, the other with 99
  ```sql

b02f52acbe45 :) insert into generic_metric_gauges_raw_local FORMAT JSONColumns {
                    "use_case_id": ["custom"],
                    "org_id": [1],
                    "project_id": [1],
                    "metric_id": [1],
                    "timestamp": [1722378310],
                    "retention_days": [90],
                    "tags.key": [[1]],
                    "tags.indexed_value": [[10]],
                    "tags.raw_value": [["c_v_1"]],
                    "set_values": [[]],
                    "count_value": [0],
                    "distribution_values": [[]],
                    "gauges_values.last": [[1]],
                    "gauges_values.min": [[1]],
                    "gauges_values.max": [[1]],
                    "gauges_values.sum": [[1]],
                    "gauges_values.count": [[1]],
                    "metric_type": ["gauge"],
                    "materialization_version": [3],
                    "timeseries_id": [0],
                    "partition": [0],
                    "offset": [0],
                    "granularities": [[2]],
                    "sampling_weight": [1]
                  }

INSERT INTO generic_metric_gauges_raw_local FORMAT JSONColumns

Query id: cd011a35-f6dc-4ae5-867e-d9551371f60f

Ok.

1 row in set. Elapsed: 0.017 sec.

b02f52acbe45 :) insert into generic_metric_gauges_raw_local FORMAT JSONColumns {
                    "use_case_id": ["custom"],
                    "org_id": [1],
                    "project_id": [1],
                    "metric_id": [1],
                    "timestamp": [1722378310],
                    "retention_days": [90],
                    "tags.key": [[1]],
                    "tags.indexed_value": [[10]],
                    "tags.raw_value": [["c_v_1"]],
                    "set_values": [[]],
                    "count_value": [0],
                    "distribution_values": [[]],
                    "gauges_values.last": [[1]],
                    "gauges_values.min": [[1]],
                    "gauges_values.max": [[1]],
                    "gauges_values.sum": [[1]],
                    "gauges_values.count": [[1]],
                    "metric_type": ["gauge"],
                    "materialization_version": [3],
                    "timeseries_id": [0],
                    "partition": [0],
                    "offset": [0],
                    "granularities": [[2]],
                    "sampling_weight": [99]
                  }


INSERT INTO generic_metric_gauges_raw_local FORMAT JSONColumns

Query id: 1d7b4c40-ab46-40ba-b908-c11574e61f88

Ok.

1 row in set. Elapsed: 0.020 sec.

  ```
  ### Query for non-extrapolated values
```sql
b02f52acbe45 :) SELECT sumMerge(count) FROM generic_metric_gauges_aggregated_local;

SELECT sumMerge(count)
FROM generic_metric_gauges_aggregated_local

Query id: fd476749-d24f-44b3-a476-991f20fed20d

┌─sumMerge(count)─┐
│               2 │
└─────────────────┘

1 row in set. Elapsed: 0.003 sec.

b02f52acbe45 :) SELECT sumMerge(sum) FROM generic_metric_gauges_aggregated_local;

SELECT sumMerge(sum)
FROM generic_metric_gauges_aggregated_local

Query id: 00b3d5c6-4d78-42b8-a3dc-d388d5c4bb38

┌─sumMerge(sum)─┐
│             2 │
└───────────────┘

1 row in set. Elapsed: 0.002 sec.
```

### Query for extrapolated values
```sql
b02f52acbe45 :) SELECT sumMerge(count_weighted) FROM generic_metric_gauges_aggregated_local;

SELECT sumMerge(count_weighted)
FROM generic_metric_gauges_aggregated_local

Query id: bc8a62f6-acc3-406e-9130-5d7e29666a98

┌─sumMerge(count_weighted)─┐
│                      100 │
└──────────────────────────┘


b02f52acbe45 :) SELECT sumMerge(sum_weighted) FROM generic_metric_gauges_aggregated_local;

SELECT sumMerge(sum_weighted)
FROM generic_metric_gauges_aggregated_local

Query id: fdf31df7-e377-4afa-acc3-d7056ce714b8

┌─sumMerge(sum_weighted)─┐
│                    100 │
└────────────────────────┘

1 row in set. Elapsed: 0.002 sec.
```

  ### Insert a row with materialization version = 2 with org_id = 10
```sql
b02f52acbe45 :) insert into generic_metric_gauges_raw_local FORMAT JSONColumns {
                    "use_case_id": ["custom"],
                    "org_id": [10],
                    "project_id": [1],
                    "metric_id": [1],
                    "timestamp": [1722378310],
                    "retention_days": [90],
                    "tags.key": [[1]],
                    "tags.indexed_value": [[10]],
                    "tags.raw_value": [["c_v_1"]],
                    "set_values": [[]],
                    "count_value": [0],
                    "distribution_values": [[]],
                    "gauges_values.last": [[1]],
                    "gauges_values.min": [[1]],
                    "gauges_values.max": [[1]],
                    "gauges_values.sum": [[1]],
                    "gauges_values.count": [[1]],
                    "metric_type": ["gauge"],
                    "materialization_version": [2],
                    "timeseries_id": [0],
                    "partition": [0],
                    "offset": [0],
                    "granularities": [[2]],
                    "sampling_weight": [99]
                  }
                  
INSERT INTO generic_metric_gauges_raw_local FORMAT JSONColumns

Query id: 752cb458-935d-43a1-99a8-1370ad23beb2

Ok.

1 row in set. Elapsed: 0.021 sec.

b02f52acbe45 :) SELECT sumMerge(sum) FROM generic_metric_gauges_aggregated_local WHERE org_id = 10;

SELECT sumMerge(sum)
FROM generic_metric_gauges_aggregated_local
WHERE org_id = 10

Query id: 4ea89a42-3fcf-4d75-b0e3-4ed4ffeaa0ad

┌─sumMerge(sum)─┐
│             1 │
└───────────────┘

1 row in set. Elapsed: 0.003 sec.
```
</details>