### PR TITLE
fix(eap): remove flask stuff from rpc

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -140,7 +140,7 @@ def run_rpc_handler(
         )
 
     try:
-        return endpoint.execute(deserialized_protobuf)
+        return cast(ProtobufMessage, endpoint.execute(deserialized_protobuf))
     except (RPCRequestException, QueryException) as e:
         return convert_rpc_exception_to_proto(e)
     except Exception as e:

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -1,9 +1,9 @@
 import os
 from typing import Generic, Type, TypeVar, cast
 
-from flask import Response
 from google.protobuf.message import DecodeError
 from google.protobuf.message import Message as ProtobufMessage
+from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
 
 from snuba import environment
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -116,40 +116,38 @@ for v, module_path in _TO_IMPORT.items():
     import_submodules_in_directory(module_path, f"snuba.web.rpc.{v}")
 
 
-def run_rpc_handler(name: str, version: str, data: bytes) -> Response:
+def run_rpc_handler(
+    name: str, version: str, data: bytes
+) -> ProtobufMessage | ErrorProto:
     try:
         endpoint = RPCEndpoint.get_from_name(name, version)()  # type: ignore
     except (AttributeError, InvalidConfigKeyError) as e:
-        err_proto = convert_rpc_exception_to_proto(
+        return convert_rpc_exception_to_proto(
             RPCRequestException(
                 status_code=404,
                 message=f"endpoint {name} with version {version} does not exist (did you use the correct version and capitalization?) {e}",
             )
         )
-        return Response(err_proto.SerializeToString(), status=404)
 
     try:
         deserialized_protobuf = endpoint.parse_from_string(data)
     except DecodeError as e:
-        err_proto = convert_rpc_exception_to_proto(
+        return convert_rpc_exception_to_proto(
             RPCRequestException(
                 status_code=400,
                 message=f"protobuf gave a decode error {e} (are all fields set and the correct types?)",
             )
         )
-        return Response(err_proto.SerializeToString(), status=400)
 
     try:
         res = endpoint.execute(deserialized_protobuf)
-        return Response(res.SerializeToString())
+        return res.SerializeToString()
     except (RPCRequestException, QueryException) as e:
-        exc_proto = convert_rpc_exception_to_proto(e)
-        return Response(exc_proto.SerializeToString(), status=exc_proto.code)
+        return convert_rpc_exception_to_proto(e)
     except Exception as e:
-        err_proto = convert_rpc_exception_to_proto(
+        return convert_rpc_exception_to_proto(
             RPCRequestException(
                 status_code=500,
                 message=f"internal error occurred while executing this RPC call: {e}",
             )
         )
-        return Response(err_proto.SerializeToString(), status=500)

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -140,8 +140,7 @@ def run_rpc_handler(
         )
 
     try:
-        res = endpoint.execute(deserialized_protobuf)
-        return res
+        return endpoint.execute(deserialized_protobuf)
     except (RPCRequestException, QueryException) as e:
         return convert_rpc_exception_to_proto(e)
     except Exception as e:

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -141,7 +141,7 @@ def run_rpc_handler(
 
     try:
         res = endpoint.execute(deserialized_protobuf)
-        return res.SerializeToString()
+        return res
     except (RPCRequestException, QueryException) as e:
         return convert_rpc_exception_to_proto(e)
     except Exception as e:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -35,6 +35,7 @@ from flask import (
     render_template,
 )
 from flask import request as http_request
+from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
 from werkzeug import Response as WerkzeugResponse
 from werkzeug.exceptions import InternalServerError
 
@@ -277,7 +278,11 @@ def unqualified_query_view(*, timer: Timer) -> Union[Response, str, WerkzeugResp
 
 @application.route("/rpc/<name>/<version>", methods=["POST"])
 def rpc(*, name: str, version: str) -> Response:
-    return run_rpc_handler(name, version, http_request.data)
+    result_proto = run_rpc_handler(name, version, http_request.data)
+    if isinstance(result_proto, ErrorProto):
+        return Response(result_proto.SerializeToString(), status=result_proto.code)
+    else:
+        return Response(result_proto.SerializeToString(), status=200)
 
 
 @application.route("/<dataset:dataset>/snql", methods=["GET", "POST"])

--- a/tests/web/rpc/test_rpc_handler.py
+++ b/tests/web/rpc/test_rpc_handler.py
@@ -6,6 +6,9 @@ from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
 from sentry_protos.snuba.v1alpha.endpoint_tags_list_pb2 import (
     TraceItemAttributesRequest as TraceItemAttributesRequestProto,
 )
+from sentry_protos.snuba.v1alpha.endpoint_tags_list_pb2 import (
+    TraceItemAttributesResponse as TraceItemAttributesResponseProto,
+)
 from sentry_protos.snuba.v1alpha.request_common_pb2 import RequestMeta
 from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import AttributeKey
 
@@ -48,7 +51,7 @@ def test_basic() -> None:
     resp = run_rpc_handler(
         "TraceItemAttributesRequest", "v1alpha", message.SerializeToString()
     )
-    assert not isinstance(resp, ErrorProto)
+    assert isinstance(resp, TraceItemAttributesResponseProto)
 
 
 @pytest.mark.parametrize(

--- a/tests/web/rpc/test_rpc_handler.py
+++ b/tests/web/rpc/test_rpc_handler.py
@@ -15,6 +15,7 @@ from sentry_protos.snuba.v1alpha.trace_item_attribute_pb2 import AttributeKey
 from snuba.web import QueryException
 from snuba.web.rpc import run_rpc_handler
 from snuba.web.rpc.common.exceptions import RPCRequestException
+from tests.base import BaseApiTest
 
 
 def test_rpc_handler_bad_request() -> None:
@@ -94,3 +95,19 @@ def test_internal_error(expected_status_code: int, error: Exception) -> None:
         )
         assert isinstance(resp, ErrorProto)
         assert resp.code == expected_status_code
+
+
+class TestAPIFailures(BaseApiTest):
+    def test_unknown_rpc(self) -> None:
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        response = self.app.post("/rpc/bloop/shmoop", data=b"asdasdasd")
+        assert response.status_code == 404
+
+    def test_bad_serialization(self) -> None:
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        response = self.app.post(
+            "/rpc/EndpointTraceItemTable/v1", data=b"11111asdasdasd"
+        )
+        assert response.status_code == 400

--- a/tests/web/rpc/test_rpc_handler.py
+++ b/tests/web/rpc/test_rpc_handler.py
@@ -18,20 +18,14 @@ def test_rpc_handler_bad_request() -> None:
     resp = run_rpc_handler(
         "TraceItemAttributesRequest", "v1alpha", b"invalid-proto-data"
     )
-    assert resp.status_code == 400
-
-    err = ErrorProto()
-    err.ParseFromString(resp.data)
-    assert err.code == 400
+    assert isinstance(resp, ErrorProto)
+    assert resp.code == 400
 
 
 def test_rpc_handler_not_found() -> None:
     resp = run_rpc_handler("SomeWeirdRequest", "v1", b"invalid-proto-data")
-    assert resp.status_code == 404
-
-    err = ErrorProto()
-    err.ParseFromString(resp.data)
-    assert err.code == 404
+    assert isinstance(resp, ErrorProto)
+    assert resp.code == 404
 
 
 @pytest.mark.clickhouse_db
@@ -54,7 +48,7 @@ def test_basic() -> None:
     resp = run_rpc_handler(
         "TraceItemAttributesRequest", "v1alpha", message.SerializeToString()
     )
-    assert resp.status_code == 200
+    assert not isinstance(resp, ErrorProto)
 
 
 @pytest.mark.parametrize(
@@ -95,4 +89,5 @@ def test_internal_error(expected_status_code: int, error: Exception) -> None:
         resp = run_rpc_handler(
             "TraceItemAttributesRequest", "v1alpha", message.SerializeToString()
         )
-        assert resp.status_code == expected_status_code
+        assert isinstance(resp, ErrorProto)
+        assert resp.code == expected_status_code


### PR DESCRIPTION
In #6402 I asked to put as [little of the error handling logic into the flask layer as possible](https://github.com/getsentry/snuba/pull/6402#discussion_r1794202135) but it went too far in the other direction and bled the flask object into the RPC code (which was not the intention).

This PR removes the flask `Response` object out of the RPC code 