### PR TITLE
cleanup(job-runner): remove dry_run

### DIFF
--- a/snuba/cli/jobs.py
+++ b/snuba/cli/jobs.py
@@ -25,24 +25,20 @@ def list(*, json_manifest: str) -> None:
     click.echo(job_specs)
 
 
-def _run_job_and_echo_status(job_spec: JobSpec, dry_run: bool) -> None:
-    status = run_job(job_spec, dry_run)
+def _run_job_and_echo_status(job_spec: JobSpec) -> None:
+    status = run_job(job_spec)
     click.echo(f"resulting job status = {status}")
 
 
 @jobs.command()
 @click.option("--json_manifest", default=MANIFEST_FILENAME)
 @click.option("--job_id")
-@click.option(
-    "--dry_run",
-    default=True,
-)
-def run_from_manifest(*, json_manifest: str, job_id: str, dry_run: bool) -> None:
+def run_from_manifest(*, json_manifest: str, job_id: str) -> None:
     job_specs = list_job_specs(json_manifest)
     if job_id not in job_specs.keys():
         raise click.ClickException("Provide a valid job id")
 
-    _run_job_and_echo_status(job_specs[job_id], dry_run)
+    _run_job_and_echo_status(job_specs[job_id])
 
 
 def _parse_params(pairs: Tuple[str, ...]) -> MutableMapping[Any, Any]:
@@ -52,17 +48,13 @@ def _parse_params(pairs: Tuple[str, ...]) -> MutableMapping[Any, Any]:
 @jobs.command()
 @click.option("--job_type")
 @click.option("--job_id")
-@click.option(
-    "--dry_run",
-    default=True,
-)
 @click.argument("pairs", nargs=-1)
-def run(*, job_type: str, job_id: str, dry_run: bool, pairs: Tuple[str, ...]) -> None:
+def run(*, job_type: str, job_id: str, pairs: Tuple[str, ...]) -> None:
     if not job_type or not job_id:
         raise click.ClickException(JOB_SPECIFICATION_ERROR_MSG)
     job_spec = JobSpec(job_id=job_id, job_type=job_type, params=_parse_params(pairs))
 
-    _run_job_and_echo_status(job_spec, dry_run)
+    _run_job_and_echo_status(job_spec)
 
 
 @jobs.command()

--- a/snuba/manual_jobs/__init__.py
+++ b/snuba/manual_jobs/__init__.py
@@ -17,9 +17,8 @@ class JobSpec:
 
 
 class Job(ABC, metaclass=RegisteredClass):
-    def __init__(self, job_spec: JobSpec, dry_run: bool) -> None:
+    def __init__(self, job_spec: JobSpec) -> None:
         self.job_spec = job_spec
-        self.dry_run = dry_run
         if job_spec.params:
             for k, v in job_spec.params.items():
                 setattr(self, k, v)

--- a/snuba/manual_jobs/job_loader.py
+++ b/snuba/manual_jobs/job_loader.py
@@ -11,9 +11,9 @@ class NonexistentJobException(SerializableException):
 
 class _JobLoader:
     @staticmethod
-    def get_job_instance(job_spec: JobSpec, dry_run: bool) -> "Job":
+    def get_job_instance(job_spec: JobSpec) -> "Job":
         job_type_class = Job.class_from_name(job_spec.job_type)
         if job_type_class is None:
             raise NonexistentJobException(job_spec.job_type)
 
-        return cast("Job", job_type_class(job_spec, dry_run=dry_run))
+        return cast("Job", job_type_class(job_spec))

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -125,7 +125,7 @@ def list_job_specs_with_status(
     }
 
 
-def run_job(job_spec: JobSpec, dry_run: bool) -> JobStatus:
+def run_job(job_spec: JobSpec) -> JobStatus:
     current_job_status = get_job_status(job_spec.job_id)
     if current_job_status is not None and current_job_status != JobStatus.NOT_STARTED:
         raise JobStatusException(job_id=job_spec.job_id, status=current_job_status)
@@ -136,17 +136,14 @@ def run_job(job_spec: JobSpec, dry_run: bool) -> JobStatus:
 
     current_job_status = _set_job_status(job_spec.job_id, JobStatus.NOT_STARTED)
 
-    job_to_run = _JobLoader.get_job_instance(job_spec, dry_run)
+    job_to_run = _JobLoader.get_job_instance(job_spec)
 
     try:
-        if not dry_run:
-            current_job_status = _set_job_status(job_spec.job_id, JobStatus.RUNNING)
+        current_job_status = _set_job_status(job_spec.job_id, JobStatus.RUNNING)
         job_to_run.execute()
-        if not dry_run:
-            current_job_status = _set_job_status(job_spec.job_id, JobStatus.FINISHED)
+        current_job_status = _set_job_status(job_spec.job_id, JobStatus.FINISHED)
     except BaseException:
