### PR TITLE
bug(query): Run entity validators in composite query pipeline

### DIFF
--- a/snuba/pipeline/stages/query_processing.py
+++ b/snuba/pipeline/stages/query_processing.py
@@ -42,6 +42,7 @@ class EntityProcessingStage(
         elif isinstance(query, CompositeQuery):
             # if we were not able to translate the storage query earlier and we got to this point, this is
             # definitely a composite entity query
+            run_entity_validators(query, pipe_input.query_settings)
             return translate_composite_query(
                 cast(CompositeQuery[Entity], query),
                 pipe_input.query_settings,

--- a/snuba/pipeline/stages/query_processing.py
+++ b/snuba/pipeline/stages/query_processing.py
@@ -34,15 +34,14 @@ class EntityProcessingStage(
         if translated_storage_query:
             return translated_storage_query
 
+        run_entity_validators(cast(EntityQuery, query), pipe_input.query_settings)
         if isinstance(query, LogicalQuery) and isinstance(
             query.get_from_clause(), Entity
         ):
-            run_entity_validators(cast(EntityQuery, query), pipe_input.query_settings)
             return run_entity_processing_executor(query, pipe_input.query_settings)
         elif isinstance(query, CompositeQuery):
             # if we were not able to translate the storage query earlier and we got to this point, this is
             # definitely a composite entity query
-            run_entity_validators(query, pipe_input.query_settings)
             return translate_composite_query(
                 cast(CompositeQuery[Entity], query),
                 pipe_input.query_settings,


### PR DESCRIPTION
This PR contains a fix for this sentry [issue](https://sentry.sentry.io/issues/5825035976/?project=300688&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=4&utc=true). In the composite query pipeline, snuba is not running entity validators. As a result, join queries with missing columns (e.g. mql formula queries with unresolved tag keys) are reaching ClickHouse and affecting our SLO. Instead, the entity validator should catch these invalid queries and fail accordingly.