### PR TITLE
fix(admin): Allow OPTIMIZE queries in sudo mode

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -105,6 +105,17 @@ SYSTEM_COMMAND_RE = re.compile(
     re.IGNORECASE + re.VERBOSE,
 )
 
+OPTIMIZE_QUERY_RE = re.compile(
+    r"""^
+        (OPTIMIZE\sTABLE)
+        \s
+        [\w\s]+
+        ;? # Optional semicolon
+        $
+    """,
+    re.IGNORECASE + re.VERBOSE,
+)
+
 ALTER_QUERY_RE = re.compile(
     r"""
         ^
@@ -154,6 +165,15 @@ def is_system_command(sql_query: str) -> bool:
     return True if match else False
 
 
+def is_query_optimize(sql_query: str) -> bool:
+    """
+    Validates whether we are running something like OPTIMIZE TABLE ...
+    """
+    sql_query = " ".join(sql_query.split())
+    match = OPTIMIZE_QUERY_RE.match(sql_query)
+    return True if match else False
+
+
 def is_query_alter(sql_query: str) -> bool:
     """
     Validates whether we are running something like ALTER TABLE ...
@@ -187,7 +207,9 @@ def run_system_query_on_host_with_sql(
     elif is_query_show(system_query_sql):
         pass
     elif sudo_mode and (
-        is_system_command(system_query_sql) or is_query_alter(system_query_sql)
+        is_system_command(system_query_sql)
+        or is_query_alter(system_query_sql)
+        or is_query_optimize(system_query_sql)
     ):
         pass
     else:

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -8,6 +8,7 @@ from snuba.admin.clickhouse.common import InvalidCustomQuery
 from snuba.admin.clickhouse.system_queries import (
     UnauthorizedForSudo,
     is_query_alter,
+    is_query_optimize,
     is_query_select,
     is_system_command,
     run_system_query_on_host_with_sql,
@@ -86,10 +87,15 @@ def test_is_query_select() -> None:
         ("system KILL", False),
         ("ALTER TABLE eap_spans_local_merge DROP PARTITION '1970-01-01'", True),
         ("CREATE TABLE eap_spans_local_merge (all my fieds)", True),
+        ("OPTIMIZE TABLE eap_spans_local", True),
     ],
 )
 def test_sudo_queries(sudo_query: str, expected: bool) -> None:
-    assert (is_system_command(sudo_query) or is_query_alter(sudo_query)) == expected
+    assert (
+        is_system_command(sudo_query)
+        or is_query_alter(sudo_query)
+        or is_query_optimize(sudo_query)
+    ) == expected
     with pytest.raises(InvalidCustomQuery):
         validate_system_query(sudo_query)
 

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -88,6 +88,8 @@ def test_is_query_select() -> None:
         ("ALTER TABLE eap_spans_local_merge DROP PARTITION '1970-01-01'", True),
         ("CREATE TABLE eap_spans_local_merge (all my fieds)", True),
         ("OPTIMIZE TABLE eap_spans_local", True),
+        ("optimize table eap_spans_local", True),
+        ("optimize   TABLE eap_spans_local", True),
     ],
 )
 def test_sudo_queries(sudo_query: str, expected: bool) -> None:


### PR DESCRIPTION
This allows OPTIMIZE queries to be run in the snuba admin when using sudo
mode. This can be useful to potentially resolve tables/partitions in bad
states.