### PR TITLE
Disable flaky optimize test until optimize job is fixed

### DIFF
--- a/tests/clickhouse/optimize/test_optimize_tracker.py
+++ b/tests/clickhouse/optimize/test_optimize_tracker.py
@@ -98,6 +98,7 @@ def test_optimized_partition_tracker(tracker: OptimizedPartitionTracker) -> None
 
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
+@pytest.mark.skip(reason="This test is flaky and fails unexpectedly on CI")
 def test_run_optimize_with_partition_tracker() -> None:
     def write_error_message(writable_storage: WritableTableStorage, time: int) -> None:
         write_processed_messages(


### PR DESCRIPTION
Lately, we have been seeing flakiness in optimize tests. For example, [this](https://github.com/getsentry/snuba/actions/runs/11061448936/job/30734331050) run failed which has nothing to do with optimize job. We have plans to take deeper look into optimize job but until that happens, this PR disables the flaky test.