### PR TITLE
feat(eap): Shard meta tables by trace ID

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0013_span_attribute_table_shard_keys.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0013_span_attribute_table_shard_keys.py
@@ -65,7 +65,7 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.DropTable(
                 storage_set=self.storage_set_key,
                 table_name=self.num_dist_table_name,
-                target=OperationTarget.LOCAL,
+                target=OperationTarget.DISTRIBUTED,
             ),
             operations.CreateTable(
                 storage_set=self.storage_set_key,
@@ -80,7 +80,7 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.DropTable(
                 storage_set=self.storage_set_key,
                 table_name=self.str_dist_table_name,
-                target=OperationTarget.LOCAL,
+                target=OperationTarget.DISTRIBUTED,
             ),
             operations.CreateTable(
                 storage_set=self.storage_set_key,
@@ -99,7 +99,7 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.DropTable(
                 storage_set=self.storage_set_key,
                 table_name=self.num_dist_table_name,
-                target=OperationTarget.LOCAL,
+                target=OperationTarget.DISTRIBUTED,
             ),
             operations.CreateTable(
                 storage_set=self.storage_set_key,
@@ -114,7 +114,7 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.DropTable(
                 storage_set=self.storage_set_key,
                 table_name=self.str_dist_table_name,
-                target=OperationTarget.LOCAL,
+                target=OperationTarget.DISTRIBUTED,
             ),
             operations.CreateTable(
                 storage_set=self.storage_set_key,

--- a/snuba/snuba_migrations/events_analytics_platform/0013_span_attribute_table_shard_keys.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0013_span_attribute_table_shard_keys.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import (
+    UUID,
+    Column,
+    DateTime,
+    Float,
+    SimpleAggregateFunction,
+    String,
+    UInt,
+)
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    This migration creates a table meant to store just the attributes seen in a particular org.
+    The table is populated by a separate materialized view for each type of attribute.
+    """
+
+    blocking = False
+    storage_set_key = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+    granularity = "8192"
+
+    num_view_name = "spans_num_attrs_mv"
+    num_local_table_name = "spans_num_attrs_local"
+    num_dist_table_name = "spans_num_attrs_dist"
+    num_table_columns: Sequence[Column[Modifiers]] = [
+        Column("organization_id", UInt(64)),
+        Column(
+            "trace_id", UUID()
+        ),  # recommended by altinity, this lets us find traces which have k=v set
+        Column("project_id", UInt(64)),
+        Column("attr_key", String()),
+        Column("attr_value", Float(64)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["ZSTD(1)"]))),
+        Column("retention_days", UInt(16)),
+        Column("duration_ms", SimpleAggregateFunction("max", [UInt(32)])),
+        Column("count", SimpleAggregateFunction("sum", [UInt(64)])),
+    ]
+
+    str_view_name = "spans_str_attrs_mv"
+    str_local_table_name = "spans_str_attrs_local"
+    str_dist_table_name = "spans_str_attrs_dist"
+    str_table_columns: Sequence[Column[Modifiers]] = [
+        Column("organization_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column(
+            "trace_id", UUID()
+        ),  # recommended by altinity, this lets us find traces which have k=v set
+        Column("attr_key", String()),
+        Column("attr_value", String()),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["ZSTD(1)"]))),
+        Column("retention_days", UInt(16)),
+        Column("count", SimpleAggregateFunction("sum", [UInt(64)])),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.num_dist_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.num_dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.num_local_table_name,
+                    sharding_key="cityHash64(reinterpretAsUInt128(trace_id))",  # sharding keys must be at most 64 bits
+                ),
+                columns=self.num_table_columns,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.str_dist_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.str_dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.str_local_table_name,
+                    sharding_key="cityHash64(reinterpretAsUInt128(trace_id))",  # sharding keys must be at most 64 bits
+                ),
+                columns=self.str_table_columns,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.num_dist_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.num_dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.num_local_table_name,
+                    sharding_key=None,
+                ),
+                columns=self.num_table_columns,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.str_dist_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.str_dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.str_local_table_name,
+                    sharding_key=None,
+                ),
+                columns=self.str_table_columns,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]


### PR DESCRIPTION
We'd like to be able to write queries like this one:

```
SELECT
    quantileTDigest(0.75)(duration_ms)
FROM eap_spans_dist
    PREWHERE name = '/npv' and is_segment = true
WHERE
    organization_id = 22381
  AND project_id = 1506863
  AND attr_str_0['transaction.op'] = 'navigation'
  AND attr_str_14['platform'] != 'roku'
  AND attr_str_14['environment'] = 'prod'
  AND _sort_timestamp > toDateTime(1725576602)
  AND (_sort_timestamp, trace_id) IN (
    SELECT any(timestamp) AS ts, trace_id FROM spans_str_attrs_local WHERE (organization_id, attr_key, attr_value) IN ((22381, 'transaction.op', 'navigation'), (22381, 'environment', 'prod'))
    AND timestamp > toDateTime(1725576602)
    GROUP BY trace_id
    HAVING groupBitOr(attr_key = 'transaction.op' AND attr_value = 'navigation')
       AND groupBitOr(attr_key = 'environment' AND attr_value = 'prod')
    ORDER BY ts
  )
LIMIT 0, 51
SETTINGS max_threads=10, max_memory_usage=0, min_bytes_to_use_direct_io=1,
distributed_product_mode = 'allow'
```

The eap_spans_dist table is sharded by this same shard key `cityHash64(reinterpretAsUInt128(trace_id))`

If you don't shard both with the same shard key, you either have to do a two step process (GLOBAL):
- select all trace IDs from all shards
- send that list of all trace IDs to all shards
this is slow.

Or, you can do
- select trace IDs on each shard

This is incorrect, since you might skip spans which match the conditions, but just happen not to have the meta table rows stored on the same shard.

If you shard both tables by trace_id, you can join on trace_id in a distributed manner, which appears to be ~5x faster.