### PR TITLE
Added a few missing details on Snuba development environment README page

### DIFF
--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -9,8 +9,20 @@ In order to set up Clickhouse, Redis, and Kafka, please refer to :doc:`/getstart
 
 Prerequisites
 -------------
-`pyenv <https://github.com/pyenv/pyenv#installation>`_ must be installed on your system.
-It is also assumed that you have completed the steps to set up the `sentry dev environment <https://develop.sentry.dev/environment/>`_.
+It is assumed that you have completed the steps to set up the `sentry dev environment <https://develop.sentry.dev/environment/>`_.
+Install `pyenv <https://github.com/pyenv/pyenv#installation>`_ on your system using Homebrew::
+
+    brew install pyenv
+
+You may have other than Python 3.11.8 installed on your machine, but Snuba needs Python 3.11.8::
+
+    pyenv install 3.11.8
+
+You will need an installation of Rust to develop Snuba. Go `here <https://rustup.rs>`_ to get one::
+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+Make sure to follow installation steps and configure your shell for cargo (Rust's build sytem and package manager).
 
 If you are using Homebrew and a M1 Mac, ensure the development packages you've installed with Homebrew are available
 by setting these environment variables::
@@ -21,9 +33,9 @@ by setting these environment variables::
 Install / Run
 -------------
 
-clone this repo into your workspace::
+Clone this repo into your workspace::
 
-    git@github.com:getsentry/snuba.git
+    git clone git@github.com:getsentry/snuba.git
 
 These commands set up the Python virtual environment::
 
@@ -33,11 +45,11 @@ These commands set up the Python virtual environment::
     pip install --upgrade pip==22.2.2
     make develop
 
-These commands start the Snuba api, which is capable of processing queries::
+This command starts the Snuba api, which is capable of processing queries::
 
     snuba api
 
-This command instead will start the api and all the Snuba consumers to ingest
+This command starts the api and Snuba consumers to ingest
 data from Kafka::
 
     snuba devserver


### PR DESCRIPTION


<!-- Describe your PR here. -->
I ran into issues regarding python 3.8.11 version and rust while setting up the local development environment using https://getsentry.github.io/snuba/contributing/environment.html. This PR fixes the documentation and makes it more consistent with what is being used in the team today.