### PR TITLE
feat(eap): Add a processor that allows you to do mapKeys on attr_str

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
@@ -64,6 +64,11 @@ query_processors:
       time_parse_columns:
         - start_timestamp
         - end_timestamp
+  - processor: HashBucketFunctionTransformer
+    args:
+      hash_bucket_names:
+        - attr_str
+        - attr_num
 
 validate_data_model: error
 validators:

--- a/snuba/query/processors/logical/hash_bucket_functions.py
+++ b/snuba/query/processors/logical/hash_bucket_functions.py
@@ -1,0 +1,65 @@
+from typing import Sequence
+
+from snuba.query.expressions import Column, Expression, FunctionCall
+from snuba.query.logical import Query
+from snuba.query.processors.logical import LogicalQueryProcessor
+from snuba.query.query_settings import QuerySettings
+from snuba.utils.constants import ATTRIBUTE_BUCKETS
+
+
+class HashBucketFunctionTransformer(LogicalQueryProcessor):
+    """
+    In eap_spans, we split up map columns for better performance.
+    In the entity, attr_str Map(String, String) becomes
+    attr_str_0 Map(String, String),
+    attr_str_1 Map(String, String),
+    etc.
+
+    This transformer converts mapKeys(attr_str) to arrayConcat(mapKeys(attr_str_0), mapKeys(attr_str_1), ...)
+    and the same for mapValues
+    """
+
+    def __init__(
+        self,
+        hash_bucket_names: Sequence[str],
+    ):
+        self.hash_bucket_names = hash_bucket_names
+
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
+        def transform_expression(exp: Expression) -> Expression:
+            if not isinstance(exp, FunctionCall):
+                return exp
+
+            if len(exp.parameters) != 1:
+                return exp
+
+            param = exp.parameters[0]
+            if not isinstance(param, Column):
+                return exp
+
+            if param.column_name not in self.hash_bucket_names:
+                return exp
+
+            if exp.function_name not in ("mapKeys", "mapValues"):
+                return exp
+
+            return FunctionCall(
+                alias=exp.alias,
+                function_name="arrayConcat",
+                parameters=tuple(
+                    FunctionCall(
+                        None,
+                        function_name=exp.function_name,
+                        parameters=(
+                            Column(
+                                None,
+                                column_name=f"{param.column_name}_{i}",
+                                table_name=param.table_name,
+                            ),
+                        ),
+                    )
+                    for i in range(ATTRIBUTE_BUCKETS)
+                ),
+            )
+
+        query.transform_expressions(transform_expression)

