### PR TITLE
dev(rate-limits): Increase backfill query allocation to 60 per s

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -265,7 +265,7 @@ allocation_policies:
       cross_org_referrer_limits:
         getsentry.tasks.backfill_grouping_records:
           max_threads: 7
-          concurrent_limit: 30
+          concurrent_limit: 60
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:


### PR DESCRIPTION
Based on the [Datadog metrics](https://app.datadoghq.com/dashboard/tht-dpn-5ui/allocation-policy?fromUser=false&fullscreen_end_ts=1727203031641&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1726598231641&fullscreen_widget=984243635966760&refresh_mode=sliding&view=spans&from_ts=1727169007884&to_ts=1727183407884&live=true) and the corresponding [Sentry error](https://sentry.sentry.io/issues/5655838252/), the `getsentry.tasks.backfill_grouping_records` referrer is hitting our 30/s rate limit pretty frequently.

We would like to increase to 60/s if okay with team. The queries that we're making are point queries, so they should not scan very much data. 