### PR TITLE
fix(database-clusters): Remove Query Node column

### DIFF
--- a/snuba/admin/clickhouse/database_clusters.py
+++ b/snuba/admin/clickhouse/database_clusters.py
@@ -16,7 +16,6 @@ class Node:
     replica: int
     version: str
     storage_name: str
-    is_query_node: bool
     is_distributed: bool
 
 
@@ -35,7 +34,6 @@ class HostInfo:
     host: str
     port: int
     storage_name: str
-    is_query_node: bool
     is_distributed: bool
 
 
@@ -49,7 +47,6 @@ def get_node_info() -> Sequence[Node]:
                     node["host"],
                     node["port"],
                     storage_info["storage_name"],
-                    storage_info["query_node"] == node,
                     True,
                 )
             )
@@ -60,7 +57,6 @@ def get_node_info() -> Sequence[Node]:
                     node["host"],
                     node["port"],
                     storage_info["storage_name"],
-                    storage_info["query_node"] == node,
                     False,
                 )
             )
@@ -82,7 +78,6 @@ def get_node_info() -> Sequence[Node]:
                 replica=result[5],
                 version=result[6],
                 storage_name=host_info.storage_name,
-                is_query_node=host_info.is_query_node,
                 is_distributed=host_info.is_distributed,
             )
             for result in connection.execute(

--- a/snuba/admin/static/database_clusters/index.tsx
+++ b/snuba/admin/static/database_clusters/index.tsx
@@ -51,12 +51,8 @@ function DatabaseClusters(props: { api: Client }) {
                 header: 'Storage Name',
             },
             {
-                accessorFn: (row) => row.is_query_node ? 'Yes' : 'No',
-                header: 'Is Query Node',
-            },
-            {
-                accessorFn: (row) => row.is_distributed ? 'Yes' : 'No',
-                header: 'Is Distributed',
+                accessorFn: (row) => row.is_distributed ? 'Query Node' : 'Storage Node',
+                header: 'Node Type',
             },
             {
                 accessorKey: 'version',

--- a/snuba/admin/static/database_clusters/types.tsx
+++ b/snuba/admin/static/database_clusters/types.tsx
@@ -7,7 +7,6 @@ type ClickhouseNodeInfo = {
     replica: number,
     version: string,
     storage_name: string,
-    is_query_node: boolean,
     is_distributed: boolean,
 };
 


### PR DESCRIPTION
Removing the query node column and replacing the distributed node column with a node type column since the query node column was not actually showing if the node was a query node.