### PR TITLE
switch readiness state to limited to skip migrations and unblock CI

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
@@ -6,7 +6,7 @@ storage:
   key: eap_spans
   set_key: events_analytics_platform
 
-readiness_state: partial
+readiness_state: limited
 
 schema:
   columns:

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -169,7 +169,7 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.EVENTS_ANALYTICS_PLATFORM: _MigrationGroup(
         loader=EventsAnalyticsPlatformLoader(),
         storage_sets_keys={StorageSetKey.EVENTS_ANALYTICS_PLATFORM},
-        readiness_state=ReadinessState.PARTIAL,
+        readiness_state=ReadinessState.LIMITED,
     ),
     MigrationGroup.GROUP_ATTRIBUTES: _MigrationGroup(
         loader=GroupAttributesLoader(),


### PR DESCRIPTION
eap_spans has a broken migration likely due to indexes dropping. Put this in so those migrations don't run and block deploys