### PR TITLE
fix: Broken tests in CI

### DIFF
--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, Mapping
 
 import pytest
@@ -19,9 +19,9 @@ from snuba.web.rpc.v1alpha.trace_item_attribute_list import (
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 
-BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timedelta(
-    minutes=180
-)
+BASE_TIME = datetime.now(timezone.utc).replace(
+    minute=0, second=0, microsecond=0
+) - timedelta(minutes=180)
 
 
 def gen_message(id: int) -> Mapping[str, Any]:

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
@@ -88,11 +88,14 @@ class TestTraceItemAttributes(BaseApiTest):
                 ),
                 end_timestamp=Timestamp(
                     seconds=int(
-                        datetime(
-                            year=BASE_TIME.year,
-                            month=BASE_TIME.month,
-                            day=BASE_TIME.day + 1,
-                            tzinfo=UTC,
+                        (
+                            datetime(
+                                year=BASE_TIME.year,
+                                month=BASE_TIME.month,
+                                day=BASE_TIME.day,
+                                tzinfo=UTC,
+                            )
+                            + timedelta(days=1)
                         ).timestamp()
                     )
                 ),

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
@@ -117,21 +117,27 @@ class TestTraceItemAttributes(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(
                     seconds=int(
-                        datetime(
-                            year=BASE_TIME.year,
-                            month=BASE_TIME.month,
-                            day=BASE_TIME.day - 1,
-                            tzinfo=UTC,
+                        (
+                            datetime(
+                                year=BASE_TIME.year,
+                                month=BASE_TIME.month,
+                                day=BASE_TIME.day,
+                                tzinfo=UTC,
+                            )
+                            - timedelta(days=1)
                         ).timestamp()
                     )
                 ),
                 end_timestamp=Timestamp(
                     seconds=int(
-                        datetime(
-                            year=BASE_TIME.year,
-                            month=BASE_TIME.month,
-                            day=BASE_TIME.day + 1,
-                            tzinfo=UTC,
+                        (
+                            datetime(
+                                year=BASE_TIME.year,
+                                month=BASE_TIME.month,
+                                day=BASE_TIME.day,
+                                tzinfo=UTC,
+                            )
+                            + timedelta(days=1)
                         ).timestamp()
                     )
                 ),
@@ -157,21 +163,27 @@ class TestTraceItemAttributes(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(
                     seconds=int(
-                        datetime(
-                            year=BASE_TIME.year,
-                            month=BASE_TIME.month,
-                            day=BASE_TIME.day - 1,
-                            tzinfo=UTC,
+                        (
+                            datetime(
+                                year=BASE_TIME.year,
+                                month=BASE_TIME.month,
+                                day=BASE_TIME.day,
+                                tzinfo=UTC,
+                            )
+                            - timedelta(days=1)
                         ).timestamp()
                     )
                 ),
                 end_timestamp=Timestamp(
                     seconds=int(
-                        datetime(
-                            year=BASE_TIME.year,
-                            month=BASE_TIME.month,
-                            day=BASE_TIME.day + 1,
-                            tzinfo=UTC,
+                        (
+                            datetime(
+                                year=BASE_TIME.year,
+                                month=BASE_TIME.month,
+                                day=BASE_TIME.day,
+                                tzinfo=UTC,
+                            )
+                            + timedelta(days=1)
                         ).timestamp()
                     )
                 ),
@@ -197,21 +209,27 @@ class TestTraceItemAttributes(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(
                     seconds=int(
-                        datetime(
-                            year=BASE_TIME.year,
-                            month=BASE_TIME.month,
-                            day=BASE_TIME.day - 1,
-                            tzinfo=UTC,
+                        (
+                            datetime(
+                                year=BASE_TIME.year,
+                                month=BASE_TIME.month,
+                                day=BASE_TIME.day,
+                                tzinfo=UTC,
+                            )
+                            - timedelta(days=1)
                         ).timestamp()
                     )
                 ),
                 end_timestamp=Timestamp(
                     seconds=int(
-                        datetime(
-                            year=BASE_TIME.year,
-                            month=BASE_TIME.month,
-                            day=BASE_TIME.day + 1,
-                            tzinfo=UTC,
+                        (
+                            datetime(
+                                year=BASE_TIME.year,
+                                month=BASE_TIME.month,
+                                day=BASE_TIME.day,
+                                tzinfo=UTC,
+                            )
+                            + timedelta(days=1)
                         ).timestamp()
                     )
                 ),

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
@@ -16,7 +16,7 @@ from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 
 BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timedelta(
-    minutes=180
+    days=2, minutes=180
 )
 COMMON_META = RequestMeta(
     project_ids=[1, 2, 3],

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
@@ -18,7 +18,6 @@ from tests.helpers import write_raw_unprocessed_events
 BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timedelta(
     minutes=180
 )
-
 COMMON_META = RequestMeta(
     project_ids=[1, 2, 3],
     organization_id=1,

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
@@ -35,11 +35,14 @@ COMMON_META = RequestMeta(
     ),
     end_timestamp=Timestamp(
         seconds=int(
-            datetime(
-                year=BASE_TIME.year,
-                month=BASE_TIME.month,
-                day=BASE_TIME.day + 1,
-                tzinfo=UTC,
+            (
+                datetime(
+                    year=BASE_TIME.year,
+                    month=BASE_TIME.month,
+                    day=BASE_TIME.day,
+                    tzinfo=UTC,
+                )
+                + timedelta(days=1)
             ).timestamp()
         )
     ),

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, Mapping
 
 import pytest
@@ -15,9 +15,9 @@ from snuba.web.rpc.v1alpha.trace_item_attribute_values import (
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 
-BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timedelta(
-    minutes=180
-)
+BASE_TIME = datetime.now(timezone.utc).replace(
+    minute=0, second=0, microsecond=0
+) - timedelta(minutes=180)
 COMMON_META = RequestMeta(
     project_ids=[1, 2, 3],
     organization_id=1,

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_values.py
@@ -16,8 +16,9 @@ from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 
 BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timedelta(
-    days=2, minutes=180
+    minutes=180
 )
+
 COMMON_META = RequestMeta(
     project_ids=[1, 2, 3],
     organization_id=1,


### PR DESCRIPTION
The test appears to be failing because it is now the end of month and the tests rely on things like (TODAY + 1). Changes base time so that we never exceed the number of days in the month.