### PR TITLE
chore(consumer): Improve debugging output on bad response

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -138,8 +138,14 @@ impl BatchFactory {
                     .send()
                     .await?;
 
-                if res.status() != reqwest::StatusCode::OK {
-                    anyhow::bail!("error writing to clickhouse: {}", res.text().await?);
+                if !response.status().is_success() {
+                    let status = response.status();
+                    let body = response.text().await;
+                    anyhow::bail!(
+                        "bad response while inserting rows, status: {}, response body: {:?}",
+                        status,
+                        body
+                    );
                 }
             }
 

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -131,7 +131,7 @@ impl BatchFactory {
             if !receiver.is_empty() {
                 // only make the request to clickhouse if there is data
                 // being added to the receiver stream from the sender
-                let res = client
+                let response = client
                     .post(&url)
                     .query(&[("query", &query)])
                     .body(reqwest::Body::wrap_stream(ReceiverStream::new(receiver)))


### PR DESCRIPTION
Mutations consumer is currently encountering 404 from clickhouse, but we
don't know why. Print response body.

In the main consumer: In the past people were confused by the error message and didn't realize that it comes from clickhouse
