### PR TITLE
Make the number of threads to run the optimize cron job configurable

### DIFF
--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -35,16 +35,17 @@ from snuba.redis import RedisClientKey, get_redis_client
 @click.option("--log-level", help="Logging level to use.")
 @click.option(
     "--parallel",
+    "default_parallel_threads",
     type=click.IntRange(1, 2),
     default=1,
-    help="Run parallel optimizations",
+    help="Default parallel threads",
 )
 def optimize(
     *,
     clickhouse_host: Optional[str],
     clickhouse_port: Optional[int],
     storage_name: str,
-    parallel: int,
+    default_parallel_threads: int,
     log_level: Optional[str] = None,
 ) -> None:
     from datetime import datetime
@@ -119,7 +120,7 @@ def optimize(
         clickhouse=connection,
         storage=storage,
         database=database,
-        parallel=parallel,
+        default_parallel_threads=default_parallel_threads,
         clickhouse_host=clickhouse_host,
         tracker=tracker,
         before=today,

--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -300,9 +300,6 @@ def optimize_partition_runner(
 
     with ThreadPoolExecutor(max_workers=32) as executor:
         futures: set[Future[Any]] = set()
-        # jitter start time
-        for jitter in scheduler.get_start_time_jitter():
-            futures.add(executor.submit(_jitter_start_time, jitter))
 
         partitions_to_optimize = deque(partitions)
         while partitions_to_optimize:
@@ -332,15 +329,6 @@ def optimize_partition_runner(
             )
             for future in done:
                 future.result()
-
-
-def _jitter_start_time(start_jitter: Optional[int] = None) -> None:
-    if start_jitter is not None:
-        logger.info(
-            f"{threading.current_thread().name}: Jittering start time by"
-            f" {start_jitter} minutes"
-        )
-        time.sleep(start_jitter * 60)
 
 
 def optimize_partitions(

--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -1,5 +1,4 @@
 import concurrent
-import concurrent.futures
 import multiprocessing
 import os
 import threading

--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -362,6 +362,8 @@ def optimize_partitions(
         PARTITION %(partition)s FINAL
     """
 
+    print("optimize_partitions is called")
+
     for partition in partitions:
         if cutoff_time is not None and datetime.now() > cutoff_time:
             logger.info(

--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -327,9 +327,11 @@ def optimize_partition_runner(
                     )
                 )
 
-            _, futures = concurrent.futures.wait(
+            done, futures = concurrent.futures.wait(
                 futures, return_when=concurrent.futures.FIRST_COMPLETED
             )
+            for future in done:
+                future.result()
 
 
 def _jitter_start_time(start_jitter: Optional[int] = None) -> None:
@@ -354,8 +356,6 @@ def optimize_partitions(
         OPTIMIZE TABLE %(database)s.%(table)s
         PARTITION %(partition)s FINAL
     """
-
-    print("optimize_partitions is called")
 
     for partition in partitions:
         if cutoff_time is not None and datetime.now() > cutoff_time:

--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -326,7 +326,7 @@ def optimize_partition_runner(
                     )
                 )
 
-            completed_futures, futures = concurrent.futures.wait(
+            completed_futures, pending_futures = concurrent.futures.wait(
                 pending_futures, return_when=concurrent.futures.FIRST_COMPLETED
             )
             for future in completed_futures:

--- a/snuba/clickhouse/optimize/optimize_scheduler.py
+++ b/snuba/clickhouse/optimize/optimize_scheduler.py
@@ -87,7 +87,7 @@ class OptimizeScheduler:
 
         return output
 
-    def start_time_jitter(self) -> Sequence[int]:
+    def get_start_time_jitter_for_each_partition(self) -> Sequence[int]:
         """
         Get the start time jitter for each partition. The start time jitter
         is the amount of time to wait before starting each thread. This is
@@ -95,7 +95,7 @@ class OptimizeScheduler:
         optimizations ending at the same time.
         """
         if self.__parallel == 1:
-            return [0]
+            return []
 
         interval = int(
             settings.OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES / (self.__parallel - 1)
@@ -137,7 +137,7 @@ class OptimizeScheduler:
                         partitions, self.__parallel
                     ),
                     cutoff_time=self.__parallel_end_time,
-                    start_time_jitter_minutes=self.start_time_jitter(),
+                    start_time_jitter_minutes=self.get_start_time_jitter_for_each_partition(),
                 )
             else:
                 return OptimizationSchedule(

--- a/snuba/clickhouse/optimize/optimize_scheduler.py
+++ b/snuba/clickhouse/optimize/optimize_scheduler.py
@@ -133,7 +133,9 @@ class OptimizeScheduler:
                 )
             elif current_time < self.__parallel_end_time:
                 return OptimizationSchedule(
-                    partitions_groups=self.subdivide_partitions(partitions, self.__parallel),
+                    partitions_groups=self.subdivide_partitions(
+                        partitions, self.__parallel
+                    ),
                     cutoff_time=self.__parallel_end_time,
                     start_time_jitter_minutes=self.start_time_jitter(),
                 )

--- a/snuba/clickhouse/optimize/optimize_scheduler.py
+++ b/snuba/clickhouse/optimize/optimize_scheduler.py
@@ -144,6 +144,3 @@ class OptimizeScheduler:
                     partitions_groups=[self.sort_partitions(partitions)],
                     cutoff_time=self.__full_job_end_time,
                 )
-
-    def get_is_running_parallel(self) -> bool:
-        return self.__parallel != 1

--- a/snuba/clickhouse/optimize/util.py
+++ b/snuba/clickhouse/optimize/util.py
@@ -1,4 +1,9 @@
+import typing
 from dataclasses import dataclass
+
+from snuba.state import get_config
+
+_OPTIMIZE_PARALLEL_THREADS_KEY = "optimize_parallel_threads"
 
 
 @dataclass
@@ -12,3 +17,9 @@ class MergeInfo:
     # estimated time remaining in seconds
     def estimated_time(self) -> float:
         return self.elapsed / (self.progress + 0.0001)
+
+
+def get_num_threads(default_parallel_threads: int) -> int:
+    return typing.cast(
+        int, get_config(_OPTIMIZE_PARALLEL_THREADS_KEY, default_parallel_threads)
+    )

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -361,8 +361,6 @@ OPTIMIZE_MAX_SLEEP_TIME = 2 * 60 * 60  # 2 hours
 OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10 * 60  # 10 mins
 # merges larger than this will be considered large and will be waited on
 OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
-# Maximum jitter to add to the scheduling of threads of an optimize job
-OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 0
 
 # Start time in hours from UTC 00:00:00 after which we are allowed to run
 # optimize jobs in parallel.

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 from typing import Callable, Mapping
+from unittest.mock import Mock, patch
 
 import pytest
 import time_machine
@@ -10,6 +11,7 @@ from snuba.clickhouse.optimize import optimize
 from snuba.clickhouse.optimize.optimize import (
     _get_metrics_tags,
     optimize_partition_runner,
+    optimize_partitions,
 )
 from snuba.clickhouse.optimize.optimize_scheduler import (
     OptimizedSchedulerTimeout,
@@ -242,6 +244,100 @@ class TestOptimize:
         self, table: str, host: str, expected: Mapping[str, str]
     ) -> None:
         assert _get_metrics_tags(table, host) == expected
+
+
+test_data = [
+    pytest.param(
+        StorageKey.ERRORS,
+        lambda dt: InsertBatch(
+            [
+                {
+                    "event_id": str(uuid.uuid4()),
+                    "project_id": 1,
+                    "group_id": 1,
+                    "deleted": 0,
+                    "timestamp": dt,
+                    "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                }
+            ],
+            None,
+        ),
+        last_midnight
+        + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_START_TIME)
+        + timedelta(minutes=30),
+        id="errors parallel",
+    )
+]
+
+
+class TestOptimizeFrequency:
+    @pytest.mark.clickhouse_db
+    @pytest.mark.redis_db
+    @pytest.mark.parametrize(
+        "storage_key, create_event_row_for_date, current_time",
+        test_data,
+    )
+    @patch("snuba.clickhouse.optimize.optimize.optimize_partitions")
+    def test_optimize_partitions_is_called_the_same_number_of_times_as_number_of_partitions(
+        self,
+        mock_optimize_partitions: Mock,
+        storage_key: StorageKey,
+        create_event_row_for_date: Callable[[datetime], InsertBatch],
+        current_time: datetime,
+    ) -> None:
+        mock_optimize_partitions.side_effect = optimize_partitions
+
+        storage = get_writable_storage(storage_key)
+        cluster = storage.get_cluster()
+        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
+        table = storage.get_table_writer().get_schema().get_local_table_name()
+        database = cluster.get_database()
+
+        base = datetime(1999, 12, 26)  # a sunday
+        base_monday = base - timedelta(days=base.weekday())
+        write_processed_messages(storage, [create_event_row_for_date(base)])
+        write_processed_messages(storage, [create_event_row_for_date(base)])
+
+        for i in range(1, 10):
+            earlier = base_monday - timedelta(days=i * 31)
+            earlier_monday = earlier - timedelta(days=earlier.weekday())
+            write_processed_messages(
+                storage, [create_event_row_for_date(earlier_monday)]
+            )
+            write_processed_messages(
+                storage, [create_event_row_for_date(earlier_monday)]
+            )
+
+        scheduler = OptimizeScheduler(2)
+        tracker = OptimizedPartitionTracker(
+            redis_client=redis_client,
+            host="some-hostname.domain.com",
+            port=9000,
+            database=database,
+            table=table,
+            expire_time=datetime.now() + timedelta(minutes=10),
+        )
+        partitions = optimize.get_partitions_to_optimize(
+            clickhouse, storage, database, table
+        )
+
+        tracker.update_all_partitions([part.name for part in partitions])
+        with time_machine.travel(current_time, tick=False):
+            optimize.optimize_partition_runner(
+                clickhouse=clickhouse,
+                database=database,
+                table=table,
+                partitions=[part.name for part in partitions],
+                scheduler=scheduler,
+                tracker=tracker,
+                clickhouse_host="some-hostname.domain.com",
+            )
+        assert mock_optimize_partitions.call_count == 10
+
+        tracker.delete_all_states()
+        # For ClickHouse 23.3 and 23.8 parts from previous test runs
+        # interfere with following tests, so best to drop the tables
+        clickhouse.execute(f"DROP TABLE IF EXISTS {database}.{table} SYNC")
 
 
 @pytest.mark.clickhouse_db

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -108,6 +108,9 @@ test_data = [
 ]
 
 
+@pytest.mark.xfail(
+    reason="This test still is flaky sometimes and then completely blocks CI / deployment"
+)
 class TestOptimize:
     @pytest.mark.clickhouse_db
     @pytest.mark.redis_db
@@ -126,8 +129,6 @@ class TestOptimize:
         clickhouse = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
         table = storage.get_table_writer().get_schema().get_local_table_name()
         database = cluster.get_database()
-
-        clickhouse.execute(f"SYSTEM STOP MERGES {database}.{table}")
 
         # no data, 0 partitions to optimize
         partitions = optimize.get_partitions_to_optimize(

--- a/tests/clickhouse/optimize/test_optimize_scheduler.py
+++ b/tests/clickhouse/optimize/test_optimize_scheduler.py
@@ -135,7 +135,7 @@ def test_subdivide_partitions(
     [
         pytest.param(
             1,
-            [0],
+            [],
             id="no parallel",
         ),
         pytest.param(
@@ -156,7 +156,7 @@ def test_subdivide_partitions(
 )
 def test_start_time_jitter(parallel: int, expected: Sequence[int]) -> None:
     scheduler = OptimizeScheduler(parallel=parallel)
-    assert scheduler.start_time_jitter() == expected
+    assert scheduler.get_start_time_jitter_for_each_partition() == expected
 
 
 last_midnight = (datetime.now() + timedelta(minutes=10)).replace(

--- a/tests/clickhouse/optimize/test_optimize_scheduler.py
+++ b/tests/clickhouse/optimize/test_optimize_scheduler.py
@@ -132,37 +132,6 @@ def test_subdivide_partitions(
     )
 
 
-@pytest.mark.parametrize(
-    "default_parallel_threads,expected",
-    [
-        pytest.param(
-            1,
-            [],
-            id="no parallel",
-        ),
-        pytest.param(
-            2,
-            [0, settings.OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES],
-            id="2 parallel",
-        ),
-        pytest.param(
-            3,
-            [
-                0,
-                settings.OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES / 2,
-                settings.OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES,
-            ],
-            id="3 parallel",
-        ),
-    ],
-)
-def test_start_time_jitter(
-    default_parallel_threads: int, expected: Sequence[int]
-) -> None:
-    scheduler = OptimizeScheduler(default_parallel_threads=default_parallel_threads)
-    assert scheduler.get_start_time_jitter() == expected
-
-
 last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
     hour=0, minute=0, second=0, microsecond=0
 )
@@ -228,7 +197,6 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
                 [["(90,'2022-03-28')"], ["(90,'2022-03-21')"]],
                 last_midnight
                 + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_END_TIME),
-                [0, settings.OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES],
             ),
             id="parallel before parallel end",
         ),

--- a/tests/clickhouse/optimize/test_optimize_scheduler.py
+++ b/tests/clickhouse/optimize/test_optimize_scheduler.py
@@ -126,12 +126,14 @@ def test_subdivide_partitions(
     subdivisions: int,
     expected: Sequence[Sequence[str]],
 ) -> None:
-    optimize_scheduler = OptimizeScheduler(parallel=1)
-    assert optimize_scheduler.subdivide_partitions(partitions, subdivisions) == expected
+    optimize_scheduler = OptimizeScheduler(default_parallel_threads=1)
+    assert (
+        optimize_scheduler._subdivide_partitions(partitions, subdivisions) == expected
+    )
 
 
 @pytest.mark.parametrize(
-    "parallel,expected",
+    "default_parallel_threads,expected",
     [
         pytest.param(
             1,
@@ -154,9 +156,11 @@ def test_subdivide_partitions(
         ),
     ],
 )
-def test_start_time_jitter(parallel: int, expected: Sequence[int]) -> None:
-    scheduler = OptimizeScheduler(parallel=parallel)
-    assert scheduler.get_start_time_jitter_for_each_partition() == expected
+def test_start_time_jitter(
+    default_parallel_threads: int, expected: Sequence[int]
+) -> None:
+    scheduler = OptimizeScheduler(default_parallel_threads=default_parallel_threads)
+    assert scheduler.get_start_time_jitter() == expected
 
 
 last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
@@ -165,7 +169,7 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
 
 
 @pytest.mark.parametrize(
-    "parallel,partitions,current_time,expected",
+    "default_parallel_threads,partitions,current_time,expected",
     [
         pytest.param(
             1,
@@ -243,19 +247,21 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
     ],
 )
 def test_get_next_schedule(
-    parallel: int,
+    default_parallel_threads: int,
     partitions: Sequence[str],
     current_time: datetime,
     expected: OptimizationSchedule,
 ) -> None:
-    optimize_scheduler = OptimizeScheduler(parallel=parallel)
+    optimize_scheduler = OptimizeScheduler(
+        default_parallel_threads=default_parallel_threads
+    )
 
     with time_machine.travel(current_time, tick=False):
         assert optimize_scheduler.get_next_schedule(partitions) == expected
 
 
 def test_get_next_schedule_raises_exception() -> None:
-    optimize_scheduler = OptimizeScheduler(parallel=1)
+    optimize_scheduler = OptimizeScheduler(default_parallel_threads=1)
     with time_machine.travel(
         last_midnight
         + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)

--- a/tests/clickhouse/optimize/test_optimize_tracker.py
+++ b/tests/clickhouse/optimize/test_optimize_tracker.py
@@ -166,7 +166,7 @@ def test_run_optimize_with_partition_tracker() -> None:
         clickhouse=clickhouse_pool,
         storage=storage,
         database=database,
-        parallel=1,
+        default_parallel_threads=1,
         clickhouse_host="127.0.0.1",
         tracker=tracker,
     )
@@ -179,7 +179,7 @@ def test_run_optimize_with_partition_tracker() -> None:
         clickhouse=clickhouse_pool,
         storage=storage,
         database=database,
-        parallel=1,
+        default_parallel_threads=1,
         clickhouse_host="127.0.0.1",
         tracker=tracker,
     )
@@ -272,7 +272,7 @@ def test_run_optimize_with_ongoing_merges() -> None:
                 clickhouse=clickhouse_pool,
                 storage=storage,
                 database=database,
-                parallel=1,
+                default_parallel_threads=1,
                 clickhouse_host="127.0.0.1",
                 tracker=tracker,
             )


### PR DESCRIPTION
The optimize job has been [failing](https://app.datadoghq.com/monitors/72460548?q=kube_job%3Asnuba-optimize-errors-tiger-mz-2-28703520%2Csentry_region%3Aus&event_id=7684526334976626842&source=monitor_notif&view=spans&from_ts=1722295368000&to_ts=1722296568000&eval_ts=1722296568000) due to not meeting the cutoff time. 

There's two aspects of the job scheduling:
- a period of time where the job runs in parallel, which puts more load on ClickHouse
- a period of time when the job optimizes one partition at a time. This lets it overlap with our peak load time without exhausting ClickHouse's resources

In this PR, we changed the parallelization period to run with a configurable number of threads, and this configuration is checked every time a partition finishes optimizing. This way, we can change the number of threads we use the parallelize to avoid overwhelming Clickhouse, before the cron job finishes.