### PR TITLE
feat(generic-metrics): Add migrations to allow sampling for distributions

### DIFF
--- a/snuba/snuba_migrations/generic_metrics/0058_distributions_raw_add_sampling_weight.py
+++ b/snuba/snuba_migrations/generic_metrics/0058_distributions_raw_add_sampling_weight.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    local_table_name = "generic_metric_distributions_raw_local"
+    dist_table_name = "generic_metric_distributions_raw_dist"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    columns: Sequence[Column[MigrationModifiers]] = [
+        Column(
+            "sampling_weight",
+            UInt(64, MigrationModifiers(codecs=["ZSTD(1)"], default=str("1"))),
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                target=target,
+            )
+            for column in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0059_distributions_aggregated_add_weighted_columns.py
+++ b/snuba/snuba_migrations/generic_metrics/0059_distributions_aggregated_add_weighted_columns.py
@@ -52,8 +52,8 @@ class Migration(migration.ClickhouseNodeMigration):
             Column(
                 "count_weighted",
                 AggregateFunction(
-                    "count",
-                    [Float(64)],
+                    "sum",
+                    [UInt(64)],
                     MigrationModifiers(codecs=["ZSTD(1)"]),
                 ),
             ),

--- a/snuba/snuba_migrations/generic_metrics/0059_distributions_aggregated_add_weighted_columns.py
+++ b/snuba/snuba_migrations/generic_metrics/0059_distributions_aggregated_add_weighted_columns.py
@@ -1,0 +1,93 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import AggregateFunction, Float, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    local_table_name = "generic_metric_distributions_aggregated_local"
+    dist_table_name = "generic_metric_distributions_aggregated_dist"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    columns: Sequence[tuple[Column[MigrationModifiers], str | None]] = [
+        (
+            Column(
+                "percentiles_weighted",
+                AggregateFunction(
+                    "quantilesTDigestWeighted(0.5, 0.75, 0.9, 0.95, 0.99)",
+                    [Float(64), UInt(64)],
+                    MigrationModifiers(codecs=["ZSTD(1)"]),
+                ),
+            ),
+            "percentiles",
+        ),
+        (
+            Column(
+                "avg_weighted",
+                AggregateFunction(
+                    "avgWeighted",
+                    [Float(64), UInt(64)],
+                    MigrationModifiers(codecs=["ZSTD(1)"]),
+                ),
+            ),
+            "avg",
+        ),
+        (
+            Column(
+                "sum_weighted",
+                AggregateFunction(
+                    "sum",
+                    [Float(64)],
+                    MigrationModifiers(codecs=["ZSTD(1)"]),
+                ),
+            ),
+            "sum",
+        ),
+        (
+            Column(
+                "count_weighted",
+                AggregateFunction(
+                    "count",
+                    [Float(64)],
+                    MigrationModifiers(codecs=["ZSTD(1)"]),
+                ),
+            ),
+            "count",
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                after=after,
+                target=target,
+            )
+            for column, after in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column, _ in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
+++ b/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
@@ -62,6 +62,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     quantilesTDigestWeightedStateIf(0.5, 0.75, 0.9, 0.95, 0.99)(values_rows, sampling_weight, disable_percentiles = 0) AS percentiles_weighted,
                     minState(values_rows) AS min,
                     maxState(values_rows) AS max,
+                    avgState(values_rows) as avg,
                     avgWeightedState(values_rows, sampling_weight) AS avg_weighted,
                     sumState(values_rows) AS sum,
                     sumState(values_rows * sampling_weight) AS sum_weighted,

--- a/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
+++ b/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
@@ -51,25 +51,26 @@ class Migration(migration.ClickhouseNodeMigration):
                     org_id,
                     project_id,
                     metric_id,
-                    arrayJoin(granularities) AS granularity,
+                    granularity,
                     toDateTime(multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1) * intDiv(toUnixTimestamp(timestamp), multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1))) AS timestamp,
                     least(retention_days, multiIf(granularity = 0, decasecond_retention_days, granularity = 1, min_retention_days, granularity = 2, hr_retention_days, granularity = 3, day_retention_days, 0)) AS retention_days,
                     tags.key,
                     tags.indexed_value,
                     tags.raw_value,
                     use_case_id,
