### PR TITLE
bug(admin): Fix invalid query error alerting in snuba admin

### DIFF
--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -65,7 +65,7 @@ function QueryDisplay(props: {
       .executeCardinalityQuery(query as CardinalityQueryRequest)
       .then((result) => {
         result.input_query = query.sql || "<Input Query>";
-        setRecentHistory(HISTORY_KEY, result)
+        setRecentHistory(HISTORY_KEY, result);
         setCardinalityQueryResultHistory((prevHistory) => [
           result,
           ...prevHistory,

--- a/snuba/admin/static/production_queries/index.tsx
+++ b/snuba/admin/static/production_queries/index.tsx
@@ -27,7 +27,9 @@ const HISTORY_KEY = "production_queries";
 function ProductionQueries(props: { api: Client }) {
   const [datasets, setDatasets] = useState<string[]>([]);
   const [allowedProjects, setAllowedProjects] = useState<string[]>([]);
-  const [snql_query, setQuery] = useState<Partial<SnQLRequest>>({dataset: getParamFromStorage("dataset")});
+  const [snql_query, setQuery] = useState<Partial<SnQLRequest>>({
+    dataset: getParamFromStorage("dataset"),
+  });
   const [queryResultHistory, setQueryResultHistory] = useState<QueryResult[]>(
     getRecentHistory(HISTORY_KEY)
   );

--- a/snuba/admin/static/querylog/query_display.tsx
+++ b/snuba/admin/static/querylog/query_display.tsx
@@ -35,7 +35,7 @@ function QueryDisplay(props: {
       .executeQuerylogQuery(query as QuerylogRequest)
       .then((result) => {
         result.input_query = query.sql || "<Input Query>";
-        setRecentHistory(HISTORY_KEY, result)
+        setRecentHistory(HISTORY_KEY, result);
         setQueryResultHistory((prevHistory) => [result, ...prevHistory]);
       });
   }

--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -13,7 +13,7 @@ import QueryEditor from "SnubaAdmin/query_editor";
 import { Table } from "SnubaAdmin/table";
 import ExecuteButton from "SnubaAdmin/utils/execute_button";
 import { getRecentHistory, setRecentHistory } from "SnubaAdmin/query_history";
-import {CustomSelect, getParamFromStorage } from "SnubaAdmin/select";
+import { CustomSelect, getParamFromStorage } from "SnubaAdmin/select";
 import { TracingRequest, TracingResult, PredefinedQuery } from "./types";
 
 type QueryState = Partial<TracingRequest>;
@@ -28,7 +28,9 @@ function QueryDisplay(props: {
   predefinedQueryOptions: Array<PredefinedQuery>;
 }) {
   const [storages, setStorages] = useState<string[]>([]);
-  const [query, setQuery] = useState<QueryState>({storage: getParamFromStorage("storage")});
+  const [query, setQuery] = useState<QueryState>({
+    storage: getParamFromStorage("storage"),
+  });
   const [queryResultHistory, setQueryResultHistory] = useState<TracingResult[]>(
     getRecentHistory(HISTORY_KEY)
   );
@@ -65,7 +67,7 @@ function QueryDisplay(props: {
           profile_events_profile: result.profile_events_profile,
           error: result.error,
         };
-        setRecentHistory(HISTORY_KEY, tracing_result)
+        setRecentHistory(HISTORY_KEY, tracing_result);
         setQueryResultHistory((prevHistory) => [
           tracing_result,
           ...prevHistory,

--- a/snuba/admin/static/utils/execute_button.tsx
+++ b/snuba/admin/static/utils/execute_button.tsx
@@ -13,7 +13,7 @@ function ExecuteButton(props: {
 
   const defaultError = (err: any) => {
     console.log("ERROR", err);
-    window.alert("An error occurred: " + err.error.message);
+    window.alert("An error occurred: " + err);
   };
   let errorCallback = props.onError || defaultError;
 


### PR DESCRIPTION
There was a bug in https://github.com/getsentry/snuba/pull/6222 which incorrectly parsed the `err` string in `snuba/admin/static/utils/execute_button.tsx`. The PR fixes that to ensure that query errors are presented back to the user in admin.