### PR TITLE
chore(admin): Allow product tools role to use querylog tool

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -85,6 +85,7 @@ TOOL_RESOURCES = {
     "sudo-system-queries": ToolResource("system-queries"),
     "clickhouse-migrations": ToolResource("clickhouse-migrations"),
     "snuba-explain": ToolResource("snuba-explain"),
+    "querylog": ToolResource("querylog"),
     "all": ToolResource("all"),
 }
 
@@ -170,6 +171,7 @@ ROLES = {
                     TOOL_RESOURCES["system-queries"],
                     TOOL_RESOURCES["clickhouse-migrations"],
                     TOOL_RESOURCES["snuba-explain"],
+                    TOOL_RESOURCES["querylog"],
                 ]
             )
         },

--- a/tests/admin/test_authorization.py
+++ b/tests/admin/test_authorization.py
@@ -41,4 +41,5 @@ def test_product_tools_role(
     assert "production-queries" in data["tools"]
     assert "clickhouse-migrations" in data["tools"]
     assert "snuba-explain" in data["tools"]
+    assert "querylog" in data["tools"]
     assert "all" not in data["tools"]


### PR DESCRIPTION
Because otherwise an SnS engineer will have to manually run it every time we have a capman issue