### PR TITLE
Cleanup some settings from settings_test.py

### DIFF
--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -39,11 +39,6 @@ REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms
 # Set enforce retention to true for tests
 ENFORCE_RETENTION = True
 
-# Ignore optimize job cut off time for tests
-OPTIMIZE_JOB_CUTOFF_TIME = 24
-
-OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 0
-
 ADMIN_ALLOWED_PROD_PROJECTS = [1, 11276]
 
 REDIS_CLUSTERS = {


### PR DESCRIPTION
During the investigation of https://github.com/getsentry/snuba/pull/6279, I found that:
- `OPTIMIZE_JOB_CUTOFF_TIME` is overridden to `24` and it was causing test failures.
- `OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES` does not seem to be used anywhere in the code.

With the change, less no. of local tests fail. The failure number is non-zero because https://github.com/getsentry/snuba/pull/6279 was reverted yesterday . I would like to verify if this small change passes through the CI and stays stable in prod.