### PR TITLE
feat(job-runner): run job from snuba admin

### DIFF
--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -109,6 +109,7 @@ interface Client {
     column_conditions: object
   ) => Promise<Response>;
   listJobSpecs: () => Promise<JobSpecMap>;
+  runJob(job_id: string): Promise<String>;
 }
 
 function Client(): Client {
@@ -526,6 +527,13 @@ function Client(): Client {
         method: "GET",
       }).then((resp) => resp.json());
     },
+    runJob: (job_id: string) => {
+      const url = baseUrl + "job-specs/" + job_id;
+      return fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      }).then((resp) => resp.text());
+    }
   };
 }
 

--- a/snuba/admin/static/manual_jobs/index.tsx
+++ b/snuba/admin/static/manual_jobs/index.tsx
@@ -1,6 +1,7 @@
 import Client from "SnubaAdmin/api_client";
 import { Table } from "SnubaAdmin/table";
 import React, { useEffect, useState } from "react";
+import Button from "react-bootstrap/esm/Button";
 
 function ViewCustomJobs(props: { api: Client }) {
   const [jobSpecs, setJobSpecs] = useState<JobSpecMap>({});
@@ -11,6 +12,13 @@ function ViewCustomJobs(props: { api: Client }) {
     });
   }, []);
 
+  function runButtonForJobId(status: string, job_id: string) {
+    if (status === "not_started") {
+      return <Button onClick={() => props.api.runJob(job_id)}>Run</Button>;
+    }
+    return <Button disabled>Not Available</Button>;
+  }
+
   function jobSpecsAsRows() {
     return Object.entries(jobSpecs).map(([_, job_info]) => {
       return [
@@ -18,7 +26,7 @@ function ViewCustomJobs(props: { api: Client }) {
         job_info.spec.job_type,
         JSON.stringify(job_info.spec.params),
         job_info.status,
-        "TODO",
+        runButtonForJobId(job_info.status, job_info.spec.job_id),
       ];
     });
   }

--- a/snuba/admin/static/manual_jobs/index.tsx
+++ b/snuba/admin/static/manual_jobs/index.tsx
@@ -12,9 +12,22 @@ function ViewCustomJobs(props: { api: Client }) {
     });
   }, []);
 
+  function updateJobStatus(job_id: string, new_status: string): any {
+    const updatedJobs = Object.fromEntries(Object.entries(jobSpecs).map(([_, job]) => {
+      if (job.spec.job_id === job_id) {
+        return [job_id, {
+          ...job,
+          status: new_status,
+        }];
+      }
+      return [job_id, job];
+    }));
+    setJobSpecs(updatedJobs);
+  }
+
   function runButtonForJobId(status: string, job_id: string) {
     if (status === "not_started") {
-      return <Button onClick={() => props.api.runJob(job_id)}>Run</Button>;
+      return <Button onClick={() => props.api.runJob(job_id).then((new_status: String) => updateJobStatus(job_id, new_status.toString()))}>Run</Button>;
     }
     return <Button disabled>Not Available</Button>;
   }

--- a/snuba/admin/static/manual_jobs/index.tsx
+++ b/snuba/admin/static/manual_jobs/index.tsx
@@ -1,7 +1,7 @@
 import Client from "SnubaAdmin/api_client";
 import { Table } from "SnubaAdmin/table";
 import React, { useEffect, useState } from "react";
-import Button from "react-bootstrap/esm/Button";
+import Button from "react-bootstrap/Button";
 
 function ViewCustomJobs(props: { api: Client }) {
   const [jobSpecs, setJobSpecs] = useState<JobSpecMap>({});

--- a/snuba/admin/static/manual_jobs/index.tsx
+++ b/snuba/admin/static/manual_jobs/index.tsx
@@ -12,22 +12,22 @@ function ViewCustomJobs(props: { api: Client }) {
     });
   }, []);
 