-        if not dry_run:
-            current_job_status = _set_job_status(job_spec.job_id, JobStatus.FAILED)
+        current_job_status = _set_job_status(job_spec.job_id, JobStatus.FAILED)
         capture_exception()
     finally:
         _release_job_lock(job_spec.job_id)

--- a/snuba/manual_jobs/toy_job.py
+++ b/snuba/manual_jobs/toy_job.py
@@ -5,15 +5,11 @@ class ToyJob(Job):
     def __init__(
         self,
         job_spec: JobSpec,
-        dry_run: bool,
     ):
-        super().__init__(job_spec, dry_run)
+        super().__init__(job_spec)
 
     def _build_query(self) -> str:
-        if self.dry_run:
-            return "dry run query"
-        else:
-            return "not dry run query"
+        return "query"
 
     def execute(self) -> None:
         logger.info(

--- a/tests/cli/test_jobs.py
+++ b/tests/cli/test_jobs.py
@@ -25,8 +25,6 @@ def test_invalid_job_errors() -> None:
             "NonexistentJob",
             "--job_id",
             "0001",
-            "--dry_run",
-            "True",
             "k1=v1",
             "k2=v2",
         ],
@@ -38,7 +36,7 @@ def test_invalid_job_errors() -> None:
 @pytest.mark.redis_db
 def test_cmd_line_no_job_specification_errors() -> None:
     runner = CliRunner()
-    result = runner.invoke(run, ["--dry_run", "True", "k1=v1", "k2=v2"])
+    result = runner.invoke(run, ["k1=v1", "k2=v2"])
     assert result.exit_code == 1
     assert result.output == "Error: " + JOB_SPECIFICATION_ERROR_MSG + "\n"
 
@@ -46,9 +44,7 @@ def test_cmd_line_no_job_specification_errors() -> None:
 @pytest.mark.redis_db
 def test_cmd_line_no_job_id_errors() -> None:
     runner = CliRunner()
-    result = runner.invoke(
-        run, ["--job_type", "ToyJob", "--dry_run", "True", "k1=v1", "k2=v2"]
-    )
+    result = runner.invoke(run, ["--job_type", "ToyJob", "k1=v1", "k2=v2"])
     assert result.exit_code == 1
     assert result.output == "Error: " + JOB_SPECIFICATION_ERROR_MSG + "\n"
 
@@ -56,9 +52,7 @@ def test_cmd_line_no_job_id_errors() -> None:
 @pytest.mark.redis_db
 def test_cmd_line_no_job_type_errors() -> None:
     runner = CliRunner()
-    result = runner.invoke(
-        run, ["--job_id", "0001", "--dry_run", "True", "k1=v1", "k2=v2"]
-    )
+    result = runner.invoke(run, ["--job_id", "0001", "k1=v1", "k2=v2"])
     assert result.exit_code == 1
     assert result.output == "Error: " + JOB_SPECIFICATION_ERROR_MSG + "\n"
 

--- a/tests/manual_jobs/test_job.py
+++ b/tests/manual_jobs/test_job.py
@@ -40,10 +40,10 @@ class SlowJob(Job):
 @pytest.mark.redis_db
 def test_job_status_changes_to_finished() -> None:
     assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
-    run_job(test_job_spec, False)
+    run_job(test_job_spec)
     assert get_job_status(JOB_ID) == JobStatus.FINISHED
     with pytest.raises(JobStatusException):
-        run_job(test_job_spec, False)
+        run_job(test_job_spec)
 
 
 @pytest.mark.redis_db
@@ -51,7 +51,7 @@ def test_job_with_exception_causes_failure() -> None:
     with patch.object(_JobLoader, "get_job_instance") as MockGetInstance:
         MockGetInstance.return_value = FailJob()
         assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
-        run_job(test_job_spec, False)
+        run_job(test_job_spec)
         assert get_job_status(JOB_ID) == JobStatus.FAILED
 
 
@@ -61,9 +61,7 @@ def test_slow_job_stay_running() -> None:
         job = SlowJob()
         MockGetInstance.return_value = job
         assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
-        t = Thread(
-            target=run_job, name="slow-background-job", args=[test_job_spec, False]
-        )
+        t = Thread(target=run_job, name="slow-background-job", args=[test_job_spec])
         t.start()
         sleep(0.1)
         assert get_job_status(JOB_ID) == JobStatus.RUNNING
@@ -79,4 +77,4 @@ def test_job_status_with_invalid_job_id() -> None:
 def test_job_lock() -> None:
     _acquire_job_lock(JOB_ID)
     with pytest.raises(JobLockedException):
-        run_job(test_job_spec, False)
+        run_job(test_job_spec)


### PR DESCRIPTION
Removing the dry_run option as we don't see it providing a ton of value, but it creates a lot of branching that makes the code less readable