### PR TITLE
feat(eap): Add an RPC for span samples, refactor a lot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,4 +45,4 @@ sqlparse==0.4.2
 google-api-python-client==2.88.0
 sentry-usage-accountant==0.0.10
 freezegun==1.2.2
-sentry-protos==0.1.14
+sentry-protos==0.1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,4 +45,4 @@ sqlparse==0.4.2
 google-api-python-client==2.88.0
 sentry-usage-accountant==0.0.10
 freezegun==1.2.2
-sentry-protos==0.1.3
+sentry-protos==0.1.14

--- a/snuba/web/rpc/common.py
+++ b/snuba/web/rpc/common.py
@@ -1,0 +1,263 @@
+from typing import Final, Mapping, Optional, Set
+
+from sentry_protos.snuba.v1alpha.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
+    AttributeKey,
+    AttributeKeyTransformContext,
+)
+from sentry_protos.snuba.v1alpha.trace_item_filter_pb2 import (
+    ComparisonFilter,
+    TraceItemFilter,
+)
+
+from snuba.query import Expression, Query
+from snuba.query.conditions import combine_and_conditions, combine_or_conditions
+from snuba.query.dsl import Functions as f
+from snuba.query.dsl import and_cond, column, in_cond, literal, literals_array, or_cond
+from snuba.query.expressions import FunctionCall, SubscriptableReference
+from snuba.web.rpc.exceptions import BadSnubaRPCRequestException
+
+
+def treeify_or_and_conditions(query: Query) -> None:
+    """
+    look for expressions like or(a, b, c) and turn them into or(a, or(b, c))
+                              and(a, b, c) and turn them into and(a, and(b, c))
+
+    even though clickhouse sql supports arbitrary amount of arguments there are other parts of the
+    codebase which assume `or` and `and` have two arguments
+
+    Adding this post-process step is easier than changing the rest of the query pipeline
+
+    Note: does not apply to the conditions of a from_clause subquery (the nested one)
+        this is bc transform_expressions is not implemented for composite queries
+    """
+
+    def transform(exp: Expression) -> Expression:
+        if not isinstance(exp, FunctionCall):
+            return exp
+
+        if exp.function_name == "and":
+            return combine_and_conditions(exp.parameters)
+        elif exp.function_name == "or":
+            return combine_or_conditions(exp.parameters)
+        else:
+            return exp
+
+    query.transform_expressions(transform)
+
+
+# These are the columns which aren't stored in attr_str_ nor attr_num_ in clickhouse
+NORMALIZED_COLUMNS: Final[Mapping[str, AttributeKey.Type]] = {
+    "project_name": AttributeKey.Type.TYPE_STRING,  # extra special column, derived from a context sent with the request
+    "organization_id": AttributeKey.Type.TYPE_INT,
+    "project_id": AttributeKey.Type.TYPE_INT,
+    "service": AttributeKey.Type.TYPE_STRING,
+    "span_id": AttributeKey.Type.TYPE_INT,
+    "parent_span_id": AttributeKey.Type.TYPE_INT,
+    "segment_id": AttributeKey.Type.TYPE_INT,
+    "segment_name": AttributeKey.Type.TYPE_STRING,
+    "is_segment": AttributeKey.Type.TYPE_BOOLEAN,
+    "duration_ms": AttributeKey.Type.TYPE_INT,
+    "exclusive_time_ms": AttributeKey.Type.TYPE_INT,
+    "retention_days": AttributeKey.Type.TYPE_INT,
+    "name": AttributeKey.Type.TYPE_STRING,
+    "sample_weight": AttributeKey.Type.TYPE_FLOAT,
+}
+
+# Columns stored as integers that are usually presented to users as hex strings
+HEX_ID_COLUMNS: Final[Set[str]] = {"span_id", "parent_span_id", "segment_id"}
+
+TIMESTAMP_COLUMNS: Final[Set[str]] = {"timestamp", "start_timestamp", "end_timestamp"}
+
+
+def attribute_key_to_expression(
+    attr_key: AttributeKey, context: Optional[AttributeKeyTransformContext]
+) -> Expression:
+    # Snuba doesn't have access to postgres, which stores project_id to project_name mappings.
+    # This context object lets the caller specify that mapping, so that they can (for example) order by project name
+    if (
+        attr_key.name == "project_name"
+        and attr_key.type == AttributeKey.Type.TYPE_STRING
+    ):
+        if context is None or len(context.project_ids_to_names) == 0:
+            raise BadSnubaRPCRequestException(
+                "If you request project_name, the AttributeKeyTransformContext must be "
+                "sent. Snuba doesn't have access to project names directly."
+            )
+        return f.transform(
+            column("project_id"),
+            literals_array(None, context.project_ids_to_names.keys()),
+            literals_array(None, context.project_ids_to_names.values()),
+            literal("unknown"),
+            alias="project_name",
+        )
+
+    if attr_key.name == "trace_id" and attr_key.type == AttributeKey.Type.TYPE_STRING:
+        return f.CAST(column("trace_id"), "String", alias="trace_id")
+
+    if attr_key.name in HEX_ID_COLUMNS:
+        if attr_key.type == AttributeKey.Type.TYPE_STRING:
+            return f.hex(column(attr_key.name))
+        raise BadSnubaRPCRequestException(
+            f"Attribute {attr_key.name} must be requested as a string, got {attr_key.type}"
+        )
+
+    if attr_key.name in TIMESTAMP_COLUMNS:
+        if attr_key.type == AttributeKey.Type.TYPE_STRING:
+            return f.CAST(column(attr_key.name), "String", alias=attr_key.name)
+        if attr_key.type == AttributeKey.Type.TYPE_INT:
+            return f.CAST(column(attr_key.name), "Int64", alias=attr_key.name)
+        if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
+            return f.CAST(column(attr_key.name), "Float64", alias=attr_key.name)
+        raise BadSnubaRPCRequestException(
+            f"Attribute {attr_key.name} must be requested as a string, float, or integer, got {attr_key.type}"
+        )
+
+    if attr_key.name in NORMALIZED_COLUMNS:
+        if NORMALIZED_COLUMNS[attr_key.name] == attr_key.type:
+            return column(attr_key.name)
+        raise BadSnubaRPCRequestException(
+            f"Attribute {attr_key.name} must be requested as {NORMALIZED_COLUMNS[attr_key.name]}, got {attr_key.type}"
+        )
+
+    # End of special handling, just send to the appropriate bucket
+    if attr_key.type == AttributeKey.Type.TYPE_STRING:
+        return SubscriptableReference(
+            alias=attr_key.name, column=column("attr_str"), key=literal(attr_key.name)
+        )
+    if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
+        return SubscriptableReference(
+            alias=attr_key.name, column=column("attr_num"), key=literal(attr_key.name)
+        )
+    if attr_key.type == AttributeKey.Type.TYPE_INT:
+        return f.CAST(
+            SubscriptableReference(
+                alias=attr_key.name,
+                column=column("attr_num"),
+                key=literal(attr_key.name),
+            ),
+            "Int64",
+        )
+    if attr_key.type == AttributeKey.Type.TYPE_BOOLEAN:
+        return f.CAST(
+            SubscriptableReference(
+                alias=attr_key.name,
+                column=column("attr_num"),
+                key=literal(attr_key.name),
+            ),
+            "Boolean",
+        )
+    raise BadSnubaRPCRequestException(
+        f"Attribute {attr_key.name} had an unknown or unset type: {attr_key.type}"
+    )
+
+
+def trace_item_filters_to_expression(
+    item_filter: TraceItemFilter, context: Optional[AttributeKeyTransformContext]
+) -> Expression:
+    """
+    Trace Item Filters are things like (span.id=12345 AND start_timestamp >= "june 4th, 2024")
+    This maps those filters into an expression which can be used in a WHERE clause
+    :param item_filter:
+    :return:
+    """
+    if item_filter.and_filter:
+        filters = item_filter.and_filter.filters
+        if len(filters) == 0:
+            return literal(True)
+        if len(filters) == 1:
+            return trace_item_filters_to_expression(filters[0], context)
+        return and_cond(
+            *(trace_item_filters_to_expression(x, context) for x in filters)
+        )
+
+    if item_filter.or_filter:
+        filters = item_filter.or_filter.filters
+        if len(filters) == 0:
+            raise BadSnubaRPCRequestException(
+                "Invalid trace item filter, empty 'or' clause"
+            )
+        if len(filters) == 1:
+            return trace_item_filters_to_expression(filters[0], context)
+        return or_cond(*(trace_item_filters_to_expression(x, context) for x in filters))
+
+    if item_filter.comparison_filter:
+        k = item_filter.comparison_filter.key
+        k_expression = attribute_key_to_expression(k, context)
+        op = item_filter.comparison_filter.op
+        v = item_filter.comparison_filter.value
+        v_expression = {
+            "val_bool": literal(v.val_bool),
+            "val_str": literal(v.val_str),
+            "val_float": literal(v.val_float),
+            "val_int": literal(v.val_int),
+        }[v.WhichOneof()]
+
+        if op == ComparisonFilter.OP_EQUALS:
+            return f.equals(k_expression, v_expression)
+        if op == ComparisonFilter.OP_NOT_EQUALS:
+            return f.notEquals(k_expression, v_expression)
+        if op == ComparisonFilter.OP_LIKE:
+            if k.type != AttributeKey.Type.TYPE_STRING:
+                raise BadSnubaRPCRequestException(
+                    "the LIKE comparison is only supported on string keys"
+                )
+            return f.like(k_expression, v_expression)
+        if op == ComparisonFilter.OP_NOT_LIKE:
+            if k.type != AttributeKey.Type.TYPE_STRING:
+                raise BadSnubaRPCRequestException(
+                    "the NOT LIKE comparison is only supported on string keys"
+                )
+            return f.notLike(k_expression, v_expression)
+        if op == ComparisonFilter.OP_LESS_THAN:
+            return f.less(k_expression, v_expression)
+        if op == ComparisonFilter.OP_LESS_THAN_OR_EQUALS:
+            return f.lessOrEquals(k_expression, v_expression)
+        if op == ComparisonFilter.OP_GREATER_THAN:
+            return f.greater(k_expression, v_expression)
+        if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
+            return f.greaterOrEquals(k_expression, v_expression)
+
+        raise BadSnubaRPCRequestException(
+            "Invalid string comparison, unknown op: ", item_filter.string_filter
+        )
+
+    if item_filter.exists_filter:
+        k = item_filter.exists_filter.key
+        if k in NORMALIZED_COLUMNS.keys():
+            return f.isNotNull(column(k))
+        if item_filter.exists_filter.type == AttributeKey.Type.TYPE_STRING:
+            # TODO: this doesn't actually work yet, need to make mapContains work with hash mapper too
+            return f.mapContains(column("attr_str"), literal(k))
+        else:
+            return f.mapContains(column("attr_num"), literal(k))
+
+    raise Exception("Unknown filter: ", item_filter)
+
+
+def base_conditions_and(meta: RequestMeta, *other_exprs: Expression) -> Expression:
+    """
+
+    :param meta: The RequestMeta field, common across all RPCs
+    :param other_exprs: other expressions to add to the *and* clause
+    :return: an expression which looks like (project_id IN (a, b, c) AND organization_id=d AND ...)
+    """
+    return and_cond(
+        in_cond(
+            column("project_id"),
+            literals_array(
+                alias=None,
+                literals=[literal(pid) for pid in meta.project_ids],
+            ),
+        ),
+        f.equals(column("organization_id"), meta.organization_id),
+        f.less(
+            column("timestamp"),
+            f.toDateTime(meta.end_timestamp.seconds),
+        ),
+        f.greaterOrEquals(
+            column("timestamp"),
+            f.toDateTime(meta.start_timestamp.seconds),
+        ),
+        *other_exprs,
+    )

