### PR TITLE
fix(eap): make execute method final

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -1,5 +1,5 @@
 import os
-from typing import Generic, List, Tuple, Type, TypeVar, cast
+from typing import Generic, List, Tuple, Type, TypeVar, cast, final
 
 from google.protobuf.message import DecodeError
 from google.protobuf.message import Message as ProtobufMessage
@@ -65,6 +65,7 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         res.ParseFromString(bytestring)
         return res
 
+    @final
     def execute(self, in_msg: Tin) -> Tout:
         self.__before_execute(in_msg)
         error = None

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -227,6 +227,10 @@ class EndpointTraceItemTable(
     def request_class(cls) -> Type[TraceItemTableRequest]:
         return TraceItemTableRequest
 
+    @classmethod
+    def response_class(cls) -> Type[TraceItemTableResponse]:
+        return TraceItemTableResponse
+
     def _execute(self, in_msg: TraceItemTableRequest) -> TraceItemTableResponse:
         in_msg = _apply_labels_to_columns(in_msg)
         _validate_select_and_groupby(in_msg)

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -227,7 +227,7 @@ class EndpointTraceItemTable(
     def request_class(cls) -> Type[TraceItemTableRequest]:
         return TraceItemTableRequest
 
-    def execute(self, in_msg: TraceItemTableRequest) -> TraceItemTableResponse:
+    def _execute(self, in_msg: TraceItemTableRequest) -> TraceItemTableResponse:
         in_msg = _apply_labels_to_columns(in_msg)
         _validate_select_and_groupby(in_msg)
         _validate_order_by(in_msg)

--- a/snuba/web/rpc/v1alpha/span_samples.py
+++ b/snuba/web/rpc/v1alpha/span_samples.py
@@ -133,7 +133,7 @@ class SpanSamplesRequest(RPCEndpoint[SpanSamplesRequestProto, SpanSamplesRespons
     def response_class(cls) -> Type[SpanSamplesResponse]:
         return SpanSamplesResponse
 
-    def execute(self, in_msg: SpanSamplesRequestProto) -> SpanSamplesResponse:
+    def _execute(self, in_msg: SpanSamplesRequestProto) -> SpanSamplesResponse:
         snuba_request = _build_snuba_request(in_msg)
         res = run_query(
             dataset=PluggableDataset(name="eap", all_entities=[]),


### PR DESCRIPTION
The execute method provides built in observability. It should not be overridden