### PR TITLE
feat(api): Add a clickhouse connection sanity check to api healthcheck

### DIFF
--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -13,6 +13,7 @@ from snuba import environment, settings
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clusters.cluster import (
     ClickhouseClientSettings,
+    ClickhouseCluster,
     ConnectionId,
     UndefinedClickhouseCluster,
 )
@@ -84,7 +85,11 @@ def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
         "thorough": str(thorough),
     }
 
-    clickhouse_health = check_clickhouse(metric_tags=metric_tags) if thorough else True
+    clickhouse_health = (
+        check_all_tables_present(metric_tags=metric_tags)
+        if thorough
+        else sanity_check_clickhouse_connections()
+    )
     metric_tags["clickhouse_ok"] = str(clickhouse_health)
 
     body: Mapping[str, Union[str, bool]]
@@ -120,17 +125,49 @@ def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
     )
 
 
-def filter_checked_storages() -> List[Storage]:
-    filtered_storages: List[Storage] = []
+def filter_checked_storages(filtered_storages: List[Storage]) -> None:
     all_storage_keys = get_all_storage_keys()
     for storage_key in all_storage_keys:
         storage = get_storage(storage_key)
         if storage.get_readiness_state().value in settings.SUPPORTED_STATES:
             filtered_storages.append(storage)
