### PR TITLE
Emits DD metric for queries statuses

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -936,7 +936,22 @@ def _apply_allocation_policies_quota(
         stats["quota_allowance"]["summary"] = summary
 
         if not can_run:
+            metrics.increment(
+                "rejected_query",
+                tags={"storage_key": allocation_policies[0].storage_key.value},
+            )
             raise AllocationPolicyViolations.from_args(stats["quota_allowance"])
+
+        if throttle_quota_and_policy is not None:
+            metrics.increment(
+                "throttled_query",
+                tags={"storage_key": allocation_policies[0].storage_key.value},
+            )
+        else:
+            metrics.increment(
+                "successful_query",
+                tags={"storage_key": allocation_policies[0].storage_key.value},
+            )
         # Before allocation policies were a thing, the query pipeline would apply
         # thread limits in a query processor. That is not necessary if there
         # is an allocation_policy in place but nobody has removed that code yet.


### PR DESCRIPTION
We currently emit these metrics on a per-policy level, which means some queries can be counted multiple times for multiple policies. This PR adds metrics so we only count each query once. This will allow us to get a more accurate sense of the % of queries that are successful/throttled/rejected