### PR TITLE
fix(subscriptions): Make scheduled subscriptions utc timezone

### DIFF
--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -1,6 +1,6 @@
 import math
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import (
     Iterator,
@@ -70,7 +70,7 @@ class ImmediateTaskBuilder(TaskBuilder):
         if timestamp % resolution == 0:
             self.__count += 1
             return ScheduledSubscriptionTask(
-                datetime.fromtimestamp(timestamp, tz=timezone.utc),
+                datetime.utcfromtimestamp(timestamp),
                 subscription_with_metadata,
             )
         else:
@@ -121,7 +121,7 @@ class JitteredTaskBuilder(TaskBuilder):
                 self.__count += 1
                 self.__count_max_resolution += 1
                 return ScheduledSubscriptionTask(
-                    datetime.fromtimestamp(timestamp, tz=timezone.utc),
+                    datetime.utcfromtimestamp(timestamp),
                     subscription_with_metadata,
                 )
             else:
@@ -131,7 +131,7 @@ class JitteredTaskBuilder(TaskBuilder):
         if timestamp % resolution == jitter:
             self.__count += 1
             return ScheduledSubscriptionTask(
-                datetime.fromtimestamp(timestamp - jitter, tz=timezone.utc),
+                datetime.utcfromtimestamp(timestamp - jitter),
                 subscription_with_metadata,
             )
         else:

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -1,6 +1,6 @@
 import math
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import (
     Iterator,
@@ -70,7 +70,8 @@ class ImmediateTaskBuilder(TaskBuilder):
         if timestamp % resolution == 0:
             self.__count += 1
             return ScheduledSubscriptionTask(
-                datetime.fromtimestamp(timestamp), subscription_with_metadata
+                datetime.fromtimestamp(timestamp, tz=timezone.utc),
+                subscription_with_metadata,
             )
         else:
             return None
@@ -120,7 +121,8 @@ class JitteredTaskBuilder(TaskBuilder):
                 self.__count += 1
                 self.__count_max_resolution += 1
                 return ScheduledSubscriptionTask(
-                    datetime.fromtimestamp(timestamp), subscription_with_metadata
+                    datetime.fromtimestamp(timestamp, tz=timezone.utc),
+                    subscription_with_metadata,
                 )
             else:
                 return None
@@ -129,7 +131,8 @@ class JitteredTaskBuilder(TaskBuilder):
         if timestamp % resolution == jitter:
             self.__count += 1
             return ScheduledSubscriptionTask(
-                datetime.fromtimestamp(timestamp - jitter), subscription_with_metadata
+                datetime.fromtimestamp(timestamp - jitter, tz=timezone.utc),
+                subscription_with_metadata,
             )
         else:
             return None


### PR DESCRIPTION
When we schedule subscription tasks, we convert a Unix timestamp from the commit log to a datetime object, so a scheduled message looks like this
```
{"timestamp":"2024-10-15T11:10:00","entity":"eap_spans","task":{"data":{"project_id":1,"time_window":3600,"resolution":60,"query":"MATCH (eap_spans) SELECT count() AS `count` WHERE project_id IN array(1) AND organization_id = 1"}},"tick_upper_offset":4679}
```

`fromtimestamp` creates naive datetime objects using system timezone,
so EDT for me locally, but we use it as a utc timestamp in our clickhouse query

```
SELECT (count() AS _snuba_count) FROM eap_spans_local WHERE in((project_id AS _snuba_project_id), [1]) AND equals((organization_id AS _snuba_organization_id), 1) AND equals(project_id, 1) AND greaterOrEquals(_sort_timestamp, toDateTime('2024-10-15T10:10:00', 'Universal')) AND less(_sort_timestamp, toDateTime('2024-10-15T11:10:00', 'Universal')) LIMIT 1000 OFFSET 0
```

Using `utcfromtimestamp` which produces a **naive** utc timestamp instead (there are some downstream operations that fail if it's a timezone aware datetime: `<datetime>.min` [here](https://github.com/getsentry/snuba/blob/master/snuba/query/snql/parser.py#L1401) produces a naive datetime obj and cannot be offset from a timezone aware object for example)

Note: this affects local development (and potentially self-hosted instances?). SaaS should be unaffected (since I think our workers are just deployed with UTC system time)