### PR TITLE
Gather ClickHouse's profile event data in Snuba admin tracing tool

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -24,6 +24,10 @@ class InvalidStorageError(SerializableException):
     pass
 
 
+class ClickHouseTimeoutError(SerializableException):
+    pass
+
+
 def is_valid_node(
     host: str, port: int, cluster: ClickhouseCluster, storage_name: str
 ) -> bool:

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -24,7 +24,7 @@ class InvalidStorageError(SerializableException):
     pass
 
 
-class ClickHouseTimeoutError(SerializableException):
+class ClickhouseTimeoutError(SerializableException):
     pass
 
 

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -21,7 +21,7 @@ class TraceOutput:
     summarized_trace_output: TracingSummary
     cols: list[tuple[str, str]]
     num_rows_result: int
-    profile_events_results: dict[dict[str, str]]
+    profile_events_results: dict[dict[str, str], Any]
     profile_events_meta: list[Any]
     profile_events_profile: Dict[str, int]
 

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -15,12 +15,20 @@ from snuba.clusters.cluster import ClickhouseClientSettings
 
 
 @dataclass
+class QueryTraceData:
+    host: str
+    port: int
+    query_id: str
+    node_name: str
+
+
+@dataclass
 class TraceOutput:
     trace_output: str
     summarized_trace_output: TracingSummary
     cols: list[tuple[str, str]]
     num_rows_result: int
-    profile_events_results: dict[dict[str, str], Any]
+    profile_events_results: dict[str, Any]
     profile_events_meta: list[Any]
     profile_events_profile: dict[str, int]
 

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from typing import Any, Dict, List
 
 from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
@@ -19,6 +21,49 @@ class TraceOutput:
     summarized_trace_output: TracingSummary
     cols: list[tuple[str, str]]
     num_rows_result: int
+    profile_events_results: dict[dict[str, str]]
+    profile_events_meta: list[Any]
+    profile_events_profile: Dict[str, int]
+
+
+@dataclass
+class FormattedTrace:
+    query_node: QueryNodeTraceResult
+    storage_nodes: List[StorageNodeTraceResult]
+
+
+class NodeTraceResult:
+    def __init__(self, node_name: str) -> None:
+        self.node_name: str = node_name
+        self.thread_ids: List[str] = []
+        self.threads_used: int = 0
+        self.query_id: str = ""
+
+
+class QueryNodeTraceResult(NodeTraceResult):
+    def __init__(self, node_name: str) -> None:
+        super(QueryNodeTraceResult, self).__init__(node_name)
+        self.node_type = "query"
+        self.number_of_storage_nodes_accessed: int = 0
+        self.storage_nodes_accessed: List[str] = []
+        self.aggregation_performance: List[str] = []
+        self.read_performance: List[str] = []
+        self.memory_performance: List[str] = []
+
+
+@dataclass
+class StorageNodeTraceResult(NodeTraceResult):
+    def __init__(self, node_name: str) -> None:
+        super(StorageNodeTraceResult, self).__init__(node_name)
+        self.node_type = "storage"
+        self.key_conditions: List[str] = []
+        self.skip_indexes: List[str] = []
+        self.filtering_algorithm: List[str] = []
+        self.selected_parts_and_marks: List[str] = []
+        self.aggregation_method: List[str] = []
+        self.aggregation_performance: List[str] = []
+        self.read_performance: List[str] = []
+        self.memory_performance: List[str] = []
 
 
 def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
@@ -35,4 +80,120 @@ def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
         summarized_trace_output=summarized_trace_output,
         cols=query_result.meta,  # type: ignore
         num_rows_result=len(query_result.results),
+        profile_events_results={},
+        profile_events_meta=[],
+        profile_events_profile={},
     )
