### PR TITLE
ref(admin): Standardize Execute Query buttons

### DIFF
--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -3,8 +3,13 @@ import Client from "SnubaAdmin/api_client";
 import { Collapse } from "SnubaAdmin/collapse";
 import { CSV } from "SnubaAdmin/cardinality_analyzer/CSV";
 import QueryEditor from "SnubaAdmin/query_editor";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
 
-import { CardinalityQueryRequest, CardinalityQueryResult, PredefinedQuery } from "./types";
+import {
+  CardinalityQueryRequest,
+  CardinalityQueryResult,
+  PredefinedQuery,
+} from "./types";
 
 enum ClipboardFormats {
   CSV = "csv",
@@ -18,7 +23,9 @@ function QueryDisplay(props: {
   predefinedQueryOptions: Array<PredefinedQuery>;
 }) {
   const [query, setQuery] = useState<QueryState>({});
-  const [queryResultHistory, setCardinalityQueryResultHistory] = useState<CardinalityQueryResult[]>([]);
+  const [queryResultHistory, setCardinalityQueryResultHistory] = useState<
+    CardinalityQueryResult[]
+  >([]);
 
   function updateQuerySql(sql: string) {
     setQuery((prevQuery) => {
@@ -29,25 +36,16 @@ function QueryDisplay(props: {
     });
   }
 
-  function executeQuery() {
-    props.api
-      .executeCardinalityQuery(query as CardinalityQueryRequest)
-      .then((result) => {
-        result.input_query = query.sql || "<Input Query>";
-        setCardinalityQueryResultHistory((prevHistory) => [result, ...prevHistory]);
-      })
-      .catch((err) => {
-        console.log("ERROR", err);
-        window.alert("An error occurred: " + err.error.message);
-      });
-  }
-
   function convertResultsToCSV(queryResult: CardinalityQueryResult) {
     return CSV.sheet([queryResult.column_names, ...queryResult.rows]);
   }
 
-  function copyText(queryResult: CardinalityQueryResult, format: ClipboardFormats) {
-    let formatter: (input: CardinalityQueryResult) => string = (s) => s.toString();
+  function copyText(
+    queryResult: CardinalityQueryResult,
+    format: ClipboardFormats
+  ) {
+    let formatter: (input: CardinalityQueryResult) => string = (s) =>
+      s.toString();
 
     if (format === ClipboardFormats.JSON) {
       formatter = JSON.stringify;
@@ -60,6 +58,18 @@ function QueryDisplay(props: {
     window.navigator.clipboard.writeText(formatter(queryResult));
   }
 
+  function executeQuery() {
+    return props.api
+      .executeCardinalityQuery(query as CardinalityQueryRequest)
+      .then((result) => {
+        result.input_query = query.sql || "<Input Query>";
+        setCardinalityQueryResultHistory((prevHistory) => [
+          result,
+          ...prevHistory,
+        ]);
+      });
+  }
+
   return (
     <div>
       <h2>Construct a Metrics Query</h2>
@@ -70,18 +80,7 @@ function QueryDisplay(props: {
         predefinedQueryOptions={props.predefinedQueryOptions}
       />
       <div style={executeActionsStyle}>
-        <div>
-          <button
-            onClick={(evt) => {
-              evt.preventDefault();
-              executeQuery();
-            }}
-            style={executeButtonStyle}
-            disabled={!query.sql}
-          >
-            Execute Query
-          </button>
-        </div>
+        <ExecuteButton onClick={executeQuery} disabled={!query.sql} />
       </div>
       <div>
         <h2>Query results</h2>
@@ -91,12 +90,18 @@ function QueryDisplay(props: {
               <div key={idx}>
                 <p>{queryResult.input_query}</p>
                 <p>
-                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.JSON)}>
+                  <button
+                    style={copyButtonStyle}
+                    onClick={() => copyText(queryResult, ClipboardFormats.JSON)}
+                  >
                     Copy to clipboard (JSON)
                   </button>
                 </p>
                 <p>
-                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.CSV)}>
+                  <button
+                    style={copyButtonStyle}
+                    onClick={() => copyText(queryResult, ClipboardFormats.CSV)}
+                  >
                     Copy to clipboard (CSV)
                   </button>
                 </p>
@@ -107,10 +112,16 @@ function QueryDisplay(props: {
 
           return (
             <Collapse key={idx} text={queryResult.input_query}>
-              <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.JSON)}>
+              <button
+                style={copyButtonStyle}
+                onClick={() => copyText(queryResult, ClipboardFormats.JSON)}
+              >
                 Copy to clipboard (JSON)
               </button>
-              <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.CSV)}>
+              <button
+                style={copyButtonStyle}
+                onClick={() => copyText(queryResult, ClipboardFormats.CSV)}
+              >
                 Copy to clipboard (CSV)
               </button>
               {props.resultDataPopulator(queryResult)}
@@ -128,7 +139,7 @@ const executeActionsStyle = {
   marginTop: 8,
 };
 
-const executeButtonStyle = {
+const copyButtonStyle = {
   height: 30,
   border: 0,
   padding: "4px 20px",

--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -9,7 +9,7 @@ import {
   CardinalityQueryRequest,
   CardinalityQueryResult,
   PredefinedQuery,
-} from "./types";
+} from "SnubaAdmin/cardinality_analyzer/types";
 
 enum ClipboardFormats {
   CSV = "csv",

--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Client from "SnubaAdmin/api_client";
 import { Collapse } from "SnubaAdmin/collapse";
 import QueryEditor from "SnubaAdmin/query_editor";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
 
 import { Prism } from "@mantine/prism";
 import { RichTextEditor } from "@mantine/tiptap";
@@ -71,15 +72,11 @@ function QueryDisplay(props: {
   }
 
   function executeQuery() {
-    props.api
+    return props.api
       .executeSystemQuery(query as QueryRequest)
       .then((result) => {
         result.input_query = `${query.sql} (${query.storage},${query.host}:${query.port})`;
         setQueryResultHistory((prevHistory) => [result, ...prevHistory]);
-      })
-      .catch((err) => {
-        console.log("ERROR", err);
-        window.alert("An error occurred: " + err.error);
       });
   }
 
@@ -167,18 +164,12 @@ function QueryDisplay(props: {
             </select>
           </div>
           <div>
-            <button
-              onClick={(evt) => {
-                evt.preventDefault();
-                executeQuery();
-              }}
-              style={executeButtonStyle}
+            <ExecuteButton
+              onClick={executeQuery}
               disabled={
                 !query.storage || !query.host || !query.port || !query.sql
               }
-            >
-              Execute query
-            </button>
+            />
           </div>
         </div>
       </form>

--- a/snuba/admin/static/production_queries/index.tsx
+++ b/snuba/admin/static/production_queries/index.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from "react";
 import Client from "SnubaAdmin/api_client";
 import { Table } from "SnubaAdmin/table";
-import { QueryResult, QueryResultColumnMeta, SnQLRequest } from "SnubaAdmin/production_queries/types";
+import {
+  QueryResult,
+  QueryResultColumnMeta,
+  SnQLRequest,
+} from "SnubaAdmin/production_queries/types";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
 import { executeActionsStyle } from "SnubaAdmin/production_queries/styles";
 import {
   Accordion,
@@ -58,11 +63,7 @@ function ProductionQueries(props: { api: Client }) {
   }
 
   function executeQuery() {
-    if (isExecuting) {
-      window.alert("A query is already running");
-    }
-    setIsExecuting(true);
-    props.api
+    return props.api
       .executeSnQLQuery(snql_query as SnQLRequest)
       .then((result) => {
         const result_columns = result.meta.map(
@@ -80,13 +81,6 @@ function ProductionQueries(props: { api: Client }) {
           quota_allowance: result.quota_allowance,
         };
         setQueryResultHistory((prevHistory) => [query_result, ...prevHistory]);
-      })
-      .catch((err) => {
-        console.log("ERROR", err);
-        window.alert("An error occurred: " + err.message);
-      })
-      .finally(() => {
-        setIsExecuting(false);
       });
   }
 
@@ -116,15 +110,12 @@ function ProductionQueries(props: { api: Client }) {
             />
           </div>
           <div>
-            <Button
+            <ExecuteButton
               onClick={executeQuery}
-              loading={isExecuting}
               disabled={
                 snql_query.dataset == undefined || snql_query.query == undefined
               }
-            >
-              Execute Query
-            </Button>
+            />
           </div>
         </div>
       </form>
@@ -225,9 +216,9 @@ function renderThrottleStatus(isThrottled: boolean, reasonHeader: string[]) {
     >
       Quota Allowance - Throttled <br />
       <ol>
-      {reasonHeader.map((line, index) => (
+        {reasonHeader.map((line, index) => (
           <li key={index}>{line}</li>
-      ))}
+        ))}
       </ol>
     </Text>
   ) : (
@@ -261,8 +252,9 @@ function QueryResultQuotaAllowance(props: { queryResult: QueryResult }) {
   const isThrottled: boolean =
     (props.queryResult.quota_allowance &&
       Object.values(props.queryResult.quota_allowance).some(
-        (policy) => policy.max_threads < 10,
-      )) || false;
+        (policy) => policy.max_threads < 10
+      )) ||
+    false;
   let reasonHeader: string[] = [];
   if (isThrottled) {
     props.queryResult.quota_allowance &&
@@ -270,8 +262,12 @@ function QueryResultQuotaAllowance(props: { queryResult: QueryResult }) {
         const policy = props.queryResult.quota_allowance![policyName];
         if (policy.max_threads < 10 && policy.explanation.reason != null) {
           reasonHeader.push(
-            policyName + ": " + policy.explanation.reason +
-            ". SnQL Query executed with " + policy.max_threads + " threads.",
+            policyName +
+              ": " +
+              policy.explanation.reason +
+              ". SnQL Query executed with " +
+              policy.max_threads +
+              " threads."
           );
         }
       });
@@ -282,9 +278,7 @@ function QueryResultQuotaAllowance(props: { queryResult: QueryResult }) {
         <Accordion.Control>
           {renderThrottleStatus(isThrottled, reasonHeader)}
         </Accordion.Control>
-        <Accordion.Panel>
-          {renderPolicyDetails(props)}
-        </Accordion.Panel>
+        <Accordion.Panel>{renderPolicyDetails(props)}</Accordion.Panel>
       </Accordion.Item>
     </Accordion>
   );

--- a/snuba/admin/static/querylog/query_display.tsx
+++ b/snuba/admin/static/querylog/query_display.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
+import { Button } from "@mantine/core";
 import Client from "SnubaAdmin/api_client";
 import { Collapse } from "SnubaAdmin/collapse";
 import QueryEditor from "SnubaAdmin/query_editor";
 
 import { QuerylogRequest, QuerylogResult, PredefinedQuery } from "./types";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
 
 type QueryState = Partial<QuerylogRequest>;
 
@@ -27,15 +29,11 @@ function QueryDisplay(props: {
   }
 
   function executeQuery() {
-    props.api
+    return props.api
       .executeQuerylogQuery(query as QuerylogRequest)
       .then((result) => {
         result.input_query = query.sql || "<Input Query>";
         setQueryResultHistory((prevHistory) => [result, ...prevHistory]);
-      })
-      .catch((err) => {
-        console.log("ERROR", err);
-        window.alert("An error occurred: " + err.error.message);
       });
   }
 
@@ -79,25 +77,15 @@ function QueryDisplay(props: {
       />
       <div style={executeActionsStyle}>
         <div>
-          <button
-            onClick={(evt) => {
-              evt.preventDefault();
-              executeQuery();
-            }}
-            style={executeButtonStyle}
-            disabled={!query.sql}
-          >
-            Execute Query
-          </button>
-          <button
-            onClick={(evt) => {
+          <ExecuteButton onClick={executeQuery} disabled={!query.sql} />
+          <Button
+            onClick={(evt: any) => {
               evt.preventDefault();
               getQuerylogSchema();
             }}
-            style={executeButtonStyle}
           >
             View Querylog Schema
-          </button>
+          </Button>
         </div>
       </div>
       <div>

--- a/snuba/admin/static/tests/tracing/index.spec.tsx
+++ b/snuba/admin/static/tests/tracing/index.spec.tsx
@@ -46,7 +46,7 @@ it("select executor rows should appear", async () => {
     target: { value: "Foo" },
   });
 
-  const submitButton = screen.getByText("Execute query");
+  const submitButton = screen.getByText("Execute Query");
   expect(submitButton.getAttribute("disabled")).toBeFalsy();
 
   fireEvent.click(submitButton);

--- a/snuba/admin/static/tests/utils/execute_button.spec.tsx
+++ b/snuba/admin/static/tests/utils/execute_button.spec.tsx
@@ -1,0 +1,51 @@
+import Nav from "SnubaAdmin/nav";
+import Client from "SnubaAdmin/api_client";
+import React from "react";
+import { it, expect, jest, afterEach } from "@jest/globals";
+import {
+  render,
+  act,
+  waitFor,
+  screen,
+  fireEvent,
+} from "@testing-library/react";
+import { AllowedTools } from "SnubaAdmin/types";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
+
+it("should call onClick", async () => {
+  let mockCall = jest.fn<() => Promise<any>>().mockResolvedValueOnce({});
+
+  render(<ExecuteButton onClick={mockCall} disabled={false} />);
+
+  const button = screen.getByRole("button");
+  fireEvent.click(button);
+
+  await waitFor(() => expect(mockCall).toBeCalledTimes(1));
+});
+
+it("should not call if disabled", async () => {
+  let mockCall = jest.fn(
+    () => new Promise((resolve) => setTimeout(resolve, 1000))
+  );
+
+  render(<ExecuteButton onClick={mockCall} disabled={true} />);
+
+  const button = screen.getByRole("button");
+  fireEvent.click(button);
+
+  await waitFor(() => expect(mockCall).toBeCalledTimes(0));
+});
+
+it("should not call if loading", async () => {
+  let mockCall = jest.fn(
+    () => new Promise((resolve) => setTimeout(resolve, 1000))
+  );
+
+  render(<ExecuteButton onClick={mockCall} disabled={false} />);
+
+  const button = screen.getByRole("button");
+  fireEvent.click(button);
+  fireEvent.click(button);
+
+  await waitFor(() => expect(mockCall).toBeCalledTimes(1));
+});

--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -3,6 +3,7 @@ import { Switch } from "@mantine/core";
 import Client from "SnubaAdmin/api_client";
 import QueryEditor from "SnubaAdmin/query_editor";
 import { Table } from "SnubaAdmin/table";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
 
 import {
   LogLine,
@@ -45,11 +46,7 @@ function QueryDisplay(props: {
   }
 
   function executeQuery() {
-    if (isExecuting) {
-      window.alert("A query is already running");
-    }
-    setIsExecuting(true);
-    props.api
+    return props.api
       .executeTracingQuery(query as TracingRequest)
       .then((result) => {
         const tracing_result = {
@@ -65,13 +62,6 @@ function QueryDisplay(props: {
           tracing_result,
           ...prevHistory,
         ]);
-      })
-      .catch((err) => {
-        console.log("ERROR", err);
-        window.alert("An error occurred: " + err.error.message);
-      })
-      .finally(() => {
-        setIsExecuting(false);
       });
   }
 
@@ -121,15 +111,10 @@ function QueryDisplay(props: {
             ))}
           </select>
         </div>
-        <div>
-          <button
-            onClick={(_) => executeQuery()}
-            style={executeButtonStyle}
-            disabled={isExecuting || !query.storage || !query.sql}
-          >
-            Execute query
-          </button>
-        </div>
+        <ExecuteButton
+          onClick={executeQuery}
+          disabled={!query.storage || !query.sql}
+        />
       </div>
       <div>
         <h2>Query results</h2>

--- a/snuba/admin/static/utils/execute_button.tsx
+++ b/snuba/admin/static/utils/execute_button.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { Button } from "@mantine/core";
+
+function ExecuteButton(props: {
+  disabled: boolean;
+  onClick: () => Promise<any>;
+  onError?: (error: any) => any;
+}) {
+  const [isExecuting, setIsExecuting] = useState<boolean>(false);
+
+  const defaultError = (err: any) => {
+    console.log("ERROR", err);
+    window.alert("An error occurred: " + err.error.message);
+  };
+  let errorCallback = props.onError || defaultError;
+
+  function executeQuery() {
+    if (isExecuting) {
+      window.alert("A query is already running");
+    }
+    setIsExecuting(true);
+    props
+      .onClick()
+      .catch((err: any) => {
+        errorCallback(err);
+      })
+      .finally(() => {
+        setIsExecuting(false);
+      });
+  }
+
+  return (
+    <div>
+      <Button
+        onClick={(evt: any) => {
+          evt.preventDefault();
+          executeQuery();
+        }}
+        loading={isExecuting}
+        disabled={isExecuting || props.disabled}
+      >
+        Execute Query
+      </Button>
+    </div>
+  );
+}
+
+export default ExecuteButton;


### PR DESCRIPTION
This removes a lot of duplicate logic around handling errors and ensures that every page has a
proper loading indicator.

![execute-button](https://github.com/user-attachments/assets/c267bdc0-f15d-498e-98f7-b3656e1fe0f9)