### PR TITLE
ref(snuba-deletes) don't run delete queries when 0 rows need to be deleted

### DIFF
--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -55,3 +55,7 @@ class QueryPlanException(SerializableException):
 class TooManyDeleteRowsException(SerializableException):
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class NoRowsToDeleteException(SerializableException):
+    pass

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -11,7 +11,7 @@ from snuba.query import SelectedExpression
 from snuba.query.conditions import combine_and_conditions
 from snuba.query.data_source.simple import Table
 from snuba.query.dsl import column, equals, in_cond, literal, literals_tuple
-from snuba.query.exceptions import TooManyDeleteRowsException
+from snuba.query.exceptions import NoRowsToDeleteException, TooManyDeleteRowsException
 from snuba.query.expressions import Expression, FunctionCall
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.reader import Result
@@ -120,6 +120,8 @@ def _enforce_max_rows(delete_query: Query) -> None:
     rows_to_delete = _get_rows_to_delete(
         storage_key=storage_key, select_query_to_count_rows=select_query_to_count_rows
     )
+    if rows_to_delete == 0:
+        raise NoRowsToDeleteException
     max_rows_allowed = (
         get_storage(storage_key).get_deletion_settings().max_rows_to_delete
     )
@@ -147,7 +149,11 @@ def _delete_from_table(
         on_cluster=on_cluster,
         is_delete=True,
     )
-    _enforce_max_rows(query)
+    try:
+        _enforce_max_rows(query)
+    except NoRowsToDeleteException:
+        result: Result = {}
+        return result
 
     deletion_processors = storage.get_deletion_processors()
     # These settings aren't needed at the moment


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2842

Currently, if there are no rows that match the criteria specified by the delete query, the code will still go through the deletion pipeline (and any post-processing). This is unnecessary. Instead, let’s short-circuit and throw an error if there are no rows to delete.