### PR TITLE
feat: CodeMirror multi-newline

### DIFF
--- a/snuba/admin/package.json
+++ b/snuba/admin/package.json
@@ -7,6 +7,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.6.0",
     "@codemirror/lang-sql": "^6.7.0",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.32.0",

--- a/snuba/admin/static/common/components/sql_editor.tsx
+++ b/snuba/admin/static/common/components/sql_editor.tsx
@@ -1,6 +1,7 @@
 import React, { useLayoutEffect, useMemo, useRef } from "react";
 import { EditorState } from "@codemirror/state";
-import { EditorView, lineNumbers } from "@codemirror/view";
+import { EditorView, lineNumbers, keymap } from "@codemirror/view";
+import { insertNewline } from "@codemirror/commands";
 
 import { sql } from "@codemirror/lang-sql";
 import { theme, highlighting } from "./theme";
@@ -22,8 +23,13 @@ export function SQLEditor({ value, onChange }: Props) {
     });
   }, [onChange]);
 
+  const multiNewLine = useMemo(() => {
+    return keymap.of([{ key: "Enter", run: insertNewline }]);
+  }, []);
+
   const extensions = [
     updateListener,
+    multiNewLine,
     theme,
     highlighting,
     lineNumbers(),

--- a/snuba/admin/yarn.lock
+++ b/snuba/admin/yarn.lock
@@ -419,6 +419,16 @@
     "@codemirror/view" "^6.17.0"
     "@lezer/common" "^1.0.0"
 
+"@codemirror/commands@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.6.0.tgz#d308f143fe1b8896ca25fdb855f66acdaf019dd4"
+  integrity sha512-qnY+b7j1UNcTS31Eenuc/5YJB6gQOzkUoNmJQc0rznwqSRpeaWWpjkWy2C/MPTcePpsKJEM26hXrOXl1+nceXg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.4.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
 "@codemirror/lang-sql@^6.7.0":
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-sql/-/lang-sql-6.7.0.tgz#a87fb9b458ae0ad1d8647c0234accca0ef11bb78"
@@ -452,6 +462,15 @@
   version "6.32.0"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.32.0.tgz#94be8aa18b60044471200ee80b0339513036680e"
   integrity sha512-AgVNvED2QTsZp5e3syoHLsrWtwJFYWdx1Vr/m3f4h1ATQz0ax60CfXF3Htdmk69k2MlYZw8gXesnQdHtzyVmAw==
+  dependencies:
+    "@codemirror/state" "^6.4.0"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
+"@codemirror/view@^6.27.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.33.0.tgz#51e270410fc3af92a6e38798e80ebf8add7dc3ec"
+  integrity sha512-AroaR3BvnjRW8fiZBalAaK+ZzB5usGgI014YKElYZvQdNH5ZIidHlO+cyf/2rWzyBFRkvG6VhiXeAEbC53P2YQ==
   dependencies:
     "@codemirror/state" "^6.4.0"
     style-mod "^4.1.0"


### PR DESCRIPTION
In a bizarre twist, CodeMirror by default does not allow multiple trailing newlines! Why? No idea! It seems like by default `Enter` inserts a newline and immediately re-formats the content, which strips multiple newlines. Fixed with this custom keymap.