+
+
+LOG_MAPPINGS_FOR_QUERY_NODES = [
+    ("<Trace>", ["Aggregator: Merging"], "aggregation_performance"),
+    ("<Debug>", ["Aggregator"], "aggregation_performance"),
+    ("<Information>", ["executeQuery"], "read_performance"),
+    ("<Debug>", ["MemoryTracker"], "memory_performance"),
+]
+
+
+LOG_MAPPINGS_FOR_STORAGE_NODES = [
+    ("<Debug>", ["Key condition"], "key_conditions"),
+    ("<Debug>", ["index condition"], "skip_indexes"),
+    (
+        "<Trace>",
+        ["binary search", "generic exclusion"],
+        "filtering_algorithm",
+    ),  # TODO: make this generic
+    ("<Debug>", ["granules"], "selected_parts_and_marks"),
+    ("<Debug>", ["partition key"], "selected_parts_and_marks"),
+    ("<Trace>", ["Aggregation method"], "aggregation_method"),
+    ("<Debug>", ["AggregatingTransform"], "aggregation_performance"),
+    ("<Information>", ["executeQuery"], "read_performance"),
+    ("<Debug>", ["MemoryTracker"], "memory_performance"),
+]
+
+
+def format_trace_output(raw_trace_logs: str) -> Dict[str, Any]:
+    formatted_logs = format_log_to_dict(raw_trace_logs)
+
+    result: dict[str, Any] = {}  # node_name: NodeTraceResult
+
+    query_node_name = formatted_logs[0]["node_name"]
+    result[query_node_name] = QueryNodeTraceResult(query_node_name)
+    query_node_trace_result = result[query_node_name]
+    assert isinstance(query_node_trace_result, QueryNodeTraceResult)
+
+    for log in formatted_logs:
+        node_name = log["node_name"]
+        if node_name not in result:
+            result[node_name] = StorageNodeTraceResult(node_name)
+            query_node_trace_result.storage_nodes_accessed.append(node_name)
+            query_node_trace_result.number_of_storage_nodes_accessed += 1
+
+        trace_result = result[node_name]
+        assert isinstance(trace_result, NodeTraceResult)
+        if log["thread_id"] not in trace_result.thread_ids:
+            trace_result.thread_ids.append(log["thread_id"])
+            trace_result.threads_used = len(trace_result.thread_ids)
+
+        if "query_id" in log:
+            trace_result.query_id = log["query_id"]
+
+        if node_name == query_node_name:
+            assert isinstance(trace_result, QueryNodeTraceResult)
+            for log_type, search_strs, trace_attr in LOG_MAPPINGS_FOR_QUERY_NODES:
+                find_and_add_log_line(
+                    log, getattr(trace_result, trace_attr), log_type, search_strs
+                )
+        else:
+            assert isinstance(trace_result, StorageNodeTraceResult)
+            for (
+                log_type,
+                search_strs,
+                trace_attr,
+            ) in LOG_MAPPINGS_FOR_STORAGE_NODES:
+                find_and_add_log_line(
+                    log, getattr(trace_result, trace_attr), log_type, search_strs
+                )
+    for key, value in result.items():
+        result[key] = vars(value)
+    return result
+
+
+def find_and_add_log_line(
+    log: Dict[str, Any],
+    trace_result_data: List[str],
+    log_type: str,
+    search_strs: List[str],
+) -> None:
+    for search_str in search_strs:
+        if log["log_type"] == log_type and search_str in log["log_content"]:
+            trace_result_data.append(log["log_content"])
+
+
+def format_log_to_dict(raw_trace_logs: str) -> List[dict[str, Any]]:
+    # CLICKHOUSE TRACING LOG STRUCTURE: '[ NODE NAME ] [ THREAD_ID ] {QUERY_ID} <LOG_TYPE> LOG_LINE'
+    formatted_logs = []
+    for line in raw_trace_logs.splitlines():
+        context = re.findall(r"\[.*?\]", line)
+        log_type = ""
+        log_type_regex = re.search(r"<.*?>", line)
+        if log_type_regex is not None:
+            log_type = log_type_regex.group()
+        query_id = ""
+        query_id_regex = re.search(r"{(.*?)}", line)
+        if query_id_regex is not None:
+            query_id = query_id_regex.group().replace("{", "").replace("}", "")
+
+        try:
+            formatted_log = {
+                "node_name": context[0][2:-2],
+                "thread_id": context[1][2:-2],
+                "query_id": query_id,
+                "log_type": log_type,
+                "log_content": re.split(r"<.*?>", line)[1].strip(),
+            }
+        except Exception:
+            # Error parsing log line, continue.
+            pass
+
+        formatted_logs.append(formatted_log)
+    return formatted_logs

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
@@ -26,46 +25,6 @@ class TraceOutput:
     profile_events_profile: Dict[str, int]
 
 
