### PR TITLE
ref(snuba-deletes): use allocation policies

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -78,11 +78,7 @@ from snuba.request.exceptions import InvalidJsonRequestException
 from snuba.request.schema import RequestSchema
 from snuba.state.explain_meta import explain_cleanup, get_explain_meta
 from snuba.utils.metrics.timer import Timer
-from snuba.web.delete_query import (
-    DeletesNotEnabledError,
-    delete_from_storage,
-    deletes_are_enabled,
-)
+from snuba.web.delete_query import delete_from_storage, deletes_are_enabled
 from snuba.web.views import dataset_query
 
 logger = structlog.get_logger().bind(module=__name__)

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1102,7 +1102,9 @@ def delete() -> Response:
         schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
         request_parts = schema.validate(body)
         delete_results = delete_from_storage(
-            storage, request_parts.query["query"]["columns"]
+            storage,
+            request_parts.query["query"]["columns"],
+            request_parts.attribution_info,
         )
     except (InvalidJsonRequestException, DeletesNotEnabledError) as schema_error:
         return make_response(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -78,7 +78,11 @@ from snuba.request.exceptions import InvalidJsonRequestException
 from snuba.request.schema import RequestSchema
 from snuba.state.explain_meta import explain_cleanup, get_explain_meta
 from snuba.utils.metrics.timer import Timer
-from snuba.web.delete_query import delete_from_storage, deletes_are_enabled
+from snuba.web.delete_query import (
+    DeletesNotEnabledError,
+    delete_from_storage,
+    deletes_are_enabled,
+)
 from snuba.web.views import dataset_query
 
 logger = structlog.get_logger().bind(module=__name__)

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -1,6 +1,6 @@
 import typing
 import uuid
-from typing import Any, Dict, Mapping, MutableMapping
+from typing import Any, Dict, Mapping, MutableMapping, Optional
 
 from snuba.attribution import get_app_id
 from snuba.attribution.attribution_info import AttributionInfo
@@ -207,8 +207,9 @@ def _execute_query(
     query: Query,
     storage: WritableTableStorage,
     table: str,
-    cluster_name: str,
+    cluster_name: Optional[str],
     attribution_info: AttributionInfo,
+    query_settings: HTTPQuerySettings,
 ) -> Result:
     """
     Formats and executes the delete query, taking into account
@@ -225,7 +226,7 @@ def _execute_query(
     stats: MutableMapping[str, Any] = {
         "clickhouse_table": table,
         "referrer": attribution_info.referrer,
-        "cluster_name": cluster_name,
+        "cluster_name": cluster_name or "<unknown>",
     }
 
     try:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -328,7 +328,9 @@ def storage_delete(
             schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
             request_parts = schema.validate(body)
             payload = delete_from_storage(
-                storage, request_parts.query["query"]["columns"]
+                storage,
+                request_parts.query["query"]["columns"],
+                request_parts.attribution_info,
             )
         except (
             InvalidJsonRequestException,

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -76,7 +76,7 @@ from snuba.utils.metrics.util import with_span
 from snuba.web import QueryException, QueryTooLongException
 from snuba.web.constants import get_http_status_for_clickhouse_error
 from snuba.web.converters import DatasetConverter, EntityConverter, StorageConverter
-from snuba.web.delete_query import delete_from_storage
+from snuba.web.delete_query import DeletesNotEnabledError, delete_from_storage
 from snuba.web.query import parse_and_run_query
 from snuba.web.rpc.timeseries import timeseries_query as timeseries_query_impl
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -76,7 +76,7 @@ from snuba.utils.metrics.util import with_span
 from snuba.web import QueryException, QueryTooLongException
 from snuba.web.constants import get_http_status_for_clickhouse_error
 from snuba.web.converters import DatasetConverter, EntityConverter, StorageConverter
-from snuba.web.delete_query import DeletesNotEnabledError, delete_from_storage
+from snuba.web.delete_query import delete_from_storage
 from snuba.web.query import parse_and_run_query
 from snuba.web.rpc.timeseries import timeseries_query as timeseries_query_impl
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow

--- a/tests/web/test_delete_query.py
+++ b/tests/web/test_delete_query.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import uuid
+from unittest import mock
+
+import pytest
+
+from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query.allocation_policies import (
+    MAX_THRESHOLD,
+    NO_SUGGESTION,
+    NO_UNITS,
+    AllocationPolicy,
+    AllocationPolicyConfig,
+    AllocationPolicyViolations,
+    QueryResultOrError,
+    QuotaAllowance,
+)
+from snuba.query.data_source.simple import Table
+from snuba.query.dsl import and_cond, column, equals, literal
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.web import QueryException
+from snuba.web.delete_query import _execute_query
+
+
+def get_delete_query() -> Query:
+    from_clause = Table(
+        "search_issues_local_v2",
+        ColumnSet([]),
+        storage_key=StorageKey.SEARCH_ISSUES,
+        allocation_policies=[],
+    )
+    occurrence_id = str(uuid.uuid4())
+    return Query(
+        from_clause=from_clause,
+        condition=and_cond(
+            equals(column("occurrence_id"), literal(occurrence_id)),
+            equals(column("project_id"), literal(3)),
+        ),
+        on_cluster=None,
+        is_delete=True,
+    )
+
+
+def test_delete_query_with_rejecting_allocation_policy() -> None:
+    # this test does not need the db or a query because the allocation policy
+    # should reject the query before it gets to execution
+    storage = get_writable_storage(StorageKey("search_issues"))
+    attr_into = AttributionInfo(
+        get_app_id("blah"),
+        {"project_id": 123, "referrer": "r"},
+        "blah",
+        None,
+        None,
+        None,
+    )
+    update_called = False
+
+    class RejectAllocationPolicy(AllocationPolicy):
+        def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
+            return []
+
+        def _get_quota_allowance(
+            self, tenant_ids: dict[str, str | int], query_id: str
+        ) -> QuotaAllowance:
+            return QuotaAllowance(
+                can_run=False,
+                max_threads=0,
+                explanation={"reason": "policy rejects all queries"},
+                is_throttled=True,
+                throttle_threshold=100000,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=MAX_THRESHOLD,
+                quota_unit=NO_UNITS,
+                suggestion=NO_SUGGESTION,
+            )
+
+        def _update_quota_balance(
+            self,
+            tenant_ids: dict[str, str | int],
+            query_id: str,
+            result_or_error: QueryResultOrError,
+        ) -> None:
+            nonlocal update_called
+            update_called = True
+            return
+
+    with mock.patch(
+        "snuba.web.delete_query._get_delete_allocation_policies",
+        return_value=[
+            RejectAllocationPolicy(StorageKey("doesntmatter"), ["a", "b", "c"], {})
+        ],
+    ):
+        with pytest.raises(QueryException) as excinfo:
+            _execute_query(
+                query=get_delete_query(),
+                storage=storage,
+                table="search_issues_local_v2",
+                cluster_name="cluster_name",
+                attribution_info=attr_into,
+                query_settings=HTTPQuerySettings(),
+            )
+        # extra data contains policy failure information
+        assert (
+            excinfo.value.extra["stats"]["quota_allowance"]["details"][
+                "RejectAllocationPolicy"
+            ]["explanation"]["reason"]
+            == "policy rejects all queries"
+        )
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, AllocationPolicyViolations)
+        assert "RejectAllocationPolicy" in cause.violations
+        assert (
+            update_called
+        ), "update_quota_balance should have been called even though the query was rejected but was not"


### PR DESCRIPTION
**context**
We have the configurations for the delete allocation policies but they aren't actually being used in the delete pipeline yet.
Some more info in the original PR that added the configuration for the delete allocation policies https://github.com/getsentry/snuba/pull/6180. 

This reuses some of the functionality from the regular select query pipeline. The delete concurrent policy we defined will not be enforced yet, so we will still be relying on the simple rate limiter  https://github.com/getsentry/snuba/blob/ea2f8e716ea519ae173e7a6833da5d2bf16859f2/snuba/web/views.py#L305
until we are ready to enforce the allocation policy. We can also add another delete policy once we verify the delete allocation policy pipeline is working as expected.

**next steps**
- [ ] add delete allocation policies to the snuba admin UI so that we can change values https://github.com/getsentry/snuba/pull/6248
- [ ] test out the delete allocation policy to verify it
- [ ] add a delete referrer guard policy