### PR TITLE
fix(admin): Allow dots and backticks in system queries

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -110,7 +110,7 @@ ALTER_QUERY_RE = re.compile(
         ^
         (ALTER|CREATE)
         \s
-        [\w\s,=()*+<>'%"\-\/:]+
+        [\w\s,=()*+<>'%"\-\/:\.`]+
         ;? # Optional semicolon
         $
     """,


### PR DESCRIPTION
CREATE TABLE queries usually have dots and backticks in them. Allow those characters
in the regex so they can be run in sudo mode.