-                    quantilesStateIf(0.5, 0.75, 0.9, 0.95, 0.99)(arrayJoin(distribution_values) AS values_rows, disable_percentiles = 0) AS percentiles,
-                    quantilesTDigestWeightedStateIf(0.5, 0.75, 0.9, 0.95, 0.99)(values_rows, sampling_weight, disable_percentiles = 0) AS percentiles_weighted,
-                    minState(values_rows) AS min,
-                    maxState(values_rows) AS max,
-                    avgState(values_rows) as avg,
-                    avgWeightedState(values_rows, sampling_weight) AS avg_weighted,
-                    sumState(values_rows) AS sum,
-                    sumState(values_rows * sampling_weight) AS sum_weighted,
-                    countState(values_rows) AS count,
-                    sumState(sampling_weight) AS count_weighted,
-                    histogramStateIf(250)(values_rows, (disable_percentiles = 0) AND enable_histogram) AS histogram_buckets
+                    quantilesStateArrayIf(0.5, 0.75, 0.9, 0.95, 0.99)(distribution_values, disable_percentiles = 0) AS percentiles,
+                    quantilesTDigestWeightedStateArrayIf(0.5, 0.75, 0.9, 0.95, 0.99)(distribution_values, arrayWithConstant(length(distribution_values) AS distribution_length, sampling_weight) AS sampling_weight_array, disable_percentiles = 0) AS percentiles_weighted,
+                    minStateArray(distribution_values) AS min,
+                    maxStateArray(distribution_values) AS max,
+                    avgStateArray(distribution_values) as avg,
+                    avgWeightedStateArray(distribution_values, sampling_weight_array) AS avg_weighted,
+                    sumStateArray(distribution_values) AS sum,
+                    sumStateArray(arrayMap(x -> (x * sampling_weight), distribution_values)) AS sum_weighted,
+                    countStateArray(distribution_values) AS count,
+                    sumState(distribution_length * sampling_weight) AS count_weighted,
+                    histogramStateArrayIf(250)(distribution_values, (disable_percentiles = 0) AND enable_histogram) AS histogram_buckets
                 FROM generic_metric_distributions_raw_local
+                ARRAY JOIN granularities AS granularity
                 WHERE (materialization_version = 4) AND (metric_type = 'distribution')
                 GROUP BY
                     org_id,

--- a/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
+++ b/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
@@ -1,0 +1,95 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_distributions_aggregation_mv_v4"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name="generic_metric_distributions_aggregated_local",
+                target=operations.OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) AS granularity,
+                    toDateTime(multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1) * intDiv(toUnixTimestamp(timestamp), multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1))) AS timestamp,
+                    least(retention_days, multiIf(granularity = 0, decasecond_retention_days, granularity = 1, min_retention_days, granularity = 2, hr_retention_days, granularity = 3, day_retention_days, 0)) AS retention_days,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    use_case_id,
+                    quantilesStateIf(0.5, 0.75, 0.9, 0.95, 0.99)(arrayJoin(distribution_values) AS values_rows, disable_percentiles = 0) AS percentiles,
+                    quantilesTDigestWeightedStateIf(0.5, 0.75, 0.9, 0.95, 0.99)(values_rows, sampling_weight, disable_percentiles = 0) AS percentiles_weighted,
+                    minState(values_rows) AS min,
+                    maxState(values_rows) AS max,
+                    avgWeightedState(values_rows, sampling_weight) AS avg_weighted,
+                    sumState(values_rows) AS sum,
+                    sumState(values_rows * sampling_weight) AS sum_weighted,
+                    countState(values_rows) AS count,
+                    sumState(count(values_rows) * sampling_weight) AS count_weighted,
+                    histogramStateIf(250)(values_rows, (disable_percentiles = 0) AND enable_histogram) AS histogram_buckets
+                FROM generic_metric_distributions_raw_local
+                WHERE (materialization_version = 4) AND (metric_type = 'distribution')
+                GROUP BY
+                    org_id,
+                    project_id,
+                    metric_id,
+                    granularity,
+                    timestamp,
+                    retention_days,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    use_case_id;
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=operations.OperationTarget.LOCAL,
+            )
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
+++ b/snuba/snuba_migrations/generic_metrics/0060_distributions_mv4.py
@@ -66,7 +66,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     sumState(values_rows) AS sum,
                     sumState(values_rows * sampling_weight) AS sum_weighted,
                     countState(values_rows) AS count,
-                    sumState(count(values_rows) * sampling_weight) AS count_weighted,
+                    sumState(sampling_weight) AS count_weighted,
                     histogramStateIf(250)(values_rows, (disable_percentiles = 0) AND enable_histogram) AS histogram_buckets
                 FROM generic_metric_distributions_raw_local
                 WHERE (materialization_version = 4) AND (metric_type = 'distribution')


### PR DESCRIPTION
# Overview

This PR is responsible for adding a set of migrations to allow materialization to account for sampled distribution values.
More specifically:
- Add a new `sampling_weight`, i.e. `sampling factor^(-1)` column to the distribution raw table 
- Add new `percentiles_weighted`, `avg_weighted`, `sum_weighted`, and `count_weighted` columns that contains the aggregated function which takes the sampling weight into consideration.
- Adds new materialized view to manifest the columns above.