-@dataclass
-class FormattedTrace:
-    query_node: QueryNodeTraceResult
-    storage_nodes: List[StorageNodeTraceResult]
-
-
-class NodeTraceResult:
-    def __init__(self, node_name: str) -> None:
-        self.node_name: str = node_name
-        self.thread_ids: List[str] = []
-        self.threads_used: int = 0
-        self.query_id: str = ""
-
-
-class QueryNodeTraceResult(NodeTraceResult):
-    def __init__(self, node_name: str) -> None:
-        super(QueryNodeTraceResult, self).__init__(node_name)
-        self.node_type = "query"
-        self.number_of_storage_nodes_accessed: int = 0
-        self.storage_nodes_accessed: List[str] = []
-        self.aggregation_performance: List[str] = []
-        self.read_performance: List[str] = []
-        self.memory_performance: List[str] = []
-
-
-@dataclass
-class StorageNodeTraceResult(NodeTraceResult):
-    def __init__(self, node_name: str) -> None:
-        super(StorageNodeTraceResult, self).__init__(node_name)
-        self.node_type = "storage"
-        self.key_conditions: List[str] = []
-        self.skip_indexes: List[str] = []
-        self.filtering_algorithm: List[str] = []
-        self.selected_parts_and_marks: List[str] = []
-        self.aggregation_method: List[str] = []
-        self.aggregation_performance: List[str] = []
-        self.read_performance: List[str] = []
-        self.memory_performance: List[str] = []
-
-
 def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
     validate_ro_query(query)
     connection = get_ro_query_node_connection(
@@ -84,116 +43,3 @@ def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
         profile_events_meta=[],
         profile_events_profile={},
     )
