### PR TITLE
fix(eap): re-enable tests and entities now that migrations ran

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/spans_num_attrs.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/spans_num_attrs.yaml
@@ -6,7 +6,7 @@ storage:
   key: spans_num_attrs
   set_key: events_analytics_platform
 
-readiness_state: limited
+readiness_state: partial
 
 schema:
   columns:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/spans_str_attrs.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/spans_str_attrs.yaml
@@ -6,7 +6,7 @@ storage:
   key: spans_str_attrs
   set_key: events_analytics_platform
 
-readiness_state: limited
+readiness_state: partial
 
 schema:
   columns:

--- a/tests/web/rpc/test_trace_item_attribute_list.py
+++ b/tests/web/rpc/test_trace_item_attribute_list.py
@@ -62,7 +62,6 @@ def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
 
 
-@pytest.mark.skip(reason="temporarily disabled to allow a migration to run")
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
 class TestTraceItemAttributes(BaseApiTest):

--- a/tests/web/rpc/test_trace_item_attribute_values.py
+++ b/tests/web/rpc/test_trace_item_attribute_values.py
@@ -84,7 +84,6 @@ def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
 
 
-@pytest.mark.skip(reason="temporarily disabled to allow a migration to run")
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
 class TestTraceItemAttributes(BaseApiTest):


### PR DESCRIPTION
We finally got the migrations through, can re-re-enable the tests.