### PR TITLE
fix: deletes api, change success response format, fix admin bug

### DIFF
--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -482,8 +482,8 @@ function Client() {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          storage: storage_name,
-          columns: column_conditions
+          "storage": storage_name,
+          "query": {"columns": column_conditions}
         })
       })
     },

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1101,7 +1101,9 @@ def delete() -> Response:
     try:
         schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
         request_parts = schema.validate(body)
-        delete_results = delete_from_storage(storage, request_parts.query["columns"])
+        delete_results = delete_from_storage(
+            storage, request_parts.query["query"]["columns"]
+        )
     except (InvalidJsonRequestException, DeletesNotEnabledError) as schema_error:
         return make_response(
             jsonify({"error": str(schema_error)}),

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -342,8 +342,9 @@ def storage_delete(
             }
             return make_response(jsonify({"error": details}), 500)
 
+        # i put the result inside "data" bc thats how sentry utils/snuba.py expects the result
         return Response(
-            dump_payload(payload), 200, {"Content-Type": "application/json"}
+            dump_payload({"data": payload}), 200, {"Content-Type": "application/json"}
         )
 
     else:


### PR DESCRIPTION
these are small changes that needed to be made that came up while connecting the deletes endpoint to sentry codebase.
## major changes
1. Made the api response results to be inside "data". This is bc the sentry codebase relies on api responses to be in this format.
2. make snuba admin requests nest `columns` inside `query`. this is bc we previously changed the schema definition to be this, so snuba admin wasnt working ever since. now it works