### PR TITLE
fix(devservices): Fixing devservices config

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -5,8 +5,6 @@ x-sentry-service-config:
   dependencies:
     clickhouse:
       description: "clickhouse"
-      remote:
-        repo_name: snuba
     redis:
       description: "redis"
     kafka:


### PR DESCRIPTION
Fixes a small bug introduced in #6350 where a remote was defined for a non remote dependency.