### PR TITLE
feat: new page in snuba admin to do deletes

### DIFF
--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -100,7 +100,7 @@ interface Client {
   ) => Promise<ReplayInstruction | null>;
   clearDlqInstruction: () => Promise<ReplayInstruction | null>;
   getAdminRegions: () => Promise<string[]>;
-  runLightweightDelete: (storage_name: string, column_conditions: object) => Promise<any>
+  runLightweightDelete: (storage_name: string, column_conditions: object) => Promise<Response>
 }
 
 function Client() {
@@ -486,11 +486,6 @@ function Client() {
           columns: column_conditions
         })
       })
-        .then(res => res.json())
-        .catch(error => {
-          alert("unexpected error: see console")
-          throw error
-        })
     },
   };
 }

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -100,6 +100,7 @@ interface Client {
   ) => Promise<ReplayInstruction | null>;
   clearDlqInstruction: () => Promise<ReplayInstruction | null>;
   getAdminRegions: () => Promise<string[]>;
+  runLightweightDelete: () => Promise<string>
 }
 
 function Client() {

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -100,7 +100,7 @@ interface Client {
   ) => Promise<ReplayInstruction | null>;
   clearDlqInstruction: () => Promise<ReplayInstruction | null>;
   getAdminRegions: () => Promise<string[]>;
-  runLightweightDelete: () => Promise<string>
+  runLightweightDelete: (storage_name: string, column_conditions: object) => void
 }
 
 function Client() {
@@ -473,6 +473,9 @@ function Client() {
         headers: { "Content-Type": "application/json" },
         method: "DELETE",
       }).then((resp) => resp.json());
+    },
+    runLightweightDelete: (storage_name: string, column_conditions: object) => {
+      alert('successfully about to go to the backend')
     },
   };
 }

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -476,7 +476,6 @@ function Client() {
     },
     runLightweightDelete: (storage_name: string, column_conditions: object) => {
       const url = baseUrl + "delete"
-      debugger;
       return fetch(url, {
         method: 'DELETE',
         headers: {
@@ -487,10 +486,10 @@ function Client() {
           columns: column_conditions
         })
       })
-        .then(response => response.json())
+        .then(res => res.json())
         .catch(error => {
           alert("unexpected error: see console")
-          console.error('Error: ', error)
+          throw error
         })
     },
   };

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -100,7 +100,7 @@ interface Client {
   ) => Promise<ReplayInstruction | null>;
   clearDlqInstruction: () => Promise<ReplayInstruction | null>;
   getAdminRegions: () => Promise<string[]>;
-  runLightweightDelete: (storage_name: string, column_conditions: object) => void
+  runLightweightDelete: (storage_name: string, column_conditions: object) => Promise<any>
 }
 
 function Client() {
@@ -475,7 +475,23 @@ function Client() {
       }).then((resp) => resp.json());
     },
     runLightweightDelete: (storage_name: string, column_conditions: object) => {
-      alert('successfully about to go to the backend')
+      const url = baseUrl + "delete"
+      debugger;
+      return fetch(url, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          storage: storage_name,
+          columns: column_conditions
+        })
+      })
+        .then(response => response.json())
+        .catch(error => {
+          alert("unexpected error: see console")
+          console.error('Error: ', error)
+        })
     },
   };
 }

--- a/snuba/admin/static/data.tsx
+++ b/snuba/admin/static/data.tsx
@@ -13,6 +13,7 @@ import CardinalityAnalyzer from "SnubaAdmin/cardinality_analyzer";
 import ProductionQueries from "SnubaAdmin/production_queries";
 import SnubaExplain from "SnubaAdmin/snuba_explain";
 import Welcome from "SnubaAdmin/welcome";
+import DeleteTool from "SnubaAdmin/delete_tool";
 
 const NAV_ITEMS = [
   { id: "overview", display: "🤿 Snuba Admin", component: Welcome },
@@ -81,6 +82,11 @@ const NAV_ITEMS = [
     id: "production-queries",
     display: "🔦 Production Queries",
     component: ProductionQueries,
+  },
+  {
+    id: "delete-tool",
+    display: "🗑️ Delete Tool",
+    component: DeleteTool,
   },
 ];
 

