### PR TITLE
chore(gocd): Exclude all EAP services from snuba healthchecks

### DIFF
--- a/gocd/templates/bash/saas-sentry-health-check.sh
+++ b/gocd/templates/bash/saas-sentry-health-check.sh
@@ -5,6 +5,7 @@
   --project-slug=snuba \
   --release="${GO_REVISION_SNUBA_REPO}" \
   --new-issues-limit=0 \
+  --additional-query="issue.type:error !level:info !server_name:*eap*" \
 
 
 # --skip-check=${SKIP_CANARY_CHECKS}


### PR DESCRIPTION
Hopefully this makes it less likely that we have to shut down all of EAP
to unblock deploys.
