### PR TITLE
Handle SIGTERM gracefully in rust-consumer

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -25,7 +25,7 @@ crate-type = ["cdylib", "rlib"]
 anyhow = { version = "1.0.69", features = ["backtrace"] }
 cadence = "0.29.1"
 chrono = { version = "0.4.26", features = ["serde"] }
-ctrlc = "3.2.5"
+ctrlc = { version = "3.2.5", features = ["termination"] }
 futures = "0.3.21"
 md5 = "0.7.0"
 procspawn = { version = "1.0.0", features = ["json"] }


### PR DESCRIPTION
<!-- Describe your PR here. -->
Currently rust consumer has a ctrlc handler which only handles `SIGINT`. If a user sends `SIGTERM` instead, then the rust consumer gets terminated abruptly. The handling `SIGTERM` section [here](https://arjo129.github.io/rustros_tf/ctrlc/index.html#handling-sigterm) describes that in order for ctrlc handler to handle `SIGTERM` (in addition to `SIGINT`), `termination` feature needs to be enabled.


### Testing done:

Before the fix:

> 1. Run rust-consumer:
> ```
> snuba rust-consumer --storage spans --consumer-group snuba-spans-consumers --auto-offset-reset=latest --max-batch-time-ms 1000 --no-strict-offset-reset
> ```
> 
> 2. Send `SIGTERM` to the rust-consumer process:
> ```
> kill -s SIGTERM <rust-consumer-pid> 
> ```
> 
> 3. Watch it terminate abruptly as you see this message on the terminal where rust-consumer was running:
> ```
> zsh: terminated  snuba rust-consumer --storage spans --consumer-group snuba-spans-consumers
> ```

After the fix:

> ```
> kill -s SIGTERM `ps -A | grep -i rust-consumer | awk {'print $1'} | head -1`
> ```
> 
> spits out following lines on the terminal instead of the abrupt termination message:
> ```
> {"timestamp":"2024-08-26T18:48:18.897120Z","level":"INFO","fields":{"message":"Shutdown requested"},"target":"rust_arroyo::processing"}
> {"timestamp":"2024-08-26T18:48:19.530181Z","level":"INFO","fields":{"message":"Shutdown processor"},"target":"rust_arroyo::processing"}
> {"timestamp":"2024-08-26T18:48:19.530479Z","level":"INFO","fields":{"message":"Partitions to revoke: [Partition { topic: Topic(\"snuba-spans\"), index: 0 }]"},"target":"rust_arroyo::processing"}
> {"timestamp":"2024-08-26T18:48:19.530557Z","level":"INFO","fields":{"message":"Joining strategy"},"target":"rust_arroyo::processing"}
> {"timestamp":"2024-08-26T18:48:19.530580Z","level":"WARN","fields":{"message":"Timeout Some(0ns) reached while waiting for tasks to finish"},"target":"rust_arroyo::processing::strategies::reduce"}
> {"timestamp":"2024-08-26T18:48:19.531675Z","level":"INFO","fields":{"message":"Partition revocation complete."},"target":"rust_arroyo::processing"}
> ```
> And the exit code shows the graceful termination:
> ```
> echo $?
> 0
> ```

With this change, the `SIGINT` behavior remains unchanged i.e. graceful shutdown happens _as is_ for `SIGINT`.