### PR TITLE
feat(eap): prefix sentry_tags with sentry.

### DIFF
--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -139,7 +139,7 @@ impl From<FromSpanMessage> for EAPSpan {
                     if k == "transaction" {
                         res.segment_name = v.clone();
                     } else {
-                        insert_string(k.clone(), v.clone());
+                        insert_string(format!("sentry.{}", k), v.clone());
                     }
                 })
             }

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
@@ -24,17 +24,17 @@ expression: span
   "sampling_weight_2": 100,
   "sign": 1,
   "attr_str_0": {
-    "relay_protocol_version": "3",
-    "transaction.op": "http.server"
+    "relay_protocol_version": "3"
+  },
+  "attr_str_1": {
+    "sentry.thread.name": "uWSGIWorker1Core0"
   },
   "attr_num_1": {
     "my.neg.float.field": -101.2,
     "my.true.bool.field": 1.0
   },
-  "attr_str_2": {
-    "trace.status": "ok",
-    "transaction.method": "POST",
-    "user": "ip:127.0.0.1"
+  "attr_str_3": {
+    "sentry.thread.id": "8522009600"
   },
   "attr_str_4": {
     "thread.id": "8522009600"
@@ -42,29 +42,35 @@ expression: span
   "attr_str_5": {
     "http.status_code": "200",
     "sentry.release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
-    "sentry.sdk.name": "sentry.python.django"
+    "sentry.sdk.name": "sentry.python.django",
+    "sentry.transaction.op": "http.server"
   },
   "attr_num_5": {
     "my.neg.field": -100.0
   },
   "attr_str_6": {
-    "op": "http.server",
     "relay_id": "88888888-4444-4444-8444-cccccccccccc",
     "thread.name": "uWSGIWorker1Core0"
   },
   "attr_num_6": {
     "my.false.bool.field": 0.0
   },
+  "attr_str_7": {
+    "sentry.trace.status": "ok"
+  },
   "attr_str_8": {
-    "sdk.name": "sentry.python.django"
+    "sentry.category": "http"
   },
   "attr_str_9": {
-    "sentry.environment": "development",
-    "status_code": "200"
+    "sentry.environment": "development"
   },
   "attr_str_10": {
-    "release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
     "sentry.sdk.version": "2.7.0"
+  },
+  "attr_str_11": {
+    "sentry.platform": "python",
+    "sentry.transaction.method": "POST",
+    "sentry.user": "ip:127.0.0.1"
   },
   "attr_num_11": {
     "num_of_spans": 50.0
@@ -73,12 +79,8 @@ expression: span
     "relay_use_post_or_schedule_rejected": "version",
     "server_name": "D23CXQ4GK2.local"
   },
-  "attr_str_13": {
-    "category": "http"
-  },
   "attr_str_14": {
-    "environment": "development",
-    "platform": "python"
+    "sentry.status": "ok"
   },
   "attr_num_14": {
     "my.int.field": 2000.0
@@ -87,16 +89,16 @@ expression: span
     "relay_endpoint_version": "3",
     "relay_no_cache": "False",
     "relay_use_post_or_schedule": "True",
-    "sdk.version": "2.7.0",
     "spans_over_limit": "False"
   },
   "attr_num_17": {
     "my.float.field": 101.2
   },
   "attr_str_18": {
-    "sentry.segment.name": "/api/0/relays/projectconfigs/"
+    "sentry.segment.name": "/api/0/relays/projectconfigs/",
+    "sentry.status_code": "200"
   },
   "attr_str_19": {
-    "status": "ok"
+    "sentry.op": "http.server"
   }
 }

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-spans-EAPSpansMessageProcessor-snuba-spans__1__basic_span.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-spans-EAPSpansMessageProcessor-snuba-spans__1__basic_span.json.snap
@@ -10,36 +10,36 @@ expression: snapshot_payload
       "http.response_content_length": 100.0
     },
     "attr_str_0": {
-      "group": "deadbeefdeadbeef",
-      "tag3": "True",
-      "transaction.op": "navigation"
+      "tag3": "True"
+    },
+    "attr_str_11": {
+      "sentry.http.method": "GET",
+      "sentry.transaction.method": "GET"
+    },
+    "attr_str_12": {
+      "sentry.domain": "targetdomain.tld:targetport"
+    },
+    "attr_str_13": {
+      "sentry.system": "python"
+    },
+    "attr_str_14": {
+      "sentry.status": "ok"
     },
     "attr_str_18": {
+      "sentry.action": "GET",
+      "sentry.status_code": "200",
       "tag1": "value1"
     },
     "attr_str_19": {
-      "status": "ok",
+      "sentry.group": "deadbeefdeadbeef",
+      "sentry.op": "http.client",
       "tag2": "123"
     },