--- a/tests/query/processors/test_hash_bucket_functions_processor.py
+++ b/tests/query/processors/test_hash_bucket_functions_processor.py
@@ -1,0 +1,196 @@
+from copy import deepcopy
+
+import pytest
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.query import SelectedExpression
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.dsl import Functions as f
+from snuba.query.dsl import binary_condition, literal
+from snuba.query.expressions import Column, FunctionCall
+from snuba.query.logical import Query
+from snuba.query.processors.logical.hash_bucket_functions import (
+    HashBucketFunctionTransformer,
+)
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.utils.constants import ATTRIBUTE_BUCKETS
+
+test_data = [
+    (
+        Query(
+            QueryEntity(EntityKey.EAP_SPANS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "keys",
+                    FunctionCall("alias", "mapKeys", (Column(None, None, "attr_str"),)),
+                ),
+                SelectedExpression(
+                    "unrelated",
+                    Column(None, None, "column2"),
+                ),
+                SelectedExpression(
+                    "unrelated_map",
+                    FunctionCall(
+                        "aliasunrelatedmap",
+                        "mapKeys",
+                        (Column(None, None, "attr_stru"),),
+                    ),
+                ),
+            ],
+        ),
+        Query(
+            QueryEntity(EntityKey.EAP_SPANS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "keys",
+                    FunctionCall(
+                        "alias",
+                        "arrayConcat",
+                        tuple(
+                            FunctionCall(
+                                None, "mapKeys", (Column(None, None, f"attr_str_{i}"),)
+                            )
+                            for i in range(ATTRIBUTE_BUCKETS)
+                        ),
+                    ),
+                ),
+                SelectedExpression(
+                    "unrelated",
+                    Column(None, None, "column2"),
+                ),
+                SelectedExpression(
+                    "unrelated_map",
+                    FunctionCall(
+                        "aliasunrelatedmap",
+                        "mapKeys",
+                        (Column(None, None, "attr_stru"),),
+                    ),
+                ),
+            ],
+        ),
+    ),
+    (
+        Query(
+            QueryEntity(EntityKey.EAP_SPANS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "values",
+                    FunctionCall(
+                        "alias", "mapValues", (Column(None, None, "attr_str"),)
+                    ),
+                ),
+                SelectedExpression(
+                    "unrelated",
+                    Column(None, None, "column2"),
+                ),
+                SelectedExpression(
+                    "unrelated_map",
+                    FunctionCall(
+                        "aliasunrelatedmap",
+                        "mapValues",
+                        (Column(None, None, "attr_stru"),),
+                    ),
+                ),
+            ],
+        ),
+        Query(
+            QueryEntity(EntityKey.EAP_SPANS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "values",
+                    FunctionCall(
+                        "alias",
+                        "arrayConcat",
+                        tuple(
+                            FunctionCall(
+                                None,
+                                "mapValues",
+                                (Column(None, None, f"attr_str_{i}"),),
+                            )
+                            for i in range(ATTRIBUTE_BUCKETS)
+                        ),
+                    ),
+                ),
+                SelectedExpression(
+                    "unrelated",
+                    Column(None, None, "column2"),
+                ),
+                SelectedExpression(
+                    "unrelated_map",
+                    FunctionCall(
+                        "aliasunrelatedmap",
+                        "mapValues",
+                        (Column(None, None, "attr_stru"),),
+                    ),
+                ),
+            ],
+        ),
+    ),
+    (
+        Query(
+            QueryEntity(EntityKey.EAP_SPANS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "unrelated",
+                    Column(None, None, "column2"),
+                ),
+            ],
+            condition=binary_condition(
+                "or",
+                f.equals(
+                    Column(None, None, "unrelated1"), Column(None, None, "unrelated2")
+                ),
+                f.greaterThan(
+                    f.length(
+                        FunctionCall(
+                            "alias", "mapValues", (Column(None, None, "attr_str"),)
+                        )
+                    ),
+                    literal(2),
+                ),
+            ),
+        ),
+        Query(
+            QueryEntity(EntityKey.EAP_SPANS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "unrelated",
+                    Column(None, None, "column2"),
+                ),
+            ],
+            condition=binary_condition(
+                "or",
+                f.equals(
+                    Column(None, None, "unrelated1"), Column(None, None, "unrelated2")
+                ),
+                f.greaterThan(
+                    f.length(
+                        FunctionCall(
+                            "alias",
+                            "arrayConcat",
+                            tuple(
+                                FunctionCall(
+                                    None,
+                                    "mapValues",
+                                    (Column(None, None, f"attr_str_{i}"),),
+                                )
+                                for i in range(ATTRIBUTE_BUCKETS)
+                            ),
+                        )
+                    ),
+                    literal(2),
+                ),
+            ),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("pre_format, expected_query", test_data)
+def test_format_expressions(pre_format: Query, expected_query: Query) -> None:
+    copy = deepcopy(pre_format)
+    HashBucketFunctionTransformer("attr_str").process_query(copy, HTTPQuerySettings())
+    assert copy.get_selected_columns() == expected_query.get_selected_columns()
+    assert copy.get_groupby() == expected_query.get_groupby()
+    assert copy.get_condition() == expected_query.get_condition()


### PR DESCRIPTION
In eap_spans, we split up map columns for better performance.
In the entity, 
`attr_str Map(String, String)`

becomes

```
attr_str_0 Map(String, String),
attr_str_1 Map(String, String),
...
```
in the storage.

This transformer converts mapKeys(attr_str) to arrayConcat(mapKeys(attr_str_0), mapKeys(attr_str_1), ...)
and the same for mapValues