### PR TITLE
fix: temporarily limit eap_attribute tables

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/spans_num_attrs.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/spans_num_attrs.yaml
@@ -6,7 +6,7 @@ storage:
   key: spans_num_attrs
   set_key: events_analytics_platform
 
-readiness_state: partial
+readiness_state: limited
 
 schema:
   columns:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/spans_str_attrs.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/spans_str_attrs.yaml
@@ -6,7 +6,7 @@ storage:
   key: spans_str_attrs
   set_key: events_analytics_platform
 
-readiness_state: partial
+readiness_state: limited
 
 schema:
   columns:


### PR DESCRIPTION
While migrating the tables in these storages, CI entered into a point where the migrations can't run because the health check is failing, and the health check is failing because the migrations can't run.