### PR TITLE
chore(eap): Add RPC folders to EAP codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@
 /snuba/datasets/configuration/events_analytics_platform   @getsentry/events-analytics-platform @getsentry/owners-snuba
 
 # EAP-related
-/snuba/protobufs @getsentry/events-analytics-platform
+/snuba/web/rpc @getsentry/events-analytics-platform @getsentry/owners-snuba
 /snuba/snuba_migrations/events-analytics-platform @getsentry/events-analytics-platform @getsentry/owners-snuba
 
 # rust_snuba


### PR DESCRIPTION
This folder is all stuff that is owned by EAP team.