--- a/snuba/admin/static/delete_tool/index.tsx
+++ b/snuba/admin/static/delete_tool/index.tsx
@@ -19,9 +19,9 @@ function DeleteTool(props: { api: Client }) {
                         alert("expect columnConditions to be valid json but its not");
                         return;
                     }
-                    props.api.runLightweightDelete(storageName, conds).then(data => setResult(data)
-                    }
-                }>Submit</button>
+                    props.api.runLightweightDelete(storageName, conds).then(data => setResult(JSON.stringify(data)))
+                }
+            }>Submit</button>
             <p>latest result: {result}</p>
         </div>
       );

--- a/snuba/admin/static/delete_tool/index.tsx
+++ b/snuba/admin/static/delete_tool/index.tsx
@@ -1,0 +1,18 @@
+import Client from "SnubaAdmin/api_client";
+import React, { useEffect, useState } from "react"
+
+function DeleteTool(props: { api: Client }) {
+    const [inputValue, setInputValue] = useState('')
+    const [submittedVal, setSubmittedVal] = useState('')
+
+
+    return (
+        <div>
+            <input type="text" value={inputValue} onChange={(event) => setInputValue(event.target.value)} />
+            <button type="submit" onClick={(event) => setSubmittedVal(inputValue)}>Submit</button>
+            <p>sent: {submittedVal}</p>
+        </div>
+      );
+}
+
+export default DeleteTool

--- a/snuba/admin/static/delete_tool/index.tsx
+++ b/snuba/admin/static/delete_tool/index.tsx
@@ -2,15 +2,27 @@ import Client from "SnubaAdmin/api_client";
 import React, { useEffect, useState } from "react"
 
 function DeleteTool(props: { api: Client }) {
-    const [inputValue, setInputValue] = useState('')
-    const [submittedVal, setSubmittedVal] = useState('')
-
+    const [storageName, setStorageName] = useState('')
+    const [columnConditions, setColumnConditions] = useState('')
+    const [result, setResult] = useState('')
 
     return (
         <div>
-            <input type="text" value={inputValue} onChange={(event) => setInputValue(event.target.value)} />
-            <button type="submit" onClick={(event) => setSubmittedVal(inputValue)}>Submit</button>
-            <p>sent: {submittedVal}</p>
+            <input type="text" value={storageName} placeholder="storage name" onChange={(event) => setStorageName(event.target.value)} /><br/>
+            <textarea value={columnConditions} placeholder="column conditions" onChange={(event) => setColumnConditions(event.target.value)} /><br/>
+            <button type="submit" onClick={
+                (event) => {
+                    let conds;
+                    try {
+                        conds = JSON.parse(columnConditions)
+                    } catch (error) {
+                        alert("expect columnConditions to be valid json but its not");
+                        return;
+                    }
+                    props.api.runLightweightDelete(storageName, conds)
+                    }
+                }>Submit</button>
+            <p>latest result: {result}</p>
         </div>
       );
 }

--- a/snuba/admin/static/delete_tool/index.tsx
+++ b/snuba/admin/static/delete_tool/index.tsx
@@ -19,10 +19,19 @@ function DeleteTool(props: { api: Client }) {
                         alert("expect columnConditions to be valid json but its not");
                         return;
                     }
-                    props.api.runLightweightDelete(storageName, conds).then(data => setResult(JSON.stringify(data)))
+                    let resp_status = ""
+                    props.api.runLightweightDelete(storageName, conds).then(res => {
+                        resp_status = `${res.status} ${res.statusText}\n`
+                        if (res.headers.get("Content-Type") == "application/json") {
+                            return res.json().then(json => JSON.stringify(json))
+                        } else {
+                            return res.text()
+                        }
+                    }).then(data_str => setResult(resp_status + data_str))
                 }
             }>Submit</button>
-            <p>latest result: {result}</p>
+            <p>latest result:</p><br/>
+            {result}
         </div>
       );
 }

