### PR TITLE
Revert "fix(gocd): Add snuba-eap-mutations consumer to US"

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -51,7 +51,6 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="group-attributes-consumer" \
   --container-name="metrics-summaries-consumer" \
   --container-name="eap-spans-consumer" \
-  --container-name="eap-mutations-consumer" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \


### PR DESCRIPTION
Reverts getsentry/snuba#6359

Consumer isn't rolling out properly for some reason in GoCD and blocking pipeline