### PR TITLE
ref(querylog): Produce request ID consistently

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from random import random
 from typing import Any, Mapping, Optional, Union
+from uuid import UUID
 
 import sentry_sdk
 from sentry_kafka_schemas.schema_types import snuba_queries_v1
@@ -204,7 +205,7 @@ def _add_tags(
 
 
 def _build_failed_request_dict(
-    request_id: str,
+    request_id: UUID,
     body: dict[str, Any],
     dataset: str,
     organization: int,
@@ -214,7 +215,7 @@ def _build_failed_request_dict(
 ) -> snuba_queries_v1.Querylog:
     return {
         "request": {
-            "id": request_id,
+            "id": request_id.hex,
             "body": body,
             "referrer": str(referrer),
             "team": None,
@@ -237,7 +238,7 @@ def _build_failed_request_dict(
 
 
 def record_invalid_request(
-    request_id: str,
+    request_id: UUID,
     body: dict[str, Any],
     dataset: str,
     organization: int,
@@ -268,7 +269,7 @@ def record_invalid_request(
 
 
 def record_error_building_request(
-    request_id: str,
+    request_id: UUID,
     body: dict[str, Any],
     dataset: str,
     organization: int,

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -302,7 +302,7 @@ class SnubaQueryMetadata:
         end = int(self.end_timestamp.timestamp()) if self.end_timestamp else None
         request_dict: snuba_queries_v1.Querylog = {
             "request": {
-                "id": self.request.id,
+                "id": self.request.id.hex,
                 "body": self.request.original_body,
                 "referrer": self.request.referrer,
                 "team": self.request.attribution_info.team,

--- a/snuba/request/__init__.py
+++ b/snuba/request/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Union
 
@@ -13,7 +14,7 @@ from snuba.query.query_settings import QuerySettings
 
 @dataclass(frozen=True)
 class Request:
-    id: str
+    id: uuid.UUID
     original_body: Dict[str, Any]
     query: Union[Query, CompositeQuery[LogicalDataSource]]
     query_settings: QuerySettings

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -124,7 +124,7 @@ def build_request(
         except (InvalidJsonRequestException, InvalidQueryException) as exception:
             request_status = get_request_status(exception)
             record_invalid_request(
-                request_id=str(uuid.uuid4),
+                request_id=uuid.uuid4(),
                 body=body,
                 dataset=get_dataset_name(dataset),
                 organization=body.get("tenant_ids", {}).get("organization_id", 0),
@@ -137,7 +137,7 @@ def build_request(
         except Exception as exception:
             request_status = get_request_status(exception)
             record_error_building_request(
-                request_id=str(uuid.uuid4),
+                request_id=uuid.uuid4(),
                 body=body,
                 dataset=get_dataset_name(dataset),
                 organization=body.get("tenant_ids", {}).get("organization_id", 0),
@@ -247,7 +247,7 @@ def _build_request(
     attribution_info = _get_attribution_info(request_parts, referrer, query_project_id)
 
     return Request(
-        id=uuid.uuid4().hex,
+        id=uuid.uuid4(),
         original_body=original_body,
         query=query,
         attribution_info=attribution_info,

--- a/snuba/web/rpc/common/eap_execute.py
+++ b/snuba/web/rpc/common/eap_execute.py
@@ -41,7 +41,7 @@ def run_eap_query(
     query.set_from_clause(entity)
 
     request = Request(
-        id=str(uuid.uuid4()),
+        id=uuid.uuid4(),
         original_body=original_body,
         query=query,
         query_settings=query_settings,

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -108,7 +108,7 @@ def _build_query(request: TraceItemTableRequest) -> Query:
 
 def _build_snuba_request(request: TraceItemTableRequest) -> SnubaRequest:
     return SnubaRequest(
-        id=request.meta.request_id,
+        id=uuid.UUID(request.meta.request_id),
         original_body=MessageToDict(request),
         query=_build_query(request),
         query_settings=HTTPQuerySettings(),

--- a/snuba/web/rpc/v1alpha/span_samples.py
+++ b/snuba/web/rpc/v1alpha/span_samples.py
@@ -80,7 +80,7 @@ def _build_snuba_request(
     request: SpanSamplesRequestProto,
 ) -> SnubaRequest:
     return SnubaRequest(
-        id=str(uuid.uuid4()),
+        id=uuid.uuid4(),
         original_body=MessageToDict(request),
         query=_build_query(request),
         query_settings=HTTPQuerySettings(),

--- a/snuba/web/rpc/v1alpha/trace_item_attribute_list.py
+++ b/snuba/web/rpc/v1alpha/trace_item_attribute_list.py
@@ -108,7 +108,7 @@ def _build_snuba_request(
     request: TraceItemAttributesRequestProto,
 ) -> SnubaRequest:
     return SnubaRequest(
-        id=str(uuid.uuid4()),
+        id=uuid.uuid4(),
         original_body=MessageToDict(request),
         query=_build_query(request),
         query_settings=HTTPQuerySettings(),

--- a/snuba/web/rpc/v1alpha/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1alpha/trace_item_attribute_values.py
@@ -77,7 +77,7 @@ def _build_snuba_request(
     request: AttributeValuesRequestProto,
 ) -> SnubaRequest:
     return SnubaRequest(
-        id=str(uuid.uuid4()),
+        id=uuid.uuid4(),
         original_body=MessageToDict(request),
         query=_build_query(request),
         query_settings=HTTPQuerySettings(),

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -41,7 +41,7 @@ def test_simple() -> None:
     )
 
     request = Request(
-        id=uuid.UUID("a" * 32).hex,
+        id=uuid.UUID("a" * 32),
         original_body=request_body,
         query=query,
         query_settings=HTTPQuerySettings(referrer="search"),

--- a/tests/pipeline/test_entity_processing_stage.py
+++ b/tests/pipeline/test_entity_processing_stage.py
@@ -1,3 +1,5 @@
+import uuid
+
 from snuba.attribution import get_app_id
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.query import Query
@@ -27,7 +29,7 @@ def _create_pipe_input_from_snql(snql_query: str) -> QueryPipelineData[Request]:
     query_settings = HTTPQuerySettings()
     timer = Timer("test")
     request = Request(
-        id="",
+        id=uuid.uuid4(),
         original_body=query_body,
         query=logical_query,
         query_settings=query_settings,

--- a/tests/pipeline/test_entity_processing_stage_composite.py
+++ b/tests/pipeline/test_entity_processing_stage_composite.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 from typing import cast
 
@@ -436,7 +437,7 @@ def test_composite(
     expected: CompositeQuery[Table],
 ) -> None:
     request = Request(
-        id="",
+        id=uuid.uuid4(),
         original_body={"query": "placeholder"},
         query=cast(LogicalQuery, logical_query),
         query_settings=HTTPQuerySettings(),
@@ -528,7 +529,7 @@ def test_invalid_composite(
     expected_error: Exception,
 ) -> None:
     request = Request(
-        id="",
+        id=uuid.uuid4(),
         original_body={"query": "placeholder"},
         query=cast(LogicalQuery, logical_query),
         query_settings=HTTPQuerySettings(),

--- a/tests/pipeline/test_execution_stage.py
+++ b/tests/pipeline/test_execution_stage.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from snuba import settings as snubasettings
@@ -68,7 +70,7 @@ class MockAllocationPolicy(AllocationPolicy):
 def get_fake_metadata() -> SnubaQueryMetadata:
     return SnubaQueryMetadata(
         Request(
-            "",
+            uuid.uuid4(),
             {},
             LogicalQuery(
                 from_clause=Entity(key=EntityKey.TRANSACTIONS, schema=ColumnSet([]))

--- a/tests/web/test_transform_names.py
+++ b/tests/web/test_transform_names.py
@@ -86,7 +86,7 @@ def test_transform_column_names() -> None:
     result = run_query(
         dataset,
         Request(
-            id="asd",
+            id=uuid.uuid4(),
             original_body={},
             query=query,
             query_settings=query_settings,


### PR DESCRIPTION
There are two ways to stringify a UUID: `str(uuid)`, and `uuid.hex` -- they produce different output, the first one is hyphenated, the second one isn't.

It seems we use both at the same time, and the consumer can only deal with the latter.

But also, sometimes we do this: `str(uuid.uuid4)`

That always produces something like `'<function uuid4 at 0x100c39620>'`,
which is total garbage but since everything is string-typed, mypy
doesn't complain.

Refactor everything to use UUID types and only convert to string on
serialization.