--- a/snuba/admin/static/delete_tool/index.tsx
+++ b/snuba/admin/static/delete_tool/index.tsx
@@ -19,7 +19,7 @@ function DeleteTool(props: { api: Client }) {
                         alert("expect columnConditions to be valid json but its not");
                         return;
                     }
-                    props.api.runLightweightDelete(storageName, conds)
+                    props.api.runLightweightDelete(storageName, conds).then(data => setResult(data)
                     }
                 }>Submit</button>
             <p>latest result: {result}</p>

--- a/snuba/admin/static/delete_tool/index.tsx
+++ b/snuba/admin/static/delete_tool/index.tsx
@@ -5,32 +5,56 @@ function DeleteTool(props: { api: Client }) {
     const [storageName, setStorageName] = useState('')
     const [columnConditions, setColumnConditions] = useState('')
     const [result, setResult] = useState('')
+    const [showHelpMessage, setShowHelpMessage] = useState(false)
+
+    function getHelpMessage() {
+        if (showHelpMessage) {
+            return <div style={{"backgroundColor":"#DDD"}}>
+                <h3><u>Inputs:</u></h3>
+                <p><u>Storage name</u> - the name of the storage you want to delete from.<br/>
+                <u>Column Conditions</u> - example input:
+                <pre><code>{
+`{
+    "project_id": [1]
+    "resource_id": ["123456789"]
+}`
+                }</code></pre>
+                which represents <pre><code>DELETE FROM ... WHERE project_id=1 AND resource_id='123456789'</code></pre></p>
+            </div>
+        } else {
+            return <div><p></p></div>
+        }
+    }
+
+    function submitRequest() {
+        let conds;
+        try {
+            conds = JSON.parse(columnConditions)
+        } catch (error) {
+            alert("expect columnConditions to be valid json but its not");
+            return;
+        }
+        let resp_status = ""
+        props.api.runLightweightDelete(storageName, conds).then(res => {
+            resp_status = `${res.status} ${res.statusText}\n`
+            if (res.headers.get("Content-Type") == "application/json") {
+                return res.json().then(json => JSON.stringify(json))
+            } else {
+                return res.text()
+            }
+        }).then(data_str => setResult(resp_status + data_str))
+    }
 
     return (
         <div>
+            <div>
+            <button type="button" onClick={(event) => setShowHelpMessage(!showHelpMessage)}>Help</button>
+            {getHelpMessage()}
+            </div>
             <input type="text" value={storageName} placeholder="storage name" onChange={(event) => setStorageName(event.target.value)} /><br/>
             <textarea value={columnConditions} placeholder="column conditions" onChange={(event) => setColumnConditions(event.target.value)} /><br/>
-            <button type="submit" onClick={
-                (event) => {
-                    let conds;
-                    try {
-                        conds = JSON.parse(columnConditions)
-                    } catch (error) {
-                        alert("expect columnConditions to be valid json but its not");
-                        return;
-                    }
-                    let resp_status = ""
-                    props.api.runLightweightDelete(storageName, conds).then(res => {
-                        resp_status = `${res.status} ${res.statusText}\n`
-                        if (res.headers.get("Content-Type") == "application/json") {
-                            return res.json().then(json => JSON.stringify(json))
-                        } else {
-                            return res.text()
-                        }
-                    }).then(data_str => setResult(resp_status + data_str))
-                }
-            }>Submit</button>
-            <p>latest result:</p><br/>
+            <button type="submit" onClick={(event) => submitRequest()}>Submit</button>
+            <p>latest result:</p>
             {result}
         </div>
       );

--- a/snuba/admin/tool_policies.py
+++ b/snuba/admin/tool_policies.py
@@ -31,6 +31,7 @@ class AdminTools(Enum):
     PRODUCTION_QUERIES = "production-queries"
     CARDINALITY_ANALYZER = "cardinality-analyzer"
     SNUBA_EXPLAIN = "snuba-explain"
+    DELETE_TOOL = "delete_tool"
 
 
 DEVELOPER_TOOLS: set[AdminTools] = {AdminTools.SNQL_TO_SQL, AdminTools.QUERY_TRACING}

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1059,6 +1059,7 @@ def get_admin_regions() -> Response:
 )
 @check_tool_perms(tools=[AdminTools.DELETE_TOOL])
 def delete() -> Response:
