### PR TITLE
fix: better error message in admin system query

### DIFF
--- a/snuba/admin/static/utils/execute_button.tsx
+++ b/snuba/admin/static/utils/execute_button.tsx
@@ -13,7 +13,12 @@ function ExecuteButton(props: {
 
   const defaultError = (err: any) => {
     console.log("ERROR", err);
-    window.alert("An error occurred: " + err);
+    try {
+      window.alert("An error occurred: " + JSON.stringify(err));
+    }
+    catch {
+      window.alert("An error occurred: " + err);
+    }
   };
   let errorCallback = props.onError || defaultError;
 


### PR DESCRIPTION
In the system queries tool i was getting this error message 
<img width="954" alt="Screenshot 2024-10-04 at 2 04 19 PM" src="https://github.com/user-attachments/assets/c0853ceb-d627-4c7e-a756-c9187e475caf">
and you can only see the actual error in console

my change makes it show the error in the alert
<img width="460" alt="Screenshot 2024-10-04 at 2 04 35 PM" src="https://github.com/user-attachments/assets/5c95d99d-0f78-4228-9bec-5c64948181b8">
