### PR TITLE
build(deps): bump redis from 4.3.4 to 4.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pytest-cov==3.0.0
 pytest-watch==4.2.0
 python-dateutil==2.8.2
 python-rapidjson==1.8
-redis==4.3.4
+redis==4.6.0
 sentry-arroyo==2.17.6
 sentry-kafka-schemas==0.1.113
 sentry-redis-tools==0.3.0


### PR DESCRIPTION
https://github.com/getsentry/snuba/security/dependabot/24