--- a/snuba/web/rpc/common.py
+++ b/snuba/web/rpc/common.py
@@ -62,6 +62,9 @@ NORMALIZED_COLUMNS: Final[Mapping[str, AttributeKey.Type.ValueType]] = {
     "retention_days": AttributeKey.Type.TYPE_INT,
     "name": AttributeKey.Type.TYPE_STRING,
     "sample_weight": AttributeKey.Type.TYPE_FLOAT,
+    "timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
+    "start_timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
+    "end_timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
 }
 
 # Columns stored as integers that are usually presented to users as hex strings
@@ -73,6 +76,10 @@ TIMESTAMP_COLUMNS: Final[Set[str]] = {"timestamp", "start_timestamp", "end_times
 def attribute_key_to_expression(
     attr_key: AttributeKey, context: Optional[AttributeKeyTransformContext]
 ) -> Expression:
+    if attr_key.type == AttributeKey.Type.TYPE_UNSPECIFIED:
+        raise BadSnubaRPCRequestException(
+            f"attribute key {attr_key.name} must have a type specified"
+        )
     # Snuba doesn't have access to postgres, which stores project_id to project_name mappings.
     # This context object lets the caller specify that mapping, so that they can (for example) order by project name
     if (

--- a/snuba/web/rpc/common.py
+++ b/snuba/web/rpc/common.py
@@ -235,13 +235,13 @@ def trace_item_filters_to_expression(
 
     if item_filter.exists_filter:
         k = item_filter.exists_filter.key
-        if k in NORMALIZED_COLUMNS.keys():
-            return f.isNotNull(column(k))
-        if item_filter.exists_filter.type == AttributeKey.Type.TYPE_STRING:
+        if k.name in NORMALIZED_COLUMNS.keys():
+            return f.isNotNull(column(k.name))
+        if k.type == AttributeKey.Type.TYPE_STRING:
             # TODO: this doesn't actually work yet, need to make mapContains work with hash mapper too
-            return f.mapContains(column("attr_str"), literal(k))
+            return f.mapContains(column("attr_str"), literal(k.name))
         else:
-            return f.mapContains(column("attr_num"), literal(k))
+            return f.mapContains(column("attr_num"), literal(k.name))
 
     raise Exception("Unknown filter: ", item_filter)
 

--- a/snuba/web/rpc/exceptions.py
+++ b/snuba/web/rpc/exceptions.py
@@ -1,0 +1,3 @@
+# equivalent to an HTTP 400
+class BadSnubaRPCRequestException(Exception):
+    pass

--- a/snuba/web/rpc/span_samples.py
+++ b/snuba/web/rpc/span_samples.py
@@ -9,7 +9,6 @@ from sentry_protos.snuba.v1alpha.endpoint_span_samples_pb2 import (
 )
 from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
     AttributeKey,
-    AttributeKeyTransformContext,
     AttributeValue,
 )
 
@@ -35,7 +34,6 @@ from snuba.web.rpc.common import (
 
 def _convert_order_by(
     order_by: Sequence[SpanSamplesRequest.OrderBy],
-    key_context: Optional[AttributeKeyTransformContext],
 ) -> Sequence[OrderBy]:
     res: List[OrderBy] = []
     for x in order_by:
@@ -43,7 +41,7 @@ def _convert_order_by(
         res.append(
             OrderBy(
                 direction=direction,
-                expression=attribute_key_to_expression(x.key, key_context),
+                expression=attribute_key_to_expression(x.key),
             )
         )
     return res
@@ -69,9 +67,7 @@ def _build_query(request: SpanSamplesRequest) -> Query:
             request.meta,
             trace_item_filters_to_expression(request.filter),
         ),
-        order_by=_convert_order_by(
-            request.order_by, request.attribute_key_transform_context
-        ),
+        order_by=_convert_order_by(request.order_by),
         limit=request.limit,
     )
     treeify_or_and_conditions(res)

--- a/snuba/web/rpc/span_samples.py
+++ b/snuba/web/rpc/span_samples.py
@@ -1,0 +1,138 @@
+import uuid
+from typing import Any, Callable, Dict, Iterable, Optional, Sequence
+
+from google.protobuf.json_format import MessageToDict
+from sentry_protos.snuba.v1alpha.endpoint_span_samples_pb2 import (
+    SpanSample,
+    SpanSamplesRequest,
+    SpanSamplesResponse,
+)
+from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
+    AttributeKey,
+    AttributeKeyTransformContext,
+    AttributeValue,
+)
+
+from snuba.attribution.appid import AppID
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.pluggable_dataset import PluggableDataset
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query.data_source.simple import Entity
+from snuba.query.logical import Query
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.request import Request as SnubaRequest
+from snuba.utils.metrics.timer import Timer
+from snuba.web.query import run_query
+from snuba.web.rpc.common import (
+    attribute_key_to_expression,
+    base_conditions_and,
+    trace_item_filters_to_expression,
+    treeify_or_and_conditions,
+)
+
+
+def _convert_order_by(
+    order_by: Sequence[SpanSamplesRequest.OrderBy],
+    key_context: Optional[AttributeKeyTransformContext],
+) -> Sequence[OrderBy]:
+    for x in order_by:
+        direction = OrderByDirection.DESC if x.descending else OrderByDirection.ASC
+        yield OrderBy(
+            direction=direction,
+            expression=attribute_key_to_expression(x.key, key_context),
+        )
+
+
+def _build_query(request: SpanSamplesRequest) -> Query:
+    entity = Entity(
+        key=EntityKey("eap_spans"),
+        schema=get_entity(EntityKey("eap_spans")).get_data_model(),
+        sample=None,
+    )
+
+    selected_columns = []
+
+    for key in request.keys:
+        key_col = attribute_key_to_expression(
+            key, request.attribute_key_transform_context
+        )
+        selected_columns.append(SelectedExpression(name=key.name, expression=key_col))
+
+    res = Query(
+        from_clause=entity,
+        selected_columns=selected_columns,
+        condition=base_conditions_and(
+            request.meta,
+            trace_item_filters_to_expression(
+                request.filter,
+                request.attribute_key_transform_context,
+            ),
+        ),
+        order_by=_convert_order_by(
+            request.order_by, request.attribute_key_transform_context
+        ),
+        limit=request.limit,
+    )
+    treeify_or_and_conditions(res)
+    return res
+
+
+def _build_snuba_request(
+    request: SpanSamplesRequest,
+) -> SnubaRequest:
+    return SnubaRequest(
+        id=str(uuid.uuid4()),
+        original_body=MessageToDict(request),
+        query=_build_query(request),
+        query_settings=HTTPQuerySettings(),
+        attribution_info=AttributionInfo(
+            referrer=request.meta.referrer,
+            team="eap",
+            feature="eap",
+            tenant_ids={
+                "organization_id": request.meta.organization_id,
+                "referrer": request.meta.referrer,
+            },
+            app_id=AppID("eap"),
+            parent_api="eap_span_samples",
+        ),
+    )
+
+
+def _convert_results(
+    request_keys: Sequence[AttributeKey], data: Iterable[Dict[str, Any]]
+) -> Iterable[SpanSample]:
+    converters: Dict[str, Callable[[Any], AttributeValue]] = {}
+
+    for req_key in request_keys:
+        if req_key.type == AttributeKey.TYPE_BOOLEAN:
+            converters[req_key.name] = lambda x: AttributeValue(val_bool=bool(x))
+        elif req_key.type == AttributeKey.TYPE_STRING:
+            converters[req_key.name] = lambda x: AttributeValue(val_str=str(x))
+        elif req_key.type == AttributeKey.TYPE_INT:
+            converters[req_key.name] = lambda x: AttributeValue(val_int=int(x))
+        elif req_key.type == AttributeKey.TYPE_FLOAT:
+            converters[req_key.name] = lambda x: AttributeValue(val_float=float(x))
+
+    for row in data:
+        results = {}
+        for attr_name, attr_val in row.items():
+            results[attr_name] = converters[attr_name](attr_val)
+        yield SpanSample(results=results)
+
+
+def span_samples_query(
+    request: SpanSamplesRequest, timer: Optional[Timer] = None
+) -> SpanSamplesResponse:
+    timer = timer or Timer("timeseries_query")
+    snuba_request = _build_snuba_request(request)
+    res = run_query(
+        dataset=PluggableDataset(name="eap", all_entities=[]),
+        request=snuba_request,
+        timer=timer,
+    )
+    span_samples = _convert_results(request.keys, res.result.get("data", []))
+
+    return SpanSamplesResponse(span_samples=span_samples)

--- a/snuba/web/rpc/span_samples.py
+++ b/snuba/web/rpc/span_samples.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Callable, Dict, Generator, Iterable, Optional, Sequence
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
 
 from google.protobuf.json_format import MessageToDict
 from sentry_protos.snuba.v1alpha.endpoint_span_samples_pb2 import (
@@ -36,13 +36,17 @@ from snuba.web.rpc.common import (
 def _convert_order_by(
     order_by: Sequence[SpanSamplesRequest.OrderBy],
     key_context: Optional[AttributeKeyTransformContext],
-) -> Generator[OrderBy]:
+) -> Sequence[OrderBy]:
+    res: List[OrderBy] = []
     for x in order_by:
         direction = OrderByDirection.DESC if x.descending else OrderByDirection.ASC
-        yield OrderBy(
-            direction=direction,
-            expression=attribute_key_to_expression(x.key, key_context),
+        res.append(
+            OrderBy(
+                direction=direction,
+                expression=attribute_key_to_expression(x.key, key_context),
+            )
         )
+    return res
 
 
 def _build_query(request: SpanSamplesRequest) -> Query:

--- a/snuba/web/rpc/span_samples.py
+++ b/snuba/web/rpc/span_samples.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Callable, Dict, Iterable, Optional, Sequence
+from typing import Any, Callable, Dict, Generator, Iterable, Optional, Sequence
 
 from google.protobuf.json_format import MessageToDict
 from sentry_protos.snuba.v1alpha.endpoint_span_samples_pb2 import (
@@ -36,7 +36,7 @@ from snuba.web.rpc.common import (
 def _convert_order_by(
     order_by: Sequence[SpanSamplesRequest.OrderBy],
     key_context: Optional[AttributeKeyTransformContext],
-) -> Sequence[OrderBy]:
+) -> Generator[OrderBy]:
     for x in order_by:
         direction = OrderByDirection.DESC if x.descending else OrderByDirection.ASC
         yield OrderBy(

--- a/snuba/web/rpc/span_samples.py
+++ b/snuba/web/rpc/span_samples.py
@@ -59,9 +59,7 @@ def _build_query(request: SpanSamplesRequest) -> Query:
     selected_columns = []
 
     for key in request.keys:
-        key_col = attribute_key_to_expression(
-            key, request.attribute_key_transform_context
-        )
+        key_col = attribute_key_to_expression(key)
         selected_columns.append(SelectedExpression(name=key.name, expression=key_col))
 
     res = Query(
@@ -69,10 +67,7 @@ def _build_query(request: SpanSamplesRequest) -> Query:
         selected_columns=selected_columns,
         condition=base_conditions_and(
             request.meta,
-            trace_item_filters_to_expression(
-                request.filter,
-                request.attribute_key_transform_context,
-            ),
+            trace_item_filters_to_expression(request.filter),
         ),
         order_by=_convert_order_by(
             request.order_by, request.attribute_key_transform_context

--- a/snuba/web/rpc/timeseries.py
+++ b/snuba/web/rpc/timeseries.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 
 from google.protobuf.json_format import MessageToDict
 from sentry_protos.snuba.v1alpha.endpoint_aggregate_bucket_pb2 import (
@@ -13,110 +12,46 @@ from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.query import SelectedExpression
-from snuba.query.conditions import combine_and_conditions, combine_or_conditions
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import CurriedFunctions as cf
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import (
-    NestedColumn,
-    and_cond,
-    column,
-    in_cond,
-    literal,
-    literals_array,
-)
-from snuba.query.expressions import Expression, FunctionCall
+from snuba.query.dsl import column
+from snuba.query.expressions import Expression
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import run_query
-
-_HARDCODED_MEASUREMENT_NAME = "eap.measurement"
-
-
-def _get_measurement_field(
-    request: AggregateBucketRequest,
-) -> Expression:
-    field = NestedColumn("attr_num")
-    # HACK
-    return field[request.metric_name]
-
-
-def _treeify_or_and_conditions(query: Query) -> None:
-    """
-    look for expressions like or(a, b, c) and turn them into or(a, or(b, c))
-                              and(a, b, c) and turn them into and(a, and(b, c))
-
-    even though clickhouse sql supports arbitrary amount of arguments there are other parts of the
-    codebase which assume `or` and `and` have two arguments
-
-    Adding this post-process step is easier than changing the rest of the query pipeline
-
-    Note: does not apply to the conditions of a from_clause subquery (the nested one)
-        this is bc transform_expressions is not implemented for composite queries
-    """
-
-    def transform(exp: Expression) -> Expression:
-        if not isinstance(exp, FunctionCall):
-            return exp
-
-        if exp.function_name == "and":
-            return combine_and_conditions(exp.parameters)
-        elif exp.function_name == "or":
-            return combine_or_conditions(exp.parameters)
-        else:
-            return exp
-
-    query.transform_expressions(transform)
+from snuba.web.rpc.common import (
+    attribute_key_to_expression,
+    base_conditions_and,
+    trace_item_filters_to_expression,
+    treeify_or_and_conditions,
+)
+from snuba.web.rpc.exceptions import BadSnubaRPCRequestException
 
 
 def _get_aggregate_func(
     request: AggregateBucketRequest,
 ) -> Expression:
-    FuncEnum = AggregateBucketRequest.Function
-    measurement_field = _get_measurement_field(request)
-    alias = "measurement"
-    lookup = {
-        FuncEnum.FUNCTION_SUM: f.sum(measurement_field, alias=alias),
-        FuncEnum.FUNCTION_AVERAGE: f.avg(measurement_field, alias=alias),
-        FuncEnum.FUNCTION_COUNT: f.count(measurement_field, alias=alias),
-        # curried functions PITA, to do later
-        FuncEnum.FUNCTION_P50: cf.quantile(0.5)(measurement_field, alias=alias),
-        FuncEnum.FUNCTION_P95: cf.quantile(0.95)(measurement_field, alias=alias),
-        FuncEnum.FUNCTION_P99: cf.quantile(0.99)(measurement_field, alias=alias),
-    }
-    res = lookup.get(request.aggregate, None)
-    if res is None:
-        NotImplementedError()
-    return res  # type: ignore
-
-
-def _build_condition(request: AggregateBucketRequest) -> Expression:
-    project_ids = in_cond(
-        column("project_id"),
-        literals_array(
-            alias=None,
-            literals=[literal(pid) for pid in request.meta.project_ids],
-        ),
+    key_col = attribute_key_to_expression(
+        request.key, request.attribute_key_transform_context
     )
+    if request.aggregate == AggregateBucketRequest.FUNCTION_SUM:
+        return f.sum(key_col, alias="sum")
+    if request.aggregate == AggregateBucketRequest.FUNCTION_AVERAGE:
+        return f.avg(key_col, alias="avg")
+    if request.aggregate == AggregateBucketRequest.FUNCTION_COUNT:
+        return f.count(key_col, alias="count")
+    if request.aggregate == AggregateBucketRequest.FUNCTION_P50:
+        return cf.quantile(0.5)(key_col, alias="p50")
+    if request.aggregate == AggregateBucketRequest.FUNCTION_P95:
+        return cf.quantile(0.95)(key_col, alias="p90")
+    if request.aggregate == AggregateBucketRequest.FUNCTION_P99:
+        return cf.quantile(0.99)(key_col, alias="p95")
 
-    return and_cond(
-        project_ids,
-        f.equals(column("organization_id"), request.meta.organization_id),
-        # HACK: timestamp name
-        f.less(
-            column("start_timestamp"),
-            f.toDateTime(
-                datetime.utcfromtimestamp(request.end_timestamp.seconds).isoformat()
-            ),
-        ),
-        f.greaterOrEquals(
-            column("start_timestamp"),
-            f.toDateTime(
-                datetime.utcfromtimestamp(request.start_timestamp.seconds).isoformat()
-            ),
-        ),
+    raise BadSnubaRPCRequestException(
+        f"Aggregate {request.aggregate} had an unknown or unset type"
     )
 
 
@@ -133,11 +68,16 @@ def _build_query(request: AggregateBucketRequest) -> Query:
             SelectedExpression(name="time", expression=column("time", alias="time")),
             SelectedExpression(name="agg", expression=_get_aggregate_func(request)),
         ],
-        condition=_build_condition(request),
+        condition=base_conditions_and(
+            request.meta,
+            trace_item_filters_to_expression(
+                request.filter, request.attribute_key_transform_context
+            ),
+        ),
         granularity=request.granularity_secs,
         groupby=[column("time")],
     )
-    _treeify_or_and_conditions(res)
+    treeify_or_and_conditions(res)
     return res
 
 

--- a/snuba/web/rpc/timeseries.py
+++ b/snuba/web/rpc/timeseries.py
@@ -34,9 +34,7 @@ from snuba.web.rpc.exceptions import BadSnubaRPCRequestException
 def _get_aggregate_func(
     request: AggregateBucketRequest,
 ) -> Expression:
-    key_col = attribute_key_to_expression(
-        request.key, request.attribute_key_transform_context
-    )
+    key_col = attribute_key_to_expression(request.key)
     if request.aggregate == AggregateBucketRequest.FUNCTION_SUM:
         return f.sum(key_col, alias="sum")
     if request.aggregate == AggregateBucketRequest.FUNCTION_AVERAGE:
@@ -70,9 +68,7 @@ def _build_query(request: AggregateBucketRequest) -> Query:
         ],
         condition=base_conditions_and(
             request.meta,
-            trace_item_filters_to_expression(
-                request.filter, request.attribute_key_transform_context
-            ),
+            trace_item_filters_to_expression(request.filter),
         ),
         granularity=request.granularity_secs,
         groupby=[column("time")],

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -1,0 +1,31 @@
+from collections import OrderedDict
+
+from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
+    AttributeKey,
+    AttributeKeyTransformContext,
+)
+
+from snuba.query.dsl import Functions as f
+from snuba.query.dsl import column, literal, literals_array
+from snuba.web.rpc.common import attribute_key_to_expression
+
+
+class TestCommon:
+    def test_project_name_to_expression(self) -> None:
+        mapping = OrderedDict()
+        mapping[5] = "proj5"
+        mapping[1] = "proj1"
+
+        assert attribute_key_to_expression(
+            AttributeKey(
+                type=AttributeKey.TYPE_STRING,
+                name="project_name",
+            ),
+            AttributeKeyTransformContext(project_ids_to_names=mapping),
+        ) == f.transform(
+            column("project_id"),
+            literals_array(None, [literal(k) for k in mapping.keys()]),
+            literals_array(None, [literal(v) for v in mapping.values()]),
+            literal("unknown"),
+            alias="project_name",
+        )

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -5,13 +5,14 @@ from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
     AttributeKeyTransformContext,
 )
 
+from snuba.query import SubscriptableReference
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal, literals_array
 from snuba.web.rpc.common import attribute_key_to_expression
 
 
 class TestCommon:
-    def test_project_name_to_expression(self) -> None:
+    def test_expression_project_name(self) -> None:
         mapping = OrderedDict()
         mapping[5] = "proj5"
         mapping[1] = "proj1"
@@ -28,4 +29,103 @@ class TestCommon:
             literals_array(None, [literal(v) for v in mapping.values()]),
             literal("unknown"),
             alias="project_name",
+        )
+
+    def test_expression_trace_id(self):
+        assert attribute_key_to_expression(
+            AttributeKey(
+                type=AttributeKey.TYPE_STRING,
+                name="trace_id",
+            ),
+            AttributeKeyTransformContext(),
+        ) == f.CAST(column("trace_id"), "String", alias="trace_id")
+
+    def test_hex_id_columns(self):
+        for col in ["span_id", "parent_span_id", "segment_id"]:
+            assert attribute_key_to_expression(
+                AttributeKey(
+                    type=AttributeKey.TYPE_STRING,
+                    name=col,
+                ),
+                AttributeKeyTransformContext(),
+            ) == f.hex(column(col), alias=col)
+
+            assert attribute_key_to_expression(
+                AttributeKey(
+                    type=AttributeKey.TYPE_INT,
+                    name=col,
+                ),
+                AttributeKeyTransformContext(),
+            ) == f.CAST(column(col), "UInt64", alias=col)
+
+    def test_timestamp_columns(self):
+        for col in ["timestamp", "start_timestamp", "end_timestamp"]:
+            assert attribute_key_to_expression(
+                AttributeKey(
+                    type=AttributeKey.TYPE_STRING,
+                    name=col,
+                ),
+                AttributeKeyTransformContext(),
+            ) == f.CAST(column(col), "String", alias=col)
+            assert attribute_key_to_expression(
+                AttributeKey(
+                    type=AttributeKey.TYPE_INT,
+                    name=col,
+                ),
+                AttributeKeyTransformContext(),
+            ) == f.CAST(column(col), "Int64", alias=col)
+            assert attribute_key_to_expression(
+                AttributeKey(
+                    type=AttributeKey.TYPE_FLOAT,
+                    name=col,
+                ),
+                AttributeKeyTransformContext(),
+            ) == f.CAST(column(col), "Float64", alias=col)
+
+    def test_normalized_col(self):
+        assert attribute_key_to_expression(
+            AttributeKey(
+                type=AttributeKey.TYPE_STRING,
+                name="service",
+            ),
+            AttributeKeyTransformContext(),
+        ) == column("service")
+
+    def test_attributes(self):
+        assert attribute_key_to_expression(
+            AttributeKey(type=AttributeKey.TYPE_STRING, name="derp"),
+            AttributeKeyTransformContext(),
+        ) == SubscriptableReference(
+            alias="derp", column=column("attr_str"), key=literal("derp")
+        )
+
+        assert attribute_key_to_expression(
+            AttributeKey(type=AttributeKey.TYPE_FLOAT, name="derp"),
+            AttributeKeyTransformContext(),
+        ) == SubscriptableReference(
+            alias="derp", column=column("attr_num"), key=literal("derp")
+        )
+
+        assert attribute_key_to_expression(
+            AttributeKey(type=AttributeKey.TYPE_INT, name="derp"),
+            AttributeKeyTransformContext(),
+        ) == f.CAST(
+            SubscriptableReference(
+                alias="derp",
+                column=column("attr_num"),
+                key=literal("derp"),
+            ),
+            "Int64",
+        )
+
+        assert attribute_key_to_expression(
+            AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="derp"),
+            AttributeKeyTransformContext(),
+        ) == f.CAST(
+            SubscriptableReference(
+                alias="derp",
+                column=column("attr_num"),
+                key=literal("derp"),
+            ),
+            "Boolean",
         )

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -1,43 +1,18 @@
-from collections import OrderedDict
-
-from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
-    AttributeKey,
-    AttributeKeyTransformContext,
-)
+from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import column, literal, literals_array
+from snuba.query.dsl import column, literal
 from snuba.query.expressions import SubscriptableReference
 from snuba.web.rpc.common import attribute_key_to_expression
 
 
 class TestCommon:
-    def test_expression_project_name(self) -> None:
-        mapping = OrderedDict()
-        mapping[5] = "proj5"
-        mapping[1] = "proj1"
-
-        assert attribute_key_to_expression(
-            AttributeKey(
-                type=AttributeKey.TYPE_STRING,
-                name="project_name",
-            ),
-            AttributeKeyTransformContext(project_ids_to_names=mapping),
-        ) == f.transform(
-            column("project_id"),
-            literals_array(None, [literal(k) for k in mapping.keys()]),
-            literals_array(None, [literal(v) for v in mapping.values()]),
-            literal("unknown"),
-            alias="project_name",
-        )
-
     def test_expression_trace_id(self) -> None:
         assert attribute_key_to_expression(
             AttributeKey(
                 type=AttributeKey.TYPE_STRING,
                 name="trace_id",
             ),
-            AttributeKeyTransformContext(),
         ) == f.CAST(column("trace_id"), "String", alias="trace_id")
 
     def test_hex_id_columns(self) -> None:
@@ -47,7 +22,6 @@ class TestCommon:
                     type=AttributeKey.TYPE_STRING,
                     name=col,
                 ),
-                AttributeKeyTransformContext(),
             ) == f.hex(column(col), alias=col)
 
             assert attribute_key_to_expression(
@@ -55,7 +29,6 @@ class TestCommon:
                     type=AttributeKey.TYPE_INT,
                     name=col,
                 ),