-  function updateJobStatus(job_id: string, new_status: string): any {
-    const updatedJobs = Object.fromEntries(Object.entries(jobSpecs).map(([_, job]) => {
-      if (job.spec.job_id === job_id) {
-        return [job_id, {
+  function updateJobStatus(jobId: string, new_status: string): any {
+    const updatedJobs = Object.fromEntries(Object.entries(jobSpecs).map(([mapJobId, job]) => {
+      if (job.spec.job_id === jobId) {
+        return [mapJobId, {
           ...job,
           status: new_status,
         }];
       }
-      return [job_id, job];
+      return [mapJobId, job];
     }));
     setJobSpecs(updatedJobs);
   }
 
-  function runButtonForJobId(status: string, job_id: string) {
+  function runButtonForJobId(status: string, jobId: string) {
     if (status === "not_started") {
-      return <Button onClick={() => props.api.runJob(job_id).then((new_status: String) => updateJobStatus(job_id, new_status.toString()))}>Run</Button>;
+      return <Button onClick={() => props.api.runJob(jobId).then((newStatus: String) => updateJobStatus(jobId, newStatus.toString()))}>Run</Button>;
     }
     return <Button disabled>Not Available</Button>;
   }

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -73,7 +73,7 @@ from snuba.datasets.storages.factory import (
     get_writable_storage,
 )
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.manual_jobs.runner import list_job_specs_with_status
+from snuba.manual_jobs.runner import list_job_specs, list_job_specs_with_status, run_job
 from snuba.migrations.connect import check_for_inactive_replicas
 from snuba.migrations.errors import InactiveClickhouseReplica, MigrationError
 from snuba.migrations.groups import MigrationGroup, get_group_readiness_state
@@ -1264,6 +1264,13 @@ def deletes_enabled() -> Response:
 @check_tool_perms(tools=[AdminTools.MANUAL_JOBS])
 def get_job_specs() -> Response:
     return make_response(jsonify(list_job_specs_with_status()), 200)
+
+
+@application.route("/job-specs/<job_id>", methods=["POST"])
+@check_tool_perms(tools=[AdminTools.MANUAL_JOBS])
+def execute_job(job_id: str) -> Response:
+    job_specs = list_job_specs()
+    return make_response(run_job(job_specs[job_id])), 200
 
 
 @application.route("/clickhouse_node_info")

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1270,7 +1270,7 @@ def get_job_specs() -> Response:
 @check_tool_perms(tools=[AdminTools.MANUAL_JOBS])
 def execute_job(job_id: str) -> Response:
     job_specs = list_job_specs()
-    return make_response(run_job(job_specs[job_id])), 200
+    return make_response(run_job(job_specs[job_id]), 200)
 
 
 @application.route("/clickhouse_node_info")


### PR DESCRIPTION
This wires job execution into snuba admin. Tested locally

https://github.com/user-attachments/assets/7f56f035-faf0-4311-bbb6-c7e3cb2c4725

Back-end logs:
```
127.0.0.1 - - [03/Oct/2024:15:05:09 -0700] "GET /static/snuba.svg HTTP/1.1" 304 215 "http://localhost:1219/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0"
{"module": "snuba.admin.views", "user": "AdminUser(email='unknown', id='unknown', roles=[Role(name='MigrationsReader', actions={<snuba.admin.auth_roles.ExecuteNoneAction object at 0x104ab4ad0>}), Role(name='TestMigrationsExecutor', actions={<snuba.admin.auth_roles.ExecuteAllAction object at 0x104ab5150>}), Role(name='SearchIssuesExecutor', actions={<snuba.admin.auth_roles.ExecuteNonBlockingAction object at 0x104ab5490>}), Role(name='product-tools', actions={<snuba.admin.auth_roles.InteractToolAction object at 0x104ab5590>}), Role(name='all-tools', actions={<snuba.admin.auth_roles.InteractToolAction object at 0x104ab4fd0>}), Role(name='clickhouse-admin', actions={<snuba.admin.auth_roles.ExecuteSudoSystemQuery object at 0x104ab56d0>})])", "event": "authorize.finished", "severity": "info", "user_ip": "127.0.0.1", "endpoint": "execute_job", "timestamp": "2024-10-03T22:05:16.981636Z"}
2024-10-03 15:05:16,996 executing job admin-run-1242 with query `query`
```

Next steps:
- I want job logging to multiplex log to both the normal logger and to Redis, so that we can create a "View Logs" button that lets us view the history within an individual job.
- support for async jobs (long-running clickhouse queries)