### PR TITLE
feat(eap): Add index on project_id

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0002_eap_spans_project_id_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0002_eap_spans_project_id_index.py
@@ -1,0 +1,31 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddIndex(
+                storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+                table_name="eap_spans_local",
+                index_name="bf_project_id",
+                index_expression="project_id",
+                index_type="bloom_filter",
+                granularity=1,
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropIndex(
+                storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+                table_name="eap_spans_local",
+                index_name="bf_project_id",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
The project_id is heavily used in queries, to narrow down to specific services.
Add a bloom filter index on it to help improve query performance.