### PR TITLE
Emit better error message when a column is not resolved properly

### DIFF
--- a/snuba/datasets/plans/entity_validation.py
+++ b/snuba/datasets/plans/entity_validation.py
@@ -41,7 +41,7 @@ def _validate_entities_with_query(
                 v.validate(query)
         except InvalidQueryException as e:
             raise ValidationException(
-                f"validation failed for entity {query.get_from_clause().key.value}: {e}",
+                f"Validation failed for entity {query.get_from_clause().key.value}: {e}",
                 should_report=e.should_report,
             )
     else:
@@ -56,7 +56,7 @@ def _validate_entities_with_query(
                         v.validate(query, alias)
                 except InvalidQueryException as e:
                     raise ValidationException(
-                        f"validation failed for entity {node.data_source.key.value}: {e}",
+                        f"Validation failed for entity {node.data_source.key.value}: {e}",
                         should_report=e.should_report,
                     )
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -983,7 +983,7 @@ class TestSnQLApi(BaseApiTest):
         assert response.status_code == 400
         assert (
             json.loads(response.data)["error"]["message"]
-            == "validation failed for entity outcomes: Entity outcomes: Query column 'fake_column' does not exist"
+            == "Validation failed for entity outcomes: Tag keys (fake_column) not resolved"
         )
 
     def test_valid_columns_composite_query(self) -> None:
@@ -1209,7 +1209,7 @@ class TestSnQLApi(BaseApiTest):
             assert data["error"]["type"] == "invalid_query"
             assert (
                 data["error"]["message"]
-                == "validation failed for entity discover: invalid tag condition on 'tags[count]': 419 must be a string"
+                == "Validation failed for entity discover: invalid tag condition on 'tags[count]': 419 must be a string"
             )
 
             response = self.post(
@@ -1240,7 +1240,7 @@ class TestSnQLApi(BaseApiTest):
             assert data["error"]["type"] == "invalid_query"
             assert (
                 data["error"]["message"]
-                == "validation failed for entity discover: invalid tag condition on 'tags[count]': array literal 419 must be a string"
+                == "Validation failed for entity discover: invalid tag condition on 'tags[count]': array literal 419 must be a string"
             )
             assert record_failure_metric_mock.call_count == 2
 


### PR DESCRIPTION
When a column/columns is/are not resolved, the query returns ambiguous error message like:
`validation failed for entity generic_metrics_distributions: Entity generic_metrics_distributions: Query column 'wrapper_type' does not exist`. 

This needs to be fixed to show a more readable message:
`Validation failed for entity generic_metrics_distributions: Tag keys (wrapper_type) not resolved`

Closes #6084

**Testing done:**
Fixed unit tests