### PR TITLE
feat(admin): Show data in clickhouse tracing tool

### DIFF
--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -61,6 +61,6 @@ def scrub_row(row: tuple[Any, ...]) -> tuple[Any, ...]:
         if isinstance(val, (int, float)):
             rv.append(val)
         else:
-            rv.append(f"<scrubbed: {type(val)}>")
+            rv.append(f"<scrubbed: {type(val).__name__}>")
 
     return tuple(rv)

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -56,7 +56,7 @@ def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
 
 
 def scrub_row(row: tuple[Any, ...]) -> tuple[Any, ...]:
-    rv = []
+    rv: list[Any] = []
     for val in row:
         if isinstance(val, (int, float)):
             rv.append(val)

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -28,6 +28,7 @@ class TraceOutput:
     summarized_trace_output: TracingSummary
     cols: list[tuple[str, str]]
     num_rows_result: int
+    result: list[tuple[Any, ...]]
     profile_events_results: dict[str, Any]
     profile_events_meta: list[Any]
     profile_events_profile: dict[str, int]
@@ -47,7 +48,19 @@ def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
         summarized_trace_output=summarized_trace_output,
         cols=query_result.meta,  # type: ignore
         num_rows_result=len(query_result.results),
+        result=list(map(scrub_row, query_result.results)),
         profile_events_results={},
         profile_events_meta=[],
         profile_events_profile={},
     )
+
+
+def scrub_row(row: tuple[Any, ...]) -> tuple[Any, ...]:
+    rv = []
+    for val in row:
+        if isinstance(val, (int, float)):
+            rv.append(val)
+        else:
+            rv.append(f"<scrubbed: {type(val)}>")
+
+    return tuple(rv)

--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -59,6 +59,7 @@ function QueryDisplay(props: {
           input_query: `${query.sql}`,
           timestamp: result.timestamp,
           num_rows_result: result.num_rows_result,
+          result: result.result,
           cols: result.cols,
           trace_output: result.trace_output,
           summarized_trace_output: result.summarized_trace_output,
@@ -146,6 +147,21 @@ function QueryDisplay(props: {
                   </Accordion.Control>
                   <Accordion.Panel>
                     <Code block>{queryResult.input_query}</Code>
+                  </Accordion.Panel>
+                </Accordion.Item>
+              </Accordion>
+              <Accordion chevronPosition="left">
+                <Accordion.Item value="input-query" key="input-query">
+                  <Accordion.Control>
+                    <Title order={3}>Query Result</Title>
+                  </Accordion.Control>
+                  <Accordion.Panel>
+                    <Table
+                      headerData={
+                        (queryResult.cols || []).map(([name, ty]) => <>{name} <small>({ty})</small></>)
+                      }
+                      rowData={queryResult.result || []}
+                    />
                   </Accordion.Panel>
                 </Accordion.Item>
               </Accordion>

--- a/snuba/admin/static/tracing/types.tsx
+++ b/snuba/admin/static/tracing/types.tsx
@@ -10,6 +10,7 @@ type TracingResult = {
   summarized_trace_output?: TracingSummary;
   cols?: Array<Array<string>>;
   num_rows_result?: number;
+  result?: Array<Array<any>>,
   profile_events_results?: Map<Map<string, string>, Object>;
   profile_events_meta?: Array<Object>;
   profile_events_profile?: {};

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -1,5 +1,5 @@
 from snuba.admin.clickhouse.tracing import scrub_row
 
 
-def test_scrub():
+def test_scrub() -> None:
     assert scrub_row((1, 2, 3, "release name")) == (1, 2, 3, "<scrubbed: str>")

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -1,0 +1,5 @@
+from snuba.admin.clickhouse.tracing import scrub_row
+
+
+def test_scrub():
+    assert scrub_row((1, 2, 3, "release name")) == (1, 2, 3, "<scrubbed: str>")


### PR DESCRIPTION
Show query results, but remove everything that is not a number. That's
practically getting rid of all PII. Discussed beforehand with Evan and
Matt.

We need this to evaluate query correctness in the context of EAP
mutability. How do we know if our percentiles are correct?

But also more generally: If you're comparing two queries for
performance, and the output is wrong in one of them, how are you going
to notice that your entire benchmark is garbage?

![image](https://github.com/user-attachments/assets/c33ed791-578c-4e3c-a102-873cfdd91f0f)
