### PR TITLE
fix(eap-spans): Make project_id index removal migration a no-op

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0007_drop_project_id_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0007_drop_project_id_index.py
@@ -1,25 +1,14 @@
 from typing import Sequence
 
-from snuba.clusters.storage_sets import StorageSetKey
-from snuba.migrations import migration, operations
+from snuba.migrations import migration
 from snuba.migrations.operations import SqlOperation
-
-storage_set_name = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
-local_table_name = "eap_spans_local"
 
 
 class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
     def forwards_ops(self) -> Sequence[SqlOperation]:
-        return [
-            operations.DropIndex(
-                storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
-                table_name="eap_spans_local",
-                index_name="bf_project_id",
-                target=operations.OperationTarget.LOCAL,
-            ),
-        ]
+        return []
 
     def backwards_ops(self) -> Sequence[SqlOperation]:
         return []


### PR DESCRIPTION
This migration will take a really long time in US and it already ran in S4S and DE, so, to prevent it from running in US while unblocking the pipeline, we're making it a no-op.