-    return filtered_storages
 
 
-def check_clickhouse(metric_tags: dict[str, Any] | None = None) -> bool:
+def sanity_check_clickhouse_connections() -> bool:
+    """
+    Check if at least a single clickhouse query node is operable,
+    returns True if so, False otherwise.
+    """
+    storages: List[Storage] = []
+
+    try:
+        filter_checked_storages(storages)
+    except KeyError:
+        pass
+
+    unique_clusters: dict[ConnectionId, ClickhouseCluster] = {}
+
+    for storage in storages:
+        try:
+            unique_clusters[
+                storage.get_cluster().get_connection_id()
+            ] = storage.get_cluster()
+        except UndefinedClickhouseCluster as err:
+            logger.error(err)
+            continue
+
+    for cluster in unique_clusters.values():
+        try:
+            clickhouse = cluster.get_query_connection(ClickhouseClientSettings.QUERY)
+            clickhouse.execute("show tables").results
+            return True
+        except Exception as err:
+            logger.error(err)
+            continue
+    return False
+
+
+def check_all_tables_present(metric_tags: dict[str, Any] | None = None) -> bool:
     """
     Checks if all the tables in all the enabled datasets exist in ClickHouse
     TODO: Eventually, when we fully migrate to readiness_states, we can remove DISABLED_DATASETS.
@@ -140,7 +177,8 @@ def check_clickhouse(metric_tags: dict[str, Any] | None = None) -> bool:
     logger = logging.getLogger("snuba.health")
 
     try:
-        storages = filter_checked_storages()
+        storages: List[Storage] = []
+        filter_checked_storages(storages)
         connection_grouped_table_names: MutableMapping[
             ConnectionId, Set[str]
         ] = defaultdict(set)

--- a/tests/cli/test_health.py
+++ b/tests/cli/test_health.py
@@ -11,22 +11,32 @@ def test_down_file_exists_pod_healthy() -> None:
     with mock.patch(
         "snuba.utils.health_info.check_down_file_exists", return_value=True
     ):
-        result = runner.invoke(health)
-        assert result.exit_code == 0
+        with mock.patch(
+            "snuba.utils.health_info.sanity_check_clickhouse_connections",
+            return_value=True,
+        ):
+            result = runner.invoke(health)
+            assert result.exit_code == 0
 
 
-def test_do_not_check_clickhouse_if_not_thorough() -> None:
+def test_bad_clickhouse_connection_healthcheck_fails() -> None:
     runner = CliRunner()
-    # don't check clickhouse if not thorough
-    with mock.patch("snuba.utils.health_info.check_clickhouse", return_value=False):
+    # sanity check clickhouse connections when not running in thorough mode
+    with mock.patch(
+        "snuba.utils.health_info.sanity_check_clickhouse_connections",
+        return_value=False,
+    ):
         result = runner.invoke(health)
-        assert result.exit_code == 0
+        assert result.exit_code == 1
 
 
 def test_bad_clickhouse_connection_thorough_healthcheck_fails() -> None:
     runner = CliRunner()
-    # thorough healthcheck fails on bad clickhouse connection
-    with mock.patch("snuba.utils.health_info.check_clickhouse", return_value=False):
+    # thorough healthcheck fails on bad clickhouse connection, because we cannot verify
+    # tables
+    with mock.patch(
+        "snuba.utils.health_info.check_all_tables_present", return_value=False
+    ):
         result = runner.invoke(health, "--thorough")
         assert result.exit_code == 1
 
@@ -34,6 +44,8 @@ def test_bad_clickhouse_connection_thorough_healthcheck_fails() -> None:
 def test_good_clickhouse_connection_thorough_healthcheck_passes() -> None:
     runner = CliRunner()
     # thorough healthcheck passes on good clickhouse connection
-    with mock.patch("snuba.utils.health_info.check_clickhouse", return_value=True):
+    with mock.patch(
+        "snuba.utils.health_info.check_all_tables_present", return_value=True
+    ):
         result = runner.invoke(health, "--thorough")
         assert result.exit_code == 0

--- a/tests/utils/test_check_clickhouse.py
+++ b/tests/utils/test_check_clickhouse.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib
-from typing import Any, Sequence
+from typing import Any, List, Sequence
 from unittest import mock
 
 import pytest
@@ -9,13 +9,14 @@ import pytest
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.readiness_state import ReadinessState
-from snuba.datasets.storage import ReadableTableStorage
+from snuba.datasets.storage import ReadableTableStorage, Storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.utils.health_info import (
     _set_shutdown,
-    check_clickhouse,
+    check_all_tables_present,
     filter_checked_storages,
     get_shutdown,
+    sanity_check_clickhouse_connections,
 )
 
 
@@ -107,18 +108,50 @@ def temp_settings() -> Any:
     return_value=[StorageKey.ERRORS_RO],
 )
 @pytest.mark.clickhouse_db
-def test_check_clickhouse(mock1: mock.MagicMock) -> None:
-    assert check_clickhouse()
+def test_check_all_tables_present(mock1: mock.MagicMock) -> None:
+    assert check_all_tables_present()
+
+
+@mock.patch(
+    "snuba.utils.health_info.get_all_storage_keys",
+    return_value=[StorageKey.ERRORS_RO],
+)
+@pytest.mark.clickhouse_db
+def test_sanity_check_clickhouse_connections(mock1: mock.MagicMock) -> None:
+    assert sanity_check_clickhouse_connections()
 
 
 @mock.patch(
     "snuba.utils.health_info.get_all_storage_keys",
     return_value=[StorageKey.ERRORS_RO, FakeStorageKey("fake_storage_key")],
 )
-def test_bad_dataset_fails_healthcheck(mock1: mock.MagicMock) -> None:
+def test_bad_dataset_fails_thorough_healthcheck(mock1: mock.MagicMock) -> None:
     # the bad dataset is enabled and not experimental, therefore the healthcheck
     # should fail
-    assert not check_clickhouse()
+    assert not check_all_tables_present()
+
+
+@mock.patch(
+    "snuba.utils.health_info.get_all_storage_keys",
+    return_value=[StorageKey.ERRORS_RO, FakeStorageKey("fake_storage_key")],
+)
+@pytest.mark.clickhouse_db
+def test_single_bad_dataset_passes_healthcheck(mock1: mock.MagicMock) -> None:
+    # a bad dataset is enabled and not operable, but at least a single
+    # clickhouse query node is still operable. We still want to pass the
+    # regular healthcheck in this case so that we can continue to serve request
+    # despite outage in a single cluster.
+    assert sanity_check_clickhouse_connections()
+
+
+@mock.patch(
+    "snuba.utils.health_info.get_all_storage_keys",
+    return_value=[FakeStorageKey("fake_storage_key")],
+)
+def test_all_bad_dataset_fails_thorough_healthcheck(mock1: mock.MagicMock) -> None:
+    # No query nodes are available, fail healthcheck because there's likely a
+    # connection issue with the underlying host
+    assert not check_all_tables_present()
 
 
 @mock.patch(
@@ -130,7 +163,7 @@ def test_dataset_undefined_storage_set(
     mock1: mock.MagicMock, mock2: mock.MagicMock
 ) -> None:
     metrics_tags: dict[str, str] = {}
-    assert not check_clickhouse(metric_tags=metrics_tags)
+    assert not check_all_tables_present(metric_tags=metrics_tags)
     for v in metrics_tags.values():
         assert isinstance(v, str)
 
@@ -146,7 +179,8 @@ def test_filter_checked_storages(mock1: mock.MagicMock, temp_settings: Any) -> N
         "partial",
         "complete",
     }  # remove deprecate from supported states
-    storages = filter_checked_storages()
+    storages: List[Storage] = []
+    filter_checked_storages(storages)
 
     # check experimental dataset's storage is not in list
     assert BadStorage() not in storages


### PR DESCRIPTION
### Overview

This is a follow up item for inc-894, where a API pod landed on a bad node with no clickhouse connection. Because it was not configured with a thorough healthcheck, the pod stayed and served 5XX to all requests.

Adds a connection check to see if any clickhouse query node is operable. Fails the healthcheck if all query nodes are inoperable, as it likely indicates connection error with the host, so k8 can rotate the pod. Renames the previous check_clickhouse function to `check_all_tables_present` to distinguish the 2.