### PR TITLE
ref: Lower mutations synchronizer's sleep

### DIFF
--- a/rust_snuba/src/mutations/factory.rs
+++ b/rust_snuba/src/mutations/factory.rs
@@ -102,7 +102,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for MutConsumerStrategyFactory {
         );
 
         let mut synchronizer = Synchronizer {
-            min_delay: TimeDelta::days(1),
+            min_delay: TimeDelta::hours(12),
         };
 
         let next_step = RunTask::new(move |m| synchronizer.process_message(m), next_step);


### PR DESCRIPTION
This value was set to 1 day, but we'd like to see some mutations in Clickhouse sooner than that so we can perform some analysis. Lower to 12 hours.
