### PR TITLE
(snuba-deletes): storage_deletes_enabled default enabled

### DIFF
--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -125,7 +125,7 @@ def _delete_from_table(
 
 
 def deletes_are_enabled() -> bool:
-    return bool(get_config("storage_deletes_enabled", 0))
+    return bool(get_config("storage_deletes_enabled", 1))
 
 
 def _get_rows_to_delete(

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -198,7 +198,6 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         assert "'query' is a required property" in res.get_json()["error"]["message"]
 
         # test for invalid column types
-        set_config("storage_deletes_enabled", 1)
         res = self.app.delete(
             "/search_issues/",
             data=json.dumps(


### PR DESCRIPTION
Makes the default `storage_deletes_enabled=1`. 

Sentry tests should be testing against this feature. In production all regions except S4S have this set to `0`. Additionally, only the `search_issues` dataset has deletes enabled in the storage configuration.