### PR TITLE
feat(job-runner): async job functionality

### DIFF
--- a/snuba/manual_jobs/__init__.py
+++ b/snuba/manual_jobs/__init__.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, MutableMapping, Optional, cast
 
-from snuba.manual_jobs.redis import _set_job_is_async, _set_job_type
+from snuba.manual_jobs.redis import _set_job_type
 from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
 
 logger = logging.getLogger("snuba.manual_jobs")
@@ -44,10 +44,6 @@ class Job(ABC, metaclass=RegisteredClass):
     def __init__(self, job_spec: JobSpec) -> None:
         self.job_spec = job_spec
         self.is_async = job_spec.is_async
-        _set_job_is_async(
-            job_spec.job_id,
-            job_spec.is_async if job_spec.is_async is not None else False,
-        )
         _set_job_type(job_spec.job_id, job_spec.job_type)
         if job_spec.params:
             for k, v in job_spec.params.items():
@@ -67,7 +63,7 @@ class Job(ABC, metaclass=RegisteredClass):
 
     @classmethod
     def async_finished_check(cls, job_id: str) -> bool:
-        return True
+        raise NotImplementedError
 
 
 import_submodules_in_directory(

--- a/snuba/manual_jobs/__init__.py
+++ b/snuba/manual_jobs/__init__.py
@@ -2,19 +2,12 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import Any, MutableMapping, Optional, cast
 
+from snuba.manual_jobs.redis import _set_job_is_async, _set_job_type
 from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
 
 logger = logging.getLogger("snuba.manual_jobs")
-
-
-class JobStatus(StrEnum):
-    RUNNING = "running"
-    FINISHED = "finished"
-    NOT_STARTED = "not_started"
-    FAILED = "failed"
 
 
 class JobLogger(ABC):
@@ -43,12 +36,19 @@ class JobLogger(ABC):
 class JobSpec:
     job_id: str
     job_type: str
+    is_async: Optional[bool] = False
     params: Optional[MutableMapping[Any, Any]] = None
 
 
 class Job(ABC, metaclass=RegisteredClass):
     def __init__(self, job_spec: JobSpec) -> None:
         self.job_spec = job_spec
+        self.is_async = job_spec.is_async
+        _set_job_is_async(
+            job_spec.job_id,
+            job_spec.is_async if job_spec.is_async is not None else False,
+        )
+        _set_job_type(job_spec.job_id, job_spec.job_type)
         if job_spec.params:
             for k, v in job_spec.params.items():
                 setattr(self, k, v)
@@ -64,6 +64,10 @@ class Job(ABC, metaclass=RegisteredClass):
     @classmethod
     def get_from_name(cls, name: str) -> "Job":
         return cast("Job", cls.class_from_name(name))
+
+    @classmethod
+    def async_finished_check(cls, job_id: str) -> bool:
+        return True
 
 
 import_submodules_in_directory(

--- a/snuba/manual_jobs/job_status.py
+++ b/snuba/manual_jobs/job_status.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class JobStatus(StrEnum):
+    RUNNING = "running"
+    FINISHED = "finished"
+    NOT_STARTED = "not_started"
+    ASYNC_RUNNING_BACKGROUND = "async_running_background"
+    FAILED = "failed"

--- a/snuba/manual_jobs/redis.py
+++ b/snuba/manual_jobs/redis.py
@@ -1,6 +1,6 @@
-from typing import Sequence
+from typing import List, Sequence
 
-from snuba.manual_jobs import JobStatus
+from snuba.manual_jobs.job_status import JobStatus
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.utils.serializable_exception import SerializableException
 
@@ -19,6 +19,14 @@ def _build_job_log_key(job_id: str) -> str:
     return f"snuba:manual_jobs:{job_id}:log"
 
 
+def _build_is_job_async_key(job_id: str) -> str:
+    return f"snuba:manual_jobs:{job_id}:is_async"
+
+
+def _build_job_type_key(job_id: str) -> str:
+    return f"snuba:manual_jobs:{job_id}:job_type"
+
+
 def _acquire_job_lock(job_id: str) -> bool:
     return bool(
         _redis_client.set(
@@ -35,14 +43,30 @@ def _release_job_lock(job_id: str) -> None:
     _redis_client.delete(_build_job_lock_key(job_id))
 
 
-def _set_job_status(job_id: str, status: JobStatus) -> JobStatus:
+def _set_job_is_async(job_id: str, is_async: bool) -> None:
+    _redis_client.set(name=_build_is_job_async_key(job_id), value=int(is_async))
+
+
+def _set_job_status(job_id: str, status: JobStatus) -> str:
     if not _redis_client.set(name=_build_job_status_key(job_id), value=status.value):
         raise SerializableException(f"Failed to set job status {status} on {job_id}")
     return status
 
 
-def _get_job_status_multi(job_ids: Sequence[str]) -> Sequence[JobStatus]:
+def _set_job_type(job_id: str, job_type: str) -> None:
+    _redis_client.set(name=_build_job_type_key(job_id), value=job_type)
+
+
+def _get_job_type(job_id: str) -> str:
+    return _redis_client.get(name=_build_job_type_key(job_id)).decode()
+
+
+def _get_job_types_multi(job_ids_keys: Sequence[str]) -> List[str]:
+    return [job_type.decode() for job_type in _redis_client.mget(job_ids_keys)]
+
+
+def _get_job_status_multi(job_ids_keys: Sequence[str]) -> List[JobStatus]:
     return [
         redis_status.decode() if redis_status is not None else JobStatus.NOT_STARTED
-        for redis_status in _redis_client.mget(job_ids)
+        for redis_status in _redis_client.mget(job_ids_keys)
     ]

--- a/snuba/manual_jobs/redis.py
+++ b/snuba/manual_jobs/redis.py
@@ -1,3 +1,4 @@
+import typing
 from typing import List, Sequence
 
 from snuba.manual_jobs.job_status import JobStatus
@@ -17,10 +18,6 @@ def _build_job_status_key(job_id: str) -> str:
 
 def _build_job_log_key(job_id: str) -> str:
     return f"snuba:manual_jobs:{job_id}:log"
-
-
-def _build_is_job_async_key(job_id: str) -> str:
-    return f"snuba:manual_jobs:{job_id}:is_async"
 
 
 def _build_job_type_key(job_id: str) -> str:
@@ -43,11 +40,7 @@ def _release_job_lock(job_id: str) -> None:
     _redis_client.delete(_build_job_lock_key(job_id))
 
 
-def _set_job_is_async(job_id: str, is_async: bool) -> None:
-    _redis_client.set(name=_build_is_job_async_key(job_id), value=int(is_async))
-
-
-def _set_job_status(job_id: str, status: JobStatus) -> str:
+def _set_job_status(job_id: str, status: JobStatus) -> JobStatus:
     if not _redis_client.set(name=_build_job_status_key(job_id), value=status.value):
         raise SerializableException(f"Failed to set job status {status} on {job_id}")
     return status
@@ -58,7 +51,9 @@ def _set_job_type(job_id: str, job_type: str) -> None:
 
 
 def _get_job_type(job_id: str) -> str:
-    return _redis_client.get(name=_build_job_type_key(job_id)).decode()
+    return typing.cast(
+        str, _redis_client.get(name=_build_job_type_key(job_id)).decode()
+    )
 
 
 def _get_job_types_multi(job_ids_keys: Sequence[str]) -> List[str]:

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -11,7 +11,6 @@ from snuba.manual_jobs.job_logging import get_job_logger
 from snuba.manual_jobs.job_status import JobStatus
 from snuba.manual_jobs.redis import (
     _acquire_job_lock,
-    _build_is_job_async_key,
     _build_job_log_key,
     _build_job_status_key,
     _get_job_status_multi,
@@ -69,9 +68,9 @@ def _build_job_spec_from_entry(content: Any) -> JobSpec:
 
 
 def _update_job_status_if_async(job_id: str, job_status: JobStatus) -> JobStatus:
-    if _redis_client.get(
-        name=_build_is_job_async_key(job_id)
-    ) is True and Job.get_from_name(_get_job_type(job_id)).async_finished_check(job_id):
+    if job_status is JobStatus.ASYNC_RUNNING_BACKGROUND and Job.get_from_name(
+        _get_job_type(job_id)
+    ).async_finished_check(job_id):
         job_status = JobStatus.FINISHED
         _set_job_status(job_id, JobStatus.FINISHED)
     return job_status

--- a/tests/manual_jobs/test_job.py
+++ b/tests/manual_jobs/test_job.py
@@ -4,8 +4,9 @@ from unittest.mock import patch
 
 import pytest
 
-from snuba.manual_jobs import Job, JobLogger, JobSpec, JobStatus
+from snuba.manual_jobs import Job, JobLogger, JobSpec
 from snuba.manual_jobs.job_loader import _JobLoader
+from snuba.manual_jobs.job_status import JobStatus
 from snuba.manual_jobs.redis import _acquire_job_lock
 from snuba.manual_jobs.runner import (
     JobLockedException,

--- a/tests/manual_jobs/test_job_statuses.py
+++ b/tests/manual_jobs/test_job_statuses.py
@@ -1,0 +1,27 @@
+import pytest
+
+from snuba.manual_jobs import Job, JobLogger, JobSpec
+from snuba.manual_jobs.job_status import JobStatus
+from snuba.manual_jobs.runner import get_job_status, run_job
+
+JOB_ID = "abc1234"
+async_job_spec = JobSpec(job_id=JOB_ID, job_type="AsyncJob", is_async=True)
+
+
+class AsyncJob(Job):
+    def __init__(self, job_spec: JobSpec):
+        super().__init__(job_spec)
+
+    def execute(self, logger: JobLogger) -> None:
+        pass
+
+    @classmethod
+    def async_finished_check(cls, job_id: str) -> bool:
+        return False
+
+
+@pytest.mark.redis_db
+def test_job_status_changes_to_async_running_background() -> None:
+    assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
+    run_job(async_job_spec)
+    assert get_job_status(JOB_ID) == JobStatus.ASYNC_RUNNING_BACKGROUND

--- a/tests/manual_jobs/test_job_statuses.py
+++ b/tests/manual_jobs/test_job_statuses.py
@@ -23,14 +23,7 @@ class AsyncJob(Job):
 
 
 @pytest.mark.redis_db
-def test_job_status_changes_to_async_running_background() -> None:
-    assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
-    run_job(async_job_spec)
-    assert get_job_status(JOB_ID) == JobStatus.ASYNC_RUNNING_BACKGROUND
-
-
-@pytest.mark.redis_db
-def test_job_status_changes_from_async_running_background_to_finished() -> None:
+def test_async_job_status_changes_correctly() -> None:
     assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
     run_job(async_job_spec)
     assert get_job_status(JOB_ID) == JobStatus.ASYNC_RUNNING_BACKGROUND

--- a/tests/manual_jobs/test_job_statuses.py
+++ b/tests/manual_jobs/test_job_statuses.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from snuba.manual_jobs import Job, JobLogger, JobSpec
@@ -25,3 +27,12 @@ def test_job_status_changes_to_async_running_background() -> None:
     assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
     run_job(async_job_spec)
     assert get_job_status(JOB_ID) == JobStatus.ASYNC_RUNNING_BACKGROUND
+
+
+@pytest.mark.redis_db
+def test_job_status_changes_from_async_running_background_to_finished() -> None:
+    assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
+    run_job(async_job_spec)
+    assert get_job_status(JOB_ID) == JobStatus.ASYNC_RUNNING_BACKGROUND
+    with patch.object(AsyncJob, "async_finished_check", return_value=True):
+        assert get_job_status(JOB_ID) == JobStatus.FINISHED


### PR DESCRIPTION
https://getsentry.atlassian.net/jira/software/c/projects/SNS/boards/147?selectedIssue=SNS-2871

At times we will want to execute long-running ClickHouse jobs that don’t fit neatly into the migrations system; either they only run in a single environment, or we don’t want to block later migrations on them finishing. This PR supports users to create job types that can run asynchronously. 