### PR TITLE
Update migrations list command to show migrations that no longer exist in the codebase

### DIFF
--- a/snuba/admin/clickhouse/migration_checks.py
+++ b/snuba/admin/clickhouse/migration_checks.py
@@ -100,7 +100,7 @@ class StatusChecker(Checker):
         ).get_migrations()
 
         migration_statuses = {}
-        for migration_id, status, _ in migrations:
+        for migration_id, status, _, _ in migrations:
             migration_statuses[migration_id] = {
                 "migration_id": migration_id,
                 "status": status,

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -208,7 +208,7 @@ def migrations_groups_list(group: str) -> Response:
                             "status": status.value,
                             "blocking": blocking,
                         }
-                        for migration_id, status, blocking in runner_group_migrations
+                        for migration_id, status, blocking, _ in runner_group_migrations
                     ]
                 ),
                 200,

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -37,7 +37,7 @@ def list() -> None:
     setup_logging()
     check_clickhouse_connections(CLUSTERS)
     runner = Runner()
-    for group, group_migrations in runner.show_all():
+    for group, group_migrations in runner.show_all(include_nonexistent=True):
         readiness_state = get_group_readiness_state(group)
         click.echo(f"{group.value} (readiness_state: {readiness_state.value})")
         for migration_id, status, blocking, existing in group_migrations:

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -40,7 +40,7 @@ def list() -> None:
     for group, group_migrations in runner.show_all():
         readiness_state = get_group_readiness_state(group)
         click.echo(f"{group.value} (readiness_state: {readiness_state.value})")
-        for migration_id, status, blocking in group_migrations:
+        for migration_id, status, blocking, existing in group_migrations:
             symbol = {
                 Status.COMPLETED: "X",
                 Status.NOT_STARTED: " ",
@@ -53,7 +53,11 @@ def list() -> None:
             if status != Status.COMPLETED and blocking:
                 blocking_text = " (blocking)"
 
-            click.echo(f"[{symbol}]  {migration_id}{in_progress_text}{blocking_text}")
+            existing_text = "" if existing else " (this migration no longer exists)"
+
+            click.echo(
+                f"[{symbol}]  {migration_id}{in_progress_text}{blocking_text}{existing_text}"
+            )
 
         click.echo()
 

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -149,7 +149,7 @@ class Runner:
             migration_groups = get_active_migration_groups()
 
         migration_status = self._get_migration_status(migration_groups)
-        clickhouse_group_migrations = {}
+        clickhouse_group_migrations: MutableMapping[MigrationGroup, List[str]] = {}
         for group, migration_id in migration_status.keys():
             clickhouse_group_migrations.setdefault(group, []).append(migration_id)
 

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -176,7 +176,7 @@ class Runner:
 
             if include_nonexistent:
                 non_existing_migrations = clickhouse_group_migrations.get(
-                    group, []
+                    group, set()
                 ).difference(set(migration_ids))
                 for migration_id in non_existing_migrations:
                     migration_key = MigrationKey(group, migration_id)

--- a/tests/admin/clickhouse_migrations/test_migration_checks.py
+++ b/tests/admin/clickhouse_migrations/test_migration_checks.py
@@ -29,9 +29,9 @@ def group_loader() -> GroupLoader:
 
 
 RUN_MIGRATIONS: Sequence[MigrationDetails] = [
-    MigrationDetails("0001", Status.COMPLETED, True),
-    MigrationDetails("0002", Status.NOT_STARTED, True),
-    MigrationDetails("0003", Status.NOT_STARTED, True),
+    MigrationDetails("0001", Status.COMPLETED, True, True),
+    MigrationDetails("0002", Status.NOT_STARTED, True, True),
+    MigrationDetails("0003", Status.NOT_STARTED, True, True),
 ]
 
 
@@ -62,9 +62,9 @@ def test_status_checker_run(
 
 
 REVERSE_MIGRATIONS: Sequence[MigrationDetails] = [
-    MigrationDetails("0001", Status.COMPLETED, True),
-    MigrationDetails("0002", Status.IN_PROGRESS, True),
-    MigrationDetails("0003", Status.NOT_STARTED, True),
+    MigrationDetails("0001", Status.COMPLETED, True, True),
+    MigrationDetails("0002", Status.IN_PROGRESS, True, True),
+    MigrationDetails("0003", Status.NOT_STARTED, True, True),
 ]
 
 
@@ -155,7 +155,10 @@ def test_run_migration_checks_and_policies(
     mock_policy = Mock()
     checker = mock_checker()
     mock_runner.show_all.return_value = [
-        (MigrationGroup("events"), [MigrationDetails("0001", Status.COMPLETED, True)])
+        (
+            MigrationGroup("events"),
+            [MigrationDetails("0001", Status.COMPLETED, True, True)],
+        )
     ]
 
     mock_policy.can_run.return_value = policy_result[0]

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -111,6 +111,26 @@ def test_show_all_for_groups() -> None:
 
 
 @pytest.mark.clickhouse_db
+def test_show_all_nonexistent_migration() -> None:
+    runner = Runner()
+    assert all(
+        [
+            migration.status == Status.NOT_STARTED
+            for (_, group_migrations) in runner.show_all()
+            for migration in group_migrations
+        ]
+    )
+    runner.run_all(force=True)
+    assert all(
+        [
+            migration.status == Status.COMPLETED
+            for (_, group_migrations) in runner.show_all()
+            for migration in group_migrations
+        ]
+    )
+
+
+@pytest.mark.clickhouse_db
 def test_run_migration() -> None:
     runner = Runner()
     runner.run_migration(


### PR DESCRIPTION
Fixes #2159

Running `snuba migrations list` will now show migrations that are in clickhouse but no longer in the codebase (e.g. because snuba was downgraded).

# Testing
Deleted migration in codebase to check that it shows up in the list.
<img width="668" alt="image" src="https://github.com/user-attachments/assets/90f855b9-94af-416d-9452-0335c2abd8d6">


