### PR TITLE
fix(snuba-admin): Updating snuba admin link to open a new tab

### DIFF
--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -92,7 +92,10 @@ function QueryDisplay(props: {
   return (
     <div>
       <h2>Construct a ClickHouse Query</h2>
-      <a href="https://getsentry.github.io/snuba/clickhouse/death_queries.html">
+      <a
+        href="https://getsentry.github.io/snuba/clickhouse/death_queries.html"
+        target="_blank"
+      >
         🛑 WARNING! BEFORE RUNNING QUERIES, READ THIS 🛑
       </a>
       <QueryEditor


### PR DESCRIPTION
This change updates the warning link on the "ClickHouse Tracing" page to open a new tab when clicked. This makes it easier to navigate back once the linked is clicked and the information is read.