### PR TITLE
ref(admin): Show raw trace output in the Admin tool

### DIFF
--- a/snuba/admin/static/tracing/index.tsx
+++ b/snuba/admin/static/tracing/index.tsx
@@ -198,7 +198,7 @@ function TracingQueries(props: { api: Client }) {
               </div>
             );
           } else if (title === "Trace") {
-            if (!showFormatted) {
+            if (showFormatted) {
               return (
                 <div>
                   <br />
@@ -213,13 +213,29 @@ function TracingQueries(props: { api: Client }) {
                   <br />
                   <b>Number of rows in result set:</b> {value.num_rows_result}
                   <br />
-                  {formattedTraceDisplay(title, value.formatted_trace_output)}
+                  {rawTraceDisplay(title, value.trace_output)}
                 </div>
               );
             }
           }
         })}
       </>
+    );
+  }
+
+  function rawTraceDisplay(title: string, value: any): JSX.Element | undefined {
+    const parsedLines: Array<string> = value.split(/\n/);
+
+    return (
+      <ol style={collapsibleStyle} key={title + "-root"}>
+        {parsedLines.map((line, index) => {
+          return (
+            <li key={title + index}>
+              <span>{line}</span>
+            </li>
+          );
+        })}
+      </ol>
     );
   }
 

--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -27,7 +27,7 @@ function QueryDisplay(props: {
     []
   );
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
-  const [showFormatted, setShowFormatted] = useState<boolean>(false);
+  const [showFormatted, setShowFormatted] = useState<boolean>(true);
 
   useEffect(() => {
     props.api.getClickhouseNodes().then((res) => {
@@ -150,9 +150,15 @@ function QueryDisplay(props: {
             <div>
               <button
                 style={executeButtonStyle}
+                onClick={() => copyText(queryResult.trace_output || "")}
+              >
+                Copy to clipboard (Raw)
+              </button>
+              <button
+                style={executeButtonStyle}
                 onClick={() => copyText(JSON.stringify(queryResult))}
               >
-                Copy to clipboard
+                Copy to clipboard (JSON)
               </button>
               {props.resultDataPopulator(queryResult, showFormatted)}
             </div>,


### PR DESCRIPTION
Have an option to show the raw trace output in the Tracing tool, as well as the ability to copy just
the raw tracing output instead of the full JSON response.

![raw-output](https://github.com/user-attachments/assets/276a6700-a376-492d-9d19-88eee3c48955)