### PR TITLE
Surface storage key for capacity management

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -756,7 +756,7 @@ def _add_quota_info(
         quota_info["quota_used"] = quota_allowance.quota_used
         quota_info["quota_unit"] = quota_allowance.quota_unit
         quota_info["suggestion"] = quota_allowance.suggestion
-        quota_info["storage_key"] = quota_and_policy.policy.storage_key
+        quota_info["storage_key"] = str(quota_and_policy.policy.storage_key)
 
         if action == _REJECTED_BY:
             quota_info["rejection_threshold"] = quota_allowance.rejection_threshold
@@ -776,12 +776,23 @@ def _populate_query_status(
     summary[is_rejected] = False
     summary[is_throttled] = False
 
+    rejection_storage_key = "rejection_storage_key"
+    throttle_storage_key = "throttle_storage_key"
+    summary[rejection_storage_key] = None
+    summary[throttle_storage_key] = None
+
     if rejection_quota_and_policy:
         summary[is_successful] = False
         summary[is_rejected] = True
+        summary[rejection_storage_key] = str(
+            rejection_quota_and_policy.policy.storage_key
+        )
     if throttle_quota_and_policy:
         summary[is_successful] = False
         summary[is_throttled] = True
+        summary[throttle_storage_key] = str(
+            throttle_quota_and_policy.policy.storage_key
+        )
 
 
 def _apply_allocation_policies_quota(

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -738,7 +738,7 @@ def db_query(
 @dataclass
 class _QuotaAndPolicy:
     quota_allowance: QuotaAllowance
-    policy_name: str
+    policy: AllocationPolicy
 
 
 def _add_quota_info(
@@ -751,11 +751,12 @@ def _add_quota_info(
     summary[action] = quota_info
 
     if quota_and_policy is not None:
-        quota_info["policy"] = quota_and_policy.policy_name
+        quota_info["policy"] = quota_and_policy.policy.config_key()
         quota_allowance = quota_and_policy.quota_allowance
         quota_info["quota_used"] = quota_allowance.quota_used
         quota_info["quota_unit"] = quota_allowance.quota_unit
         quota_info["suggestion"] = quota_allowance.suggestion
+        quota_info["storage_key"] = quota_and_policy.policy.storage_key
 
         if action == _REJECTED_BY:
             quota_info["rejection_threshold"] = quota_allowance.rejection_threshold
@@ -823,7 +824,7 @@ def _apply_allocation_policies_quota(
                 ):
                     throttle_quota_and_policy = _QuotaAndPolicy(
                         quota_allowance=allowance,
-                        policy_name=allocation_policy.config_key(),
+                        policy=allocation_policy,
                     )
                 min_threads_across_policies = min(
                     min_threads_across_policies, allowance.max_threads
@@ -831,7 +832,7 @@ def _apply_allocation_policies_quota(
                 if not can_run:
                     rejection_quota_and_policy = _QuotaAndPolicy(
                         quota_allowance=allowance,
-                        policy_name=allocation_policy.config_key(),
+                        policy=allocation_policy,
                     )
                     break
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1351,16 +1351,22 @@ class TestSnQLApi(BaseApiTest):
                     "is_successful": False,
                     "is_rejected": True,
                     "is_throttled": False,
+                    "rejection_storage_key": "StorageKey.DOESNTMATTER",
+                    "throttle_storage_key": None,
                     "rejected_by": {
                         "policy": "RejectAllocationPolicy123",
                         "quota_used": 0,
                         "quota_unit": "no_units",
                         "suggestion": "no_suggestion",
+                        "storage_key": "StorageKey.DOESNTMATTER",
                         "rejection_threshold": 1000000000000,
                     },
                     "throttled_by": {},
                 },
             }
+
+            print("info")
+            print(info)
 
             assert (
                 response.json["error"]["message"]

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -309,6 +309,8 @@ def test_db_query_success() -> None:
             "is_successful": False,
             "is_rejected": False,
             "is_throttled": True,
+            "rejection_storage_key": None,
+            "throttle_storage_key": "StorageKey.ERRORS_RO",
             "rejected_by": {},
             "throttled_by": {
                 "policy": "BytesScannedRejectingPolicy",
@@ -316,6 +318,7 @@ def test_db_query_success() -> None:
                 "quota_unit": "bytes",
                 "suggestion": "The feature, organization/project is scanning too many bytes, this usually means they are abusing that API",
                 "throttle_threshold": 1706666666666,
+                "storage_key": "StorageKey.ERRORS_RO",
             },
         },
         "details": {
@@ -590,6 +593,8 @@ def test_apply_allocation_policies_quota_sets_throttle_policy() -> None:
                 "is_successful": False,
                 "is_rejected": False,
                 "is_throttled": True,
+                "rejection_storage_key": None,
+                "throttle_storage_key": "StorageKey.DOESNTMATTER",
                 "rejected_by": {},
                 "throttled_by": {
                     "policy": "ThrottleAllocationPolicy1",
@@ -597,6 +602,7 @@ def test_apply_allocation_policies_quota_sets_throttle_policy() -> None:
                     "quota_unit": NO_UNITS,
                     "suggestion": NO_SUGGESTION,
                     "throttle_threshold": 1000000000000,
+                    "storage_key": "StorageKey.DOESNTMATTER",
                 },
             },
         }
@@ -666,12 +672,15 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
                 "is_successful": False,
                 "is_rejected": True,
                 "is_throttled": True,
+                "rejection_storage_key": "StorageKey.DOESNTMATTER",
+                "throttle_storage_key": "StorageKey.DOESNTMATTER",
                 "rejected_by": {
                     "policy": "RejectAllocationPolicy",
                     "rejection_threshold": MAX_THRESHOLD,
                     "quota_used": 0,
                     "quota_unit": NO_UNITS,
                     "suggestion": NO_SUGGESTION,
+                    "storage_key": "StorageKey.DOESNTMATTER",
                 },
                 "throttled_by": {
                     "policy": "RejectAllocationPolicy",
@@ -679,6 +688,7 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
                     "quota_used": 0,
                     "quota_unit": NO_UNITS,
                     "suggestion": NO_SUGGESTION,
+                    "storage_key": "StorageKey.DOESNTMATTER",
                 },
             },
             "details": {
@@ -909,12 +919,15 @@ def test_allocation_policy_updates_quota() -> None:
             "is_successful": False,
             "is_rejected": True,
             "is_throttled": False,
+            "rejection_storage_key": "StorageKey.DOESNTMATTER",
+            "throttle_storage_key": None,
             "rejected_by": {
                 "policy": "CountQueryPolicy",
                 "rejection_threshold": MAX_QUERIES_TO_RUN,
                 "quota_used": queries_run,
                 "quota_unit": "queries",
                 "suggestion": "scan less concurrent queries",
+                "storage_key": "StorageKey.DOESNTMATTER",
             },
             "throttled_by": {},
         },


### PR DESCRIPTION
Upon getting a request to increase the thresholds for a customer, one of the things we need to figure out is which storage. This PR surfaces the `StorageKey` to allow easier querying using SnubaAdmin's QueryLog