### PR TITLE
ref: make deletes not enabled return 400 error instead of 500

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1103,6 +1103,17 @@ def delete() -> Response:
             jsonify({"error": str(schema_error)}),
             400,
         )
+    except ValueError as e:
+        import traceback
+
+        # if the ValueError came from delete_from_storage
+        # (as opposed to some deeper level of the stack)
+        tb = traceback.extract_tb(e.__traceback__)
+        if tb[-1].name == delete_from_storage.__name__:
+            return make_response(
+                jsonify({"error": str(e)}),
+                400,
+            )
     except Exception as e:
         if application.debug:
             from traceback import format_exception

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -78,7 +78,11 @@ from snuba.request.exceptions import InvalidJsonRequestException
 from snuba.request.schema import RequestSchema
 from snuba.state.explain_meta import explain_cleanup, get_explain_meta
 from snuba.utils.metrics.timer import Timer
-from snuba.web.delete_query import delete_from_storage, deletes_are_enabled
+from snuba.web.delete_query import (
+    DeletesNotEnabledError,
+    delete_from_storage,
+    deletes_are_enabled,
+)
 from snuba.web.views import dataset_query
 
 logger = structlog.get_logger().bind(module=__name__)
@@ -1098,22 +1102,11 @@ def delete() -> Response:
         schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
         request_parts = schema.validate(body)
         delete_results = delete_from_storage(storage, request_parts.query["columns"])
-    except InvalidJsonRequestException as schema_error:
+    except (InvalidJsonRequestException, DeletesNotEnabledError) as schema_error:
         return make_response(
             jsonify({"error": str(schema_error)}),
             400,
         )
-    except ValueError as e:
-        import traceback
-
-        # if the ValueError came from delete_from_storage
-        # (as opposed to some deeper level of the stack)
-        tb = traceback.extract_tb(e.__traceback__)
-        if tb[-1].name == delete_from_storage.__name__:
-            return make_response(
-                jsonify({"error": str(e)}),
-                400,
-            )
     except Exception as e:
         if application.debug:
             from traceback import format_exception

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -19,6 +19,10 @@ from snuba.state import get_config
 from snuba.utils.metrics.util import with_span
 
 
+class DeletesNotEnabledError(Exception):
+    pass
+
+
 @with_span()
 def delete_from_storage(
     storage: WritableTableStorage,
@@ -43,11 +47,13 @@ def delete_from_storage(
     will be an entry for every local clickhouse table that makes up the storage.
     """
     if not deletes_are_enabled():
-        raise ValueError("Deletes not enabled in this region")
+        raise DeletesNotEnabledError("Deletes not enabled in this region")
 
     delete_settings = storage.get_deletion_settings()
     if not delete_settings.is_enabled:
-        raise ValueError(f"Deletes not enabled for {storage.get_storage_key().value}")
+        raise DeletesNotEnabledError(
+            f"Deletes not enabled for {storage.get_storage_key().value}"
+        )
 
     results: dict[str, Result] = {}
     for table in delete_settings.tables:

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -43,11 +43,11 @@ def delete_from_storage(
     will be an entry for every local clickhouse table that makes up the storage.
     """
     if not deletes_are_enabled():
-        raise Exception("Deletes not enabled")
+        raise ValueError("Deletes not enabled in this region")
 
     delete_settings = storage.get_deletion_settings()
     if not delete_settings.is_enabled:
-        raise Exception(f"Deletes not enabled for {storage.get_storage_key().value}")
+        raise ValueError(f"Deletes not enabled for {storage.get_storage_key().value}")
 
     results: dict[str, Result] = {}
     for table in delete_settings.tables:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -318,6 +318,17 @@ def storage_delete(
                 jsonify({"error": str(schema_error)}),
                 400,
             )
+        except ValueError as e:
+            import traceback
+
+            # if the ValueError came from delete_from_storage
+            # (as opposed to some deeper level of the stack)
+            tb = traceback.extract_tb(e.__traceback__)
+            if tb[-1].name == delete_from_storage.__name__:
+                return make_response(
+                    jsonify({"error": str(e)}),
+                    400,
+                )
         except Exception as error:
             logger.warning("Failed query", exc_info=error)
             return make_response(jsonify({"error": error}), 500)


### PR DESCRIPTION
If you try to delete from a region or storage where deletes are disabled, our HTTP endpoints used to give 500 errors. It should be a 400 error though, this PR changes it to 400.