### PR TITLE
feat(migrations): allow drop indices to not block on mutations

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -532,7 +532,7 @@ class DropIndex(SqlOperation):
 
     def _block_on_mutations(
         self, conn: ClickhousePool, poll_seconds: int = 5, timeout_seconds: int = 300
-    ):
+    ) -> None:
         if self.__run_async:
             return
         else:

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -530,6 +530,14 @@ class DropIndex(SqlOperation):
             settings = " SETTINGS mutations_sync=0"
         return f"ALTER TABLE {self.__table_name} DROP INDEX IF EXISTS {self.__index_name}{settings};"
 
+    def _block_on_mutations(
+        self, conn: ClickhousePool, poll_seconds: int = 5, timeout_seconds: int = 300
+    ):
+        if self.__run_async:
+            return
+        else:
+            super()._block_on_mutations(conn, poll_seconds, timeout_seconds)
+
 
 class DropIndices(SqlOperation):
     """


### PR DESCRIPTION
TIL there is a _block_on_mutations function. idk why it exists but if we're running async we def don't need to block on it