### PR TITLE
feat(devservices): Add shared redis/kafka and containerized mode for snuba

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -40,7 +40,7 @@ services:
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
-      - sentry
+      - devservices
 
   snuba:
     image: ghcr.io/getsentry/snuba:latest
@@ -69,11 +69,11 @@ services:
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
-      - sentry
+      - devservices
 
 volumes:
   clickhouse-data:
 
 networks:
-  sentry:
-    name: sentry
+  devservices:
+    name: devservices

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -4,66 +4,67 @@ x-sentry-service-config:
   service_name: snuba
   dependencies:
     clickhouse:
-      description: "Real time analytics database"
+      description: Real time analytics database
     redis:
-      description: "Shared instance of redis used by sentry services"
+      description: Shared instance of redis used by sentry services
       remote:
         repo_name: sentry-shared-redis
         branch: main
         repo_link: git@github.com:getsentry/sentry-shared-redis.git
     kafka:
-      description: "Shared instance of kafka used by sentry services"
+      description: Shared instance of kafka used by sentry services
       remote:
         repo_name: sentry-shared-kafka
         branch: main
         repo_link: git@github.com:getsentry/sentry-shared-kafka.git
     snuba:
-      description: "Service that provides a rich data model on top of Clickhouse together with a fast ingestion consumer and a query optimizer"
+      description: Service that provides a rich data model on top of Clickhouse together with a fast ingestion consumer and a query optimizer
   modes:
     default: [redis, kafka, clickhouse]
     containerized: [clickhouse, redis, kafka, snuba]
 
 services:
   clickhouse:
-    image: "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.8.11.29.altinitystable"
+    image: ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.8.11.29.altinitystable
     ulimits:
       nofile:
         soft: 262144
         hard: 262144
     ports:
-      - "9000:9000"
-      - "9009:9009"
-      - "8123:8123"
+      - 9000:9000
+      - 9009:9009
+      - 8123:8123
     volumes:
-      - "clickhouse-data:/var/lib/clickhouse"
-      - "./clickhouse/config.xml:/etc/clickhouse-server/config.d/sentry.xml"
+      - clickhouse-data:/var/lib/clickhouse
+      - ./clickhouse/config.xml:/etc/clickhouse-server/config.d/sentry.xml
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
       - sentry
+
   snuba:
     image: ghcr.io/getsentry/snuba:latest
     ports:
-      - '1218:1218'
-      - '1219:1219'
-    command: ['devserver']
+      - 1218:1218
+      - 1219:1219
+    command: [devserver]
     environment:
-      PYTHONUNBUFFERED: '1'
+      PYTHONUNBUFFERED: 1
       SNUBA_SETTINGS: docker
-      DEBUG: '1'
-      CLICKHOUSE_HOST: 'clickhouse'
-      CLICKHOUSE_PORT: '9000'
-      CLICKHOUSE_HTTP_PORT: '8123'
-      DEFAULT_BROKERS: 'kafka:9093'
-      REDIS_HOST: 'redis'
-      REDIS_PORT: '6379'
-      REDIS_DB: '1'
-      ENABLE_SENTRY_METRICS_DEV: '${ENABLE_SENTRY_METRICS_DEV:-}'
-      ENABLE_PROFILES_CONSUMER: '${ENABLE_PROFILES_CONSUMER:-}'
-      ENABLE_SPANS_CONSUMER: '${ENABLE_SPANS_CONSUMER:-}'
-      ENABLE_ISSUE_OCCURRENCE_CONSUMER: '${ENABLE_ISSUE_OCCURRENCE_CONSUMER:-}'
-      ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES: '1'
-      ENABLE_GROUP_ATTRIBUTES_CONSUMER: '${ENABLE_GROUP_ATTRIBUTES_CONSUMER:-}'
+      DEBUG: 1
+      CLICKHOUSE_HOST: clickhouse
+      CLICKHOUSE_PORT: 9000
+      CLICKHOUSE_HTTP_PORT: 8123
+      DEFAULT_BROKERS: kafka:9093
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 1
+      ENABLE_SENTRY_METRICS_DEV: ${ENABLE_SENTRY_METRICS_DEV:-}
+      ENABLE_PROFILES_CONSUMER: ${ENABLE_PROFILES_CONSUMER:-}
+      ENABLE_SPANS_CONSUMER: ${ENABLE_SPANS_CONSUMER:-}
+      ENABLE_ISSUE_OCCURRENCE_CONSUMER: ${ENABLE_ISSUE_OCCURRENCE_CONSUMER:-}
+      ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES: 1
+      ENABLE_GROUP_ATTRIBUTES_CONSUMER: ${ENABLE_GROUP_ATTRIBUTES_CONSUMER:-}
     platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -37,6 +37,8 @@ services:
     volumes:
       - "clickhouse:/var/lib/clickhouse"
       - "./clickhouse/config.xml:/etc/clickhouse-server/config.d/sentry.xml"
+    extra_hosts:
+      host.docker.internal: host-gateway
     networks:
       - sentry
   snuba:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -4,21 +4,28 @@ x-sentry-service-config:
   service_name: snuba
   dependencies:
     clickhouse:
-      description: "clickhouse"
+      description: "Real time analytics database"
     redis:
-      description: "redis"
+      description: "Shared instance of redis used by sentry services"
+      remote:
+        repo_name: sentry-shared-redis
+        branch: main
+        repo_link: git@github.com:getsentry/sentry-shared-redis.git
     kafka:
