### PR TITLE
feat(eap): Start ingesting data into sample_weight_2 column

### DIFF
--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -52,7 +52,8 @@ struct EAPSpan {
     name: String, //aka description
 
     sampling_factor: f64,
-    sampling_weight: f64,
+    sampling_weight: f64, //remove eventually
+    sampling_weight_2: u64,
     sign: u8, //1 for additions, -1 for deletions - for this worker it should be 1
 
     #(
@@ -101,7 +102,8 @@ impl From<FromSpanMessage> for EAPSpan {
             retention_days: from.retention_days,
             name: from.description.unwrap_or_default(),
 
-            sampling_weight: 1.,
+            sampling_weight: 1., //remove eventually
+            sampling_weight_2: 1,
             sampling_factor: 1.,
             sign: 1,
 
@@ -153,6 +155,7 @@ impl From<FromSpanMessage> for EAPSpan {
                     if k == "client_sample_rate" && v.value != 0.0 {
                         res.sampling_factor = v.value;
                         res.sampling_weight = 1.0 / v.value;
+                        res.sampling_weight_2 = (1.0 / v.value) as u64;
                     } else {
                         insert_num(k.clone(), v.value);
                     }

--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -220,6 +220,9 @@ mod tests {
     "measurements": {
         "num_of_spans": {
             "value": 50.0
+        },
+        "client_sample_rate": {
+            "value": 0.01
         }
     },
     "organization_id": 1,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
@@ -20,6 +20,7 @@ expression: span
   "retention_days": 90,
   "name": "/api/0/relays/projectconfigs/",
   "sampling_factor": 1.0,
+  "sampling_weight": 1.0,
   "sampling_weight_2": 1,
   "sign": 1,
   "attr_str_0": {

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
@@ -20,7 +20,7 @@ expression: span
   "retention_days": 90,
   "name": "/api/0/relays/projectconfigs/",
   "sampling_factor": 1.0,
-  "sampling_weight": 1.0,
+  "sampling_weight_2": 1,
   "sign": 1,
   "attr_str_0": {
     "relay_protocol_version": "3",

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
@@ -19,9 +19,9 @@ expression: span
   "exclusive_time_ms": 0.228,
   "retention_days": 90,
   "name": "/api/0/relays/projectconfigs/",
-  "sampling_factor": 1.0,
-  "sampling_weight": 1.0,
-  "sampling_weight_2": 1,
+  "sampling_factor": 0.01,
+  "sampling_weight": 100.0,
+  "sampling_weight_2": 100,
   "sign": 1,
   "attr_str_0": {
     "relay_protocol_version": "3",

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-spans-EAPSpansMessageProcessor-snuba-spans__1__basic_span.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-spans-EAPSpansMessageProcessor-snuba-spans__1__basic_span.json.snap
@@ -52,6 +52,7 @@ expression: snapshot_payload
     "retention_days": 90,
     "sampling_factor": 1.0,
     "sampling_weight": 1.0,
+    "sampling_weight_2": 1,
     "segment_id": 16045690984833335023,
     "segment_name": "/organizations/:orgId/issues/",
     "service": "1",

--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
@@ -22,7 +22,8 @@ schema:
     { name: retention_days, type: UInt, args: { size: 16 } },
     { name: name, type: String },
     { name: sampling_factor, type: Float, args: { size: 64 } },
-    { name: sampling_weight, type: UInt, args: { size: 64 } },
+    { name: sampling_weight, type: Float, args: { size: 64 } },
+    { name: sampling_weight_2, type: UInt, args: { size: 64 } },
     { name: sign, type: Int, args: { size: 8 } },
     { name: attr_str, type: Map, args: { key: { type: String }, value: { type: String } } },
     { name: attr_num, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
@@ -39,12 +40,7 @@ storages:
             from_col_name: timestamp
             to_table_name: null
             to_col_name: _sort_timestamp
-        - mapper: ColumnToColumn
-          args:
-            from_table_name: null
-            from_col_name: sampling_weight
-            to_table_name: null
-            to_col_name: sampling_weight_2
+
       subscriptables:
         - mapper: SubscriptableHashBucketMapper
           args:


### PR DESCRIPTION
This migration was added, but the consumer was never set up to insert into it.