### PR TITLE
fix: Fix SyntaxWarning in Python 3.12

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 ignore_missing_imports = False
+exclude = (?x)(.*rust_snuba.*)
 
 [mypy-_strptime]
 ignore_missing_imports = True

--- a/scripts/copy_tables.py
+++ b/scripts/copy_tables.py
@@ -21,7 +21,7 @@ def _get_client(
 
 
 def get_regex_match(curr_create_table_statement: str) -> str:
-    match = re.search("\/clickhouse([a-z\/\-{}_]*)", curr_create_table_statement)
+    match = re.search(r"\/clickhouse([a-z\/\-{}_]*)", curr_create_table_statement)
     assert match is not None
     return match.group(0)
 
@@ -77,8 +77,8 @@ def verify_local_tables_exist_from_mv(
 
     """
     print(f"...checking table statement: {table}")
-    to_search = re.search("TO(.[.\w]*)", curr_create_table_statement)
-    from_search = re.search("FROM(.[.\w]*)", curr_create_table_statement)
+    to_search = re.search(r"TO(.[.\w]*)", curr_create_table_statement)
+    from_search = re.search(r"FROM(.[.\w]*)", curr_create_table_statement)
 
     assert to_search is not None
     assert from_search is not None

--- a/snuba/clickhouse/optimize/optimize_scheduler.py
+++ b/snuba/clickhouse/optimize/optimize_scheduler.py
@@ -6,7 +6,7 @@ from typing import MutableSequence, Sequence
 from snuba import settings
 from snuba.clickhouse.optimize.util import get_num_threads
 
-CLICKHOUSE_PARTITION_RE = re.compile("\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])")
+CLICKHOUSE_PARTITION_RE = re.compile(r"\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])")
 
 
 class OptimizedSchedulerTimeout(Exception):

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -15,10 +15,10 @@ POSTGRES_DATE_FORMAT_WITH_NS = "%Y-%m-%d %H:%M:%S.%f%z"
 POSTGRES_DATE_FORMAT_WITHOUT_NS = "%Y-%m-%d %H:%M:%S%z"
 
 date_re = re.compile(
-    "^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,6})?(\+\d{2})"
+    r"^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,6})?(\+\d{2})"
 )
 
-date_with_nanosec = re.compile("^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.")
+date_with_nanosec = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.")
 
 
 def parse_postgres_datetime(date: str) -> datetime:

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -136,7 +136,7 @@ def enforce_retention(
     return retention_days
 
 
-ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\|", "=": "\="})
+ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\\|", "=": "\\="})
 
 
 class EventTooOld(SerializableException):

--- a/snuba/migrations/check_dangerous.py
+++ b/snuba/migrations/check_dangerous.py
@@ -68,7 +68,7 @@ def _check_codecs(old_type: str, new_col_type: ColumnType[MigrationModifiers]) -
 
         def _has_codec(codec_str: str, modifiers: MigrationModifiers) -> bool:
             for codec in modifiers.codecs or []:
-                if re.match(f"^{codec_str.lower()}[\w\D\(\)]*", codec.lower()):
+                if re.match(rf"^{codec_str.lower()}[\w\D\(\)]*", codec.lower()):
                     return True
             return False
 

--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -110,7 +110,7 @@ def check_clickhouse(clickhouse: ClickhousePool) -> None:
     Checks that the clickhouse version is at least the min version and at most the max version
     """
     ver = clickhouse.execute("SELECT version()").results[0][0]
-    ver = re.search("(\d+.\d+.\d+.\d+)", ver)
+    ver = re.search(r"(\d+.\d+.\d+.\d+)", ver)
     if ver is None or version.parse(ver.group()) < version.parse(
         CLICKHOUSE_SERVER_MIN_VERSION
     ):

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -34,7 +34,7 @@ class DirectoryLoader(GroupLoader, ABC):
     represents the migration ID.
 
     Migrations must be named: xxxx_migration_name.py where xxxx is 4 digit,
-    0 padded migration number. As regex: [0-9][0-9][0-9][0-9]_.*\.py
+    0 padded migration number. As regex: [0-9][0-9][0-9][0-9]_.*.py
     Within a dir, migration number are strictly increasing by 1 beginning at
     0001
     """

--- a/snuba/query/processors/physical/mapping_optimizer.py
+++ b/snuba/query/processors/physical/mapping_optimizer.py
@@ -33,7 +33,7 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 metrics = MetricsWrapper(environment.metrics, "processors.tags_hash_map")
 logger = logging.getLogger("snuba.mapping_optimizer")
 
-ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "=": "\="})
+ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "=": "\\="})
 
 
 class ConditionClass(Enum):

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -90,17 +90,17 @@ def decode_part_str(part_str: str, partition_format: Sequence[PartSegment]) -> P
         cache_key = ",".join([segment.value for segment in format])
 
         PARTSEGMENT_RE = {
-            PartSegment.DATE: "('(?P<date>\d{4}-\d{2}-\d{2})')",
-            PartSegment.RETENTION_DAYS: "(?P<retention_days>\d+)",
+            PartSegment.DATE: r"('(?P<date>\d{4}-\d{2}-\d{2})')",
+            PartSegment.RETENTION_DAYS: r"(?P<retention_days>\d+)",
         }
 
-        SEP = ",\s*"
+        SEP = r",\s*"
 
         try:
             return re_cache[cache_key]
         except KeyError:
             re_cache[cache_key] = re.compile(
-                f"\({SEP.join([PARTSEGMENT_RE[s] for s in partition_format])}\)"
+                rf"\({SEP.join([PARTSEGMENT_RE[s] for s in partition_format])}\)"
             )
 
         return re_cache[cache_key]

--- a/tests/query/processors/test_mapping_optimizer.py
+++ b/tests/query/processors/test_mapping_optimizer.py
@@ -80,7 +80,7 @@ TEST_CASES = [
             "has",
             (
                 column("_tags_hash_map", True),
-                FunctionCall(None, "cityHash64", (Literal(None, "my\=t\\\\ag=a"),)),
+                FunctionCall(None, "cityHash64", (Literal(None, "my\\=t\\\\ag=a"),)),
             ),
         ),
         id="Optimizable simple escaped condition",


### PR DESCRIPTION
When an escape character is used in a string, Python 3.12 will now show a SyntaxWarning.

See here: https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes

This was causing mypy to fail to run. Fix this bug across the codebase.

Also exclude the rust_snuba files (which suffer from this problem) since they are autogenerated.