### PR TITLE
feat(eap): Add the TimeSeriesProcessor to entities/eap_spans

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
@@ -54,7 +54,14 @@ storages:
 storage_selector:
   selector: DefaultQueryStorageSelector
 
-query_processors: []
+query_processors:
+  - processor: TimeSeriesProcessor
+    args:
+      time_group_columns:
+        time: _sort_timestamp
+      time_parse_columns:
+        - start_timestamp
+        - end_timestamp
 
 validate_data_model: error
 validators:

--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
@@ -13,6 +13,8 @@ schema:
     { name: segment_id, type: UInt, args: { size: 64 } },
     { name: segment_name, type: String },
     { name: is_segment, type: UInt, args: { size: 8 } },
+    { name: time, type: DateTime }, # virtual column, used by TimeSeriesProcessor
+    { name: timestamp, type: DateTime }, # virtual column, mapped to _sort_timestamp
     { name: start_timestamp, type: DateTime64, args: { precision: 6 } },
     { name: end_timestamp, type: DateTime64, args: { precision: 6 } },
     { name: duration_ms, type: UInt, args: { size: 32 } },
@@ -34,7 +36,7 @@ storages:
         - mapper: ColumnToColumn
           args:
             from_table_name: null
-            from_col_name: start_timestamp
+            from_col_name: timestamp
             to_table_name: null
             to_col_name: _sort_timestamp
       subscriptables:
@@ -58,7 +60,7 @@ query_processors:
   - processor: TimeSeriesProcessor
     args:
       time_group_columns:
-        time: _sort_timestamp
+        time: timestamp
       time_parse_columns:
         - start_timestamp
         - end_timestamp
@@ -69,4 +71,4 @@ validators:
     args:
       required_filter_columns: [organization_id]
 
-required_time_column: start_timestamp
+required_time_column: timestamp


### PR DESCRIPTION
@wmak can you check this works in dev? There are no tests for EAP spans yet until your sentry acceptance tests are done, so this is completely blind for now