### PR TITLE
ref(admin): include delete policies in capacity mgmt

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -74,8 +74,8 @@ from snuba.migrations.connect import check_for_inactive_replicas
 from snuba.migrations.errors import InactiveClickhouseReplica, MigrationError
 from snuba.migrations.groups import MigrationGroup, get_group_readiness_state
 from snuba.migrations.runner import MigrationKey, Runner
-from snuba.query.allocation_policies import AllocationPolicy
 from snuba.migrations.status import Status
+from snuba.query.allocation_policies import AllocationPolicy
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.replacers.replacements_and_expiry import (

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -949,7 +949,11 @@ def storages_with_allocation_policies() -> Response:
 @check_tool_perms(tools=[AdminTools.CAPACITY_MANAGEMENT])
 def get_allocation_policy_configs(storage_key: str) -> Response:
 
-    policies = get_storage(StorageKey(storage_key)).get_allocation_policies()
+    policies = (
+        get_storage(StorageKey(storage_key)).get_allocation_policies()
+        + get_storage(StorageKey(storage_key)).get_delete_allocation_policies()
+    )
+
     data = [
         {
             "policy_name": policy.config_key(),
@@ -978,7 +982,10 @@ def set_allocation_policy_config() -> Response:
         assert key != "", "Key cannot be empty string"
         assert isinstance(policy_name, str), "Invalid policy name"
 
-        policies = get_storage(StorageKey(storage)).get_allocation_policies()
+        policies = (
+            get_storage(StorageKey(storage)).get_allocation_policies()
+            + get_storage(StorageKey(storage)).get_delete_allocation_policies()
+        )
         policy = next(
             (p for p in policies if p.config_key() == policy_name),
             None,

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -76,7 +76,7 @@ from snuba.utils.metrics.util import with_span
 from snuba.web import QueryException, QueryTooLongException
 from snuba.web.constants import get_http_status_for_clickhouse_error
 from snuba.web.converters import DatasetConverter, EntityConverter, StorageConverter
-from snuba.web.delete_query import delete_from_storage
+from snuba.web.delete_query import DeletesNotEnabledError, delete_from_storage
 from snuba.web.query import parse_and_run_query
 from snuba.web.rpc.timeseries import timeseries_query as timeseries_query_impl
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -76,7 +76,7 @@ from snuba.utils.metrics.util import with_span
 from snuba.web import QueryException, QueryTooLongException
 from snuba.web.constants import get_http_status_for_clickhouse_error
 from snuba.web.converters import DatasetConverter, EntityConverter, StorageConverter
-from snuba.web.delete_query import DeletesNotEnabledError, delete_from_storage
+from snuba.web.delete_query import delete_from_storage
 from snuba.web.query import parse_and_run_query
 from snuba.web.rpc.timeseries import timeseries_query as timeseries_query_impl
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow


### PR DESCRIPTION
Adds delete allocation policies to show up in snuba admin per storage along side the other allocation policies.
> <img width="946" alt="Screenshot 2024-08-28 at 3 54 24 PM" src="https://github.com/user-attachments/assets/b3b6651b-d671-4d3b-8d6c-2c49a0e29b73">

<br/>

If there are no delete query allocation policies listed it will look like the following:
> <img width="992" alt="Screenshot 2024-08-28 at 3 54 42 PM" src="https://github.com/user-attachments/assets/9b83de50-f0e2-4018-bc43-79fb98c08d4d">


