### PR TITLE
feat(generic-metrics): Forward sampling information from consumer to clickhouse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.3.4
 sentry-arroyo==2.17.1
-sentry-kafka-schemas==0.1.105
+sentry-kafka-schemas==0.1.106
 sentry-redis-tools==0.3.0
 sentry-relay==0.8.44
 sentry-sdk==1.40.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.3.4
 sentry-arroyo==2.17.1
-sentry-kafka-schemas==0.1.103
+sentry-kafka-schemas==0.1.105
 sentry-redis-tools==0.3.0
 sentry-relay==0.8.44
 sentry-sdk==1.40.5

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3143,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "0.1.105"
+version = "0.1.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdab08ff5292944441f9cc23993b477822020399b7003842ffcacc0ef7b3c935"
+checksum = "8d0494399692172f9b971f2d8eec62b9ca2ecc50d92df0341508e302318ea230"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3143,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "0.1.103"
+version = "0.1.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa71f61368e4a64120deea72b0c3fe9120ecf508b3816e632ae58a4cca877a7"
+checksum = "bdab08ff5292944441f9cc23993b477822020399b7003842ffcacc0ef7b3c935"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -33,7 +33,7 @@ pyo3 = { version = "0.18.1", features = ["chrono"] }
 reqwest = { version = "0.11.11", features = ["stream"] }
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo" }
 sentry = { version = "0.32.0", features = ["anyhow", "tracing"] }
-sentry-kafka-schemas = "0.1.103"
+sentry-kafka-schemas = "0.1.105"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -33,7 +33,7 @@ pyo3 = { version = "0.18.1", features = ["chrono"] }
 reqwest = { version = "0.11.11", features = ["stream"] }
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo" }
 sentry = { version = "0.32.0", features = ["anyhow", "tracing"] }
-sentry-kafka-schemas = "0.1.105"
+sentry-kafka-schemas = "0.1.106"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 thiserror = "1.0"

--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -65,7 +65,7 @@ struct FromGenericMetricsMessage {
     #[serde(flatten)]
     value: MetricValue,
     retention_days: u16,
-    sampling_weight: Option<u64>,
+    sampling_weight: Option<f64>,
     aggregation_option: Option<String>,
 }
 
