### PR TITLE
Revert "Revert "fix(gocd): Add snuba-eap-mutations consumer to US""

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -51,6 +51,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="group-attributes-consumer" \
   --container-name="metrics-summaries-consumer" \
   --container-name="eap-spans-consumer" \
+  --container-name="eap-mutations-consumer" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \


### PR DESCRIPTION
Reverts getsentry/snuba#6364

In order to roll out #6366 , we need to... deploy the eap consumer

i wish we could just exclude it from our deployment health checks instead, will check that next