### PR TITLE
ref(bulk-deletes): bulk delete query path and producer

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -127,6 +127,9 @@ deletion_settings:
   max_rows_to_delete: 100000
   tables:
     - search_issues_local_v2
+  allowed_columns:
+    - project_id
+    - group_id
 
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -601,6 +601,11 @@ DELETION_SETTINGS_SCHEMA = {
             "items": {"type": "string"},
             "description": "Names of the tables to delete from.",
         },
+        "allowed_columns": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Columns allowed in WHERE clause.",
+        },
         "max_rows_to_delete": {
             "type": "integer",
         },

--- a/snuba/datasets/deletion_settings.py
+++ b/snuba/datasets/deletion_settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional, Sequence
+from typing import Sequence
 
 MAX_ROWS_TO_DELETE_DEFAULT = 100000
 
@@ -10,5 +10,5 @@ MAX_ROWS_TO_DELETE_DEFAULT = 100000
 class DeletionSettings:
     is_enabled: int
     tables: Sequence[str]
-    allowed_columns: Optional[Sequence[str]] = field(default_factory=list)
+    allowed_columns: Sequence[str] = field(default_factory=list)
     max_rows_to_delete: int = MAX_ROWS_TO_DELETE_DEFAULT

--- a/snuba/datasets/deletion_settings.py
+++ b/snuba/datasets/deletion_settings.py
@@ -10,4 +10,5 @@ MAX_ROWS_TO_DELETE_DEFAULT = 1000
 class DeletionSettings:
     is_enabled: int
     tables: Sequence[str]
+    allowed_columns: Sequence[str]
     max_rows_to_delete: int = MAX_ROWS_TO_DELETE_DEFAULT

--- a/snuba/datasets/deletion_settings.py
+++ b/snuba/datasets/deletion_settings.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Sequence
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
 
-MAX_ROWS_TO_DELETE_DEFAULT = 1000
+MAX_ROWS_TO_DELETE_DEFAULT = 100000
 
 
 @dataclass
 class DeletionSettings:
     is_enabled: int
     tables: Sequence[str]
-    allowed_columns: Sequence[str]
+    allowed_columns: Optional[Sequence[str]] = field(default_factory=list)
     max_rows_to_delete: int = MAX_ROWS_TO_DELETE_DEFAULT

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -140,7 +140,7 @@ class ReadableTableStorage(ReadableStorage):
     ) -> None:
         self.__storage_key = storage_key
         self.__query_processors = query_processors or []
-        self.__deletion_settings = deletion_settings or DeletionSettings(0, [], 0)
+        self.__deletion_settings = deletion_settings or DeletionSettings(0, [], [], 0)
         self.__deletion_processors = deletion_processors or []
         self.__mandatory_condition_checkers = mandatory_condition_checkers or []
         self.__allocation_policies = allocation_policies or []

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -70,6 +70,8 @@ class Topic(Enum):
     METRICS_SUMMARIES = "snuba-metrics-summaries"
     EAP_MUTATIONS = "snuba-eap-mutations"
 
+    LW_DELETIONS = "snuba-lw-deletions"
+
     COGS_SHARED_RESOURCES_USAGE = "shared-resources-usage"
 
 

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -70,7 +70,7 @@ class Topic(Enum):
     METRICS_SUMMARIES = "snuba-metrics-summaries"
     EAP_MUTATIONS = "snuba-eap-mutations"
 
-    LW_DELETIONS = "snuba-lw-deletions"
+    LW_DELETIONS_SEARCH_ISSUES = "snuba-lw-deletions-search-issues"
 
     COGS_SHARED_RESOURCES_USAGE = "shared-resources-usage"
 

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -57,7 +57,6 @@ class InvalidStorageTopic(Exception):
 def _get_kafka_producer(topic: Topic) -> Producer:
     producer = PRODUCER_MAP.get(topic.value)
     if not producer:
-
         producer = Producer(
             build_kafka_producer_configuration(
                 topic=topic,

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Mapping, Optional, Sequence, TypedDict
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence, TypedDict
 
 import rapidjson
 from confluent_kafka import KafkaError
@@ -10,7 +10,8 @@ from snuba import environment, settings
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
-from snuba.datasets.storage import StorageKey, WritableTableStorage
+from snuba.datasets.storage import WritableTableStorage
+from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.conditions import combine_or_conditions
 from snuba.query.data_source.simple import Table
 from snuba.query.dsl import literal
@@ -43,7 +44,7 @@ class DeleteQueryMessage(TypedDict):
     tenant_ids: Mapping[str, str | int]
 
 
-PRODUCER_MAP: Mapping[str, Producer] = {}
+PRODUCER_MAP: MutableMapping[str, Producer] = {}
 STORAGE_TOPIC: Mapping[str, Topic] = {
     StorageKey.SEARCH_ISSUES.value: Topic.LW_DELETIONS_SEARCH_ISSUES
 }

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -75,7 +75,7 @@ def flush_producers() -> None:
     producers to make sure the delivery callbacks are called.
     """
 
-    def _flush_producers():
+    def _flush_producers() -> None:
         while True:
             for storage, producer in PRODUCER_MAP.items():
                 messages_remaining = producer.flush(5.0)

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -1,0 +1,183 @@
+import logging
+from typing import Any, Dict, Mapping, Optional, Sequence, TypedDict
+
+import rapidjson
+from confluent_kafka import KafkaError
+from confluent_kafka import Message as KafkaMessage
+from confluent_kafka import Producer
+
+from snuba import environment, settings
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.datasets.storage import WritableTableStorage
+from snuba.query.conditions import combine_or_conditions
+from snuba.query.data_source.simple import Table
+from snuba.query.dsl import literal
+from snuba.query.exceptions import InvalidQueryException, NoRowsToDeleteException
+from snuba.query.expressions import Expression
+from snuba.reader import Result
+from snuba.utils.metrics.util import with_span
+from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.utils.schemas import ColumnValidator, InvalidColumnType
+from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
+from snuba.utils.streams.topics import Topic
+from snuba.web.delete_query import (
+    DeletesNotEnabledError,
+    _construct_condition,
+    _enforce_max_rows,
+    _get_attribution_info,
+    deletes_are_enabled,
+)
+
+metrics = MetricsWrapper(environment.metrics, "snuba.delete")
+logger = logging.getLogger(__name__)
+
+ConditionsType = Mapping[str, Sequence[str | int | float]]
+
+
+class DeleteQueryMessage(TypedDict):
+    rows_to_delete: int
+    storage_name: str
+    conditions: ConditionsType
+    tenant_ids: Mapping[str, str | int]
+
+
+delete_kfk: Producer | None = None
+
+
+def _delete_kafka_producer() -> Producer:
+    global delete_kfk
+    if delete_kfk is None:
+        delete_kfk = Producer(
+            build_kafka_producer_configuration(
+                topic=Topic.LW_DELETIONS,
+            )
+        )
+    return delete_kfk
+
+
+def _record_query_delivery_callback(
+    error: Optional[KafkaError], message: KafkaMessage
+) -> None:
+    metrics.increment(
+        "record_query.delivery_callback",
+        tags={"status": "success" if error is None else "failure"},
+    )
+
+    if error is not None:
+        logger.warning("Could not produce delete query due to error: %r", error)
+
+
+def produce_delete_query(delete_query: DeleteQueryMessage) -> None:
+    try:
+        producer = _delete_kafka_producer()
+        data = rapidjson.dumps(delete_query)
+        producer.poll(0)  # trigger queued delivery callbacks
+        producer.produce(
+            settings.KAFKA_TOPIC_MAP.get(
+                Topic.LW_DELETIONS.value, Topic.LW_DELETIONS.value
+            ),
+            data.encode("utf-8"),
+            on_delivery=_record_query_delivery_callback,
+            # TODO(should we add headers? or key)
+        )
+    except Exception as ex:
+        logger.exception("Could not produce delete query due to error: %r", ex)
+
+
+@with_span()
+def delete_from_storage(
+    storage: WritableTableStorage,
+    conditions: Dict[str, list[Any]],
+    attribution_info: Mapping[str, Any],
+) -> dict[str, Result]:
+    """
+    Copied over from delete_query.py with some modifications
+    """
+    if not deletes_are_enabled():
+        raise DeletesNotEnabledError("Deletes not enabled in this region")
+
+    delete_settings = storage.get_deletion_settings()
+    if not delete_settings.is_enabled:
+        raise DeletesNotEnabledError(
+            f"Deletes not enabled for {storage.get_storage_key().value}"
+        )
+
+    if list(conditions.keys()).sort() != list(delete_settings.allowed_columns).sort():
+        raise InvalidQueryException(
+            f"Invalid Columns to filter by, must be in {delete_settings.allowed_columns}"
+        )
+
+    # validate column types
+    columns = storage.get_schema().get_columns()
+    column_validator = ColumnValidator(columns)
+    try:
+        for col, values in conditions.items():
+            column_validator.validate(col, values)
+    except InvalidColumnType as e:
+        raise InvalidQueryException(e.message)
+
+    attr_info = _get_attribution_info(attribution_info)
+    return delete_from_tables(storage, delete_settings.tables, conditions, attr_info)
+
+
+def construct_query(
+    storage: WritableTableStorage, table: str, condition: Expression
+) -> Query:
+    cluster_name = storage.get_cluster().get_clickhouse_cluster_name()
+    on_cluster = literal(cluster_name) if cluster_name else None
+    return Query(
+        from_clause=Table(
+            table,
+            ColumnSet([]),
+            storage_key=storage.get_storage_key(),
+            allocation_policies=storage.get_delete_allocation_policies(),
+        ),
+        condition=condition,
+        on_cluster=on_cluster,
+        is_delete=True,
+    )
+
+
+def delete_from_tables(
+    storage: WritableTableStorage,
+    tables: Sequence[str],
+    conditions: Dict[str, Any],
+    attribution_info: AttributionInfo,
+) -> dict[str, Result]:
+
+    highest_rows_to_delete = 0
+    result: dict[str, Result] = {}
+    for table in tables:
+        query = construct_query(storage, table, _construct_condition(conditions))
+        try:
+            num_rows_to_delete = _enforce_max_rows(query)
+            highest_rows_to_delete = max(highest_rows_to_delete, num_rows_to_delete)
+            result[table] = {"data": [{"rows_to_delete": num_rows_to_delete}]}
+        except NoRowsToDeleteException:
+            result[table] = {}
+
+    if highest_rows_to_delete == 0:
+        return result
+
+    delete_query: DeleteQueryMessage = {
+        "rows_to_delete": highest_rows_to_delete,
+        "storage_name": storage.get_storage_key().value,
+        "conditions": conditions,
+        "tenant_ids": attribution_info.tenant_ids,
+    }
+    produce_delete_query(delete_query)
+    return result
+
+
+def construct_or_conditions(conditions: Sequence[Dict[str, Any]]) -> Expression:
+    """
+    Combines multiple AND conditions: (equals(project_id, 1) AND in(group_id, (2, 3, 4, 5))
+    into OR conditions for a bulk delete
+    """
+    or_conditions = []
+    for cond in conditions:
+        and_condition = _construct_condition(cond)
+        or_conditions.append(and_condition)
+    return combine_or_conditions(or_conditions)

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -200,7 +200,7 @@ def _get_rows_to_delete(
     return typing.cast(int, select_query_results["data"][0]["count"])
 
 
-def _enforce_max_rows(delete_query: Query) -> None:
+def _enforce_max_rows(delete_query: Query) -> int:
     """
     The cost of a lightweight delete operation depends on the number of matching rows in the WHERE clause and the current number of data parts.
     This operation will be most efficient when matching a small number of rows, **and on wide parts** (where the `_row_exists` column is stored
@@ -250,6 +250,8 @@ def _enforce_max_rows(delete_query: Query) -> None:
         raise TooManyDeleteRowsException(
             f"Too many rows to delete ({rows_to_delete}), maximum allowed is {max_rows_allowed}"
         )
+
+    return rows_to_delete
 
 
 def _get_attribution_info(attribution_info: Mapping[str, Any]) -> AttributionInfo:

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -24,6 +24,7 @@ CONSUMER_CONFIG = {
     "bootstrap.servers": settings.BROKER_CONFIG["bootstrap.servers"],
     "group.id": "lwd-search-issues",
     "enable.auto.commit": True,
+    "enable.auto.offset.store": False,
     # helps diagnose failures
     "debug": "broker,topic,msg",
 }

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Any, Mapping, Optional
 from unittest.mock import Mock, patch
 
@@ -20,7 +21,8 @@ CONSUMER_CONFIG = {
     "bootstrap.servers": settings.BROKER_CONFIG["bootstrap.servers"],
     "group.id": "lwd-search-issues",
     "enable.auto.commit": True,
-    "auto.offset.reset": "latest",
+    # helps diagnose failures
+    "debug": "broker,topic,msg",
 }
 
 
@@ -44,6 +46,8 @@ def test_delete_success(mock_enforce_max_row: Mock) -> None:
     conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
     attr_info = get_attribution_info()
 
+    # just give in second before subscribing
+    time.sleep(2.0)
     consumer.subscribe([Topic.LW_DELETIONS.value])
 
     result = delete_from_storage(storage, conditions, attr_info)

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -17,7 +17,7 @@ from snuba.state import set_config
 from snuba.utils.manage_topics import create_topics
 from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic
-from snuba.web.bulk_delete_query import _get_kafka_producer, delete_from_storage
+from snuba.web.bulk_delete_query import delete_from_storage
 from snuba.web.delete_query import DeletesNotEnabledError
 
 CONSUMER_CONFIG = {
@@ -61,11 +61,7 @@ def test_delete_success(mock_enforce_max_row: Mock) -> None:
     result = delete_from_storage(storage, conditions, attr_info)
     assert result["search_issues_local_v2"]["data"] == [{"rows_to_delete": 10}]
 
-    # make sure message got delivered
-    p = _get_kafka_producer(Topic.LW_DELETIONS_SEARCH_ISSUES)
-    p.flush()
-
-    attempts = 11
+    attempts = 12
     kafka_msg = None
     while attempts > 0 and not kafka_msg:
         kafka_msg = consumer.poll(1.0)

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+from unittest.mock import Mock, patch
+
+import pytest
+import rapidjson
+from confluent_kafka import Consumer
+
+from snuba import settings
+from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.state import set_config
+from snuba.utils.streams.topics import Topic
+from snuba.web.bulk_delete_query import (
+    DeletesNotEnabledError,
+    InvalidQueryException,
+    _get_kafka_producer,
+    delete_from_storage,
+)
+
+CONSUMER_CONFIG = {
+    "bootstrap.servers": settings.BROKER_CONFIG["bootstrap.servers"],
+    "group.id": "lwd-search-issues",
+    "enable.auto.commit": True,
+    "auto.offset.reset": "latest",
+}
+
+
+def get_attribution_info(
+    tenant_ids: Optional[Mapping[str, int | str]] = None
+) -> Mapping[str, Any]:
+    return {
+        "tenant_ids": tenant_ids or {"project_id": 1, "organization_id": 1},
+        "referrer": "some_referrer",
+        "app_id": "test",
+        "team": "test",
+        "parent_api": "test",
+        "feature": "test",
+    }
+
+
+@patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+def test_delete_success(mock_enforce_max_row: Mock) -> None:
+    consumer = Consumer(CONSUMER_CONFIG)
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
+    attr_info = get_attribution_info()
+
+    consumer.subscribe([Topic.LW_DELETIONS.value])
+
+    result = delete_from_storage(storage, conditions, attr_info)
+    assert result["search_issues_local_v2"]["data"] == [{"rows_to_delete": 10}]
+
+    # make sure message got delivered
+    p = _get_kafka_producer()
+    p.flush()
+
+    kafka_msg = consumer.poll(10.0)
+    message = rapidjson.loads(kafka_msg.value())
+    assert message["rows_to_delete"] == 10
+    assert message == {
+        "rows_to_delete": 10,
+        "storage_name": "search_issues",
+        "conditions": conditions,
+        "tenant_ids": {"project_id": 1, "organization_id": 1},
+    }
+    consumer.close()
+
+
+def test_deletes_not_enabled_on_storage() -> None:
+    storage = get_writable_storage(StorageKey("replays"))
+    conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
+    attr_info = get_attribution_info()
+
+    with pytest.raises(DeletesNotEnabledError):
+        delete_from_storage(storage, conditions, attr_info)
+
+
+@pytest.mark.redis_db
+def test_deletes_not_enabled_runtime_config() -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
+    attr_info = get_attribution_info()
+
+    set_config("storage_deletes_enabled", 0)
+    with pytest.raises(DeletesNotEnabledError):
+        delete_from_storage(storage, conditions, attr_info)
+
+
+@pytest.mark.redis_db
+def test_delete_invalid_column_type() -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": ["invalid_project"], "group_id": [1, 2, 3, 4]}
+    attr_info = get_attribution_info()
+
+    with pytest.raises(InvalidQueryException):
+        delete_from_storage(storage, conditions, attr_info)
+
+
+@pytest.mark.redis_db
+def test_delete_invalid_column_name() -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": [1], "bad_column": [1, 2, 3, 4]}
+    attr_info = get_attribution_info()
+
+    with pytest.raises(InvalidQueryException):
+        delete_from_storage(storage, conditions, attr_info)

--- a/tests/web/test_max_rows_enforcer.py
+++ b/tests/web/test_max_rows_enforcer.py
@@ -84,7 +84,10 @@ class TestMaxRowsEnforcer(SimpleAPITest, BaseApiTest, ConfigurationTest):
     @mock.patch(
         "snuba.datasets.storage.ReadableTableStorage.get_deletion_settings",
         return_value=DeletionSettings(
-            is_enabled=1, tables=["search_issues_local_v2"], max_rows_to_delete=0
+            is_enabled=1,
+            tables=["search_issues_local_v2"],
+            max_rows_to_delete=0,
+            allowed_columns=["project_id", "group_id"],
         ),
     )
     def test_max_row_enforcer_rejects(self, mock: mock.MagicMock) -> None:


### PR DESCRIPTION
**context**
The current pipeline we have for deleting data (via lightweight deletes) is an API endpoint that executes the query directly. `DELETE` requests are technically synchronous at the moment due to the ClickHouse version we are on (the `lightweight_delete_mutations_sync` parameter exist in newer version).

**problem**
We'd like to keep the number of concurrent `DELETE` requests to a minimum since they add an increased load to ClickHouse. Though the number of rows being deleted does have an effect on load, even a delete that deletes a few rows can have a significant enough effect because it's still a mutation (under the hood the `DELETE FROM` becomes an `UPDATE`). 

**batched deletes**
In order to scale we are adding a consumer that will batch up DELETE queries so that we have fewer mutations, even though the number of rows deleted/mutated will be higher.

The new pipeline is a bit different and has some new components:
- [ ] `DELETE` api endpoint will now take a request and produce it to a topic (This PR)
    * The topics are storage specific, ex. `LW_DELETIONS_SEARCH_ISSUES = "snuba-lw-deletions-search-issues"`
- [ ] Consumer(s) will be added to consume from the topic that corresponds to the storage the consumer is for, right now this will just be search issues

**other notable changes (in this pr)**
* addition of `allowed_columns` in the deletion settings, this will eventually replace the `ColumnFilterProcessor` once deletes are fully on the bulk delete endpoint
* `rows_to_delete` is added to the delete query payload so that we can batch based on number of rows to be delete instead of batching on number of messages