### PR TITLE
fix(admin): Handle NaN in admin results

### DIFF
--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -58,7 +59,9 @@ def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
 def scrub_row(row: tuple[Any, ...]) -> tuple[Any, ...]:
     rv: list[Any] = []
     for val in row:
-        if isinstance(val, (int, float)):
+        if math.isnan(val):
+            rv.append(None)
+        elif isinstance(val, (int, float)):
             rv.append(val)
         else:
             rv.append(f"<scrubbed: {type(val).__name__}>")

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -59,10 +59,11 @@ def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
 def scrub_row(row: tuple[Any, ...]) -> tuple[Any, ...]:
     rv: list[Any] = []
     for val in row:
-        if math.isnan(val):
-            rv.append(None)
-        elif isinstance(val, (int, float)):
-            rv.append(val)
+        if isinstance(val, (int, float)):
+            if math.isnan(val):
+                rv.append(None)
+            else:
+                rv.append(val)
         else:
             rv.append(f"<scrubbed: {type(val).__name__}>")
 

--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -151,7 +151,7 @@ function QueryDisplay(props: {
                 </Accordion.Item>
               </Accordion>
               <Accordion chevronPosition="left">
-                <Accordion.Item value="input-query" key="input-query">
+                <Accordion.Item value="query-result" key="query-result">
                   <Accordion.Control>
                     <Title order={3}>Query Result</Title>
                   </Accordion.Control>


### PR DESCRIPTION
Python will encode NaN into JSON, even though it's not actually valid JSON.
This will cause the frontend to error out. Handle this case for the admin tool.