### PR TITLE
(system-queries): use default db in create_table_query

### DIFF
--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -30,7 +30,7 @@ class CreateTableQuery(SystemQuery):
     SELECT
         create_table_query
     FROM system.tables
-    WHERE database not in ('system')
+    WHERE database in ('default')
     """
 
 


### PR DESCRIPTION
Small change that has just been bugging me - the `CreateTableQuery` right now shows all the [INFORMATION_SCHEMA](https://clickhouse.com/docs/en/operations/system-tables/information_schema) tables which is annoying, so now this just uses the `default` database.