### PR TITLE
Fixing Snuba Admin trace UI error.

### DIFF
--- a/snuba/admin/static/tracing/index.tsx
+++ b/snuba/admin/static/tracing/index.tsx
@@ -259,7 +259,7 @@ function TracingQueries(props: { api: Client }) {
             {aggregation_summaries}
             {sorting_summaries}
             <Title order={4}>Total</Title>
-            {value.execute_summaries.map((e) => executeSummary(e))}
+            {value.execute_summaries && value.execute_summaries.map((e) => executeSummary(e))}
           </Stack>
         </Accordion.Panel>
       </Accordion.Item>


### PR DESCRIPTION
Another instance where a null check was missing before calling the function to retrieve values.
