### PR TITLE
feat(replays): Add materialized tags column and index

### DIFF
--- a/snuba/snuba_migrations/replays/0021_index_tags.py
+++ b/snuba/snuba_migrations/replays/0021_index_tags.py
@@ -1,0 +1,89 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt, Array
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import TAGS_HASH_MAP_COLUMN
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return forward_columns_iter()
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return backward_columns_iter()
+
+
+def forward_columns_iter() -> list[operations.SqlOperation]:
+    return [
+        operations.AddColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_local",
+            column=Column(
+                "_tags_hash_map",
+                Array(UInt(64), Modifiers(materialized=TAGS_HASH_MAP_COLUMN)),
+            ),
+            after="tags.value",
+            target=operations.OperationTarget.LOCAL,
+        ),
+        operations.AddColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_dist",
+            column=Column(
+                "_tags_hash_map",
+                Array(UInt(64), Modifiers(materialized=TAGS_HASH_MAP_COLUMN)),
+            ),
+            after="tags.value",
+            target=operations.OperationTarget.DISTRIBUTED,
+        ),
+        operations.AddIndex(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_local",
+            index_name="bf_tags_hash_map",
+            index_expression="_tags_hash_map",
+            index_type="bloom_filter",
+            granularity=1,
+            target=operations.OperationTarget.LOCAL,
+        ),
+        operations.AddIndex(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_dist",
+            index_name="bf_tags_hash_map",
+            index_expression="_tags_hash_map",
+            index_type="bloom_filter",
+            granularity=1,
+            target=operations.OperationTarget.DISTRIBUTED,
+        ),
+    ]
+
+
+def backward_columns_iter() -> list[operations.SqlOperation]:
+    return [
+        operations.DropIndex(
+            StorageSetKey.REPLAYS,
+            "replays_dist",
+            "_tags_hash_map",
+            target=operations.OperationTarget.DISTRIBUTED,
+        ),
+        operations.DropIndex(
+            StorageSetKey.REPLAYS,
+            "replays_local",
+            "_tags_hash_map",
+            target=operations.OperationTarget.LOCAL,
+        ),
+        operations.DropColumn(
+            StorageSetKey.REPLAYS,
+            "replays_dist",
+            "_tags_hash_map",
+            operations.OperationTarget.DISTRIBUTED,
+        ),
+        operations.DropColumn(
+            StorageSetKey.REPLAYS,
+            "replays_local",
+            "_tags_hash_map",
+            operations.OperationTarget.LOCAL,
+        ),
+    ]

--- a/snuba/snuba_migrations/replays/0021_index_tags.py
+++ b/snuba/snuba_migrations/replays/0021_index_tags.py
@@ -56,7 +56,7 @@ def backward_columns_iter() -> list[operations.SqlOperation]:
         operations.DropIndex(
             StorageSetKey.REPLAYS,
             "replays_local",
-            "_tags_hash_map",
+            "bf_tags_hash_map",
             target=operations.OperationTarget.LOCAL,
         ),
         operations.DropColumn(

--- a/snuba/snuba_migrations/replays/0021_index_tags.py
+++ b/snuba/snuba_migrations/replays/0021_index_tags.py
@@ -48,26 +48,11 @@ def forward_columns_iter() -> list[operations.SqlOperation]:
             granularity=1,
             target=operations.OperationTarget.LOCAL,
         ),
-        operations.AddIndex(
-            storage_set=StorageSetKey.REPLAYS,
-            table_name="replays_dist",
-            index_name="bf_tags_hash_map",
-            index_expression="_tags_hash_map",
-            index_type="bloom_filter",
-            granularity=1,
-            target=operations.OperationTarget.DISTRIBUTED,
-        ),
     ]
 
 
 def backward_columns_iter() -> list[operations.SqlOperation]:
     return [
-        operations.DropIndex(
-            StorageSetKey.REPLAYS,
-            "replays_dist",
-            "_tags_hash_map",
-            target=operations.OperationTarget.DISTRIBUTED,
-        ),
         operations.DropIndex(
             StorageSetKey.REPLAYS,
             "replays_local",


### PR DESCRIPTION
Adds materialized _tags_hash_map column and indexes it.  Follow the prior art established by the errors table.

Addresses the following problems:
1. The number of bytes scanned searching for a tag.
2. The amount of time it takes to search by tag.

Related: https://github.com/getsentry/sentry/issues/76289