-                AttributeKeyTransformContext(),
             ) == f.CAST(column(col), "UInt64", alias=col)
 
     def test_timestamp_columns(self) -> None:
@@ -65,21 +38,18 @@ class TestCommon:
                     type=AttributeKey.TYPE_STRING,
                     name=col,
                 ),
-                AttributeKeyTransformContext(),
             ) == f.CAST(column(col), "String", alias=col)
             assert attribute_key_to_expression(
                 AttributeKey(
                     type=AttributeKey.TYPE_INT,
                     name=col,
                 ),
-                AttributeKeyTransformContext(),
             ) == f.CAST(column(col), "Int64", alias=col)
             assert attribute_key_to_expression(
                 AttributeKey(
                     type=AttributeKey.TYPE_FLOAT,
                     name=col,
                 ),
-                AttributeKeyTransformContext(),
             ) == f.CAST(column(col), "Float64", alias=col)
 
     def test_normalized_col(self) -> None:
@@ -88,27 +58,23 @@ class TestCommon:
                 type=AttributeKey.TYPE_STRING,
                 name="service",
             ),
-            AttributeKeyTransformContext(),
         ) == column("service")
 
     def test_attributes(self) -> None:
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_STRING, name="derp"),
-            AttributeKeyTransformContext(),
         ) == SubscriptableReference(
             alias="derp", column=column("attr_str"), key=literal("derp")
         )
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_FLOAT, name="derp"),
-            AttributeKeyTransformContext(),
         ) == SubscriptableReference(
             alias="derp", column=column("attr_num"), key=literal("derp")
         )
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_INT, name="derp"),
-            AttributeKeyTransformContext(),
         ) == f.CAST(
             SubscriptableReference(
                 alias="derp",
@@ -120,7 +86,6 @@ class TestCommon:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="derp"),
-            AttributeKeyTransformContext(),
         ) == f.CAST(
             SubscriptableReference(
                 alias="derp",

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -5,9 +5,9 @@ from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import (
     AttributeKeyTransformContext,
 )
 
-from snuba.query import SubscriptableReference
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal, literals_array
+from snuba.query.expressions import SubscriptableReference
 from snuba.web.rpc.common import attribute_key_to_expression
 
 

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -31,7 +31,7 @@ class TestCommon:
             alias="project_name",
         )
 
-    def test_expression_trace_id(self):
+    def test_expression_trace_id(self) -> None:
         assert attribute_key_to_expression(
             AttributeKey(
                 type=AttributeKey.TYPE_STRING,
@@ -40,7 +40,7 @@ class TestCommon:
             AttributeKeyTransformContext(),
         ) == f.CAST(column("trace_id"), "String", alias="trace_id")
 
-    def test_hex_id_columns(self):
+    def test_hex_id_columns(self) -> None:
         for col in ["span_id", "parent_span_id", "segment_id"]:
             assert attribute_key_to_expression(
                 AttributeKey(
@@ -58,7 +58,7 @@ class TestCommon:
                 AttributeKeyTransformContext(),
             ) == f.CAST(column(col), "UInt64", alias=col)
 
-    def test_timestamp_columns(self):
+    def test_timestamp_columns(self) -> None:
         for col in ["timestamp", "start_timestamp", "end_timestamp"]:
             assert attribute_key_to_expression(
                 AttributeKey(
@@ -82,7 +82,7 @@ class TestCommon:
                 AttributeKeyTransformContext(),
             ) == f.CAST(column(col), "Float64", alias=col)
 
-    def test_normalized_col(self):
+    def test_normalized_col(self) -> None:
         assert attribute_key_to_expression(
             AttributeKey(
                 type=AttributeKey.TYPE_STRING,
@@ -91,7 +91,7 @@ class TestCommon:
             AttributeKeyTransformContext(),
         ) == column("service")
 
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_STRING, name="derp"),
             AttributeKeyTransformContext(),

--- a/tests/web/rpc/test_timeseries_api.py
+++ b/tests/web/rpc/test_timeseries_api.py
@@ -9,6 +9,7 @@ from sentry_protos.snuba.v1alpha.endpoint_aggregate_bucket_pb2 import (
     AggregateBucketRequest,
 )
 from sentry_protos.snuba.v1alpha.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -113,10 +114,10 @@ class TestTimeSeriesApi(BaseApiTest):
                 organization_id=1,
                 cogs_category="something",
                 referrer="something",
+                start_timestamp=ts,
+                end_timestamp=ts,
             ),
             aggregate=AggregateBucketRequest.FUNCTION_SUM,
-            start_timestamp=ts,
-            end_timestamp=ts,
             granularity_secs=60,
         )
         response = self.app.post("/timeseries", data=message.SerializeToString())
@@ -131,10 +132,10 @@ class TestTimeSeriesApi(BaseApiTest):
                 organization_id=1,
                 cogs_category="something",
                 referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
             ),
-            start_timestamp=Timestamp(seconds=hour_ago),
-            end_timestamp=ts,
-            metric_name="eap.measurement",
+            key=AttributeKey(name="eap.measurement", type=AttributeKey.TYPE_FLOAT),
             aggregate=AggregateBucketRequest.FUNCTION_AVERAGE,
             granularity_secs=1,
         )
@@ -150,10 +151,10 @@ class TestTimeSeriesApi(BaseApiTest):
                 organization_id=1,
                 cogs_category="something",
                 referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
             ),
-            start_timestamp=Timestamp(seconds=hour_ago),
-            end_timestamp=ts,
-            metric_name="eap.measurement",
+            key=AttributeKey(name="eap.measurement", type=AttributeKey.TYPE_FLOAT),
             aggregate=AggregateBucketRequest.FUNCTION_P99,
             granularity_secs=1,
         )

--- a/tests/web/rpc/test_timeseries_api.py
+++ b/tests/web/rpc/test_timeseries_api.py
@@ -117,6 +117,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 start_timestamp=ts,
                 end_timestamp=ts,
             ),
+            key=AttributeKey(name="project_id", type=AttributeKey.TYPE_INT),
             aggregate=AggregateBucketRequest.FUNCTION_SUM,
             granularity_secs=60,
         )


### PR DESCRIPTION
This lays the foundation for a lot of the shared snuba RPC logic, including evaluating column names and filters.