### PR TITLE
feat(eap): Include server-side sample rates in sampling weight

### DIFF
--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_spans__tests__serialization.snap
@@ -19,9 +19,9 @@ expression: span
   "exclusive_time_ms": 0.228,
   "retention_days": 90,
   "name": "/api/0/relays/projectconfigs/",
-  "sampling_factor": 0.01,
-  "sampling_weight": 100.0,
-  "sampling_weight_2": 100,
+  "sampling_factor": 0.02,
+  "sampling_weight": 50.0,
+  "sampling_weight_2": 50,
   "sign": 1,
   "attr_str_0": {
     "relay_protocol_version": "3",


### PR DESCRIPTION
Adds support for the new `server_sample_rate` measurement on spans and includes
it in computing the final sampling factor and weight. This allows us to
extrapolate span metrics correctly in organizations that have dynamic sampling
enabled.

This also rounds the sampling factor to a precision of 10^-9 to avoid floating
point errors in the multiplication. For example, without the test using sample
rates of _10%_ and _20%_ respectively already shows floating point error.

In a follow-up, we might revise the schema and move these sample rates into
`span.data`.

See https://github.com/getsentry/relay/pull/4063
See https://github.com/getsentry/relay/issues/4038
