### PR TITLE
bug(mql): Fix WITH TOTALS for MQL queries

### DIFF
--- a/snuba/query/mql/context_population.py
+++ b/snuba/query/mql/context_population.py
@@ -114,12 +114,6 @@ def rollup_expressions(
         Literal(None, rollup.granularity),
     )
 
-    # Validate totals/interval
-    if rollup.interval is None and rollup.with_totals in (None, "False"):
-        raise ParsingException(
-            "either interval or with_totals must be specified in rollup"
-        )
-
     # Validate totals/orderby
     if rollup.with_totals is not None and rollup.with_totals not in ("True", "False"):
         raise ParsingException("with_totals must be a string, either 'True' or 'False'")

--- a/snuba/query/mql/parser_supported_join.py
+++ b/snuba/query/mql/parser_supported_join.py
@@ -1301,7 +1301,6 @@ def populate_query_from_mql_context(
         )
         query.add_condition_to_ast(context_condition)
 
-        query.set_totals(with_totals)
         if orderby:
             query.set_ast_orderby([orderby])
 
@@ -1314,6 +1313,10 @@ def populate_query_from_mql_context(
                 query.set_ast_groupby(list(groupby) + [selected_time.expression])
             else:
                 query.set_ast_groupby([selected_time.expression])
+
+        if query.get_groupby():
+            # Only set WITH TOTALS if there is a group by.
+            query.set_totals(with_totals)
 
     if isinstance(query, CompositeQuery):
 

--- a/snuba/query/mql/parser_supported_join.py
+++ b/snuba/query/mql/parser_supported_join.py
@@ -1389,7 +1389,7 @@ def populate_query_from_mql_context(
             # ensure we correctly join the subqueries. The column names will be the same for all the
             # subqueries, so we just need to map all the table aliases.
             add_time_join_keys(join_clause)
-        elif query.has_totals() and no_groupby_or_one_sided_groupby:
+        elif with_totals and no_groupby_or_one_sided_groupby:
             # If formula query has no interval and no group by or a onesided groupby, but has totals, we need to convert
             # join type to a CROSS join. This is because without a group by, each sub-query will return
             # a single row with single value column. In order to combine the results in the outer query,

--- a/tests/query/parser/test_formula_mql_query.py
+++ b/tests/query/parser/test_formula_mql_query.py
@@ -1311,7 +1311,7 @@ def test_formula_no_groupby_no_interval_with_totals() -> None:
         order_by=[],
         limit=1000,
         offset=0,
-        totals=True,
+        totals=False,
     )
 
     generic_metrics = get_dataset(

--- a/tests/query/parser/test_formula_mql_query.py
+++ b/tests/query/parser/test_formula_mql_query.py
@@ -877,6 +877,94 @@ def test_groupby() -> None:
     assert eq, reason
 
 
+def test_groupby_with_totals() -> None:
+    mql_context_new = deepcopy(mql_context)
+    mql_context_new["rollup"]["with_totals"] = "True"
+    mql_context_new["rollup"]["interval"] = None
+    query_body = "sum(`d:transactions/duration@millisecond`){status_code:200} by transaction / sum(`d:transactions/duration@millisecond`) by transaction"
+
+    expected_selected = SelectedExpression(
+        "aggregate_value",
+        divide(
+            FunctionCall(
+                None,
+                "sum",
+                (Column("_snuba_value", "d0", "value"),),
+            ),
+            FunctionCall(
+                None,
+                "sum",
+                (Column("_snuba_value", "d1", "value"),),
+            ),
+            "_snuba_aggregate_value",
+        ),
+    )
+
+    join_clause = JoinClause(
+        left_node=IndividualNode(
+            alias="d1",
+            data_source=from_distributions,
+        ),
+        right_node=IndividualNode(
+            alias="d0",
+            data_source=from_distributions,
+        ),
+        keys=[
+            JoinCondition(
+                left=JoinConditionExpression(
+                    table_alias="d1", column="tags_raw[333333]"
+                ),
+                right=JoinConditionExpression(
+                    table_alias="d0", column="tags_raw[333333]"
+                ),
+            )
+        ],
+        join_type=JoinType.INNER,
+        join_modifier=None,
+    )
+
+    tag_condition = binary_condition(
+        "equals", tag_column("status_code", "d0"), Literal(None, "200")
+    )
+    metric_condition1 = metric_id_condition(123456, "d0")
+    metric_condition2 = metric_id_condition(123456, "d1")
+    formula_condition = combine_and_conditions(
+        condition("d0")
+        + condition("d1")
+        + [tag_condition, metric_condition1, metric_condition2]
+    )
+
+    expected = CompositeQuery(
+        from_clause=join_clause,
+        selected_columns=[
+            expected_selected,
+            SelectedExpression(
+                "transaction",
+                subscriptable_expression("333333", "d0"),
+            ),
+            SelectedExpression(
+                "transaction",
+                subscriptable_expression("333333", "d1"),
+            ),
+        ],
+        groupby=[
+            subscriptable_expression("333333", "d0"),
+            subscriptable_expression("333333", "d1"),
+        ],
+        condition=formula_condition,
+        limit=1000,
+        offset=0,
+        totals=True,
+    )
+
+    generic_metrics = get_dataset(
+        "generic_metrics",
+    )
+    query = parse_mql_query_new(str(query_body), mql_context_new, generic_metrics)
+    eq, reason = query.equals(expected)
+    assert eq, reason
+
+
 def test_mismatch_groupby() -> None:
     query_body = "sum(`d:transactions/duration@millisecond`){status_code:200} by transaction / sum(`d:transactions/duration@millisecond`) by status_code"
     generic_metrics = get_dataset(

--- a/tests/query/parser/test_parser.py
+++ b/tests/query/parser/test_parser.py
@@ -40,7 +40,7 @@ def test_mql() -> None:
             "orderby": "ASC",
             "granularity": 60,
             "interval": None,
-            "with_totals": "True",
+            "with_totals": "False",
         },
         "scope": {
             "org_ids": [1],
@@ -130,7 +130,7 @@ def test_mql() -> None:
                 ),
             ),
         ],
