### PR TITLE
feat(eap): Add a proto definition for the aggregate bucket endpoint

### DIFF
--- a/snuba/protobufs/AggregateBucket.proto
+++ b/snuba/protobufs/AggregateBucket.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+import "snuba/protobufs/Filters.proto";
+import "google/protobuf/timestamp.proto";
+
+message AggregateBucketRequest {
+  enum Function {
+    SUM = 0;
+    AVERAGE = 1;
+    COUNT = 2;
+    P50 = 3;
+    P95 = 4;
+    P99 = 5;
+  }
+
+  google.protobuf.Timestamp start_timestamp = 1;
+  google.protobuf.Timestamp end_timestamp = 2;
+  Function aggregate = 3;
+  TraceItemFilter filter = 4;
+  //TODO: group by, topn, etc, not necessary for MVP
+}
+
+message AggregateBucketResponse {
+  float result = 1;
+}

--- a/snuba/protobufs/AggregateBucket.proto
+++ b/snuba/protobufs/AggregateBucket.proto
@@ -17,9 +17,15 @@ message AggregateBucketRequest {
   google.protobuf.Timestamp end_timestamp = 2;
   Function aggregate = 3;
   TraceItemFilter filter = 4;
+  uint64 organization_id = 5;
+  string cogs_category = 6;
+  string referrer = 7;
+  repeated uint64 project_ids = 8;
+  uint64 num_buckets = 9;
+
   //TODO: group by, topn, etc, not necessary for MVP
 }
 
 message AggregateBucketResponse {
-  float result = 1;
+  repeated float result = 1;
 }


### PR DESCRIPTION
Instead of a big complicated endpoint that returns multiple buckets, just let people query a single bucket at a time for now.