### PR TITLE
Revert "fix(eap): Switch to sampling_weight_2 in entity (#6287)"

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_spans.yaml
@@ -23,7 +23,6 @@ schema:
     { name: name, type: String },
     { name: sampling_factor, type: Float, args: { size: 64 } },
     { name: sampling_weight, type: Float, args: { size: 64 } },
-    { name: sampling_weight_2, type: UInt, args: { size: 64 } },
     { name: sign, type: Int, args: { size: 8 } },
     { name: attr_str, type: Map, args: { key: { type: String }, value: { type: String } } },
     { name: attr_num, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
@@ -40,7 +39,6 @@ storages:
             from_col_name: timestamp
             to_table_name: null
             to_col_name: _sort_timestamp
-
       subscriptables:
         - mapper: SubscriptableHashBucketMapper
           args:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
@@ -29,7 +29,6 @@ schema:
       { name: name, type: String },
       { name: sampling_factor, type: Float, args: { size: 64 } },
       { name: sampling_weight, type: Float, args: { size: 64 } },
-      { name: sampling_weight_2, type: UInt, args: { size: 64 } },
       { name: sign, type: Int, args: { size: 8 } },
       { name: attr_str_0, type: Map, args: { key: { type: String }, value: { type: String } } },
       { name: attr_str_1, type: Map, args: { key: { type: String }, value: { type: String } } },


### PR DESCRIPTION
- This reverts commit e7fe504332c7d118eb6baf508b2dd5653a44ec8d. since sampling_weight_2 isn't currently populated. Sentry code is going to do a `toUInt64` in the meantime so we can test