### PR TITLE
Bump sentry-kafka-schemas to new release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.3.4
 sentry-arroyo==2.17.6
-sentry-kafka-schemas==0.1.110
+sentry-kafka-schemas==0.1.112
 sentry-redis-tools==0.3.0
 sentry-relay==0.8.44
 sentry-sdk==1.40.5


### PR DESCRIPTION
Bumping new release following https://github.com/getsentry/sentry-kafka-schemas/pull/336