### PR TITLE
fix(snuba-deletes): max row enforcer should query dist table

### DIFF
--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -92,9 +92,13 @@ def _enforce_max_rows(delete_query: Query) -> None:
             .get_schema()
             .get_table_name()
         )
-        from_clause_dict = delete_query.get_from_clause().__dict__
-        from_clause_dict["table_name"] = dist_table_name
-        return Table(**from_clause_dict)
+        from_clause = delete_query.get_from_clause()
+        return Table(
+            table_name=dist_table_name,
+            schema=from_clause.schema,
+            storage_key=from_clause.storage_key,
+            allocation_policies=from_clause.allocation_policies,
+        )
 
     select_query_to_count_rows = Query(
         selected_columns=[

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -5,7 +5,7 @@ from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.query import format_query
 from snuba.clickhouse.query import Query
 from snuba.datasets.storage import WritableTableStorage
-from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query import SelectedExpression
 from snuba.query.conditions import combine_and_conditions
@@ -78,14 +78,31 @@ def _enforce_max_rows(delete_query: Query) -> None:
     Because of the above, we want to limit the number of rows one deletes at a time. The `MaxRowsEnforcer` will query clickhouse to see how many
       rows we plan on deleting and if it crosses the `max_rows_to_delete` set for that storage we will reject the query.
     """
+    storage_key = delete_query.get_from_clause().storage_key
+
+    def get_new_from_clause() -> Table:
+        """
+        The delete query targets the local table, but when we are checking the
+        row count we are querying the dist tables (if applicable). This function
+        updates the from_clause to have the correct table.
+        """
+        dist_table_name = (
+            get_writable_storage((storage_key))
+            .get_table_writer()
+            .get_schema()
+            .get_table_name()
+        )
+        from_clause_dict = delete_query.get_from_clause().__dict__
+        from_clause_dict["table_name"] = dist_table_name
+        return Table(**from_clause_dict)
+
     select_query_to_count_rows = Query(
         selected_columns=[
             SelectedExpression("count", FunctionCall("count", "count", ())),
         ],
-        from_clause=delete_query.get_from_clause(),
+        from_clause=get_new_from_clause(),
         condition=delete_query.get_condition(),
     )
-    storage_key = delete_query.get_from_clause().storage_key
     rows_to_delete = _get_rows_to_delete(
         storage_key=storage_key, select_query_to_count_rows=select_query_to_count_rows
     )


### PR DESCRIPTION
We can't just re-use the same `from_clause` from the delete query because the table we query from will be different (select queries target the dist table). 

We saw this error in [SNUBA-5A2](https://sentry.sentry.io/issues/5662439338/?project=300688&query=firstRelease%3A1aab7d69cea520eba3deb565065744813510e5fa+issue.type%3Aerror+%21level%3Ainfo&referrer=issue-stream&statsPeriod=1h&stream_index=0). This should provide the correct table using https://github.com/getsentry/snuba/blob/0ffa35091853f719ab5012e9b6f5da4d7739904a/snuba/datasets/schemas/tables.py#L85-L94