### PR TITLE
ref(clickhouse): update versions and add 24.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,7 @@ jobs:
         version:
           [
             "23.8.11.29.altinitystable",
+            "24.3.5.47.altinitystable",
           ]
 
     steps:

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -56,6 +56,7 @@ class ClickhouseClientSettings(Enum):
             "replication_alter_partitions_sync": 2,
             "mutations_sync": 2,
             "database_atomic_wait_for_drop_and_detach_synchronously": 1,
+            "allow_suspicious_primary_key": 1,
         },
         10000,
     )

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -56,7 +56,6 @@ class ClickhouseClientSettings(Enum):
             "replication_alter_partitions_sync": 2,
             "mutations_sync": 2,
             "database_atomic_wait_for_drop_and_detach_synchronously": 1,
-            "allow_suspicious_primary_key": 1,
         },
         10000,
     )

--- a/snuba/migrations/clickhouse.py
+++ b/snuba/migrations/clickhouse.py
@@ -1,4 +1,5 @@
-CLICKHOUSE_SERVER_MIN_VERSION = "21.8.12.29"
-# Note: 21.8.12.29 and 21.8.13.1 are used in self-hosted builds
-# even though SaaS clusters are all on 22.8 or above
-CLICKHOUSE_SERVER_MAX_VERSION = "23.8.11.29"
+CLICKHOUSE_SERVER_MIN_VERSION = "22.8.15.25"
+# Note: some test regions are using 22.8.15.25.
+# 23.8.11.29 is the base image for self-hosted and
+# saas clusters should be on 23.8.11.29
+CLICKHOUSE_SERVER_MAX_VERSION = "24.3.5.47"

--- a/snuba/migrations/clickhouse.py
+++ b/snuba/migrations/clickhouse.py
@@ -1,5 +1,4 @@
-CLICKHOUSE_SERVER_MIN_VERSION = "22.8.15.25"
-# Note: some test regions are using 22.8.15.25.
-# 23.8.11.29 is the base image for self-hosted and
-# saas clusters should be on 23.8.11.29
+CLICKHOUSE_SERVER_MIN_VERSION = "23.8.11.29"
+# Note: SaaS, self-hosted, and sentry dev
+# environements should all be on 23.8.11.29
 CLICKHOUSE_SERVER_MAX_VERSION = "24.3.5.47"

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -352,7 +352,10 @@ def test_query_trace_bad_query(admin_api: FlaskClient) -> None:
     )
     assert response.status_code == 400
     data = json.loads(response.data)
-    assert "Exception: Missing columns" in data["error"]["message"]
+    assert (
+        "Exception: Unknown expression or function identifier"
+        in data["error"]["message"]
+    )
     assert "clickhouse" == data["error"]["type"]
 
 

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -352,9 +352,11 @@ def test_query_trace_bad_query(admin_api: FlaskClient) -> None:
     )
     assert response.status_code == 400
     data = json.loads(response.data)
+    # error message is different in CH versions 23.8 and 24.3
     assert (
         "Exception: Unknown expression or function identifier"
         in data["error"]["message"]
+        or "Exception: Missing columns" in data["error"]["message"]
     )
     assert "clickhouse" == data["error"]["type"]
 


### PR DESCRIPTION
**clickhouse versions of note:**

* ~`22.8.15.25`: is still used in some [test clusters](https://github.com/getsentry/ops/blob/01c48827f96427e2a2858adb70ff530705ec2d01/salt/pillar/clickhouse/sentry-test-region/snuba-metrics.sls#L3), can update this to be higher once confirmed those test regions aren't needed~
* ~`23.3.19.33`: is still used in [sentry development](https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L2324), should probably be updated~
* `23.8.11.29`: latest version used for all production clusters and [self-hosted](https://github.com/getsentry/self-hosted/blob/3cf323843ab9e63515bd2816a426bd5116324834/docker-compose.yml#L178) and [sentry development](https://github.com/getsentry/sentry/blob/65fcca934b0604fe65149f12ec648c030b71b6e0/src/sentry/conf/server.py#L2350)
* `24.3.5.47`: latest [altinity stable build](https://docs.altinity.com/releasenotes/altinity-stable-release-notes/24.3/) that we want to start including in CI to prep for eventual upgrade this year