### PR TITLE
feat(job-runner): scaffolding for job manifest testing

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -72,6 +72,7 @@ from snuba.datasets.storages.factory import (
     get_writable_storage,
 )
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.manual_jobs.manifest_reader import read_jobs_manifest
 from snuba.migrations.connect import check_for_inactive_replicas
 from snuba.migrations.errors import InactiveClickhouseReplica, MigrationError
 from snuba.migrations.groups import MigrationGroup, get_group_readiness_state
@@ -1264,3 +1265,9 @@ def delete() -> Response:
 @check_tool_perms(tools=[AdminTools.DELETE_TOOL])
 def deletes_enabled() -> Response:
     return make_response(jsonify(deletes_are_enabled()), 200)
+
+
+@application.route("/job-manifests", methods=["GET"])
+@check_tool_perms(tools=[AdminTools.ALL])
+def get_job_manifests() -> Response:
+    return make_response(jsonify(read_jobs_manifest()), 200)

--- a/snuba/manual_jobs/manifest_reader.py
+++ b/snuba/manual_jobs/manifest_reader.py
@@ -5,7 +5,8 @@ import simplejson
 
 
 class _ManifestReader:
-    def read(filename) -> Sequence[Any]:
+    @staticmethod
+    def read(filename: str) -> Sequence[Any]:
         local_root = os.path.dirname(__file__)
         with open(os.path.join(local_root, filename)) as stream:
             contents = simplejson.loads(stream.read())

--- a/snuba/manual_jobs/manifest_reader.py
+++ b/snuba/manual_jobs/manifest_reader.py
@@ -1,0 +1,17 @@
+import os
+from typing import Any, Sequence
+
+import simplejson
+
+
+class _ManifestReader:
+    def read(filename) -> Sequence[Any]:
+        local_root = os.path.dirname(__file__)
+        with open(os.path.join(local_root, filename)) as stream:
+            contents = simplejson.loads(stream.read())
+            assert isinstance(contents, Sequence)
+            return contents
+
+
+def read_jobs_manifest() -> Sequence[Any]:
+    return _ManifestReader.read("run_manifest.json")

--- a/snuba/manual_jobs/run_manifest.json
+++ b/snuba/manual_jobs/run_manifest.json
@@ -1,0 +1,1 @@
+[{ "id": "abc1234", "job_type": "ToyJob", "params": { "p1": "value1" } }]


### PR DESCRIPTION
In this PR, I'm creating a sample job run manifest along with a reader and an API endpoint to return what's in the static file. This will help me test whether the plumbing to put different static files in this location is working.

Next steps: deploy to prod, validate the correct result. Start working on providing a different payload in a different environment based on the ops repo.