Optimization changes:
From [investigating arrayJoin performance](https://www.notion.so/sentry/Avoiding-arrayJoin-4fb650aca98a42ba9a2b4178a6560e96?pvs=4), it was discovered that `arrayJoin` in the materialized view consumes significant amounts of memory. To mitigate this, we should `-StateArray` combinator instead in order to avoid deep copying all other columns for each row in the `SELECT`. As a result, this PR also replaces `arrayJoin` with `-StateArray` combinators for each aggregation function. See below for performance benchmarking in sandbox. TLDR:  the `stateArray` approach uses ~10% of the memory that the `arrayJoin` approach does.

# Local testing

<details>
  <summary>Click to expand</summary>
  
  ### Run the migrations

```bash
make apply-migrations
```

  ### Insert data into clickhouse, 2 rows, with sample weight at 1 with [10, 10, 10, 10, 10], and the other with sample weight 2 with `[20, 20, 20, 20, 20]`
  ```sql
a2417b8a6e36 :) insert into generic_metric_distributions_raw_local FORMAT JSONColumns {
                    "use_case_id": ["custom"],
                    "org_id": [1],
                    "project_id": [1],
                    "metric_id": [1],
                    "timestamp": [1722378310],
                    "retention_days": [90],
                    "tags.key": [[1]],
                    "tags.indexed_value": [[10]],
                    "tags.raw_value": [["c_v_1"]],
                    "set_values": [[]],
                    "count_value": [0],
                    "distribution_values": [[10, 10, 10, 10, 10]],
                    "metric_type": ["distribution"],
                    "materialization_version": [4],
                    "timeseries_id": [0],
                    "partition": [0],
                    "offset": [0],
                    "granularities": [[2]],
                    "sampling_weight": [1]
                  }

INSERT INTO generic_metric_distributions_raw_local FORMAT JSONColumns

Query id: e0f8a691-dd9a-4595-8704-7423114bab48

Ok.

1 row in set. Elapsed: 0.039 sec.

a2417b8a6e36 :) insert into generic_metric_distributions_raw_local FORMAT JSONColumns {
                    "use_case_id": ["custom"],
                    "org_id": [1],
                    "project_id": [1],
                    "metric_id": [1],
                    "timestamp": [1722378310],
                    "retention_days": [90],
                    "tags.key": [[1]],
                    "tags.indexed_value": [[10]],
                    "tags.raw_value": [["c_v_1"]],
                    "set_values": [[]],
                    "count_value": [0],
                    "distribution_values": [[20, 20, 20, 20, 20]],
                    "metric_type": ["distribution"],
                    "materialization_version": [4],
                    "timeseries_id": [0],
                    "partition": [0],
                    "offset": [0],
                    "granularities": [[2]],
                    "sampling_weight": [2]
                  }

INSERT INTO generic_metric_distributions_raw_local FORMAT JSONColumns

Query id: 9bccfed1-6cc8-4a3f-97fd-d193fed0b026

Ok.

1 row in set. Elapsed: 0.041 sec.
```

  ### Query for non-extrapolated values
```sql
a2417b8a6e36 :) SELECT quantilesMerge(0.5)(percentiles) FROM generic_metric_distributions_aggregated_local


SELECT quantilesMerge(0.5)(percentiles)
FROM generic_metric_distributions_aggregated_local

Query id: 32913273-cf6f-434d-b3eb-1dd27fc95dc4

┌─quantilesMerge(0.5)(percentiles)─┐
│ [15]                             │
└──────────────────────────────────┘

1 row in set. Elapsed: 0.007 sec.

a2417b8a6e36 :) SELECT avgMerge(avg) FROM generic_metric_distributions_aggregated_local;

SELECT avgMerge(avg)
FROM generic_metric_distributions_aggregated_local

Query id: 5e9c6094-21af-4624-b607-751520e1662f

┌─avgMerge(avg)─┐
│            15 │
└───────────────┘

1 row in set. Elapsed: 0.004 sec.

a2417b8a6e36 :) SELECT sumMerge(sum) FROM generic_metric_distributions_aggregated_local;

SELECT sumMerge(sum)
FROM generic_metric_distributions_aggregated_local

Query id: cfc1863e-2ff9-4b03-8176-d6088b0ce379

┌─sumMerge(sum)─┐
│           150 │
└───────────────┘

1 row in set. Elapsed: 0.005 sec.

a2417b8a6e36 :) SELECT countMerge(count) FROM generic_metric_distributions_aggregated_local;

SELECT countMerge(count)
FROM generic_metric_distributions_aggregated_local

Query id: 90b0c6e8-c69d-4347-be47-f391de9ba369

┌─countMerge(count)─┐
│                10 │
└───────────────────┘

1 row in set. Elapsed: 0.004 sec.
```

### Query for extrapolated values
```sql
a2417b8a6e36 :) SELECT quantilesTDigestWeightedMerge(0.5)(percentiles_weighted) FROM generic_metric_distributions_aggregated_local;

SELECT quantilesTDigestWeightedMerge(0.5)(percentiles_weighted)
FROM generic_metric_distributions_aggregated_local

Query id: 04e14d70-7dd4-45fb-87ef-77b58309c9b1

┌─quantilesTDigestWeightedMerge(0.5)(percentiles_weighted)─┐
│ [20]                                                     │
└──────────────────────────────────────────────────────────┘

1 row in set. Elapsed: 0.006 sec.

a2417b8a6e36 :) SELECT avgWeightedMerge(avg_weighted) FROM generic_metric_distributions_aggregated_local;

SELECT avgWeightedMerge(avg_weighted)
FROM generic_metric_distributions_aggregated_local

Query id: 69ad7748-60dd-404c-a653-8411440438e0

┌─avgWeightedMerge(avg_weighted)─┐
│             16.666666666666668 │
└────────────────────────────────┘

1 row in set. Elapsed: 0.005 sec.

a2417b8a6e36 :) SELECT sumMerge(sum_weighted) FROM generic_metric_distributions_aggregated_local;

SELECT sumMerge(sum_weighted)
FROM generic_metric_distributions_aggregated_local

Query id: eaf5d545-5b97-482b-a2f6-32b70460b37c

┌─sumMerge(sum_weighted)─┐
│                    250 │
└────────────────────────┘

1 row in set. Elapsed: 0.006 sec.

a2417b8a6e36 :) SELECT sumMerge(count_weighted) FROM generic_metric_distributions_aggregated_local;

SELECT sumMerge(count_weighted)
FROM generic_metric_distributions_aggregated_local

Query id: e554d950-c658-4a55-ba0a-db95d84ae9b6

┌─sumMerge(count_weighted)─┐
│                       15 │
└──────────────────────────┘

1 row in set. Elapsed: 0.007 sec.

```
  ### Insert a row with materialization version = 3 with org_id = 10
```sql
a2417b8a6e36 :) insert into generic_metric_distributions_raw_local FORMAT JSONColumns {
                    "use_case_id": ["custom"],
                    "org_id": [10],
                    "project_id": [1],
                    "metric_id": [1],
                    "timestamp": [1722378310],
                    "retention_days": [90],
                    "tags.key": [[1]],
                    "tags.indexed_value": [[10]],
                    "tags.raw_value": [["c_v_1"]],
                    "set_values": [[]],
                    "count_value": [0],
                    "distribution_values": [[10, 10, 10, 10, 10]],
                    "metric_type": ["distribution"],
                    "materialization_version": [3],
                    "timeseries_id": [0],
                    "partition": [0],
                    "offset": [0],
                    "granularities": [[2]],
                    "sampling_weight": [1]
                  }

INSERT INTO generic_metric_distributions_raw_local FORMAT JSONColumns

Query id: 481a3706-79fd-4c3e-b665-d0843d27a024

Ok.

1 row in set. Elapsed: 0.043 sec.

a2417b8a6e36 :) SELECT sumMerge(sum) FROM generic_metric_distributions_aggregated_local WHERE org_id = 10;

SELECT sumMerge(sum)
FROM generic_metric_distributions_aggregated_local
WHERE org_id = 10

Query id: 089d5a3e-a2c2-4538-a83c-f07bbdfc05b4

┌─sumMerge(sum)─┐
│            50 │
└───────────────┘

1 row in set. Elapsed: 0.007 sec.
```
</details>

# Sandbox testing (effects of removing arrayJoin)
<details>
  <summary>Click to expand</summary>
Running the current distributions mat view query (version=3) against production data on the sandbox environment produces the follow result:
```
Received exception from server (version 24.3.5):
Code: 241. DB::Exception: Received from localhost:9000. DB::Exception: Memory limit (total) exceeded: would use 61.70 GiB (attempt to allocate chunk of 13903378556 bytes), maximum: 56.52 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker.: while executing 'ARRAY JOIN __table1.distribution_values :: 6 -> arrayJoin(__table1.distribution_values) Float64 : 4'. (MEMORY_LIMIT_EXCEEDED)
```
 
Running the new distributions mat view query (version=4) with a sample rate of 1% (sampling_weight=100) produces the following result:
```
52058 rows in set. Elapsed: 31.821 sec. Processed 116.12 million rows, 16.09 GB (3.65 million rows/s., 505.58 MB/s.)
Peak memory usage: 5.12 GiB.
```



</details>
  