+    return make_response(jsonify("hi", "there"), 200)
     body = request.get_json()
     if "storage" not in body:
         return make_response(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1099,6 +1099,10 @@ def delete() -> Response:
     except ValueError as e:
         return make_response(jsonify({"error": str(e)}), 400)
     except Exception as e:
-        import traceback
+        if application.debug:
+            from traceback import format_exception
 
-        return make_response(jsonify({"error": traceback.format_exception(e)}), 500)
+            return make_response(jsonify({"error": format_exception(e)}), 500)
+        else:
+            sentry_sdk.capture_exception(e)
+            return make_response(jsonify({"error": "unexpected internal error"}), 500)

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1059,7 +1059,7 @@ def get_admin_regions() -> Response:
 )
 @check_tool_perms(tools=[AdminTools.DELETE_TOOL])
 def delete() -> Response:
-    return make_response(jsonify("hi", "there"), 200)
+    return make_response(jsonify({"hi": "there"}), 200)
     body = request.get_json()
     if "storage" not in body:
         return make_response(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1059,6 +1059,14 @@ def get_admin_regions() -> Response:
 )
 @check_tool_perms(tools=[AdminTools.DELETE_TOOL])
 def delete() -> Response:
+    """
+    Given a storage name and columns object, parses the input and calls
+    delete_from_storage with them.
+
+    Input:
+        an http DELETE request with a json body containing elements "storage" and "columns"
+        see delete_from_storage for definition of these inputs.
+    """
     body = request.get_json()
     if "storage" not in body:
         return make_response(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1046,3 +1046,26 @@ def get_allowed_projects() -> Response:
 @application.route("/admin_regions", methods=["GET"])
 def get_admin_regions() -> Response:
     return make_response(jsonify(settings.ADMIN_REGIONS), 200)
+
+
+@application.route(
+    "/delete",
+    methods=["DELETE"],
+)
+@check_tool_perms(tools=[AdminTools.DELETE_TOOL])
+def delete() -> Response:
+    body = request.get_json()
+    try:
+        storage = body["storage"]
+        conditions = body["conditions"]
+    except Exception:
+        return make_response(
+            jsonify(
+                {
+                    "error",
+                    "all required inputs ('storage', 'conditions') were not present in the request body",
+                }
+            ),
+            400,
+        )
+    return make_response(200)

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1060,18 +1060,39 @@ def get_admin_regions() -> Response:
 @check_tool_perms(tools=[AdminTools.DELETE_TOOL])
 def delete() -> Response:
     body = request.get_json()
-    try:
-        storage = body["storage"]
-        conditions = body["conditions"]
-    except Exception:
+    if "storage" not in body:
         return make_response(
             jsonify(
                 {
                     "error",
-                    "all required inputs ('storage', 'conditions') were not present in the request body",
+                    "all required input 'storage' is not present in the request body",
                 }
             ),
             400,
         )
-    results = delete_from_storage(get_writable_storage(StorageKey(storage)), conditions)
+    storage = body["storage"]
+    if "conditions" not in body:
+        return make_response(
+            jsonify(
+                {
+                    "error",
+                    "all required input 'storage' is not present in the request body",
+                }
+            ),
+            400,
+        )
+    conditions = body["conditions"]
+    try:
+        storage = get_writable_storage(StorageKey(storage))
+    except Exception as e:
+        return make_response(
+            jsonify(
+                {
+                    "error",
+                    e,
+                }
+            ),
+            400,
+        )
+    results = delete_from_storage(storage, conditions)
     return Response(json.dumps(results), 200, {"Content-Type": "application/json"})

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -59,7 +59,11 @@ from snuba.consumers.dlq import (
     store_instruction,
 )
 from snuba.datasets.factory import InvalidDatasetError, get_enabled_dataset_names
-from snuba.datasets.storages.factory import get_all_storage_keys, get_storage
+from snuba.datasets.storages.factory import (
+    get_all_storage_keys,
+    get_storage,
+    get_writable_storage,
+)
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.migrations.connect import check_for_inactive_replicas
 from snuba.migrations.errors import InactiveClickhouseReplica, MigrationError
@@ -71,6 +75,7 @@ from snuba.replacers.replacements_and_expiry import (
 )
 from snuba.state.explain_meta import explain_cleanup, get_explain_meta
 from snuba.utils.metrics.timer import Timer
+from snuba.web.delete_query import delete_from_storage
 from snuba.web.views import dataset_query
 
 logger = structlog.get_logger().bind(module=__name__)
@@ -1068,4 +1073,5 @@ def delete() -> Response:
             ),
             400,
         )
