### PR TITLE
ref(snuba-deletes): introduce delete allocation policies

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -89,6 +89,15 @@ allocation_policies:
         is_enforced: 0
         is_active: 0
 
+delete_allocation_policies:
+  - name: DeleteConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
+
 query_processors:
   - processor: TableRateLimit
   - processor: MappingOptimizer

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -593,6 +593,7 @@ V1_READABLE_STORAGE_SCHEMA = {
         "deletion_processors": DELETION_PROCESSORS_SCHEMA,
         "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
         "allocation_policies": STORAGE_ALLOCATION_POLICIES_SCHEMA,
+        "delete_allocation_policies": STORAGE_ALLOCATION_POLICIES_SCHEMA,
         "required_time_column": {
             "type": ["string", "null"],
             "description": "The name of the required time column specifed in schema",
@@ -625,6 +626,7 @@ V1_WRITABLE_STORAGE_SCHEMA = {
         "deletion_processors": DELETION_PROCESSORS_SCHEMA,
         "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
         "allocation_policies": STORAGE_ALLOCATION_POLICIES_SCHEMA,
+        "delete_allocation_policies": STORAGE_ALLOCATION_POLICIES_SCHEMA,
         "replacer_processor": STORAGE_REPLACER_PROCESSOR_SCHEMA,
         "writer_options": {
             "type": "object",

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -51,6 +51,7 @@ SUBCRIPTION_SCHEDULER_MODE = "subscription_scheduler_mode"
 DLQ_POLICY = "dlq_policy"
 REPLACER_PROCESSOR = "replacer_processor"
 ALLOCATION_POLICIES = "allocation_policies"
+DELETE_ALLOCATION_POLICIES = "delete_allocation_policies"
 REQUIRED_TIME_COLUMN = "required_time_column"
 
 
@@ -95,6 +96,19 @@ def __build_readable_storage_kwargs(config: dict[str, Any]) -> dict[str, Any]:
             else []
         ),
         ALLOCATION_POLICIES: (
+            [
+                AllocationPolicy.get_from_name(policy["name"]).from_kwargs(
+                    **{
+                        **policy.get("args", {}),
+                        "storage_key": storage_key.value,
+                    }
+                )
+                for policy in config[ALLOCATION_POLICIES]
+            ]
+            if ALLOCATION_POLICIES in config
+            else []
+        ),
+        DELETE_ALLOCATION_POLICIES: (
             [
                 AllocationPolicy.get_from_name(policy["name"]).from_kwargs(
                     **{

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -116,9 +116,9 @@ def __build_readable_storage_kwargs(config: dict[str, Any]) -> dict[str, Any]:
                         "storage_key": storage_key.value,
                     }
                 )
-                for policy in config[ALLOCATION_POLICIES]
+                for policy in config[DELETE_ALLOCATION_POLICIES]
             ]
-            if ALLOCATION_POLICIES in config
+            if DELETE_ALLOCATION_POLICIES in config
             else []
         ),
         REQUIRED_TIME_COLUMN: config.get(REQUIRED_TIME_COLUMN, None),

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -135,6 +135,7 @@ class ReadableTableStorage(ReadableStorage):
         deletion_processors: Optional[Sequence[ClickhouseQueryProcessor]] = None,
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
         allocation_policies: Optional[list[AllocationPolicy]] = None,
+        delete_allocation_policies: Optional[list[AllocationPolicy]] = None,
         required_time_column: Optional[str] = None,
     ) -> None:
         self.__storage_key = storage_key
@@ -143,6 +144,7 @@ class ReadableTableStorage(ReadableStorage):
         self.__deletion_processors = deletion_processors or []
         self.__mandatory_condition_checkers = mandatory_condition_checkers or []
         self.__allocation_policies = allocation_policies or []
+        self.__delete_allocation_policies = delete_allocation_policies or []
         super().__init__(
             storage_set_key,
             schema,
@@ -162,6 +164,9 @@ class ReadableTableStorage(ReadableStorage):
     def get_allocation_policies(self) -> list[AllocationPolicy]:
         return self.__allocation_policies or super().get_allocation_policies()
 
+    def get_delete_allocation_policies(self) -> list[AllocationPolicy]:
+        return self.__delete_allocation_policies
+
     def get_deletion_settings(self) -> DeletionSettings:
         return self.__deletion_settings
 
@@ -180,6 +185,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
         stream_loader: KafkaStreamLoader,
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
         allocation_policies: Optional[list[AllocationPolicy]] = None,
+        delete_allocation_policies: Optional[list[AllocationPolicy]] = None,
         replacer_processor: Optional[ReplacerProcessor[Any]] = None,
         deletion_settings: Optional[DeletionSettings] = None,
         deletion_processors: Optional[Sequence[ClickhouseQueryProcessor]] = None,
@@ -199,6 +205,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
             deletion_processors,
             mandatory_condition_checkers,
             allocation_policies,
+            delete_allocation_policies,
             required_time_column=required_time_column,
         )
         assert isinstance(schema, WritableTableSchema)

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -286,3 +286,9 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
             return
         rate_limit_params, _ = self._get_rate_limit_params(tenant_ids)
         self._end_query(query_id, rate_limit_params, result_or_error)
+
+
+class DeleteConcurrentRateLimitAllocationPolicy(ConcurrentRateLimitAllocationPolicy):
+    @property
+    def rate_limit_name(self) -> str:
+        return "delete_concurrent_rate_limit_policy"

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -131,8 +131,7 @@ def _delete_from_table(
             table,
             ColumnSet([]),
             storage_key=storage.get_storage_key(),
-            # TODO: add allocation policies
-            allocation_policies=[],
+            allocation_policies=storage.get_delete_allocation_policies(),
         ),
         condition=_construct_condition(conditions),
         on_cluster=on_cluster,


### PR DESCRIPTION
**context**
Right now we have a simple ratelimiter that limits deletes to `1` concurrent query at a time for the whole endpoint https://github.com/getsentry/snuba/blob/ea2f8e716ea519ae173e7a6833da5d2bf16859f2/snuba/web/views.py#L305

This is good enough for testing out ourselves, but beyond that we wanted to add a more robust ratelimiter that allowed for more granular levers that we have for other endpoints. Product should also be ratelimiting on their end though, this is not supposed to be in lieu of that. 

**delete allocation policies**
We can reuse the allocation policy framework for the delete query pipeline. I've made these policies separate to the other allocation policies definitions because we should be adjusting the limits separately; deletes should not have as high thresholds as select queries because the load those queries cause will be higher, even though they are 'lightweight' (lightweight compared to heavy mutations).

**`DeleteConcurrentRateLimitAllocationPolicy`**
I made a separate class because I want the redis key to be different than the `ConcurrentRateLimitAllocationPolicy` so that we don't clobber ratelimits

This PR just adds the set up for the allocation policies, and does nothing with them (aside from adding they to the `Query` object. The rest of the logic will be in https://github.com/getsentry/snuba/pull/6181