### PR TITLE
feat: update admin delete-tool UI when deletes are disabled

### DIFF
--- a/snuba/admin/static/delete_tool/index.tsx
+++ b/snuba/admin/static/delete_tool/index.tsx
@@ -6,6 +6,7 @@ function DeleteTool(props: { api: Client }) {
     const [columnConditions, setColumnConditions] = useState('')
     const [result, setResult] = useState('')
     const [showHelpMessage, setShowHelpMessage] = useState(false)
+    const [isDeletesEnabled, setIsDeletesEnabled] = useState(false)
 
     function getHelpMessage() {
         if (showHelpMessage) {
@@ -43,6 +44,19 @@ function DeleteTool(props: { api: Client }) {
                 return res.text()
             }
         }).then(data_str => setResult(resp_status + data_str))
+    }
+
+    useEffect(() => {
+        fetch("/deletes-enabled").then(res => res.json()).then(data => {
+            if (!(data === true || data === false)) {
+                throw Error("Expected deletes-enabled to return true/false value but it didnt")
+            }
+            setIsDeletesEnabled(data)
+        })
+    }, [])
+
+    if (!isDeletesEnabled) {
+        return <p>Deletion is not enabled for this region</p>
     }
 
     return (

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -78,7 +78,7 @@ from snuba.request.exceptions import InvalidJsonRequestException
 from snuba.request.schema import RequestSchema
 from snuba.state.explain_meta import explain_cleanup, get_explain_meta
 from snuba.utils.metrics.timer import Timer
-from snuba.web.delete_query import delete_from_storage
+from snuba.web.delete_query import delete_from_storage, deletes_are_enabled
 from snuba.web.views import dataset_query
 
 logger = structlog.get_logger().bind(module=__name__)
@@ -1115,3 +1115,12 @@ def delete() -> Response:
     return Response(
         json.dumps(delete_results), 200, {"Content-Type": "application/json"}
     )
+
+
+@application.route(
+    "/deletes-enabled",
+    methods=["GET"],
+)
+@check_tool_perms(tools=[AdminTools.DELETE_TOOL])
+def deletes_enabled() -> Response:
+    return make_response(jsonify(deletes_are_enabled()), 200)

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -40,7 +40,7 @@ def delete_from_storage(
     Returns a mapping from clickhouse table name to deletion results, there
     will be an entry for every local clickhouse table that makes up the storage.
     """
-    if not get_config("storage_deletes_enabled", 0):
+    if not deletes_are_enabled():
         raise Exception("Deletes not enabled")
 
     delete_settings = storage.get_deletion_settings()
@@ -52,6 +52,10 @@ def delete_from_storage(
         result = _delete_from_table(storage, table, columns)
         results[table] = result
     return results
+
+
+def deletes_are_enabled() -> bool:
+    return bool(get_config("storage_deletes_enabled", 0))
 
 
 def _get_rows_to_delete(


### PR DESCRIPTION
## major changes
1. add a new endpoint to snuba admin `/deletes-enabled` that returns true if deletes are enabled for the current region, false otherwise
2. make the delete-tool only render if deletes are enabled for that region
previously every region could use the delete tool, even if they werent enabled for that region it would just give a 500 errors when they try to do it. now if they try it will look like this
<img width="736" alt="Screenshot 2024-08-01 at 10 12 37 AM" src="https://github.com/user-attachments/assets/7acc5b99-1fe5-4032-bdad-226c31b9dbda">
