### PR TITLE
feat(job-runner): record job's start timestamp to support timeouts

### DIFF
--- a/snuba/manual_jobs/redis.py
+++ b/snuba/manual_jobs/redis.py
@@ -1,4 +1,5 @@
 import typing
+from datetime import datetime
 from typing import List, Sequence
 
 from snuba.manual_jobs.job_status import JobStatus
@@ -10,6 +11,10 @@ _redis_client = get_redis_client(RedisClientKey.MANUAL_JOBS)
 
 def _build_job_lock_key(job_id: str) -> str:
     return f"snuba:manual_jobs:{job_id}:lock"
+
+
+def _build_start_time_key(job_id: str) -> str:
+    return f"snuba:manual_jobs:{job_id}:start_time"
 
 
 def _build_job_status_key(job_id: str) -> str:
@@ -38,6 +43,12 @@ def _push_job_log_line(job_id: str, line: str) -> bool:
 
 def _release_job_lock(job_id: str) -> None:
     _redis_client.delete(_build_job_lock_key(job_id))
+
+
+def _record_start_time(job_id: str) -> None:
+    _redis_client.set(
+        name=_build_start_time_key(job_id), value=datetime.utcnow().isoformat()
+    )
 
 
 def _set_job_status(job_id: str, status: JobStatus) -> JobStatus:

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -124,17 +124,14 @@ def run_job(job_spec: JobSpec) -> JobStatus:
 
     job_to_run = _JobLoader.get_job_instance(job_spec)
 
+    running_status_type = (
+        JobStatus.ASYNC_RUNNING_BACKGROUND if job_spec.is_async else JobStatus.RUNNING
+    )
     try:
-        if job_spec.is_async:
-            current_job_status = _set_job_status(
-                job_spec.job_id, JobStatus.ASYNC_RUNNING_BACKGROUND
-            )
-            _record_start_time(job_spec.job_id)
-            job_to_run.execute(job_logger)
-        else:
-            current_job_status = _set_job_status(job_spec.job_id, JobStatus.RUNNING)
-            _record_start_time(job_spec.job_id)
-            job_to_run.execute(job_logger)
+        current_job_status = _set_job_status(job_spec.job_id, running_status_type)
+        _record_start_time(job_spec.job_id)
+        job_to_run.execute(job_logger)
+        if not job_spec.is_async:
             current_job_status = _set_job_status(job_spec.job_id, JobStatus.FINISHED)
             job_logger.info("[runner] job execution finished")
     except BaseException:

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -15,6 +15,7 @@ from snuba.manual_jobs.redis import (
     _build_job_status_key,
     _get_job_status_multi,
     _get_job_type,
+    _record_start_time,
     _redis_client,
     _release_job_lock,
     _set_job_status,
@@ -128,9 +129,11 @@ def run_job(job_spec: JobSpec) -> JobStatus:
             current_job_status = _set_job_status(
                 job_spec.job_id, JobStatus.ASYNC_RUNNING_BACKGROUND
             )
+            _record_start_time(job_spec.job_id)
             job_to_run.execute(job_logger)
         else:
             current_job_status = _set_job_status(job_spec.job_id, JobStatus.RUNNING)
+            _record_start_time(job_spec.job_id)
             job_to_run.execute(job_logger)
             current_job_status = _set_job_status(job_spec.job_id, JobStatus.FINISHED)
             job_logger.info("[runner] job execution finished")

--- a/tests/manual_jobs/test_record_job_start.py
+++ b/tests/manual_jobs/test_record_job_start.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+import pytest
+
+from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs.redis import _build_start_time_key, _redis_client
+from snuba.manual_jobs.runner import run_job
+
+JOB_ID = "abc1234"
+job_spec = JobSpec(job_id=JOB_ID, job_type="ToyJob")
+
+
+@pytest.mark.redis_db
+def test_record_job_start_time_correctly() -> None:
+    with patch("snuba.manual_jobs.redis.datetime") as mock_datetime:
+        mock_datetime.utcnow.return_value.isoformat.return_value = (
+            "2024-10-23T01:12:23.456789"
+        )
+        run_job(job_spec)
+        assert (
+            _redis_client.get(name=_build_start_time_key(JOB_ID)).decode()
+            == "2024-10-23T01:12:23.456789"
+        )


### PR DESCRIPTION
store a record of when a job started executing so that we can support timeouts