@@ -320,7 +320,9 @@ impl Parse for CountersRawRow {
             tags_indexed_value: vec![0; tag_keys.len()],
             tags_raw_value: tag_values,
             materialization_version: parse_matview_ver_from_runtime_opt("counter").unwrap_or(2),
-            sampling_weight: from.sampling_weight,
+            sampling_weight: from
+                .sampling_weight
+                .map(|sampling_weight| sampling_weight as u64),
             timeseries_id,
             granularities,
             min_retention_days: Some(retention_days as u8),
@@ -592,7 +594,9 @@ impl Parse for DistributionsRawRow {
             tags_raw_value: tag_values,
             materialization_version: parse_matview_ver_from_runtime_opt("distribution")
                 .unwrap_or(3),
-            sampling_weight: from.sampling_weight,
+            sampling_weight: from
+                .sampling_weight
+                .map(|sampling_weight| sampling_weight as u64),
             timeseries_id,
             granularities,
             min_retention_days: Some(retention_days as u8),
@@ -695,7 +699,9 @@ impl Parse for GaugesRawRow {
             tags_indexed_value: vec![0; tag_keys.len()],
             tags_raw_value: tag_values,
             materialization_version: parse_matview_ver_from_runtime_opt("gauge").unwrap_or(2),
-            sampling_weight: from.sampling_weight,
+            sampling_weight: from
+                .sampling_weight
+                .map(|sampling_weight| sampling_weight as u64),
             timeseries_id,
             granularities,
             min_retention_days: Some(retention_days as u8),
@@ -763,7 +769,7 @@ mod tests {
         "mapping_meta":{"h":{"9223372036854776017":"session.status","9223372036854776010":"environment"},"f":{"65689":"metric_e2e_spans_counter_k_VUW93LMS"},"d":{"65561":"c:spans/spans@none"}},
         "type": "c",
         "value": 1,
-        "sampling_weight": 100
+        "sampling_weight": 100.1
     }"#;
 
     const DUMMY_SET_MESSAGE: &str = r#"{
@@ -1543,7 +1549,7 @@ mod tests {
                 origin_timestamp: None,
                 sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
                 cogs_data: Some(CogsData {
-                    data: BTreeMap::from([("genericmetrics_spans".to_string(), 647)])
+                    data: BTreeMap::from([("genericmetrics_spans".to_string(), 649)])
                 }),
             }
         );

--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -65,6 +65,7 @@ struct FromGenericMetricsMessage {
     #[serde(flatten)]
     value: MetricValue,
     retention_days: u16,
+    sampling_weight: Option<u64>,
     aggregation_option: Option<String>,
 }
 
@@ -240,6 +241,8 @@ struct CommonMetricFields {
     timeseries_id: u32,
     granularities: Vec<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    sampling_weight: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     decasecond_retention_days: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     min_retention_days: Option<u8>,
@@ -316,7 +319,8 @@ impl Parse for CountersRawRow {
             tags_key: tag_keys.iter().map(|k| k.parse::<u64>().unwrap()).collect(),
             tags_indexed_value: vec![0; tag_keys.len()],
             tags_raw_value: tag_values,
-            materialization_version: 2,
+            materialization_version: parse_matview_ver_from_runtime_opt("counter").unwrap_or(2),
+            sampling_weight: from.sampling_weight,
             timeseries_id,
             granularities,
             min_retention_days: Some(retention_days as u8),
@@ -338,21 +342,12 @@ fn should_use_killswitch(config: Result<Option<String>, Error>, use_case: &Messa
     false
 }
 
-fn parse_dist_materialization_version(
-    config: Result<Option<String>, Error>,
-    metric_type: String,
-) -> u8 {
-    if metric_type == *"distribution" {
-        if let Some(mat_version) = config.ok().flatten() {
-            if !mat_version.trim().is_empty() {
-                let mat_version_int = mat_version.parse::<u8>().unwrap();
-                return mat_version_int;
-            }
-        }
-    }
-
-    // return the currently used materialization version if runtime config is not set
-    2u8
+fn parse_matview_ver_from_runtime_opt(metric_type: &str) -> Option<u8> {
+    get_str_config(&format!("gen_metrics_{}_matview_version", metric_type))
+        .ok()
+        .flatten()?
+        .parse::<u8>()
+        .ok()
 }
 
 fn process_message<T>(
@@ -595,10 +590,9 @@ impl Parse for DistributionsRawRow {
             tags_key: tag_keys.iter().map(|k| k.parse::<u64>().unwrap()).collect(),
             tags_indexed_value: vec![0; tag_keys.len()],
             tags_raw_value: tag_values,
-            materialization_version: parse_dist_materialization_version(
-                get_str_config("gen_metrics_dist_mat_version"),
-                "distribution".to_string(),
-            ),
+            materialization_version: parse_matview_ver_from_runtime_opt("distribution")
+                .unwrap_or(3),
+            sampling_weight: from.sampling_weight,
             timeseries_id,
             granularities,
             min_retention_days: Some(retention_days as u8),
@@ -700,7 +694,8 @@ impl Parse for GaugesRawRow {
             tags_key: tag_keys.iter().map(|k| k.parse::<u64>().unwrap()).collect(),
             tags_indexed_value: vec![0; tag_keys.len()],
             tags_raw_value: tag_values,
-            materialization_version: 2,
+            materialization_version: parse_matview_ver_from_runtime_opt("gauge").unwrap_or(2),
+            sampling_weight: from.sampling_weight,
             timeseries_id,
             granularities,
             min_retention_days: Some(retention_days as u8),
@@ -753,6 +748,22 @@ mod tests {
         "mapping_meta":{"h":{"9223372036854776017":"session.status","9223372036854776010":"environment"},"f":{"65689":"metric_e2e_spans_counter_k_VUW93LMS"},"d":{"65561":"c:spans/spans@none"}},
         "type": "c",
         "value": 1
+    }"#;
+
+    const DUMMY_COUNTER_MESSAGE_WITH_SAMPLING_WEIGHT: &str = r#"{
+        "version": 2,
+        "use_case_id": "spans",
+        "org_id": 1,
+        "project_id": 3,
+        "metric_id": 65561,
+        "timestamp": 1704614940,
+        "sentry_received_timestamp": 1704614940,
+        "tags": {"9223372036854776010": "production", "9223372036854776017": "init", "65689": "metric_e2e_spans_counter_v_VUW93LMS"},
+        "retention_days": 90,
+        "mapping_meta":{"h":{"9223372036854776017":"session.status","9223372036854776010":"environment"},"f":{"65689":"metric_e2e_spans_counter_k_VUW93LMS"},"d":{"65561":"c:spans/spans@none"}},
+        "type": "c",
+        "value": 1,
+        "sampling_weight": 100
     }"#;
 
     const DUMMY_SET_MESSAGE: &str = r#"{
@@ -862,6 +873,22 @@ mod tests {
         "value": {"count": 10, "last": 10.0, "max": 10.0, "min": 1.0, "sum": 20.0}
     }"#;
 
+    const DUMMY_GAUGE_MESSAGE_WITH_SAMPLING_WEIGHT: &str = r#"{
+        "version": 2,
+        "use_case_id": "spans",
+        "org_id": 1,
+        "project_id": 3,
+        "metric_id": 65564,
+        "timestamp": 1704614940,
+        "sentry_received_timestamp": 1704614940.123,
+        "tags": {"9223372036854776010": "production", "9223372036854776017": "init", "65690": "metric_e2e_spans_gauge_v_VUW93LMS"},
+        "retention_days": 90,
+        "mapping_meta":{"h":{"9223372036854776017":"session.status","9223372036854776010":"environment"},"f":{"65689":"metric_e2e_spans_gauge_k_VUW93LMS"},"d":{"65564":"g:spans/spans@none"}},
+        "type": "g",
+        "value": {"count": 10, "last": 10.0, "max": 10.0, "min": 1.0, "sum": 20.0},
+        "sampling_weight": 100
+    }"#;
+
     const DUMMY_GAUGE_MESSAGE_WITH_TEN_SECOND_AGGREGATE_OPTION: &str = r#"{
         "version": 2,
         "use_case_id": "spans",
@@ -938,6 +965,22 @@ mod tests {
         "value": {"format": "zstd", "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"}
     }"#;
 
+    const DUMMY_ZSTD_ENCODED_DISTRIBUTION_MESSAGE_WITH_SAMPLING_WEIGHT: &str = r#"{
+        "version": 2,
+        "use_case_id": "spans",
+        "org_id": 1,
+        "project_id": 3,
+        "metric_id": 65563,
+        "timestamp": 1704614940,
+        "sentry_received_timestamp": 1704614940,
+        "tags": {"9223372036854776010":"production","9223372036854776017":"healthy","65690":"metric_e2e_spans_dist_v_VUW93LMS"},
+        "retention_days": 90,
+        "mapping_meta":{"d":{"65560":"d:spans/duration@second"},"h":{"9223372036854776017":"session.status","9223372036854776010":"environment"},"f":{"65691":"metric_e2e_spans_dist_k_VUW93LMS"}},
+        "type": "d",
+        "value": {"format": "zstd", "data": "KLUv/QBYrQAAcAAA8D8AQAAAAAAAAAhAAgBgRgCw"},
+        "sampling_weight": 100
+    }"#;
+
     #[test]
     fn test_base64_decode_f64() {
         assert!(
@@ -992,7 +1035,7 @@ mod tests {
                     "healthy".to_string(),
                 ],
                 metric_type: "distribution".to_string(),
-                materialization_version: 2,
+                materialization_version: 3,
                 timeseries_id: 1436359714,
                 granularities: vec![
                     GRANULARITY_ONE_MINUTE,
@@ -1004,6 +1047,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             distribution_values: vec![3f64, 1f64, 2f64],
             enable_histogram: None,
@@ -1050,7 +1094,7 @@ mod tests {
                     "healthy".to_string(),
                 ],
                 metric_type: "distribution".to_string(),
-                materialization_version: 2,
+                materialization_version: 3,
                 timeseries_id: 1436359714,
                 granularities: vec![
                     GRANULARITY_ONE_MINUTE,
@@ -1062,6 +1106,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             distribution_values: vec![1f64, 2f64, 3f64],
             enable_histogram: None,
@@ -1075,6 +1120,65 @@ mod tests {
                 sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
                 cogs_data: Some(CogsData {
                     data: BTreeMap::from([("genericmetrics_spans".to_string(), 681)])
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn test_distribution_processor_with_weighted_distribution_message() {
+        let result = test_processor_with_payload(
+            &(process_distribution_message
+                as fn(
+                    rust_arroyo::backends::kafka::types::KafkaPayload,
+                    crate::types::KafkaMessageMetadata,
+                    &crate::ProcessorConfig,
+                )
+                    -> std::result::Result<crate::types::InsertBatch, anyhow::Error>),
+            DUMMY_ZSTD_ENCODED_DISTRIBUTION_MESSAGE_WITH_SAMPLING_WEIGHT,
+        );
+        let expected_row = DistributionsRawRow {
+            common_fields: CommonMetricFields {
+                use_case_id: "spans".to_string(),
+                org_id: 1,
+                project_id: 3,
+                metric_id: 65563,
+                timestamp: 1704614940,
+                retention_days: 90,
+                tags_key: vec![65690, 9223372036854776010, 9223372036854776017],
+                tags_indexed_value: vec![0; 3],
+                tags_raw_value: vec![
+                    "metric_e2e_spans_dist_v_VUW93LMS".to_string(),
+                    "production".to_string(),
+                    "healthy".to_string(),
+                ],
+                metric_type: "distribution".to_string(),
+                materialization_version: 3,
+                timeseries_id: 1436359714,
+                granularities: vec![
+                    GRANULARITY_ONE_MINUTE,
+                    GRANULARITY_ONE_HOUR,
+                    GRANULARITY_ONE_DAY,
+                ],
+                decasecond_retention_days: None,
+                min_retention_days: Some(90),
+                hr_retention_days: None,
+                day_retention_days: None,
+                record_meta: Some(1),
+                sampling_weight: Some(100),
+            },
+            distribution_values: vec![1f64, 2f64, 3f64],
+            enable_histogram: None,
+            disable_percentiles: None,
+        };
+        assert_eq!(
+            result.unwrap(),
+            InsertBatch {
+                rows: RowData::from_rows([expected_row]).unwrap(),
+                origin_timestamp: None,
+                sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
+                cogs_data: Some(CogsData {
+                    data: BTreeMap::from([("genericmetrics_spans".to_string(), 713)])
                 })
             }
         );
@@ -1155,6 +1259,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             set_values: vec![1u32, 7u32],
         };
@@ -1211,6 +1316,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             set_values: vec![1u32, 7u32],
         };
@@ -1285,72 +1391,6 @@ mod tests {
         let fake_config = Ok(None);
 
         assert!(!should_use_killswitch(fake_config, &use_case));
-    }
-
-    #[test]
-    fn test_dont_use_new_matview_dist() {
-        let fake_config: Result<Option<String>, _> = Ok(Some("2".to_string()));
-        let metric_type = "distribution".to_string();
-
-        assert_eq!(
-            parse_dist_materialization_version(fake_config, metric_type),
-            2
-        )
-    }
-
-    #[test]
-    fn test_dont_use_new_matview_dist_space() {
-        let fake_config: Result<Option<String>, _> = Ok(Some(" ".to_string()));
-        let metric_type = "distribution".to_string();
-
-        assert_eq!(
-            parse_dist_materialization_version(fake_config, metric_type),
-            2
-        )
-    }
-
-    #[test]
-    fn test_dont_use_new_matview_dist_empty() {
-        let fake_config: Result<Option<String>, _> = Ok(Some("".to_string()));
-        let metric_type = "distribution".to_string();
-
-        assert_eq!(
-            parse_dist_materialization_version(fake_config, metric_type),
-            2
-        )
-    }
-
-    #[test]
-    fn test_use_new_matview_dist() {
-        let fake_config: Result<Option<String>, _> = Ok(Some("3".to_string()));
-        let metric_type = "distribution".to_string();
-
-        assert_eq!(
-            parse_dist_materialization_version(fake_config, metric_type),
-            3
-        )
-    }
-
-    #[test]
-    fn test_dont_use_new_matview_non_dist() {
-        let fake_config: Result<Option<String>, _> = Ok(Some("3".to_string()));
-        let metric_type = "counter".to_string();
-
-        assert_eq!(
-            parse_dist_materialization_version(fake_config, metric_type),
-            2
-        )
-    }
-
-    #[test]
-    fn test_dont_use_new_matview() {
-        let fake_config: Result<Option<String>, _> = Ok(None);
-        let metric_type = "distribution".to_string();
-
-        assert_eq!(
-            parse_dist_materialization_version(fake_config, metric_type),
-            2
-        )
     }
 
     #[test]
@@ -1435,6 +1475,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             count_value: 1.0,
         };
@@ -1446,6 +1487,63 @@ mod tests {
                 sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
                 cogs_data: Some(CogsData {
                     data: BTreeMap::from([("genericmetrics_spans".to_string(), 615)])
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn test_counter_processor_with_counter_message_with_sampling_weight() {
+        let result = test_processor_with_payload(
+            &(process_counter_message
+                as fn(
+                    rust_arroyo::backends::kafka::types::KafkaPayload,
+                    crate::types::KafkaMessageMetadata,
+                    &crate::ProcessorConfig,
+                )
+                    -> std::result::Result<crate::types::InsertBatch, anyhow::Error>),
+            DUMMY_COUNTER_MESSAGE_WITH_SAMPLING_WEIGHT,
+        );
+        let expected_row = CountersRawRow {
+            common_fields: CommonMetricFields {
+                use_case_id: "spans".to_string(),
+                org_id: 1,
+                project_id: 3,
+                metric_id: 65561,
+                timestamp: 1704614940,
+                retention_days: 90,
+                tags_key: vec![65689, 9223372036854776010, 9223372036854776017],
+                tags_indexed_value: vec![0; 3],
+                tags_raw_value: vec![
+                    "metric_e2e_spans_counter_v_VUW93LMS".to_string(),
+                    "production".to_string(),
+                    "init".to_string(),
+                ],
+                metric_type: "counter".to_string(),
+                materialization_version: 2,
+                timeseries_id: 1979522105,
+                granularities: vec![
+                    GRANULARITY_ONE_MINUTE,
+                    GRANULARITY_ONE_HOUR,
+                    GRANULARITY_ONE_DAY,
+                ],
+                decasecond_retention_days: None,
+                min_retention_days: Some(90),
+                hr_retention_days: None,
+                day_retention_days: None,
+                record_meta: Some(1),
+                sampling_weight: Some(100),
+            },
+            count_value: 1.0,
+        };
+        assert_eq!(
+            result.unwrap(),
+            InsertBatch {
+                rows: RowData::from_rows([expected_row]).unwrap(),
+                origin_timestamp: None,
+                sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
+                cogs_data: Some(CogsData {
+                    data: BTreeMap::from([("genericmetrics_spans".to_string(), 647)])
                 }),
             }
         );
@@ -1506,6 +1604,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             set_values: vec![0, 1, 2, 3, 4, 5],
         };
@@ -1565,7 +1664,7 @@ mod tests {
                     "healthy".to_string(),
                 ],
                 metric_type: "distribution".to_string(),
-                materialization_version: 2,
+                materialization_version: 3,
                 timeseries_id: 1436359714,
                 granularities: vec![
                     GRANULARITY_ONE_MINUTE,
@@ -1577,6 +1676,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             distribution_values: vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
             enable_histogram: None,
@@ -1623,7 +1723,7 @@ mod tests {
                     "healthy".to_string(),
                 ],
                 metric_type: "distribution".to_string(),
-                materialization_version: 2,
+                materialization_version: 3,
                 timeseries_id: 1436359714,
                 granularities: vec![
                     GRANULARITY_ONE_MINUTE,
@@ -1635,6 +1735,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             distribution_values: vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
             enable_histogram: None,
@@ -1681,7 +1782,7 @@ mod tests {
                     "healthy".to_string(),
                 ],
                 metric_type: "distribution".to_string(),
-                materialization_version: 2,
+                materialization_version: 3,
                 timeseries_id: 1436359714,
                 granularities: vec![
                     GRANULARITY_ONE_MINUTE,
@@ -1693,6 +1794,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             distribution_values: vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
             enable_histogram: Some(1),
@@ -1739,7 +1841,7 @@ mod tests {
                     "healthy".to_string(),
                 ],
                 metric_type: "distribution".to_string(),
-                materialization_version: 2,
+                materialization_version: 3,
                 timeseries_id: 1436359714,
                 granularities: vec![
                     GRANULARITY_ONE_MINUTE,
@@ -1751,6 +1853,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             distribution_values: vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
             enable_histogram: None,
@@ -1824,6 +1927,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             gauges_values_last: vec![10.0],
             gauges_values_count: vec![10],
@@ -1839,6 +1943,67 @@ mod tests {
                 sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
                 cogs_data: Some(CogsData {
                     data: BTreeMap::from([("genericmetrics_spans".to_string(), 679)])
+                })
+            }
+        );
+    }
+
+    #[test]
+    fn test_gauge_processor_with_gauge_message_with_sampling_weight() {
+        let result = test_processor_with_payload(
+            &(process_gauge_message
+                as fn(
+                    rust_arroyo::backends::kafka::types::KafkaPayload,
+                    crate::types::KafkaMessageMetadata,
+                    &crate::ProcessorConfig,
+                )
+                    -> std::result::Result<crate::types::InsertBatch, anyhow::Error>),
+            DUMMY_GAUGE_MESSAGE_WITH_SAMPLING_WEIGHT,
+        );
+        let expected_row = GaugesRawRow {
+            common_fields: CommonMetricFields {
+                use_case_id: "spans".to_string(),
+                org_id: 1,
+                project_id: 3,
+                metric_id: 65564,
+                timestamp: 1704614940,
+                retention_days: 90,
+                tags_key: vec![65690, 9223372036854776010, 9223372036854776017],
+                tags_indexed_value: vec![0; 3],
+                tags_raw_value: vec![
+                    "metric_e2e_spans_gauge_v_VUW93LMS".to_string(),
+                    "production".to_string(),
+                    "init".to_string(),
+                ],
+                metric_type: "gauge".to_string(),
+                materialization_version: 2,
+                timeseries_id: 569776957,
+                granularities: vec![
+                    GRANULARITY_ONE_MINUTE,
+                    GRANULARITY_ONE_HOUR,
+                    GRANULARITY_ONE_DAY,
+                ],
+                decasecond_retention_days: None,
+                min_retention_days: Some(90),
+                hr_retention_days: None,
+                day_retention_days: None,
+                record_meta: Some(1),
+                sampling_weight: Some(100),
+            },
+            gauges_values_last: vec![10.0],
+            gauges_values_count: vec![10],
+            gauges_values_max: vec![10.0],
+            gauges_values_min: vec![1.0],
+            gauges_values_sum: vec![20.0],
+        };
+        assert_eq!(
+            result.unwrap(),
+            InsertBatch {
+                rows: RowData::from_rows([expected_row]).unwrap(),
+                origin_timestamp: None,
+                sentry_received_timestamp: DateTime::from_timestamp(1704614940, 0),
+                cogs_data: Some(CogsData {
+                    data: BTreeMap::from([("genericmetrics_spans".to_string(), 711)])
                 })
             }
         );
@@ -1885,6 +2050,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             gauges_values_last: vec![10.0],
             gauges_values_count: vec![10],
@@ -1960,6 +2126,7 @@ mod tests {
                 hr_retention_days: None,
                 day_retention_days: None,
                 record_meta: Some(1),
+                sampling_weight: None,
             },
             set_values: vec![0, 1, 2, 3, 4, 5],
         };

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericDistributionsMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics-dist-base64.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericDistributionsMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics-dist-base64.json.snap
@@ -15,7 +15,7 @@ expression: snapshot_payload
       2,
       3
     ],
-    "materialization_version": 2,
+    "materialization_version": 3,
     "metric_id": 65563,
     "metric_type": "distribution",
     "min_retention_days": 90,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericDistributionsMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics-dist-encoded-plain-array.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericDistributionsMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics-dist-encoded-plain-array.json.snap
@@ -18,7 +18,7 @@ expression: snapshot_payload
       2,
       3
     ],
-    "materialization_version": 2,
+    "materialization_version": 3,
     "metric_id": 65563,
     "metric_type": "distribution",
     "min_retention_days": 90,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericDistributionsMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics-dist-zstd.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-generic-metrics-GenericDistributionsMetricsProcessor-snuba-generic-metrics__1__snuba-generic-metrics-dist-zstd.json.snap
@@ -15,7 +15,7 @@ expression: snapshot_payload
       2,
       3
     ],
-    "materialization_version": 2,
+    "materialization_version": 3,
     "metric_id": 65563,
     "metric_type": "distribution",
     "min_retention_days": 90,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-metrics-PolymorphicMetricsProcessor-snuba-metrics__1__snuba-metrics-sampled.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-metrics-PolymorphicMetricsProcessor-snuba-metrics__1__snuba-metrics-sampled.json.snap
@@ -1,0 +1,38 @@
+---
+source: src/processors/mod.rs
+description: "{\n  \"use_case_id\": \"release-health\",\n  \"org_id\": 1,\n  \"project_id\": 2,\n  \"metric_id\": 1232341,\n  \"type\": \"s\",\n  \"timestamp\": 1676388965,\n  \"tags\": {\n    \"10\": 11,\n    \"20\": 22,\n    \"30\": 33\n  },\n  \"value\": [324234, 345345, 456456, 567567],\n  \"retention_days\": 22,\n  \"sample_weight\": 100.1,\n  \"mapping_meta\": {\n    \"c\": {\n      \"10\": \"tag-1\",\n      \"20\": \"tag-2\",\n      \"11\": \"value-1\",\n      \"22\": \"value-2\",\n      \"30\": \"tag-3\"\n    },\n    \"d\": {\n      \"33\": \"value-3\"\n    }\n  }\n}\n"
+expression: snapshot_payload
+---
+[
+  {
+    "count_value": null,
+    "distribution_values": null,
+    "materialization_version": 4,
+    "metric_id": 1232341,
+    "metric_type": "set",
+    "offset": 1,
+    "org_id": 1,
+    "partition": 0,
+    "project_id": 2,
+    "retention_days": 30,
+    "set_values": [
+      324234,
+      345345,
+      456456,
+      567567
+    ],
+    "tags.key": [
+      10,
+      20,
+      30
+    ],
+    "tags.value": [
+      11,
+      22,
+      33
+    ],
+    "timeseries_id": 1521156896,
+    "timestamp": 1676388965,
+    "use_case_id": "release-health"
+  }
+]

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-metrics-PolymorphicMetricsProcessor-snuba-metrics__1__snuba-metrics-unsampled.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-metrics-PolymorphicMetricsProcessor-snuba-metrics__1__snuba-metrics-unsampled.json.snap
@@ -1,0 +1,38 @@
+---
+source: src/processors/mod.rs
+description: "{\n  \"use_case_id\": \"release-health\",\n  \"org_id\": 1,\n  \"project_id\": 2,\n  \"metric_id\": 1232341,\n  \"type\": \"s\",\n  \"timestamp\": 1676388965,\n  \"tags\": {\n    \"10\": 11,\n    \"20\": 22,\n    \"30\": 33\n  },\n  \"value\": [324234, 345345, 456456, 567567],\n  \"retention_days\": 22,\n  \"mapping_meta\": {\n    \"c\": {\n      \"10\": \"tag-1\",\n      \"20\": \"tag-2\",\n      \"11\": \"value-1\",\n      \"22\": \"value-2\",\n      \"30\": \"tag-3\"\n    },\n    \"d\": {\n      \"33\": \"value-3\"\n    }\n  }\n}\n"
+expression: snapshot_payload
+---
+[
+  {
+    "count_value": null,
+    "distribution_values": null,
+    "materialization_version": 4,
+    "metric_id": 1232341,
+    "metric_type": "set",
+    "offset": 1,
+    "org_id": 1,
+    "partition": 0,
+    "project_id": 2,
+    "retention_days": 30,
+    "set_values": [
+      324234,
+      345345,
+      456456,
+      567567
+    ],
+    "tags.key": [
+      10,
+      20,
+      30
+    ],
+    "tags.value": [
+      11,
+      22,
+      33
+    ],
+    "timeseries_id": 1521156896,
+    "timestamp": 1676388965,
+    "use_case_id": "release-health"
+  }
+]


### PR DESCRIPTION
### Overview

Previous PR in the stack https://github.com/getsentry/snuba/pull/6172

Forwards sampling information (aka `sampling_weight`) to clickhouse now that it can handle sampled data.


# Local testing

<details>
  <summary>Click to expand</summary>

Apply migrations and run snuba devserver
```bash
make apply-migrations
snuba devserver
```

Send some metrics
```sql
Use the following SQL to verify clickhouse, there should be 4 metrics for each use cases, 24 in total.

SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_counters_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*VH12IXDX'), tags.raw_value)
UNION ALL
SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_distributions_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*VH12IXDX'), tags.raw_value)
UNION ALL
SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_sets_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*VH12IXDX'), tags.raw_value)
UNION ALL
SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_gauges_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*VH12IXDX'), tags.raw_value)

Query id: c625859c-de52-4911-a9b1-2b7aad9ae1bd

┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value──────────────────────────────────────────────────────────┐
│                       3 │ 2024-08-02 22:06:57 │ [87082,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_dist_v_VH12IXDX','production','healthy']            │
│                       3 │ 2024-08-02 22:06:57 │ [87092,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_dist_v_VH12IXDX','production','healthy'] │
│                       3 │ 2024-08-02 22:06:57 │ [87094,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_dist_v_VH12IXDX','production','healthy']      │
│                       3 │ 2024-08-02 22:06:57 │ [87103,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_dist_v_VH12IXDX','production','healthy']          │
│                       3 │ 2024-08-02 22:06:57 │ [87101,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_dist_v_VH12IXDX','production','healthy']             │
│                       3 │ 2024-08-02 22:06:57 │ [87088,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_dist_v_VH12IXDX','production','healthy']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value──────────────────────────────────────────────────────────┐
│                       2 │ 2024-08-02 22:06:57 │ [87084,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_counter_v_VH12IXDX','production','init']            │
│                       2 │ 2024-08-02 22:06:57 │ [87093,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_counter_v_VH12IXDX','production','init'] │
│                       2 │ 2024-08-02 22:06:57 │ [87096,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_counter_v_VH12IXDX','production','init']      │
│                       2 │ 2024-08-02 22:06:57 │ [87102,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_counter_v_VH12IXDX','production','init']          │
│                       2 │ 2024-08-02 22:06:57 │ [87098,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_counter_v_VH12IXDX','production','init']             │
│                       2 │ 2024-08-02 22:06:57 │ [87089,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_counter_v_VH12IXDX','production','init']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value─────────────────────────────────────────────────────────┐
│                       2 │ 2024-08-02 22:06:57 │ [87085,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_set_v_VH12IXDX','production','errored']            │
│                       2 │ 2024-08-02 22:06:57 │ [87091,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_set_v_VH12IXDX','production','errored'] │
│                       2 │ 2024-08-02 22:06:57 │ [87095,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_set_v_VH12IXDX','production','errored']      │
│                       2 │ 2024-08-02 22:06:57 │ [87104,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_set_v_VH12IXDX','production','errored']          │
│                       2 │ 2024-08-02 22:06:57 │ [87099,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_set_v_VH12IXDX','production','errored']             │
│                       2 │ 2024-08-02 22:06:57 │ [87086,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_set_v_VH12IXDX','production','errored']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value───────────────────────────────────────────────────────────┐
│                       2 │ 2024-08-02 22:06:57 │ [87083,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_gauge_v_VH12IXDX','production','errored']            │
│                       2 │ 2024-08-02 22:06:57 │ [87090,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_gauge_v_VH12IXDX','production','errored'] │
│                       2 │ 2024-08-02 22:06:57 │ [87097,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_gauge_v_VH12IXDX','production','errored']      │
│                       2 │ 2024-08-02 22:06:57 │ [87105,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_gauge_v_VH12IXDX','production','errored']          │
│                       2 │ 2024-08-02 22:06:57 │ [87100,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_gauge_v_VH12IXDX','production','errored']             │
│                       2 │ 2024-08-02 22:06:57 │ [87087,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_gauge_v_VH12IXDX','production','errored']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────┘
```

Update runtime config
![image](https://github.com/user-attachments/assets/b858cd40-189d-4f30-9616-bbaedc2ed473)



Send some more metrics

```sql
Use the following SQL to verify clickhouse, there should be 4 metrics for each use cases, 24 in total.
SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_counters_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*N156YV3A'), tags.raw_value)
UNION ALL
SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_distributions_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*N156YV3A'), tags.raw_value)
UNION ALL
SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_sets_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*N156YV3A'), tags.raw_value)
UNION ALL
SELECT
    materialization_version,
    timestamp,
    tags.key,
    tags.raw_value
FROM generic_metric_gauges_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*N156YV3A'), tags.raw_value)

Query id: 65df81de-344d-4312-bdfa-66b7a3e84bae

┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value──────────────────────────────────────────────────────────┐
│                       4 │ 2024-08-02 22:11:28 │ [87137,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_dist_v_N156YV3A','production','healthy']            │
│                       4 │ 2024-08-02 22:11:28 │ [87140,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_dist_v_N156YV3A','production','healthy'] │
│                       4 │ 2024-08-02 22:11:28 │ [87133,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_dist_v_N156YV3A','production','healthy']      │
│                       4 │ 2024-08-02 22:11:28 │ [87147,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_dist_v_N156YV3A','production','healthy']          │
│                       4 │ 2024-08-02 22:11:28 │ [87151,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_dist_v_N156YV3A','production','healthy']             │
│                       4 │ 2024-08-02 22:11:28 │ [87142,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_dist_v_N156YV3A','production','healthy']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value──────────────────────────────────────────────────────────┐
│                       3 │ 2024-08-02 22:11:28 │ [87136,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_counter_v_N156YV3A','production','init']            │
│                       3 │ 2024-08-02 22:11:28 │ [87138,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_counter_v_N156YV3A','production','init'] │
│                       3 │ 2024-08-02 22:11:28 │ [87131,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_counter_v_N156YV3A','production','init']      │
│                       3 │ 2024-08-02 22:11:28 │ [87146,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_counter_v_N156YV3A','production','init']          │
│                       3 │ 2024-08-02 22:11:28 │ [87150,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_counter_v_N156YV3A','production','init']             │
│                       3 │ 2024-08-02 22:11:28 │ [87145,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_counter_v_N156YV3A','production','init']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value─────────────────────────────────────────────┐
│                       2 │ 2024-08-02 22:11:28 │ [87153,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_set_v_N156YV3A','production','errored'] │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value──────────────────────────────────────────────────────┐
│                       3 │ 2024-08-02 22:11:28 │ [87130,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_gauge_v_N156YV3A','production','errored'] │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value───────────────────────────────────────────────────────────┐
│                       3 │ 2024-08-02 22:11:28 │ [87135,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_gauge_v_N156YV3A','production','errored']            │
│                       3 │ 2024-08-02 22:11:28 │ [87139,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_gauge_v_N156YV3A','production','errored'] │
│                       3 │ 2024-08-02 22:11:28 │ [87149,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_gauge_v_N156YV3A','production','errored']          │
│                       3 │ 2024-08-02 22:11:28 │ [87152,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_gauge_v_N156YV3A','production','errored']             │
│                       3 │ 2024-08-02 22:11:28 │ [87143,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_gauge_v_N156YV3A','production','errored']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────┘
┌─materialization_version─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value─────────────────────────────────────────────────────────┐
│                       2 │ 2024-08-02 22:11:28 │ [87134,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_set_v_N156YV3A','production','errored']            │
│                       2 │ 2024-08-02 22:11:28 │ [87141,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_set_v_N156YV3A','production','errored'] │
│                       2 │ 2024-08-02 22:11:28 │ [87132,9223372036854776010,9223372036854776017] │ ['metric_e2e_metric_stats_set_v_N156YV3A','production','errored']      │
│                       2 │ 2024-08-02 22:11:28 │ [87148,9223372036854776010,9223372036854776017] │ ['metric_e2e_profiles_set_v_N156YV3A','production','errored']          │
│                       2 │ 2024-08-02 22:11:28 │ [87144,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_set_v_N156YV3A','production','errored']      │
└─────────────────────────┴─────────────────────┴─────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────┘

24 rows in set. Elapsed: 0.009 sec.
```
</details>