### PR TITLE
fix: store event ID (it is not in tags)

### DIFF
--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -133,6 +133,9 @@ impl From<FromSpanMessage> for EAPSpan {
                 attr_num_buckets[(fnv_1a(k.as_bytes()) as usize) % attr_num_buckets.len()]
                     .insert(k.clone(), v);
             };
+            if let Some(event_id) = from.event_id {
+                insert_string("sentry.event_id".into(), event_id.to_string())
+            }
 
             if let Some(sentry_tags) = from.sentry_tags {
                 sentry_tags.iter().for_each(|(k, v)| {

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
@@ -71,6 +71,7 @@ expression: span
   },
   "attr_str_12": {
     "relay_use_post_or_schedule_rejected": "version",
+    "sentry.event_id": "d826225d-e75d-42d6-b2f0-1b957d51f18f",
     "server_name": "D23CXQ4GK2.local"
   },
   "attr_str_13": {

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-spans-EAPSpansMessageProcessor-snuba-spans__1__basic_span.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-spans-EAPSpansMessageProcessor-snuba-spans__1__basic_span.json.snap
@@ -14,6 +14,9 @@ expression: snapshot_payload
       "tag3": "True",
       "transaction.op": "navigation"
     },
+    "attr_str_12": {
+      "sentry.event_id": "dcc403b7-3ef5-4864-8188-bbfa6012e9dc"
+    },
     "attr_str_18": {
       "tag1": "value1"
     },


### PR DESCRIPTION
For some reason event ID is sent normalized and not in any _tags fields, pull it out explicitly.