### PR TITLE
ref(deletes): increase max rows to 100000

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -124,7 +124,7 @@ query_processors:
 
 deletion_settings:
   is_enabled: 1
-  max_rows_to_delete: 1000
+  max_rows_to_delete: 100000
   tables:
     - search_issues_local_v2
 


### PR DESCRIPTION
We can delete by `group_id` now and many have above `1000` events. Might need to raise it even more later, but this is to allow testing deleting larger groups in S4S (the only region deletes are enabled in currently)