-
-
-LOG_MAPPINGS_FOR_QUERY_NODES = [
-    ("<Trace>", ["Aggregator: Merging"], "aggregation_performance"),
-    ("<Debug>", ["Aggregator"], "aggregation_performance"),
-    ("<Information>", ["executeQuery"], "read_performance"),
-    ("<Debug>", ["MemoryTracker"], "memory_performance"),
-]
-
-
-LOG_MAPPINGS_FOR_STORAGE_NODES = [
-    ("<Debug>", ["Key condition"], "key_conditions"),
-    ("<Debug>", ["index condition"], "skip_indexes"),
-    (
-        "<Trace>",
-        ["binary search", "generic exclusion"],
-        "filtering_algorithm",
-    ),  # TODO: make this generic
-    ("<Debug>", ["granules"], "selected_parts_and_marks"),
-    ("<Debug>", ["partition key"], "selected_parts_and_marks"),
-    ("<Trace>", ["Aggregation method"], "aggregation_method"),
-    ("<Debug>", ["AggregatingTransform"], "aggregation_performance"),
-    ("<Information>", ["executeQuery"], "read_performance"),
-    ("<Debug>", ["MemoryTracker"], "memory_performance"),
-]
-
-
-def format_trace_output(raw_trace_logs: str) -> Dict[str, Any]:
-    formatted_logs = format_log_to_dict(raw_trace_logs)
-
-    result: dict[str, Any] = {}  # node_name: NodeTraceResult
-
-    query_node_name = formatted_logs[0]["node_name"]
-    result[query_node_name] = QueryNodeTraceResult(query_node_name)
-    query_node_trace_result = result[query_node_name]
-    assert isinstance(query_node_trace_result, QueryNodeTraceResult)
-
-    for log in formatted_logs:
-        node_name = log["node_name"]
-        if node_name not in result:
-            result[node_name] = StorageNodeTraceResult(node_name)
-            query_node_trace_result.storage_nodes_accessed.append(node_name)
-            query_node_trace_result.number_of_storage_nodes_accessed += 1
-
-        trace_result = result[node_name]
-        assert isinstance(trace_result, NodeTraceResult)
-        if log["thread_id"] not in trace_result.thread_ids:
-            trace_result.thread_ids.append(log["thread_id"])
-            trace_result.threads_used = len(trace_result.thread_ids)
-
-        if "query_id" in log:
-            trace_result.query_id = log["query_id"]
-
-        if node_name == query_node_name:
-            assert isinstance(trace_result, QueryNodeTraceResult)
-            for log_type, search_strs, trace_attr in LOG_MAPPINGS_FOR_QUERY_NODES:
-                find_and_add_log_line(
-                    log, getattr(trace_result, trace_attr), log_type, search_strs
-                )
-        else:
-            assert isinstance(trace_result, StorageNodeTraceResult)
-            for (
-                log_type,
-                search_strs,
-                trace_attr,
-            ) in LOG_MAPPINGS_FOR_STORAGE_NODES:
-                find_and_add_log_line(
-                    log, getattr(trace_result, trace_attr), log_type, search_strs
-                )
-    for key, value in result.items():
-        result[key] = vars(value)
-    return result
-
-
-def find_and_add_log_line(
-    log: Dict[str, Any],
-    trace_result_data: List[str],
-    log_type: str,
-    search_strs: List[str],
-) -> None:
-    for search_str in search_strs:
-        if log["log_type"] == log_type and search_str in log["log_content"]:
-            trace_result_data.append(log["log_content"])
-
-
-def format_log_to_dict(raw_trace_logs: str) -> List[dict[str, Any]]:
-    # CLICKHOUSE TRACING LOG STRUCTURE: '[ NODE NAME ] [ THREAD_ID ] {QUERY_ID} <LOG_TYPE> LOG_LINE'
-    formatted_logs = []
-    for line in raw_trace_logs.splitlines():
-        context = re.findall(r"\[.*?\]", line)
-        log_type = ""
-        log_type_regex = re.search(r"<.*?>", line)
-        if log_type_regex is not None:
-            log_type = log_type_regex.group()
-        query_id = ""
-        query_id_regex = re.search(r"{(.*?)}", line)
-        if query_id_regex is not None:
-            query_id = query_id_regex.group().replace("{", "").replace("}", "")
-
-        try:
-            formatted_log = {
-                "node_name": context[0][2:-2],
-                "thread_id": context[1][2:-2],
-                "query_id": query_id,
-                "log_type": log_type,
-                "log_content": re.split(r"<.*?>", line)[1].strip(),
-            }
-        except Exception:
-            # Error parsing log line, continue.
-            pass
-
-        formatted_logs.append(formatted_log)
-    return formatted_logs

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any
 
 from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
@@ -22,7 +22,7 @@ class TraceOutput:
     num_rows_result: int
     profile_events_results: dict[dict[str, str], Any]
     profile_events_meta: list[Any]
-    profile_events_profile: Dict[str, int]
+    profile_events_profile: dict[str, int]
 
 
 def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:

--- a/snuba/admin/static/tracing/index.tsx
+++ b/snuba/admin/static/tracing/index.tsx
@@ -16,7 +16,14 @@ import {
   SortingSummary,
 } from "SnubaAdmin/tracing/types";
 
-type BucketedLogs = Map<String, Map<MessageCategory, LogLine[]>>;
+type ProfileEventValue = {
+  column_names: string[];
+  rows: string[];
+};
+
+type ProfileEvent = {
+  [host_name: string]: ProfileEventValue;
+};
 
 enum MessageCategory {
   housekeeping,
@@ -100,7 +107,7 @@ function TracingQueries(props: { api: Client }) {
                   <br />
                   <b>Number of rows in result set:</b> {value.num_rows_result}
                   <br />
-                  {rawTraceDisplay(title, value.trace_output)}
+                  {rawTraceDisplay(title, value.trace_output, value.profile_events_results)}
                 </div>
               );
             }
@@ -110,11 +117,25 @@ function TracingQueries(props: { api: Client }) {
     );
   }
 
