### PR TITLE
feat: add support for tuple type to the json schema

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -231,6 +231,11 @@ _SIMPLE_ARRAY_INNER_TYPES = [
     del_name_field(col_type) for col_type in SIMPLE_COLUMN_SCHEMAS
 ]
 
+# Tuple inner types are the same as normal column types except they don't have a name
+_SIMPLE_TUPLE_INNER_TYPES = [
+    del_name_field(col_type) for col_type in SIMPLE_COLUMN_SCHEMAS
+]
+
 # Up to one subarray is supported. Eg Array(Array(String())).
 _SUB_ARRAY_SCHEMA = make_column_schema(
     column_type={"const": "Array"},
@@ -264,11 +269,26 @@ MAP_SCHEMA = make_column_schema(
     },
 )
 
+TUPLE_SCHEMA = make_column_schema(
+    column_type={"const": "Tuple"},
+    args={
+        "type": "object",
+        "properties": {
+            "inner_types": {
+                "type": "array",
+                "items": {"anyOf": _SIMPLE_TUPLE_INNER_TYPES},
+            }
+        },
+        "additionalProperties": False,
+    },
+)
+
 
 COLUMN_SCHEMAS = [
     *SIMPLE_COLUMN_SCHEMAS,
     ARRAY_SCHEMA,
     MAP_SCHEMA,
+    TUPLE_SCHEMA,
 ]
 
 
@@ -282,6 +302,7 @@ NESTED_SCHEMA = make_column_schema(
         "additionalProperties": False,
     },
 )
+
 
 SCHEMA_COLUMNS = {
     "type": "array",

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -12,6 +12,7 @@ from snuba.clickhouse.columns import (
     Nested,
     SchemaModifiers,
     String,
+    Tuple,
     UInt,
 )
 from snuba.query.processors.condition_checkers import ConditionChecker
@@ -120,6 +121,9 @@ def __parse_column_type(col: dict[str, Any]) -> ColumnType[SchemaModifiers]:
         )
     elif col["type"] == "Array":
         column_type = Array(__parse_column_type(col["args"]["inner_type"]), modifiers)
+    elif col["type"] == "Tuple":
+        types = [__parse_column_type(typ) for typ in col["args"]["inner_types"]]
+        column_type = Tuple(tuple(types), modifiers)
     elif col["type"] == "AggregateFunction":
         column_type = AggregateFunction(
             col["args"]["func"],

--- a/tests/datasets/configuration/column_validation_entity.yaml
+++ b/tests/datasets/configuration/column_validation_entity.yaml
@@ -27,6 +27,16 @@ schema:
         type: String
       - name: value
         type: String
+- name: tuple_example
+  type: Tuple
+  args:
+    inner_types:
+      - type: String
+      - type: UUID
+      - type: DateTime64
+        args: { precision: 6, schema_modifiers: [nullable] }
+      - type: DateTime64
+        args: { precision: 6 }
 storages:
 - storage: discover
   translation_mappers:


### PR DESCRIPTION
This is a follow up of PR https://github.com/getsentry/snuba/pull/6416 and adds the support for the `tuple` type to be used in the `yaml` configurations.