### PR TITLE
fix: fix broken admin error message displays

### DIFF
--- a/snuba/admin/static/utils/execute_button.tsx
+++ b/snuba/admin/static/utils/execute_button.tsx
@@ -12,13 +12,17 @@ function ExecuteButton(props: {
   let label = props.label || "Execute Query";
 
   const defaultError = (err: any) => {
-    console.log("ERROR", err);
-    try {
-      window.alert("An error occurred: " + JSON.stringify(err));
+    console.log("ERROR ", err);
+    let errmsg = err.toString();
+    if (typeof err === 'object' &&
+      err !== null &&
+      err.hasOwnProperty("error") &&
+      err.error.hasOwnProperty("message")) {
+      errmsg = err.error.message;
+      console.log("inside")
     }
-    catch {
-      window.alert("An error occurred: " + err);
-    }
+    window.alert("An error occurred: " + errmsg)
+
   };
   let errorCallback = props.onError || defaultError;
 

--- a/snuba/admin/static/utils/execute_button.tsx
+++ b/snuba/admin/static/utils/execute_button.tsx
@@ -19,7 +19,6 @@ function ExecuteButton(props: {
       err.hasOwnProperty("error") &&
       err.error.hasOwnProperty("message")) {
       errmsg = err.error.message;
-      console.log("inside")
     }
     window.alert("An error occurred: " + errmsg)
 


### PR DESCRIPTION
error messages in the snuba admin tool haven't been showing up properly on some of the tools. my previous pr #6390 tried to address this, you can see it for an example of the issue.

unfortunately this change fixed the error messages on "system query" tool but broke them on "production query tool".

![Screenshot 2024-10-17 at 10 49 59 AM](https://github.com/user-attachments/assets/bbd58eb2-8a90-408f-92e9-1f1c8eee6072)

I have since found out this is because the error messages come from the execute_button component which is used across many different pages, and receives a variety of different looking error variables as input. Related to #6280.

In this PR I updated the logic again and verified across all pages that use the execute button that the error display looks good.