-      description: "kafka"
+      description: "Shared instance of kafka used by sentry services"
+      remote:
+        repo_name: sentry-shared-kafka
+        branch: main
+        repo_link: git@github.com:getsentry/sentry-shared-kafka.git
+    snuba:
+      description: "snuba"
   modes:
-    default: [clickhouse, redis, kafka]
+    default: [redis, kafka, clickhouse]
+    containerized: [clickhouse, redis, kafka, snuba]
 
 services:
-  redis:
-    image: "redis:6.2.14-alpine"
-    healthcheck:
-      test: redis-cli ping
   clickhouse:
-    image: "altinity/clickhouse-server:23.8.11.29.altinitystable"
+    image: "ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:23.8.11.29.altinitystable"
     ulimits:
       nofile:
         soft: 262144
@@ -30,36 +37,40 @@ services:
     volumes:
       - "clickhouse:/var/lib/clickhouse"
       - "./clickhouse/config.xml:/etc/clickhouse-server/config.d/sentry.xml"
-  kafka:
-    image: "confluentinc/cp-kafka:7.6.1"
-    environment:
-      # https://docs.confluent.io/platform/current/installation/docker/config-reference.html#cp-kakfa-example
-      KAFKA_PROCESS_ROLES: "broker,controller"
-      KAFKA_CONTROLLER_QUORUM_VOTERS: "1001@127.0.0.1:29093"
-      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
-      KAFKA_NODE_ID: "1001"
-      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
-      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:29092,INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://127.0.0.1:29092,INTERNAL://kafka:9093,EXTERNAL://127.0.0.1:9092"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT"
-      KAFKA_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "1"
-      KAFKA_LOG_RETENTION_HOURS: "24"
-      KAFKA_MESSAGE_MAX_BYTES: "50000000" #50MB or bust
-      KAFKA_MAX_REQUEST_SIZE: "50000000" #50MB on requests apparently too
-      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-      KAFKA_LOG4J_LOGGERS: "kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,state.change.logger=WARN"
-      KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
-      KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
-    ulimits:
-      nofile:
-        soft: 4096
-        hard: 4096
-    volumes:
-      - "kafka:/var/lib/kafka/data"
+    networks:
+      - sentry
+  snuba:
+    image: ghcr.io/getsentry/snuba:latest
     ports:
-      - "9092:9092"
+      - '1218:1218'
+      - '1219:1219'
+    command: ['devserver']
+    environment:
+      PYTHONUNBUFFERED: '1'
+      SNUBA_SETTINGS: docker
+      DEBUG: '1'
+      CLICKHOUSE_HOST: 'clickhouse'
+      CLICKHOUSE_PORT: '9000'
+      CLICKHOUSE_HTTP_PORT: '8123'
+      DEFAULT_BROKERS: 'kafka:9093'
+      REDIS_HOST: 'redis'
+      REDIS_PORT: '6379'
+      REDIS_DB: '1'
+      ENABLE_SENTRY_METRICS_DEV: '${ENABLE_SENTRY_METRICS_DEV:-}'
+      ENABLE_PROFILES_CONSUMER: '${ENABLE_PROFILES_CONSUMER:-}'
+      ENABLE_SPANS_CONSUMER: '${ENABLE_SPANS_CONSUMER:-}'
+      ENABLE_ISSUE_OCCURRENCE_CONSUMER: '${ENABLE_ISSUE_OCCURRENCE_CONSUMER:-}'
+      ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES: '1'
+      ENABLE_GROUP_ATTRIBUTES_CONSUMER: '${ENABLE_GROUP_ATTRIBUTES_CONSUMER:-}'
+    platform: linux/amd64
+    extra_hosts:
+      host.docker.internal: host-gateway
+    networks:
+      - sentry
+
 volumes:
   clickhouse:
-  kafka:
+
+networks:
+  sentry:
+    name: sentry

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -35,7 +35,7 @@ services:
       - "9009:9009"
       - "8123:8123"
     volumes:
-      - "clickhouse:/var/lib/clickhouse"
+      - "clickhouse-data:/var/lib/clickhouse"
       - "./clickhouse/config.xml:/etc/clickhouse-server/config.d/sentry.xml"
     extra_hosts:
       host.docker.internal: host-gateway
@@ -71,7 +71,7 @@ services:
       - sentry
 
 volumes:
-  clickhouse:
+  clickhouse-data:
 
 networks:
   sentry:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -18,7 +18,7 @@ x-sentry-service-config:
         branch: main
         repo_link: git@github.com:getsentry/sentry-shared-kafka.git
     snuba:
-      description: "snuba"
+      description: "Service that provides a rich data model on top of Clickhouse together with a fast ingestion consumer and a query optimizer"
   modes:
     default: [redis, kafka, clickhouse]
     containerized: [clickhouse, redis, kafka, snuba]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.3
 clickhouse-driver==0.2.6
 confluent-kafka==2.3.0
 datadog==0.21.0
-devservices==0.0.3
+devservices==0.0.4
 flake8==5.0.4
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
This allows devservices to use a shared version of redis/kafka defined here:
https://github.com/getsentry/sentry-shared-kafka
https://github.com/getsentry/sentry-shared-redis

This allows relay/snuba/sentry to use the same redis/kafka configurations

It also adds a containerized mode to the config, which sentry will need in order to run snuba devserver inside a container with the lastest snuba image