### PR TITLE
Fix snuba admin trace query execution

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -520,19 +520,20 @@ def clickhouse_trace_query() -> Response:
                 else:
                     break
 
-            query_trace.profile_events_meta.append(system_query_result.meta)
-            query_trace.profile_events_profile = cast(
-                Dict[str, int], system_query_result.profile
-            )
-            columns = system_query_result.meta
-            if columns:
-                res = {}
-                res["column_names"] = [name for name, _ in columns]
-                res["rows"] = []
-                for query_result in system_query_result.results:
-                    if query_result[0]:
-                        res["rows"].append(json.dumps(query_result[0]))
-                query_trace.profile_events_results[query_trace_data.node_name] = res
+            if system_query_result is not None and len(system_query_result.results) > 0:
+                query_trace.profile_events_meta.append(system_query_result.meta)
+                query_trace.profile_events_profile = cast(
+                    Dict[str, int], system_query_result.profile
+                )
+                columns = system_query_result.meta
+                if columns:
+                    res = {}
+                    res["column_names"] = [name for name, _ in columns]
+                    res["rows"] = []
+                    for query_result in system_query_result.results:
+                        if query_result[0]:
+                            res["rows"].append(json.dumps(query_result[0]))
+                    query_trace.profile_events_results[query_trace_data.node_name] = res
         return make_response(jsonify(asdict(query_trace)), 200)
     except InvalidCustomQuery as err:
         return make_response(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -503,7 +503,7 @@ def clickhouse_trace_query() -> Response:
             sql = profile_events_raw_sql.format(query_trace_data.query_id)
             system_query_result, counter = None, 0
 
-            while counter < 10:
+            while counter < 60:
                 # There is a race between the trace query and the 'SELECT ProfileEvents...' query. ClickHouse does not immediately
                 # return the rows for 'SELECT ProfileEvents...' query. To make it return rows, sleep between the query executions.
                 system_query_result = run_system_query_on_host_with_sql(
@@ -519,11 +519,6 @@ def clickhouse_trace_query() -> Response:
                     counter += 1
                 else:
                     break
-
-            if system_query_result is None or len(system_query_result.results) == 0:
-                raise ClickhouseTimeoutError(
-                    "Waited too long for getting the result of query: {}".format(sql)
-                )
 
             query_trace.profile_events_meta.append(system_query_result.meta)
             query_trace.profile_events_profile = cast(


### PR DESCRIPTION
Snuba admin changes to append ProfileEvents to the trace query output were timing out after 10 seconds and not returning the trace query output. The fix involves updating the Snuba admin trace query execution to wait 60 seconds for retrieving ProfileEvents from both storage and query nodes where the query was executed. If the ProfileEvents aren't available within that time, it will return just the trace query output.