-  function rawTraceDisplay(title: string, value: any): JSX.Element {
+  function rawTraceDisplay(title: string, value: any, profileEventResults: ProfileEvent): JSX.Element | undefined {
     const parsedLines: Array<string> = value.split(/\n/);
+
+    const profileEventRows: Array<string> = [];
+    for (const [k, v] of Object.entries(profileEventResults)) {
+      profileEventRows.push(v.rows[0]);
+    }
 
     return (
       <ol style={collapsibleStyle} key={title + "-root"}>
+        <h4>Profile Events Output</h4>
+        {profileEventRows.map((line, index) => {
+          return (
+            <li key={title + index}>
+              <span>{line}</span>
+            </li>
+          );
+        })}
+        <h4>Trace Output</h4>
         {parsedLines.map((line, index) => {
           return (
             <li key={title + index}>

--- a/snuba/admin/static/tracing/index.tsx
+++ b/snuba/admin/static/tracing/index.tsx
@@ -122,24 +122,27 @@ function TracingQueries(props: { api: Client }) {
 
     const profileEventRows: Array<string> = [];
     for (const [k, v] of Object.entries(profileEventResults)) {
-      profileEventRows.push(v.rows[0]);
+      profileEventRows.push(k + '=>' + v.rows[0]);
     }
 
     return (
       <ol style={collapsibleStyle} key={title + "-root"}>
-        <h4>Profile Events Output</h4>
+        <Title order={4}>Profile Events Output</Title>
         {profileEventRows.map((line, index) => {
+          console.log("line: ", line)
+          const node_name = line.split("=>")[0];
+          const row = line.split("=>")[1];
           return (
             <li key={title + index}>
-              <span>{line}</span>
+              <Text>[ {node_name} ] {row}</Text>
             </li>
           );
         })}
-        <h4>Trace Output</h4>
+        <Title order={4}>Trace Output</Title>
         {parsedLines.map((line, index) => {
           return (
             <li key={title + index}>
-              <span>{line}</span>
+              <Text>{line}</Text>
             </li>
           );
         })}

--- a/snuba/admin/static/tracing/index.tsx
+++ b/snuba/admin/static/tracing/index.tsx
@@ -129,7 +129,6 @@ function TracingQueries(props: { api: Client }) {
       <ol style={collapsibleStyle} key={title + "-root"}>
         <Title order={4}>Profile Events Output</Title>
         {profileEventRows.map((line, index) => {
-          console.log("line: ", line)
           const node_name = line.split("=>")[0];
           const row = line.split("=>")[1];
           return (
@@ -138,6 +137,7 @@ function TracingQueries(props: { api: Client }) {
             </li>
           );
         })}
+        <br/>
         <Title order={4}>Trace Output</Title>
         {parsedLines.map((line, index) => {
           return (

--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -58,6 +58,9 @@ function QueryDisplay(props: {
           cols: result.cols,
           trace_output: result.trace_output,
           summarized_trace_output: result.summarized_trace_output,
+          profile_events_results: result.profile_events_results,
+          profile_events_meta: result.profile_events_meta,
+          profile_events_profile: result.profile_events_profile,
           error: result.error,
         };
         setQueryResultHistory((prevHistory) => [

--- a/snuba/admin/static/tracing/types.tsx
+++ b/snuba/admin/static/tracing/types.tsx
@@ -10,6 +10,9 @@ type TracingResult = {
   summarized_trace_output?: TracingSummary;
   cols?: Array<Array<string>>;
   num_rows_result?: number;
+  profile_events_results?: Map<Map<string, string>, Object>;
+  profile_events_meta?: Array<Object>;
+  profile_events_profile?: {};
   error?: string;
 };
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -538,10 +538,22 @@ def parse_trace_for_query_ids(
     matched = next(
         (info for info in storage_info if info["storage_name"] == storage_key), None
     )
+    print(
+        "\n summarized_trace_output: {} \n storage_info: {} \n matched: {}".format(
+            summarized_trace_output, storage_info, matched
+        )
+    )
     if matched is not None:
         local_nodes = matched.get("local_nodes", [])
+        print("\n local_nodes: {}".format(local_nodes))
         for host, query_summary in summarized_trace_output.query_summaries.items():
+            print("\n host: {}, query_id: {}".format(host, query_summary.query_id))
             if not valid_host_regex.match(host):
+                print(
+                    "\n host {} was not matched by valid host regex. Setting host to 127.0.0.1".format(
+                        host
+                    )
+                )
                 host = "127.0.0.1"
 
             result.append(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -4,6 +4,7 @@ import io
 import re
 import sys
 import time
+import traceback
 from contextlib import redirect_stdout
 from dataclasses import asdict
 from datetime import datetime
@@ -514,6 +515,11 @@ def clickhouse_trace_query() -> Response:
         }
         return make_response(jsonify({"error": details}), 400)
     except Exception as err:
+        print(
+            "\n HTTP 500 error message: {} \n traceback: {}".format(
+                str(err), traceback.print_exc()
+            )
+        )
         return make_response(
             jsonify({"error": {"type": "unknown", "message": str(err)}}),
             500,

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import io
-
-# import re
 import sys
 import time
-import traceback
 from contextlib import redirect_stdout
 from dataclasses import asdict
 from datetime import datetime
@@ -472,7 +469,6 @@ def clickhouse_trace_query() -> Response:
                 else:
                     break
 
-            print("\n system_query_result = {}".format(system_query_result))
             assert (
                 system_query_result is not None
                 and len(system_query_result.results) != 0
@@ -518,14 +514,10 @@ def clickhouse_trace_query() -> Response:
         }
         return make_response(jsonify({"error": details}), 400)
     except Exception as err:
-        traceback.print_exc()
         return make_response(
             jsonify({"error": {"type": "unknown", "message": str(err)}}),
             500,
         )
-
-
-# valid_host_regex = re.compile("^[a-zA-Z0-9-]+-\d-\d$")
 
 
 def parse_trace_for_query_ids(
@@ -537,37 +529,18 @@ def parse_trace_for_query_ids(
     matched = next(
         (info for info in storage_info if info["storage_name"] == storage_key), None
     )
-    print(
-        "\n summarized_trace_output: {} \n storage_info: {} \n matched: {}".format(
-            summarized_trace_output, storage_info, matched
-        )
-    )
     if matched is not None:
         local_nodes = matched.get("local_nodes", [])
         query_node = matched.get("query_node", None)
-        print("\n local_nodes: {}, \n query_node: {}".format(local_nodes, query_node))
         for node_name, query_summary in summarized_trace_output.query_summaries.items():
-            print(
-                "\n node_name: {}, query_id: {}".format(
-                    node_name, query_summary.query_id
-                )
-            )
-            # if not valid_host_regex.match(host):
-            #     print(
-            #         "\n host {} was not matched by valid host regex. Setting host to 127.0.0.1".format(
-            #             host
-            #         )
-            #     )
-            #     host = "127.0.0.1"
-
             result.append(
                 {
                     "host": local_nodes[0].get("host")
                     if local_nodes
-                    else query_node.get("host"),
+                    else query_node.get("host"),  # type: ignore
                     "port": local_nodes[0].get("port")
                     if local_nodes
-                    else query_node.get("port"),
+                    else query_node.get("port"),  # type: ignore
                     "query_id": query_summary.query_id,
                     "node_name": node_name,
                 }

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -236,6 +236,7 @@ def test_query_trace(admin_api: FlaskClient) -> None:
     data = json.loads(response.data)
     assert "<Debug> executeQuery" in data["trace_output"]
     assert "summarized_trace_output" in data
+    assert "profile_events_results" in data
 
 
 @pytest.mark.redis_db


### PR DESCRIPTION
<!-- Describe your PR here. -->
ClickHouse's profile events have a lot of useful data that can be found [here](https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ProfileEvents.cpp). The query passed to tracing tool is appended with `SETTINGS log_profile_events=1` so that ClickHouse makes an entry in the `system.query_log` table. Then another query is made to scan `system.query_log` to get the profile event data. 

Finally, the Snuba admin frontend is modified to accommodate the extra information returned.

Testing done:
![Screenshot 2024-08-23 at 12 14 28 PM](https://github.com/user-attachments/assets/22a5785a-7519-487d-a0c1-f1bfde47cc49)