### PR TITLE
feat(devservices): Add devservices cli tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ click==8.1.3
 clickhouse-driver==0.2.6
 confluent-kafka==2.3.0
 datadog==0.21.0
+devservices==0.0.3
 flake8==5.0.4
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
This adds the devservices cli tool to be used once the venv is activated. The devservices [configurations](https://github.com/getsentry/snuba/pull/6323) are already added to the snuba repo so you should be able to use it as soon as you install the new cli tool. 

We are also offering a binary to be used for a system installation of devservices (installation instructions in the README [here](https://github.com/getsentry/devservices)). However, use this at your own risk given that we're changing things pretty constantly and bumping/downgrading versions isn't quite as easy as pinning to a version in the venv.