### PR TITLE
fix(eap): add a default row limit if not specified

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -87,7 +87,6 @@ def _build_query(request: TraceItemTableRequest) -> Query:
         # protobuf sets limit to 0 by default if it is not set,
         # give it a default value that will actually return data
         limit=request.limit if request.limit > 0 else _DEFAULT_ROW_LIMIT,
-        # limit=request.limit
     )
     treeify_or_and_conditions(res)
     apply_virtual_columns(res, request.virtual_column_contexts)

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -32,6 +32,8 @@ from snuba.web.rpc.common.common import (
 )
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 
+_DEFAULT_ROW_LIMIT = 10_000
+
 
 def _convert_order_by(
     order_by: Sequence[TraceItemTableRequest.OrderBy],
@@ -82,7 +84,10 @@ def _build_query(request: TraceItemTableRequest) -> Query:
             trace_item_filters_to_expression(request.filter),
         ),
         order_by=_convert_order_by(request.order_by),
-        limit=request.limit,
+        # protobuf sets limit to 0 by default if it is not set,
+        # give it a default value that will actually return data
+        limit=request.limit if request.limit > 0 else _DEFAULT_ROW_LIMIT,
+        # limit=request.limit
     )
     treeify_or_and_conditions(res)
     apply_virtual_columns(res, request.virtual_column_contexts)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -187,7 +187,6 @@ class TestTraceItemTable(BaseApiTest):
                     )
                 )
             ],
-            limit=61,
         )
         response = EndpointTraceItemTable().execute(message)
 


### PR DESCRIPTION
Protobuf was setting this value to 0 by default, making it return no values if not specified in the request payload