### PR TITLE
ref(snuba-deletes): add ColumnValidator

### DIFF
--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -718,7 +718,7 @@ class ColumnValidator:
 
     def validate(self, column_name: str, values: Sequence[AnyType]) -> None:
         expected_type = self._column_set[column_name].type
-        is_valid_func: Optional[Callable[[AnyType], None]]
+        is_valid_func: Optional[Callable[[AnyType], bool]]
         match expected_type:
             case UUID():
                 is_valid_func = self._valid_uuid

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -725,7 +725,7 @@ class ColumnValidator:
             case Int():
                 is_valid_func = self._valid_int
             case UInt():
-                is_valid_func = self._valid_int
+                is_valid_func = self._valid_uint
             case Float():
                 is_valid_func = self._valid_float
             case String():
@@ -748,6 +748,9 @@ class ColumnValidator:
 
     def _valid_int(self, value: int) -> bool:
         return isinstance(value, int)
+
+    def _valid_uint(self, value: int) -> bool:
+        return isinstance(value, int) and value > 0
 
     def _valid_float(self, value: float) -> bool:
         return isinstance(value, float)

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -4,7 +4,9 @@ import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from itertools import chain
+from typing import Any as AnyType
 from typing import (
+    Callable,
     Generic,
     Iterator,
     List,
@@ -709,9 +711,9 @@ class ColumnValidator:
     def __init__(self, column_set: ColumnSet):
         self._column_set = column_set
 
-    def validate(self, column, values) -> None:
-        expected_type = self._column_set[column].type
-        val_func = None
+    def validate(self, column_name: str, values: Sequence[AnyType]) -> None:
+        expected_type = self._column_set[column_name].type
+        val_func: Optional[Callable[[AnyType], None]]
         match expected_type:
             case UUID():
                 val_func = self._validate_uuid
@@ -724,18 +726,20 @@ class ColumnValidator:
             case String():
                 val_func = self._validate_string
             case _:
-                raise Exception("no type found")
+                raise NotImplementedError(
+                    f"ColumnValidator not implement for: {expected_type}"
+                )
         for val in values:
             val_func(val)
 
-    def _validate_uuid(self, value) -> None:
+    def _validate_uuid(self, value: str) -> None:
         assert uuid.UUID(str(value))
 
-    def _validate_int(self, value) -> None:
+    def _validate_int(self, value: int) -> None:
         assert isinstance(value, int)
 
-    def _validate_float(self, value) -> None:
+    def _validate_float(self, value: float) -> None:
         assert isinstance(value, float)
 
-    def _validate_string(self, value) -> None:
+    def _validate_string(self, value: str) -> None:
         assert isinstance(value, str)

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from itertools import chain
@@ -702,3 +703,39 @@ class Enum(ColumnType[TModifiers]):
 
     def get_raw(self) -> Enum[TModifiers]:
         return Enum(self.values)
+
+
+class ColumnValidator:
+    def __init__(self, column_set: ColumnSet):
+        self._column_set = column_set
+
+    def validate(self, column, values) -> None:
+        expected_type = self._column_set[column].type
+        val_func = None
+        match expected_type:
+            case UUID():
+                val_func = self._validate_uuid
+            case Int():
+                val_func = self._validate_int
+            case UInt():
+                val_func = self._validate_int
+            case Float():
+                val_func = self._validate_float
+            case String():
+                val_func = self._validate_string
+            case _:
+                raise Exception("no type found")
+        for val in values:
+            val_func(val)
+
+    def _validate_uuid(self, value) -> None:
+        assert uuid.UUID(str(value))
+
+    def _validate_int(self, value) -> None:
+        assert isinstance(value, int)
+
+    def _validate_float(self, value) -> None:
+        assert isinstance(value, float)
+
+    def _validate_string(self, value) -> None:
+        assert isinstance(value, str)

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -131,6 +131,9 @@ def _enforce_max_rows(delete_query: Query) -> None:
         )
 
 
