### PR TITLE
Snuba admin sudo mode for system commands

### DIFF
--- a/snuba/admin/audit_log/action.py
+++ b/snuba/admin/audit_log/action.py
@@ -16,6 +16,7 @@ class AuditLogAction(Enum):
     ALLOCATION_POLICY_UPDATE = "allocation_policy.update"
     ALLOCATION_POLICY_DELETE = "allocation_policy.delete"
     DLQ_REPLAY = "dlq.replay"
+    RAN_SUDO_SYSTEM_QUERY = "ran.sudo.system.query"
 
 
 RUNTIME_CONFIG_ACTIONS = [

--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -82,6 +82,7 @@ TOOL_RESOURCES = {
     "cardinality-analyzer": ToolResource("cardinality-analyzer"),
     "production-queries": ToolResource("production-queries"),
     "system-queries": ToolResource("system-queries"),
+    "sudo-system-queries": ToolResource("system-queries"),
     "clickhouse-migrations": ToolResource("clickhouse-migrations"),
     "snuba-explain": ToolResource("snuba-explain"),
     "all": ToolResource("all"),
@@ -107,6 +108,14 @@ class ExecuteNonBlockingAction(MigrationAction):
 
 
 class ExecuteNoneAction(MigrationAction):
+    pass
+
+
+class ExecuteSudoSystemQuery(ToolAction):
+    """
+    Allow specific users to run system queries with elevated permissions
+    """
+
     pass
 
 
@@ -173,6 +182,10 @@ ROLES = {
         name="AllMigrationsExecutor",
         actions={ExecuteAllAction(list(MIGRATIONS_RESOURCES.values()))},
     ),
+    "ClickhouseAdmin": Role(
+        name="clickhouse-admin",
+        actions={ExecuteSudoSystemQuery([TOOL_RESOURCES["sudo-system-queries"]])},
+    ),
 }
 
 DEFAULT_ROLES = [
@@ -184,3 +197,4 @@ DEFAULT_ROLES = [
 
 if settings.TESTING or settings.DEBUG:
     DEFAULT_ROLES.append(ROLES["AllTools"])
+    DEFAULT_ROLES.append(ROLES["ClickhouseAdmin"])

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -7,6 +7,7 @@ from sql_metadata import Parser, QueryType  # type: ignore
 from snuba import settings
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseCluster
+from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.utils.serializable_exception import SerializableException
@@ -36,6 +37,31 @@ def is_valid_node(
     return any(node.host_name == host and node.port == port for node in nodes)
 
 
+def _get_storage(storage_name: str) -> ReadableTableStorage:
+    storage_key = None
+    try:
+        storage_key = StorageKey(storage_name)
+    except ValueError:
+        raise InvalidStorageError(
+            f"storage {storage_name} is not a valid storage name",
+            extra_data={"storage_name": storage_name},
+        )
+    return get_storage(storage_key)
+
+
+def _validate_node(
+    clickhouse_host: str,
+    clickhouse_port: int,
+    cluster: ClickhouseCluster,
+    storage_name: str,
+) -> None:
+    if not is_valid_node(clickhouse_host, clickhouse_port, cluster, storage_name):
+        raise InvalidNodeError(
+            f"host {clickhouse_host} and port {clickhouse_port} are not valid",
+            extra_data={"host": clickhouse_host, "port": clickhouse_port},
+        )
+
+
 NODE_CONNECTIONS: MutableMapping[str, ClickhousePool] = {}
 
 
@@ -45,29 +71,15 @@ def get_ro_node_connection(
     storage_name: str,
     client_settings: ClickhouseClientSettings,
 ) -> ClickhousePool:
-    storage_key = None
-    try:
-        storage_key = StorageKey(storage_name)
-    except ValueError:
-        raise InvalidStorageError(
-            f"storage {storage_name} is not a valid storage name",
-            extra_data={"storage_name": storage_name},
-        )
+    storage = _get_storage(storage_name)
 
-    key = f"{storage_key}-{clickhouse_host}"
+    key = f"{storage.get_storage_key()}-{clickhouse_host}"
     if key in NODE_CONNECTIONS:
         return NODE_CONNECTIONS[key]
 
-    storage = get_storage(storage_key)
     cluster = storage.get_cluster()
-
-    if not is_valid_node(clickhouse_host, clickhouse_port, cluster, storage_name):
-        raise InvalidNodeError(
-            f"host {clickhouse_host} and port {clickhouse_port} are not valid",
-            extra_data={"host": clickhouse_host, "port": clickhouse_port},
-        )
-
     database = cluster.get_database()
+    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
 
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
@@ -111,15 +123,7 @@ def get_ro_query_node_connection(
     if storage_name in CLUSTER_CONNECTIONS:
         return CLUSTER_CONNECTIONS[storage_name]
 
-    try:
-        storage_key = StorageKey(storage_name)
-    except ValueError:
-        raise InvalidStorageError(
-            f"storage {storage_name} is not a valid storage name",
-            extra_data={"storage_name": storage_name},
-        )
-
-    storage = get_storage(storage_key)
+    storage = _get_storage(storage_name)
     cluster = storage.get_cluster()
     connection_id = cluster.get_connection_id()
     connection = get_ro_node_connection(
@@ -127,6 +131,36 @@ def get_ro_query_node_connection(
     )
 
     CLUSTER_CONNECTIONS[storage_name] = connection
+    return connection
+
+
+def get_sudo_node_connection(
+    clickhouse_host: str,
+    clickhouse_port: int,
+    storage_name: str,
+    client_settings: ClickhouseClientSettings,
+) -> ClickhousePool:
+    storage = _get_storage(storage_name)
+
+    key = f"{storage.get_storage_key()}-{clickhouse_host}-sudo"
+    if key in NODE_CONNECTIONS:
+        return NODE_CONNECTIONS[key]
+
+    cluster = storage.get_cluster()
+    database = cluster.get_database()
+    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
+
+    (clickhouse_user, clickhouse_password) = storage.get_cluster().get_credentials()
+    connection = ClickhousePool(
+        clickhouse_host,
+        clickhouse_port,
+        clickhouse_user,
+        clickhouse_password,
+        database,
+        max_pool_size=2,
+        client_settings=client_settings.value.settings,
+    )
+    NODE_CONNECTIONS[key] = connection
     return connection
 
 

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -108,7 +108,7 @@ SYSTEM_COMMAND_RE = re.compile(
 ALTER_QUERY_RE = re.compile(
     r"""
         ^
-        (ALTER)
+        (ALTER|CREATE)
         \s
         [\w\s,=()*+<>'%"\-\/:]+
         ;? # Optional semicolon

--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -48,6 +48,13 @@
         "group:team-sns@sentry.io"
       ],
       "role": "roles/AllMigrationsExecutor"
+    },
+    {
+      "members": [
+        "group:team-ops@sentry.io",
+        "group:team-sns@sentry.io"
+      ],
+      "role": "roles/ClickhouseAdmin"
     }
   ]
 }

--- a/snuba/admin/static/clickhouse_queries/types.tsx
+++ b/snuba/admin/static/clickhouse_queries/types.tsx
@@ -8,7 +8,7 @@ type ClickhouseNodeData = {
   local_table_name: string;
   local_nodes: ClickhouseNode[];
   dist_nodes: ClickhouseNode[];
-  query_node: ClickhouseNode
+  query_node: ClickhouseNode;
 };
 
 type QueryRequest = {
@@ -16,6 +16,7 @@ type QueryRequest = {
   host: string;
   port: number;
   sql: string;
+  sudo: boolean;
 };
 
 type QueryResultColumnMetadata = [string];

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -30,7 +30,10 @@ from snuba.admin.clickhouse.predefined_cardinality_analyzer_queries import (
 from snuba.admin.clickhouse.predefined_querylog_queries import QuerylogQuery
 from snuba.admin.clickhouse.predefined_system_queries import SystemQuery
 from snuba.admin.clickhouse.querylog import describe_querylog_schema, run_querylog_query
-from snuba.admin.clickhouse.system_queries import run_system_query_on_host_with_sql
+from snuba.admin.clickhouse.system_queries import (
+    UnauthorizedForSudo,
+    run_system_query_on_host_with_sql,
+)
 from snuba.admin.clickhouse.tracing import run_query_and_get_trace
 from snuba.admin.dead_letter_queue import get_dlq_topics
 from snuba.admin.kafka.topics import get_broker_data
@@ -375,7 +378,7 @@ def auto_replacements_bypass_projects() -> Response:
 # Sample cURL command:
 #
 # curl -X POST \
-#  -d '{"host": "127.0.0.1", "port": 9000, "sql": "select count() from system.parts;", storage: "errors"}' \
+#  -d '{"host": "127.0.0.1", "port": 9000, "sql": "select count() from system.parts;", storage: "errors", sudo: false}' \
 #  -H 'Content-Type: application/json' \
 #  http://127.0.0.1:1219/run_clickhouse_system_query
 @application.route("/run_clickhouse_system_query", methods=["POST"])
@@ -390,20 +393,26 @@ def clickhouse_system_query() -> Response:
         port = req["port"]
         storage = req["storage"]
         raw_sql = req["sql"]
+        sudo_mode = req.get("sudo", False)
     except KeyError:
         return make_response(jsonify({"error": "Invalid request"}), 400)
 
     try:
-        result = run_system_query_on_host_with_sql(host, port, storage, raw_sql)
+        result = run_system_query_on_host_with_sql(
+            host, port, storage, raw_sql, sudo_mode, g.user
+        )
         rows = []
         rows, columns = cast(List[List[str]], result.results), result.meta
 
-        if columns:
+        if columns is not None:
             res = {}
             res["column_names"] = [name for name, _ in columns]
             res["rows"] = [[str(col) for col in row] for row in rows]
 
             return make_response(jsonify(res), 200)
+    except UnauthorizedForSudo as err:
+        return make_response(jsonify({"error": err.message or "Cannot sudo"}), 400)
+
     except InvalidCustomQuery as err:
         return make_response(jsonify({"error": err.message or "Invalid query"}), 400)
 

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -85,6 +85,7 @@ def test_is_query_select() -> None:
         ("system SHUTDOWN", False),
         ("system KILL", False),
         ("ALTER TABLE eap_spans_local_merge DROP PARTITION '1970-01-01'", True),
+        ("CREATE TABLE eap_spans_local_merge (all my fieds)", True),
     ],
 )
 def test_sudo_queries(sudo_query: str, expected: bool) -> None:

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -1,7 +1,19 @@
+from typing import Sequence
+
 import pytest
 
+from snuba import settings
+from snuba.admin.auth_roles import ROLES, Role
 from snuba.admin.clickhouse.common import InvalidCustomQuery
-from snuba.admin.clickhouse.system_queries import is_query_select, validate_system_query
+from snuba.admin.clickhouse.system_queries import (
+    UnauthorizedForSudo,
+    is_query_alter,
+    is_query_select,
+    is_system_command,
+    run_system_query_on_host_with_sql,
+    validate_system_query,
+)
+from snuba.admin.user import AdminUser
 
 
 @pytest.mark.parametrize(
@@ -62,3 +74,88 @@ ORDER BY table, flush_time
 
 def test_is_query_select() -> None:
     assert is_query_select(select_sql) == True
+
+
+@pytest.mark.parametrize(
+    "sudo_query, expected",
+    [
+        ("SYSSSSSSSTEM DO SOMETHING", False),
+        ("SYSTEM STOP MERGES", True),
+        ("system STOP MerGes", True),
+        ("system SHUTDOWN", False),
+        ("system KILL", False),
+        ("ALTER TABLE eap_spans_local_merge DROP PARTITION '1970-01-01'", True),
+    ],
+)
+def test_sudo_queries(sudo_query: str, expected: bool) -> None:
+    assert (is_system_command(sudo_query) or is_query_alter(sudo_query)) == expected
+    with pytest.raises(InvalidCustomQuery):
+        validate_system_query(sudo_query)
+
+
+@pytest.mark.parametrize(
+    "query, roles, sudo_mode, expect_authorized, expect_valid",
+    [
+        pytest.param(
+            "SYSTEM START MERGES",
+            [ROLES["ClickhouseAdmin"], ROLES["ProductTools"]],
+            True,
+            True,
+            True,
+            id="Admin user",
+        ),
+        pytest.param(
+            "SYSTEM START MERGES",
+            [ROLES["ClickhouseAdmin"], ROLES["ProductTools"]],
+            False,
+            True,
+            False,
+            id="Admin not using sudo",
+        ),
+        pytest.param(
+            "SYSTEM START MERGES",
+            [ROLES["ProductTools"]],
+            True,
+            False,
+            True,
+            id="Not admin trying to use sudo",
+        ),
+        pytest.param(
+            "SYSTEM START MERGES",
+            [ROLES["ProductTools"]],
+            False,
+            True,
+            False,
+            id="Not admin not trying sudo. Query invalid",
+        ),
+    ],
+)
+def test_run_sudo_queries(
+    query: str,
+    roles: Sequence[Role],
+    sudo_mode: bool,
+    expect_authorized: bool,
+    expect_valid: bool,
+) -> None:
+    def run_query() -> None:
+        run_system_query_on_host_with_sql(
+            settings.CLUSTERS[0]["host"],
+            int(settings.CLUSTERS[0]["port"]),
+            "errors",
+            query,
+            sudo_mode,
+            AdminUser(
+                "me@myself.org",
+                "me@myself.org",
+                roles,
+            ),
+        )
+
+    if not expect_authorized:
+        with pytest.raises(UnauthorizedForSudo):
+            run_query()
+    elif not expect_valid:
+        with pytest.raises(Exception):
+            run_query()
+    else:
+        run_query()

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -130,6 +130,7 @@ def test_sudo_queries(sudo_query: str, expected: bool) -> None:
         ),
     ],
 )
+@pytest.mark.clickhouse_db
 def test_run_sudo_queries(
     query: str,
     roles: Sequence[Role],


### PR DESCRIPTION
There has been a lot of requirests for prodction access and SRE tickets
to execute clickhouse system commands that were not supported in the
snuba admin.

This includes commands like: SYSTEM and ALTER.

These commands do not expose customer data. 
They were not exposed at the beginning because they are as safe as
playing with an armed nuclear warhead.

Now snuba has RBAC and an audit log. The Sns team can consider revisiting
this decision.

This PR implements the sudo mode for the system queries
tool in the snuba admin:
- a new parameter is passed to http://127.0.0.1:1219/run_clickhouse_system_query. Which is called `sudo` 
- if the parameter is true the user is trying to execute a query in sudo mode
- If the user has the required role, the system would accept SYSTEM and ALTER statements
- SYSTEM KILL and SYSTEM SHUTDOWN are still not allowed as the servers cannot be restarted without external intervention.
- The role is assigned to sns and ops so far.
- if the parameter is false and a system query is attempted, the behavior is the same as before.
- Using sudo mode writes an entry in the audit log.

The UI (my web design abilities stopped improving in 1997 on Internet Explorer 4)
<img width="1156" alt="Screenshot 2024-08-28 at 11 57 39 PM" src="https://github.com/user-attachments/assets/44323553-f88a-40ab-9758-8d00d96bf0e4">