-    "attr_str_2": {
-      "transaction.method": "GET"
-    },
-    "attr_str_4": {
-      "http.method": "GET",
-      "system": "python"
-    },
     "attr_str_5": {
-      "domain": "targetdomain.tld:targetport",
-      "module": "http"
+      "sentry.transaction.op": "navigation"
     },
-    "attr_str_6": {
-      "op": "http.client"
-    },
-    "attr_str_7": {
-      "action": "GET"
-    },
-    "attr_str_9": {
-      "status_code": "200"
+    "attr_str_8": {
+      "sentry.module": "http"
     },
     "duration_ms": 1000,
     "end_timestamp": 1715868486370551,

--- a/snuba/web/rpc/common.py
+++ b/snuba/web/rpc/common.py
@@ -26,7 +26,7 @@ def truncate_request_meta_to_day(meta: RequestMeta) -> None:
     start_timestamp = datetime.utcfromtimestamp(meta.start_timestamp.seconds)
     end_timestamp = datetime.utcfromtimestamp(meta.end_timestamp.seconds)
     start_timestamp = start_timestamp.replace(
-        day=start_timestamp.day, hour=0, minute=0, second=0, microsecond=0
+        day=start_timestamp.day - 1, hour=0, minute=0, second=0, microsecond=0
     )
     end_timestamp = end_timestamp.replace(
         day=end_timestamp.day + 1, hour=0, minute=0, second=0, microsecond=0

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -11,39 +11,48 @@ class TestCommon:
         assert attribute_key_to_expression(
             AttributeKey(
                 type=AttributeKey.TYPE_STRING,
-                name="trace_id",
+                name="sentry.trace_id",
             ),
-        ) == f.CAST(column("trace_id"), "String", alias="trace_id")
+        ) == f.CAST(column("trace_id"), "String", alias="sentry.trace_id")
 
     def test_timestamp_columns(self) -> None:
-        for col in ["timestamp", "start_timestamp", "end_timestamp"]:
+        for col in [
+            "sentry.timestamp",
+            "sentry.start_timestamp",
+            "sentry.end_timestamp",
+        ]:
             assert attribute_key_to_expression(
                 AttributeKey(
                     type=AttributeKey.TYPE_STRING,
                     name=col,
                 ),
-            ) == f.CAST(column(col), "String", alias=col)
+            ) == f.CAST(column(col[len("sentry.") :]), "String", alias=col)
             assert attribute_key_to_expression(
                 AttributeKey(
                     type=AttributeKey.TYPE_INT,
                     name=col,
                 ),
-            ) == f.CAST(column(col), "Int64", alias=col)
+            ) == f.CAST(column(col[len("sentry.") :]), "Int64", alias=col)
             assert attribute_key_to_expression(
                 AttributeKey(
                     type=AttributeKey.TYPE_FLOAT,
                     name=col,
                 ),
-            ) == f.CAST(column(col), "Float64", alias=col)
+            ) == f.CAST(column(col[len("sentry.") :]), "Float64", alias=col)
 
     def test_normalized_col(self) -> None:
-        for col in ["span_id", "parent_span_id", "segment_id", "service"]:
+        for col in [
+            "sentry.span_id",
+            "sentry.parent_span_id",
+            "sentry.segment_id",
+            "sentry.service",
+        ]:
             assert attribute_key_to_expression(
                 AttributeKey(
                     type=AttributeKey.TYPE_STRING,
                     name=col,
                 ),
-            ) == column(col, alias=col)
+            ) == column(col[len("sentry.") :], alias=col)
 
     def test_attributes(self) -> None:
         assert attribute_key_to_expression(

--- a/tests/web/rpc/test_span_samples.py
+++ b/tests/web/rpc/test_span_samples.py
@@ -129,13 +129,13 @@ class TestSpanSamples(BaseApiTest):
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="category")
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="color")
                 )
             ),
