### PR TITLE
Fix local Snuba Admin import errors by adding codemirror packages

### DIFF
--- a/snuba/admin/package.json
+++ b/snuba/admin/package.json
@@ -34,6 +34,10 @@
     "typescript": "^4.8.3"
   },
   "devDependencies": {
+    "@codemirror/commands": "^6.6.0",
+    "@codemirror/lang-sql": "^6.7.0",
+    "@codemirror/state": "^6.4.1",
+    "@codemirror/view": "^6.32.0",
     "@emotion/react": "^11.11.1",
     "@jest/globals": "^29.4.3",
     "@mantine/core": "^6.0.15",


### PR DESCRIPTION
`make watch-admin `on local shows up a bunch of errors like this:
```
ERROR in /Users/onkardeshpande/code/snuba/snuba/admin/static/common/components/sql_editor.tsx
./static/common/components/sql_editor.tsx 6:20-42
[tsl] ERROR in /Users/onkardeshpande/code/snuba/snuba/admin/static/common/components/sql_editor.tsx(6,21)
      TS2307: Cannot find module '@codemirror/lang-sql' or its corresponding type declarations.
 @ ./static/query_editor.tsx 40:19-69
 @ ./static/snuba_explain/index.tsx 51:37-71
 @ ./static/data.tsx 20:38-73
 @ ./static/index.tsx 35:13-39
``` 
This change fixes it by adding these modules in dev dependencies.