### PR TITLE
fix(eap): make attr table truncate even more permissive

### DIFF
--- a/snuba/web/rpc/common.py
+++ b/snuba/web/rpc/common.py
@@ -26,7 +26,7 @@ def truncate_request_meta_to_day(meta: RequestMeta) -> None:
     start_timestamp = datetime.utcfromtimestamp(meta.start_timestamp.seconds)
     end_timestamp = datetime.utcfromtimestamp(meta.end_timestamp.seconds)
     start_timestamp = start_timestamp.replace(
-        day=start_timestamp.day, hour=0, minute=0, second=0, microsecond=0
+        day=start_timestamp.day - 1, hour=0, minute=0, second=0, microsecond=0
     )
     end_timestamp = end_timestamp.replace(
         day=end_timestamp.day + 1, hour=0, minute=0, second=0, microsecond=0


### PR DESCRIPTION
This table is truncated to `toStartOfDay` and has weird artifacts around timezones, just truncate to a whole 48 hour span.