### PR TITLE
fix(rpc): Correct config key for rpc endpoints

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -43,7 +43,9 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
 
     @classmethod
     def config_key(cls) -> str:
-        return f"{cls.__name__}__{cls.version()}"
+        request_class = cls.request_class().__name__
+        request_version = cls.version()
+        return f"{request_class}__{request_version}"
 
     @property
     def metrics(self) -> MetricsWrapper:

--- a/tests/web/rpc/test_base.py
+++ b/tests/web/rpc/test_base.py
@@ -2,6 +2,7 @@ import time
 from typing import Type
 
 import pytest
+from google.protobuf.message import Message
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from snuba.web.rpc import RPCEndpoint
@@ -12,20 +13,32 @@ class RPCException(Exception):
     pass
 
 
-class MyRPC(RPCEndpoint[Timestamp, Timestamp]):
+class RPCRequest(Message):
+    pass
+
+
+class MyRPC(RPCEndpoint[RPCRequest, Timestamp]):
     duration_millis = 100
 
     @classmethod
     def version(cls) -> str:
         return "v1"
 
-    def _execute(self, in_msg: Timestamp) -> Timestamp:
+    @classmethod
+    def request_class(cls) -> Type[RPCRequest]:
+        return RPCRequest
+
+    def _execute(self, in_msg: RPCRequest) -> Timestamp:
         time.sleep(self.duration_millis / 1000)
         return Timestamp()
 
 
-class ErrorRPC(RPCEndpoint[Timestamp, Timestamp]):
+class ErrorRPC(RPCEndpoint[RPCRequest, Timestamp]):
     duration_millis = 100
+
+    @classmethod
+    def request_class(cls) -> Type[RPCRequest]:
+        return RPCRequest
 
     @classmethod
     def response_class(cls) -> Type[Timestamp]:
@@ -33,7 +46,7 @@ class ErrorRPC(RPCEndpoint[Timestamp, Timestamp]):
 
     @classmethod
     def version(cls) -> str:
-        return "v1"
+        return "error"
 
     def _execute(self, in_msg: Timestamp) -> Timestamp:
         time.sleep(self.duration_millis / 1000)
@@ -41,33 +54,37 @@ class ErrorRPC(RPCEndpoint[Timestamp, Timestamp]):
 
 
 def test_endpoint_name_resolution() -> None:
-    assert RPCEndpoint.get_from_name("MyRPC", "v1") is MyRPC
+    assert RPCEndpoint.get_from_name("RPCRequest", "v1") is MyRPC
 
 
 def test_before_and_after_execute() -> None:
     before_called = False
     after_called = False
 
-    class BeforeAndAfter(RPCEndpoint[Timestamp, Timestamp]):
+    class BeforeAndAfter(RPCEndpoint[RPCRequest, Timestamp]):
         @classmethod
         def version(cls) -> str:
-            return "v1"
+            return "beforeafter"
 
-        def _before_execute(self, in_msg: Timestamp) -> None:
+        @classmethod
+        def request_class(cls) -> Type[RPCRequest]:
+            return RPCRequest
+
+        def _before_execute(self, in_msg: RPCRequest) -> None:
             nonlocal before_called
             before_called = True
 
-        def _execute(self, in_msg: Timestamp) -> Timestamp:
-            return in_msg
+        def _execute(self, in_msg: RPCRequest) -> Timestamp:
+            return Timestamp()
 
         def _after_execute(
-            self, in_msg: Timestamp, out_msg: Timestamp, error: Exception | None
+            self, in_msg: RPCRequest, out_msg: Timestamp, error: Exception | None
         ) -> Timestamp:
             nonlocal after_called
             after_called = True
             return out_msg
 
-    BeforeAndAfter().execute(Timestamp())
+    BeforeAndAfter().execute(RPCRequest())
     assert before_called
     assert after_called
 
@@ -75,7 +92,7 @@ def test_before_and_after_execute() -> None:
 def test_metrics() -> None:
     metrics_backend = TestingMetricsBackend()
     rpc_call = MyRPC(metrics_backend=metrics_backend)
-    rpc_call.execute(Timestamp())
+    rpc_call.execute(RPCRequest())
     metric_tags = [m.tags for m in metrics_backend.calls]
     assert metric_tags == [
         {"endpoint_name": "MyRPC", "version": "v1"}
@@ -94,7 +111,7 @@ def test_error_metrics() -> None:
         rpc_call.execute(Timestamp())
     metric_tags = [m.tags for m in metrics_backend.calls]
     assert metric_tags == [
-        {"endpoint_name": "ErrorRPC", "version": "v1"}
+        {"endpoint_name": "ErrorRPC", "version": "error"}
         for _ in range(len(metrics_backend.calls))
     ]
 

--- a/tests/web/rpc/test_rpc_handler.py
+++ b/tests/web/rpc/test_rpc_handler.py
@@ -108,6 +108,6 @@ class TestAPIFailures(BaseApiTest):
         ts = Timestamp()
         ts.GetCurrentTime()
         response = self.app.post(
-            "/rpc/EndpointTraceItemTable/v1", data=b"11111asdasdasd"
+            "/rpc/TraceItemTableRequest/v1", data=b"11111asdasdasd"
         )
         assert response.status_code == 400

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -152,7 +152,7 @@ class TestTraceItemTable(BaseApiTest):
             limit=10,
         )
         response = self.app.post(
-            "/rpc/EndpointTraceItemTable/v1", data=message.SerializeToString()
+            "/rpc/TraceItemTableRequest/v1", data=message.SerializeToString()
         )
         assert response.status_code == 200, response.text
 


### PR DESCRIPTION
The config key should be based on the protobuf classes instead of the endpoint.