-        totals=True,
+        totals=False,
         limit=1000,
     )
     actual = parse_mql_query_new(mql, context, get_dataset("generic_metrics"))
@@ -147,7 +147,7 @@ def test_mql_wildcards() -> None:
             "orderby": "ASC",
             "granularity": 60,
             "interval": None,
-            "with_totals": "True",
+            "with_totals": "False",
         },
         "scope": {
             "org_ids": [1],
@@ -236,7 +236,7 @@ def test_mql_wildcards() -> None:
             ),
         ],
         limit=1000,
-        totals=True,
+        totals=False,
     )
     actual = parse_mql_query_new(mql, context, get_dataset("generic_metrics"))
     eq, reason = actual.equals(expected)
@@ -252,7 +252,7 @@ def test_mql_negated_wildcards() -> None:
             "orderby": "ASC",
             "granularity": 60,
             "interval": None,
-            "with_totals": "True",
+            "with_totals": "False",
         },
         "scope": {
             "org_ids": [1],
@@ -341,7 +341,7 @@ def test_mql_negated_wildcards() -> None:
             ),
         ],
         limit=1000,
-        totals=True,
+        totals=False,
     )
     actual = parse_mql_query_new(mql, context, get_dataset("generic_metrics"))
     eq, reason = actual.equals(expected)

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -742,7 +742,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
 
         assert response.status_code == 200, response.data
         data = json.loads(response.data)
-        assert data["totals"]["aggregate_value"] == 4.0
+        assert len(data["data"]) == 1, data
 
     def test_formula_no_groupby_with_interval_no_totals(self) -> None:
         query = MetricsQuery(

--- a/tests/test_metrics_mql_api.py
+++ b/tests/test_metrics_mql_api.py
@@ -1560,9 +1560,7 @@ class TestGenericMetricsMQLApi(BaseApiTest):
             ).serialize_mql(),
         )
         data = json.loads(response.data)
-        assert (
-            data["totals"]["aggregate_value"] > 180
-        )  # Should be more than the number of data points
+        assert len(data["data"]) == 1, data
         assert response.status_code == 200
 
     def test_simple_formula_filters_with_scalar(self) -> None:


### PR DESCRIPTION
### Overview
This PR is responsible for fixing a bug with the `totals` flag in MQL. When the `totals` flag is set to true, snuba will insert a `WITH TOTALS` modifier next to the `GROUP BY` in the query. Read more about WITH TOTALS [here](https://clickhouse.com/docs/en/sql-reference/statements/select/group-by#with-totals-modifier). However, if the query does not contain a `GROUP BY` then the modifier will not be added to the query. As a result, the flag is ignored and CH does not return a totals row. When this happens, the query AST still has `totals` set to true, and during [result transformation](https://github.com/getsentry/snuba/blob/fc11af17f7558e56a4139d061f47bef0369de0b7/snuba/clickhouse/native.py#L472), snuba pops the last element of the data array and assumes it is the totals row (even though it isn't).

To fix this, in MQL parsing, we should only set and respect the totals flag only if there exists a group by. If not `WITH TOTALS` cannot be applied anyways, and therefore we should not set the flag.