### PR TITLE
fix(eap): Use arrayElement directly to fix alias issues with HashBucketMapper

### DIFF
--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -244,7 +244,7 @@ class SubscriptableHashBucketMapper(SubscriptableReferenceMapper):
         self,
         expression: SubscriptableReference,
         children_translator: SnubaClickhouseStrictTranslator,
-    ) -> Optional[SubscriptableReference]:
+    ) -> Optional[FunctionCallExpr]:
         if (
             expression.column.table_name != self.from_column_table
             or expression.column.column_name != self.from_column_name
@@ -257,15 +257,10 @@ class SubscriptableHashBucketMapper(SubscriptableReferenceMapper):
             return None
 
         bucket_idx = fnv_1a(key.value.encode("utf-8")) % ATTRIBUTE_BUCKETS
-        return SubscriptableReference(
-            column=ColumnExpr(
-                None,
-                table_name=self.to_col_table,
-                column_name=f"{self.to_col_name}_{bucket_idx}",
-            ),
-            key=key,
-            alias=expression.alias,
-            emit_as_subscript=True,
+        return arrayElement(
+            expression.alias,
+            ColumnExpr(None, self.to_col_table, f"{self.to_col_name}_{bucket_idx}"),
+            key,
         )
 
 

--- a/snuba/datasets/plans/storage_processing.py
+++ b/snuba/datasets/plans/storage_processing.py
@@ -104,9 +104,6 @@ def transform_subscriptables(expression: Expression) -> Expression:
     # assume that it maps to an associative array column with the same name and `value` as the
     # name of the value column
     if isinstance(expression, SubscriptableReference):
-        if expression.emit_as_subscript:
-            # clickhouse itself now supports subscripts, so we can emit things directly
-            return expression
         res = SubscriptableMapper(
             expression.column.table_name,
             expression.column.column_name,

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -355,9 +355,6 @@ class SubscriptableReference(Expression):
 
     column: Column
     key: Literal
-    emit_as_subscript: bool = (
-        False  # do not mangle the column, forward it to clickhouse as a subscript
-    )
 
     def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
         return visitor.visit_subscriptable_reference(self)

--- a/tests/clickhouse/translators/snuba/test_translation.py
+++ b/tests/clickhouse/translators/snuba/test_translation.py
@@ -9,6 +9,7 @@ from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToLiteral,
     ColumnToMapping,
     FunctionNameMapper,
+    SubscriptableHashBucketMapper,
     SubscriptableMapper,
 )
 from snuba.clickhouse.translators.snuba.mapping import (
@@ -23,6 +24,8 @@ from snuba.query.expressions import (
     Literal,
     SubscriptableReference,
 )
+from snuba.utils import constants
+from snuba.utils.hashes import fnv_1a
 
 
 def test_column_translation() -> None:
@@ -119,6 +122,26 @@ def test_tag_translation() -> None:
                 "indexOf",
                 (Column(None, None, "tags.key"), Literal(None, "release")),
             ),
+        ),
+    )
+
+
+def test_hash_bucket_tag_translation() -> None:
+    translated = SubscriptableHashBucketMapper(None, "tags", None, "tags").attempt_map(
+        SubscriptableReference(
+            "tags[release]", Column(None, None, "tags"), Literal(None, "release")
+        ),
+        SnubaClickhouseMappingTranslator(TranslationMappers()),
+    )
+
+    assert translated == FunctionCall(
+        "tags[release]",
+        "arrayElement",
+        (
+            Column(
+                None, None, f"tags_{fnv_1a(b'release') % constants.ATTRIBUTE_BUCKETS}"
+            ),
+            Literal(None, "release"),
         ),
     )
 


### PR DESCRIPTION
Originally, alias on HashBucketMapper would not work (for some reason)

This adds a test that aliasing works, and sends tags as `arrayElement` which clickhouse converts to anyways (Map in clickhouse is Array(Tuple(k, v)))