### PR TITLE
feat(replay): add arrayJoin translation_mappers for tags.key and value

### DIFF
--- a/snuba/datasets/configuration/replays/entities/replays.yaml
+++ b/snuba/datasets/configuration/replays/entities/replays.yaml
@@ -147,6 +147,20 @@ required_time_column: timestamp
 storages:
   - storage: replays
     is_writable: true
+    translation_mappers:
+      columns:
+        - mapper: ColumnToFunctionOnColumn
+          args:
+            from_table_name: null
+            from_col_name: tags_key
+            to_function_name: arrayJoin
+            to_function_column: tags.key
+        - mapper: ColumnToFunctionOnColumn
+          args:
+            from_table_name: null
+            from_col_name: tags_value
+            to_function_name: arrayJoin
+            to_function_column: tags.value
 
 storage_selector:
   selector: DefaultQueryStorageSelector

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -177,18 +177,31 @@ schema:
     ]
   local_table_name: replays_local
   dist_table_name: replays_dist
+
 query_processors:
   - processor: ClickhouseSettingsOverride
     args:
       settings:
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
+  - processor: MappingOptimizer
+    args:
+      column_name: tags
+      hash_map_name: _tags_hash_map
+      killswitch: tags_hash_map_enabled
+  - processor: EmptyTagConditionProcessor
+  - processor: ArrayJoinKeyValueOptimizer
+    args:
+      column_name: tags
+
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
+
 stream_loader:
   processor: ReplaysProcessor
   default_topic: ingest-replay-events
   dlq_topic: snuba-dead-letter-replays
+
 allocation_policies:
   - name: ConcurrentRateLimitAllocationPolicy
     args:


### PR DESCRIPTION
Needed for https://github.com/getsentry/sentry/issues/78531. Sentry tagstore makes this query:

```
MATCH (replays SAMPLE 1.0) SELECT count() AS `count` BY
tags_key WHERE timestamp >= toDateTime('2024-08-12T00:00:00') AND
timestamp < toDateTime('2024-08-13T23:59:59') AND project_id IN
tuple(1) AND project_id IN tuple(1) ORDER BY count DESC LIMIT 1000
```

And right now we're getting http response `'Validation failed for entity replays: Tag keys (tags_key) not resolved'`.

Uses [entities/search_issues.yaml](https://github.com/getsentry/snuba/blob/2544b8e87d9693bc8ffe9feadf5b6809e1cf71d8/snuba/datasets/configuration/issues/entities/search_issues.yaml#L1-L1) and [storages/search_issues.yaml](https://github.com/getsentry/snuba/blob/2544b8e87d9693bc8ffe9feadf5b6809e1cf71d8/snuba/datasets/configuration/issues/storages/search_issues.yaml#L1-L1) as references. I don't think we _need_ the additions to storage `query_processors`, but they may come in handy.