### PR TITLE
feat(eap): Go through snuba query pipeline for attributes list

### DIFF
--- a/snuba/web/rpc/v1alpha/trace_item_attribute_list.py
+++ b/snuba/web/rpc/v1alpha/trace_item_attribute_list.py
@@ -1,59 +1,119 @@
-from typing import List, Optional
+import uuid
 
+from google.protobuf.json_format import MessageToDict
 from sentry_protos.snuba.v1alpha.endpoint_tags_list_pb2 import (
     TraceItemAttributesRequest,
     TraceItemAttributesResponse,
 )
 from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import AttributeKey
 
-from snuba.clickhouse.formatter.nodes import FormattedQuery, StringNode
-from snuba.datasets.schemas.tables import TableSource
-from snuba.datasets.storages.factory import get_storage
-from snuba.datasets.storages.storage_key import StorageKey
+from snuba.attribution import AppID
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.pluggable_dataset import PluggableDataset
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query.data_source.simple import Entity
+from snuba.query.dsl import column
+from snuba.query.logical import Query
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.request import Request as SnubaRequest
 from snuba.utils.metrics.timer import Timer
-from snuba.web.rpc.common.common import truncate_request_meta_to_day
+from snuba.web.query import run_query
+from snuba.web.rpc.common.common import (
+    base_conditions_and,
+    treeify_or_and_conditions,
+    truncate_request_meta_to_day,
+)
 from snuba.web.rpc.exceptions import BadSnubaRPCRequestException
 
 
-def trace_item_attribute_list_query(
-    request: TraceItemAttributesRequest, _timer: Optional[Timer] = None
-) -> TraceItemAttributesResponse:
-    if request.type == AttributeKey.Type.TYPE_STRING:
-        storage = get_storage(StorageKey("spans_str_attrs"))
-    elif request.type == AttributeKey.Type.TYPE_FLOAT:
-        storage = get_storage(StorageKey("spans_num_attrs"))
-    else:
-        return TraceItemAttributesResponse(tags=[])
-
-    data_source = storage.get_schema().get_data_source()
-    assert isinstance(data_source, TableSource)
-
+def _build_query(request: TraceItemAttributesRequest) -> Query:
     if request.limit > 1000:
         raise BadSnubaRPCRequestException("Limit can be at most 1000")
 
+    if request.type == AttributeKey.Type.TYPE_STRING:
+        entity = Entity(
+            key=EntityKey("spans_str_attrs"),
+            schema=get_entity(EntityKey("spans_str_attrs")).get_data_model(),
+            sample=None,
+        )
+    elif request.type in (
+        AttributeKey.Type.TYPE_FLOAT,
+        AttributeKey.Type.TYPE_INT,
+        AttributeKey.Type.TYPE_BOOLEAN,
+    ):
+        entity = Entity(
+            key=EntityKey("spans_num_attrs"),
+            schema=get_entity(EntityKey("spans_num_attrs")).get_data_model(),
+            sample=None,
+        )
+    else:
+        raise BadSnubaRPCRequestException(f"Unknown attribute type: {request.type}")
+
     truncate_request_meta_to_day(request.meta)
 
-    query = f"""
-SELECT DISTINCT attr_key, timestamp
-FROM {data_source.get_table_name()}
-WHERE organization_id={request.meta.organization_id}
-AND project_id IN ({', '.join(str(pid) for pid in request.meta.project_ids)})
-AND timestamp BETWEEN fromUnixTimestamp({request.meta.start_timestamp.seconds}) AND fromUnixTimestamp({request.meta.end_timestamp.seconds})
-ORDER BY attr_key
-LIMIT {request.limit} OFFSET {request.offset}
-"""
+    res = Query(
+        from_clause=entity,
+        selected_columns=[
+            SelectedExpression(
+                name="attr_key",
+                expression=column("attr_key", alias="attr_key"),
+            ),
+        ],
+        condition=base_conditions_and(request.meta),
+        order_by=[
+            OrderBy(
+                direction=OrderByDirection.ASC, expression=column("organization_id")
+            ),
+            OrderBy(direction=OrderByDirection.ASC, expression=column("attr_key")),
+        ],
+        groupby=[
+            column("organization_id", alias="organization_id"),
+            column("attr_key", alias="attr_key"),
+        ],
+        limit=request.limit,
+        offset=request.offset,
+    )
+    treeify_or_and_conditions(res)
+    return res
 
-    cluster = storage.get_cluster()
-    reader = cluster.get_reader()
-    result = reader.execute(FormattedQuery([StringNode(query)]))
 
-    tags: List[TraceItemAttributesResponse.Tag] = []
-    for row in result.get("data", []):
-        tags.append(
-            TraceItemAttributesResponse.Tag(
-                name=row["attr_key"],
-                type=request.type,
-            )
-        )
+def _build_snuba_request(
+    request: TraceItemAttributesRequest,
+) -> SnubaRequest:
+    return SnubaRequest(
+        id=str(uuid.uuid4()),
+        original_body=MessageToDict(request),
+        query=_build_query(request),
+        query_settings=HTTPQuerySettings(),
+        attribution_info=AttributionInfo(
+            referrer=request.meta.referrer,
+            team="eap",
+            feature="eap",
+            tenant_ids={
+                "organization_id": request.meta.organization_id,
+                "referrer": request.meta.referrer,
+            },
+            app_id=AppID("eap"),
+            parent_api="trace_item_attribute_list",
+        ),
+    )
 
-    return TraceItemAttributesResponse(tags=tags)
+
+def trace_item_attribute_list_query(
+    request: TraceItemAttributesRequest, timer: Timer | None = None
+) -> TraceItemAttributesResponse:
+    timer = timer or Timer("trace_item_attributes")
+    snuba_request = _build_snuba_request(request)
+    res = run_query(
+        dataset=PluggableDataset(name="eap", all_entities=[]),
+        request=snuba_request,
+        timer=timer,
+    )
+    return TraceItemAttributesResponse(
+        tags=[
+            TraceItemAttributesResponse.Tag(name=r["attr_key"], type=request.type)
+            for r in res.result.get("data", [])
+        ]
+    )

--- a/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
+++ b/tests/web/rpc/v1alpha/test_trace_item_attribute_list.py
@@ -100,6 +100,7 @@ class TestTraceItemAttributes(BaseApiTest):
                     )
                 ),
             ),
+            type=AttributeKey.Type.TYPE_STRING,
             limit=10,
             offset=20,
         )


### PR DESCRIPTION
We'd like to make sure rate limits / etc are run for all EAP endpoints, this migrates the last remaining one.