-    return make_response(200)
+    results = delete_from_storage(get_writable_storage(StorageKey(storage)), conditions)
+    return Response(json.dumps(results), 200, {"Content-Type": "application/json"})

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -22,7 +22,7 @@ from snuba.utils.metrics.util import with_span
 def delete_from_storage(
     storage: WritableTableStorage,
     columns: Dict[str, Any],
-) -> dict[str, Any]:
+) -> dict[str, Result]:
     """
     Inputs:
         storage - storage to delete from
@@ -37,6 +37,9 @@ def delete_from_storage(
 
     Deletes all rows in the given storage, that satisfy the conditions
     defined in 'columns' input.
+
+    Returns a mapping from clickhouse table name to deletion results, there
+    will be an entry for every local clickhouse table that makes up the storage.
     """
     if not get_config("storage_deletes_enabled", 0):
         raise Exception("Deletes not enabled")
@@ -45,11 +48,11 @@ def delete_from_storage(
     if not delete_settings.is_enabled:
         raise Exception(f"Deletes not enabled for {storage.get_storage_key().value}")
 
-    payload: dict[str, Any] = {}
+    results: dict[str, Result] = {}
     for table in delete_settings.tables:
         result = _delete_from_table(storage, table, columns)
-        payload[table] = {**result}
-    return payload
+        results[table] = result
+    return results
 
 
 def _get_rows_to_delete(

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -20,8 +20,7 @@ from snuba.utils.metrics.util import with_span
 
 @with_span()
 def delete_from_storage(
-    storage: WritableTableStorage,
-    columns: Dict[str, Any],
+    storage: WritableTableStorage, columns: Dict[str, list[Any]]
 ) -> dict[str, Result]:
     """
     Inputs:
@@ -47,6 +46,15 @@ def delete_from_storage(
     delete_settings = storage.get_deletion_settings()
     if not delete_settings.is_enabled:
         raise Exception(f"Deletes not enabled for {storage.get_storage_key().value}")
+
+    # assert isinstance(columns, dict[str, list[Any]])
+    columns_is_expected_type = isinstance(columns, dict) and all(
+        [isinstance(k, str) and isinstance(v, list) for k, v in columns.items()]
+    )
+    if not columns_is_expected_type:
+        raise ValueError(
+            "expected input 'columns' to be of type dict[str, list[Any]] but it was not"
+        )
 
     results: dict[str, Result] = {}
     for table in delete_settings.tables:

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -47,15 +47,6 @@ def delete_from_storage(
     if not delete_settings.is_enabled:
         raise Exception(f"Deletes not enabled for {storage.get_storage_key().value}")
 
-    # assert isinstance(columns, dict[str, list[Any]])
-    columns_is_expected_type = isinstance(columns, dict) and all(
-        [isinstance(k, str) and isinstance(v, list) for k, v in columns.items()]
-    )
-    if not columns_is_expected_type:
-        raise ValueError(
-            "expected input 'columns' to be of type dict[str, list[Any]] but it was not"
-        )
-
     results: dict[str, Result] = {}
     for table in delete_settings.tables:
         result = _delete_from_table(storage, table, columns)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -312,7 +312,9 @@ def storage_delete(
         try:
             schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
             request_parts = schema.validate(body)
-            payload = delete_from_storage(storage, request_parts.query["columns"])
+            delete_results = delete_from_storage(
+                storage, request_parts.query["columns"]
+            )
         except InvalidJsonRequestException as schema_error:
             return make_response(
                 jsonify({"error": str(schema_error)}),
@@ -325,7 +327,7 @@ def storage_delete(
             return make_response(jsonify({"error": error}), 500)
 
         return Response(
-            dump_payload(results), 200, {"Content-Type": "application/json"}
+            dump_payload(delete_results), 200, {"Content-Type": "application/json"}
         )
 
     else:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -323,7 +323,7 @@ def storage_delete(
             return make_response(jsonify({"error": error}), 500)
 
         return Response(
-            dump_payload(payload), 200, {"Content-Type": "application/json"}
+            dump_payload(results), 200, {"Content-Type": "application/json"}
         )
 
     else:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -312,9 +312,7 @@ def storage_delete(
         try:
             schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
             request_parts = schema.validate(body)
-            delete_results = delete_from_storage(
-                storage, request_parts.query["columns"]
-            )
+            payload = delete_from_storage(storage, request_parts.query["columns"])
         except InvalidJsonRequestException as schema_error:
             return make_response(
                 jsonify({"error": str(schema_error)}),
@@ -325,7 +323,7 @@ def storage_delete(
             return make_response(jsonify({"error": error}), 500)
 
         return Response(
-            dump_payload(delete_results), 200, {"Content-Type": "application/json"}
+            dump_payload(payload), 200, {"Content-Type": "application/json"}
         )
 
     else:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -318,6 +318,8 @@ def storage_delete(
                 jsonify({"error": str(schema_error)}),
                 400,
             )
+        except ValueError as error:
+            return make_response(jsonify({"error": str(error)}), 400)
         except Exception as error:
             logger.warning("Failed query", exc_info=error)
             return make_response(jsonify({"error": error}), 500)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -320,8 +320,6 @@ def storage_delete(
                 jsonify({"error": str(schema_error)}),
                 400,
             )
-        except ValueError as error:
-            return make_response(jsonify({"error": str(error)}), 400)
         except Exception as error:
             logger.warning("Failed query", exc_info=error)
             return make_response(jsonify({"error": error}), 500)


### PR DESCRIPTION
this is a redo of #6157

This PR adds a page to snuba admin that we can use to test deletes in prod.

## major changes
1. create a front-end react interface for deletes
* `static/delete_tool/index.tsx` is the new react UI, it calls `api_client.tsx:runLightweightDelete` 
* `api_client.py:runLightweightDelete` sends the input via http request to `/delete` endpoint. (note: i think it would have been equally valid to just send the http request from index.tsx rather than having this separate function, but I did it like this bc everyone else in the codebase did)
* `data.tsx` adds the new page to the Nav bar
2. create a new `/delete` endpoint in snuba admin `admin/views.py:delete`
As said in bullet 1, the react UI sends the input to `/delete`. This is a new endpoint we created, it mostly just calls `delete_from_storage` (what Meredith implemented that actually does the delete)
3. set permissions for `/delete` endpoint and UI `tool_policies.py`
It just goes into AllTools by default which is the most restrictive role, only snuba team and people with access to everything can use it. I think this should be good.
4. small `delete_query.py` changes
* I slightly changed the input/output types of `delete_query.py:delete_from_storage` in order to make the interface more strict/clear.
* added more input verification for the `columns` input.

## considerations
This tool is pretty much just a layer on top of `delete_from_storage` meaning it can do anything that `delete_from_storage` can do. Hence it will be able to delete in any environment, and any dataset that has deletes enabled. Is this fine or should we add additional strictness to this interface, so that it can only be used for search_issues in s4s no matter what.

<img width="1212" alt="Screenshot 2024-07-30 at 1 10 29 PM" src="https://github.com/user-attachments/assets/d3ad9005-69b1-4995-8934-f85494fdb3b5">
