### PR TITLE
feat: do not clobber existing overrides with new overrides

### DIFF
--- a/snuba/query/processors/physical/clickhouse_settings_override.py
+++ b/snuba/query/processors/physical/clickhouse_settings_override.py
@@ -14,7 +14,7 @@ class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
         self.__settings = settings
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
-        new_settings = {}
+        new_settings: MutableMapping[str, Any] = {}
         new_settings.update(query_settings.get_clickhouse_settings())
         new_settings.update(self.__settings)
         query_settings.set_clickhouse_settings(new_settings)

--- a/snuba/query/processors/physical/clickhouse_settings_override.py
+++ b/snuba/query/processors/physical/clickhouse_settings_override.py
@@ -14,4 +14,7 @@ class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
         self.__settings = settings
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
-        query_settings.set_clickhouse_settings(self.__settings)
+        new_settings = {}
+        new_settings.update(query_settings.get_clickhouse_settings())
+        new_settings.update(self.__settings)
+        query_settings.set_clickhouse_settings(new_settings)

--- a/tests/query/processors/test_clickhouse_settings_override.py
+++ b/tests/query/processors/test_clickhouse_settings_override.py
@@ -52,7 +52,11 @@ def test_apply_clickhouse_settings(
             )
         ],
     )
+
     settings = HTTPQuerySettings()
+    settings.set_clickhouse_settings({"use_query_cache": "true"})
 
     ClickhouseSettingsOverride(clickhouse_settings).process_query(query, settings)
-    assert settings.get_clickhouse_settings() == clickhouse_settings
+    expected = dict(clickhouse_settings)
+    expected["use_query_cache"] = "true"
+    assert settings.get_clickhouse_settings() == expected

--- a/tests/query/processors/test_clickhouse_settings_override.py
+++ b/tests/query/processors/test_clickhouse_settings_override.py
@@ -52,11 +52,48 @@ def test_apply_clickhouse_settings(
             )
         ],
     )
-
     settings = HTTPQuerySettings()
-    settings.set_clickhouse_settings({"use_query_cache": "true"})
 
     ClickhouseSettingsOverride(clickhouse_settings).process_query(query, settings)
-    expected = dict(clickhouse_settings)
-    expected["use_query_cache"] = "true"
+    assert settings.get_clickhouse_settings() == clickhouse_settings
+
+
+def test_per_query_settings() -> None:
+    query = Query(
+        Table(
+            "discover",
+            ColumnSet(
+                [
+                    ("timestamp", DateTime()),
+                    ("mismatched1", String(Modifiers(nullable=True))),
+                    ("mismatched2", String(Modifiers(nullable=True))),
+                ]
+            ),
+            storage_key=StorageKey("dontmatter"),
+        ),
+        selected_columns=[
+            SelectedExpression(
+                name="_snuba_count_unique_sdk_version",
+                expression=FunctionCall(
+                    None, "uniq", (Column(None, None, "mismatched1"),)
+                ),
+            )
+        ],
+    )
+
+    initial_settings = {"initial_setting": "true", "overridden_setting": "1"}
+    overrides = {"overridden_setting": "2", "max_rows_to_group_by": 1000000}
+
+    # create initial settings for the query
+    settings = HTTPQuerySettings()
+    settings.set_clickhouse_settings(initial_settings)
+
+    # apply the overrides (for the entire dataset)
+    ClickhouseSettingsOverride(overrides).process_query(query, settings)
+
+    expected = {
+        "initial_setting": "true",
+        "overridden_setting": "2",
+        "max_rows_to_group_by": 1000000,
+    }
     assert settings.get_clickhouse_settings() == expected


### PR DESCRIPTION
We want to optimize things in EAP by setting clickhouse overrides per-endpoint, this facilitates that