### PR TITLE
fix: Add profiled spans consumer to GoCD deployment

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -52,6 +52,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="metrics-summaries-consumer" \
   --container-name="eap-spans-consumer" \
   --container-name="eap-mutations-consumer" \
+  --container-name="eap-spans-profiled-consumer" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \


### PR DESCRIPTION
This will make sure the profiled consumer can grab the Snuba image
