### PR TITLE
Update github @actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
           force_orphan: true
 
       - name: Archive Docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/build


### PR DESCRIPTION
After a PR is merged, the github actions is failing in `docs.yml` - https://github.com/getsentry/snuba/actions/workflows/docs.yml. The failure is because we are using deprecated upload artifact v2 instead of the latest and greatest [v4](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new).