### PR TITLE
ref(eap): Change sampling_weight to a UInt

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0004_modify_sampling_weight.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0004_modify_sampling_weight.py
@@ -1,0 +1,33 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.utils.schemas import Column, Float, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+                table_name="eap_spans_local",
+                column=Column(
+                    "sampling_weight", UInt(64, modifiers=Modifiers(codecs=["ZSTD(1)"]))
+                ),
+            )
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+                table_name="eap_spans_local",
+                column=Column(
+                    "sampling_weight",
+                    Float(64, modifiers=Modifiers(codecs=["ZSTD(1)"])),
+                ),
+            )
+        ]


### PR DESCRIPTION
All of the Clickhouse -Weighted quantile functions require a UInt as the weight.
Change the column in spans to be a `UInt64` so it can be used directly in
-Weighted functions, without needing to do any type conversion.