+from snuba.utils.schemas import ColumnValidator
+
+
 def _delete_from_table(
     storage: WritableTableStorage,
     table: str,
@@ -149,6 +152,12 @@ def _delete_from_table(
         on_cluster=on_cluster,
         is_delete=True,
     )
+
+    columns = storage.get_schema().get_columns()
+    column_validator = ColumnValidator(columns)
+    for col, values in conditions.items():
+        column_validator.validate(col, values)
+
     try:
         _enforce_max_rows(query)
     except NoRowsToDeleteException:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -337,7 +337,11 @@ def storage_delete(
             payload = delete_from_storage(
                 storage, request_parts.query["query"]["columns"]
             )
-        except (InvalidJsonRequestException, DeletesNotEnabledError) as error:
+        except (
+            InvalidJsonRequestException,
+            DeletesNotEnabledError,
+            InvalidQueryException,
+        ) as error:
             details = {
                 "type": "invalid_query",
                 "message": str(error),

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -197,6 +197,29 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         assert int(res.status_code / 100) == 4  # 400 status code
         assert "'query' is a required property" in res.get_json()["error"]["message"]
 
+        # test for invalid column types
+        set_config("storage_deletes_enabled", 1)
+        res = self.app.delete(
+            "/search_issues/",
+            data=json.dumps(
+                {
+                    "columns": {
+                        "occurrence_id": ["invalid_id"],
+                        "project_id": [3],
+                    },
+                    "debug": True,
+                    "tenant_ids": {"referrer": "test", "organization_id": 1},
+                }
+            ),
+            headers={"referer": "test"},
+        )
+        assert res.status_code == 400
+        data = json.loads(res.data)
+        assert (
+            data["error"]
+            == "Invalid value invalid_id for column type schemas.UUID(modifiers=None)"
+        )
+
     def test_simple_search_query(self) -> None:
         now = datetime.now().replace(minute=0, second=0, microsecond=0)
 

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -203,9 +203,11 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
             "/search_issues/",
             data=json.dumps(
                 {
-                    "columns": {
-                        "occurrence_id": ["invalid_id"],
-                        "project_id": [3],
+                    "query": {
+                        "columns": {
+                            "occurrence_id": ["invalid_id"],
+                            "project_id": [3],
+                        },
                     },
                     "debug": True,
                     "tenant_ids": {"referrer": "test", "organization_id": 1},
@@ -216,7 +218,7 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         assert res.status_code == 400
         data = json.loads(res.data)
         assert (
-            data["error"]
+            data["error"]["message"]
             == "Invalid value invalid_id for column type schemas.UUID(modifiers=None)"
         )
 

--- a/tests/utils/test_columns_validator.py
+++ b/tests/utils/test_columns_validator.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any, Sequence
 
 import pytest
 
@@ -45,7 +46,7 @@ COLUMNS = ColumnSet(
         pytest.param("date_param", [datetime.now()], False),
     ],
 )
-def test_validator(column_name, values, is_valid) -> None:
+def test_validator(column_name: str, values: Sequence[Any], is_valid: bool) -> None:
     col_validator = ColumnValidator(COLUMNS)
 
     if is_valid == True:

--- a/tests/utils/test_columns_validator.py
+++ b/tests/utils/test_columns_validator.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+
+import pytest
+
+from snuba.utils.schemas import (
+    UUID,
+    Column,
+    ColumnSet,
+    ColumnValidator,
+    Date,
+    Float,
+    Int,
+    String,
+    UInt,
+)
+
+COLUMNS = ColumnSet(
+    [
+        Column("str_param", String()),
+        Column("uint_param", UInt(32)),
+        Column("int_param", Int(32)),
+        Column("float_param", Float(64)),
+        Column("uuid_param", UUID()),
+        Column("date_param", Date()),
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    "column_name, values, is_valid",
+    [
+        # valid column types
+        pytest.param("uint_param", [1, 2, 3, 4], True),
+        pytest.param("str_param", ["hi", "hello"], True),
+        pytest.param("int_param", [1, 2, 3, 4], True),
+        pytest.param("float_param", [1.20, 2.0], True),
+        pytest.param("uuid_param", ["06a910bc-7682-4c76-b818-666124cc8898"], True),
+        # invalid column types
+        pytest.param("uint_param", ["hillo"], False),
+        pytest.param("str_param", ["hi", 3], False),
+        pytest.param("int_param", [1, 2, 3, 4.0], False),
+        pytest.param("float_param", [1.20, 2], False),
+        pytest.param("uuid_param", ["123456"], False),
+        # unsupported column types
+        pytest.param("date_param", [datetime.now()], False),
+    ],
+)
+def test_validator(column_name, values, is_valid) -> None:
+    col_validator = ColumnValidator(COLUMNS)
+
+    if is_valid == True:
+        col_validator.validate(column_name, values)
+    else:
+        with pytest.raises(Exception):
+            col_validator.validate(column_name, values)

--- a/tests/utils/test_columns_validator.py
+++ b/tests/utils/test_columns_validator.py
@@ -37,7 +37,7 @@ COLUMNS = ColumnSet(
         pytest.param("float_param", [1.20, 2.0], True),
         pytest.param("uuid_param", ["06a910bc-7682-4c76-b818-666124cc8898"], True),
         # invalid column types
-        pytest.param("uint_param", ["hillo"], False),
+        pytest.param("uint_param", [-17], False),
         pytest.param("str_param", ["hi", 3], False),
         pytest.param("int_param", [1, 2, 3, 4.0], False),
         pytest.param("float_param", [1.20, 2], False),


### PR DESCRIPTION
We have some [schema validation](https://github.com/getsentry/snuba/blob/d4b164c06710e15bed33d868102305adf8fe495c/snuba/query/schema.py#L38) on delete api, but because the columns depend on the storage, we can't do that level of type validation when parsing the payload. The only required column we have is the `project_id` (which is debatable on whether we should have that there but anyway)

If the column `occurrence_id` is an uuid and someone sends:

```json
{ "columns": {"occurrence_id": ["hello"]}
```
we'll get a clickhouse error when trying to run the delete.

**ColumnValidator**
This validator will check to make sure that the type defined in the schema matches the values passed through in the api. I've only implemented a handful of types and I don't expect that we will need many more, at least for now. 