-            keys=[AttributeKey(type=AttributeKey.TYPE_STRING, name="platform")],
+            keys=[AttributeKey(type=AttributeKey.TYPE_STRING, name="location")],
             order_by=[
                 SpanSamplesRequest.OrderBy(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="status")
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="location")
                 )
             ],
             limit=10,
@@ -159,13 +159,13 @@ class TestSpanSamples(BaseApiTest):
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="category")
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="color")
                 )
             ),
-            keys=[AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.sdk.name")],
+            keys=[AttributeKey(type=AttributeKey.TYPE_STRING, name="server_name")],
             order_by=[
                 SpanSamplesRequest.OrderBy(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="status")
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="server_name")
                 )
             ],
             limit=61,
@@ -174,7 +174,7 @@ class TestSpanSamples(BaseApiTest):
         assert [
             dict((k, x.results[k].val_str) for k in x.results)
             for x in response.span_samples
-        ] == [{"sentry.sdk.name": "sentry.python.django"} for _ in range(60)]
+        ] == [{"server_name": "D23CXQ4GK2.local"} for _ in range(60)]
 
     def test_booleans_and_number_compares(self, setup_teardown: Any) -> None:
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
@@ -215,12 +215,14 @@ class TestSpanSamples(BaseApiTest):
                 )
             ),
             keys=[
-                AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="is_segment"),
-                AttributeKey(type=AttributeKey.TYPE_STRING, name="span_id"),
+                AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.is_segment"),
+                AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.span_id"),
             ],
             order_by=[
                 SpanSamplesRequest.OrderBy(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="status")
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING, name="sentry.status"
+                    )
                 )
             ],
             limit=61,
@@ -231,7 +233,10 @@ class TestSpanSamples(BaseApiTest):
                 (k, (x.results[k].val_bool or x.results[k].val_str)) for k in x.results
             )
             for x in response.span_samples
-        ] == [{"is_segment": True, "span_id": "123456781234567d"} for _ in range(60)]
+        ] == [
+            {"sentry.is_segment": True, "sentry.span_id": "123456781234567d"}
+            for _ in range(60)
+        ]
 
     def test_with_virtual_columns(self, setup_teardown: Any) -> None:
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
@@ -247,12 +252,16 @@ class TestSpanSamples(BaseApiTest):
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="category")
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING, name="sentry.category"
+                    )
                 )
             ),
             keys=[
-                AttributeKey(type=AttributeKey.TYPE_STRING, name="project_name"),
-                AttributeKey(type=AttributeKey.TYPE_STRING, name="release_version"),
+                AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.project_name"),
+                AttributeKey(
+                    type=AttributeKey.TYPE_STRING, name="sentry.release_version"
+                ),
                 AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.sdk.name"),
             ],
             order_by=[
@@ -265,13 +274,13 @@ class TestSpanSamples(BaseApiTest):
             limit=61,
             virtual_column_contexts=[
                 VirtualColumnContext(
-                    from_column_name="project_id",
-                    to_column_name="project_name",
+                    from_column_name="sentry.project_id",
+                    to_column_name="sentry.project_name",
                     value_map={"1": "sentry", "2": "snuba"},
                 ),
                 VirtualColumnContext(
-                    from_column_name="release",
-                    to_column_name="release_version",
+                    from_column_name="sentry.release",
+                    to_column_name="sentry.release_version",
                     value_map={_RELEASE_TAG: "4.2.0.69"},
                 ),
             ],
@@ -282,9 +291,9 @@ class TestSpanSamples(BaseApiTest):
             for x in response.span_samples
         ] == [
             {
-                "project_name": "sentry",
+                "sentry.project_name": "sentry",
                 "sentry.sdk.name": "sentry.python.django",
-                "release_version": "4.2.0.69",
+                "sentry.release_version": "4.2.0.69",
             }
             for _ in range(60)
         ]
@@ -303,7 +312,9 @@ class TestSpanSamples(BaseApiTest):
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="category")
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING, name="sentry.category"
+                    )
                 )
             ),
             keys=[


### PR DESCRIPTION
If you don't namespace things before inserting, it causes problems where `sentry_tags` can overwrite data a user sends.
There should be minimal performance impact, because `sentry.` will be compressed out.