### PR TITLE
feat(admin): Add trace log visualization to RPC endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,21 +26,25 @@
   },
 
   "[javascript]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
   },
 
   "[javascriptreact]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
   },
 
   "[typescript]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
   },
 
   "[typescriptreact]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "vscode.typescript-language-features",
+    "editor.tabSize": 2
   },
 
   "[less]": {

--- a/snuba/admin/static/rpc_endpoints/index.tsx
+++ b/snuba/admin/static/rpc_endpoints/index.tsx
@@ -7,66 +7,66 @@ import { QueryInfo } from 'SnubaAdmin/rpc_endpoints/types';
 const DEBUG_SUPPORTED_VERSIONS = ['v1'];
 
 function RpcEndpoints() {
-const api = useApi();
-const [endpoints, setEndpoints] = useState<Array<{ name: string, version: string }>>([]);
-const [selectedEndpoint, setSelectedEndpoint] = useState<string | null>(null);
-const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
-const [requestBody, setRequestBody] = useState('');
-const [response, setResponse] = useState<any | null>(null);
-const exampleRequestTemplates: Record<string, Record<string, any>> = require('SnubaAdmin/rpc_endpoints/exampleRequestTemplates.json');
-const [accordionOpened, setAccordionOpened] = useState(false);
-const [isLoading, setIsLoading] = useState(false);
-const [debugMode, setDebugMode] = useState(false);
-const [showTraceLogs, setShowTraceLogs] = useState(false);
+  const api = useApi();
+  const [endpoints, setEndpoints] = useState<Array<{ name: string, version: string }>>([]);
+  const [selectedEndpoint, setSelectedEndpoint] = useState<string | null>(null);
+  const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
+  const [requestBody, setRequestBody] = useState('');
+  const [response, setResponse] = useState<any | null>(null);
+  const exampleRequestTemplates: Record<string, Record<string, any>> = require('SnubaAdmin/rpc_endpoints/exampleRequestTemplates.json');
+  const [accordionOpened, setAccordionOpened] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [debugMode, setDebugMode] = useState(false);
+  const [showTraceLogs, setShowTraceLogs] = useState(false);
 
-const fetchEndpoints = useCallback(async () => {
-try {
-    const fetchedEndpoints: [string, string][] = await api.getRpcEndpoints();
-    const formattedEndpoints = fetchedEndpoints.map((endpoint: [string, string]) => ({
+  const fetchEndpoints = useCallback(async () => {
+    try {
+      const fetchedEndpoints: [string, string][] = await api.getRpcEndpoints();
+      const formattedEndpoints = fetchedEndpoints.map((endpoint: [string, string]) => ({
         name: endpoint[0],
         version: endpoint[1]
-    }));
-    setEndpoints(formattedEndpoints);
-} catch (error) {
-    console.error("Error fetching endpoints:", error);
-}
-}, []);
+      }));
+      setEndpoints(formattedEndpoints);
+    } catch (error) {
+      console.error("Error fetching endpoints:", error);
+    }
+  }, []);
 
-useEffect(() => {
-fetchEndpoints();
-}, []);
+  useEffect(() => {
+    fetchEndpoints();
+  }, []);
 
-const handleEndpointSelect = (value: string | null) => {
-setSelectedEndpoint(value);
-const selectedEndpointData = endpoints.find(e => e.name === value);
-setSelectedVersion(selectedEndpointData?.version || null);
-setRequestBody('');
-setResponse(null);
-setDebugMode(false);
-};
+  const handleEndpointSelect = (value: string | null) => {
+    setSelectedEndpoint(value);
+    const selectedEndpointData = endpoints.find(e => e.name === value);
+    setSelectedVersion(selectedEndpointData?.version || null);
+    setRequestBody('');
+    setResponse(null);
+    setDebugMode(false);
+  };
 
-const handleExecute = async () => {
-if (!selectedEndpoint || !selectedVersion) return;
-setIsLoading(true);
-try {
-    const parsedBody = JSON.parse(requestBody);
-    if (debugMode && DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion)) {
+  const handleExecute = async () => {
+    if (!selectedEndpoint || !selectedVersion) return;
+    setIsLoading(true);
+    try {
+      const parsedBody = JSON.parse(requestBody);
+      if (debugMode && DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion)) {
         parsedBody.meta = parsedBody.meta || {};
         parsedBody.meta.debug = true;
+      }
+      const result = await api.executeRpcEndpoint(selectedEndpoint, selectedVersion, parsedBody);
+      setResponse(result);
+    } catch (error: any) {
+      alert(`Error: ${error.message}`);
+      setResponse({ error: error.message });
+    } finally {
+      setIsLoading(false);
     }
-    const result = await api.executeRpcEndpoint(selectedEndpoint, selectedVersion, parsedBody);
-    setResponse(result);
-} catch (error: any) {
-    alert(`Error: ${error.message}`);
-    setResponse({ error: error.message });
-} finally {
-    setIsLoading(false);
-}
-};
+  };
 
-const useStyles = createStyles((theme) => ({
-accordion: {
-    '& .mantine-Accordion-control': {
+  const useStyles = createStyles((theme) => ({
+    accordion: {
+      '& .mantine-Accordion-control': {
         backgroundColor: theme.colors.blue[1],
         color: theme.colors.blue[7],
         fontSize: theme.fontSizes.xs,
@@ -76,118 +76,118 @@ accordion: {
         cursor: 'pointer',
         fontWeight: 'bold',
         '&:hover': {
-            backgroundColor: theme.colors.blue[2],
+          backgroundColor: theme.colors.blue[2],
         },
+      },
     },
-},
-table: {
-    border: `1px solid ${theme.colors.gray[3]}`,
-    '& th, & td': {
+    table: {
+      border: `1px solid ${theme.colors.gray[3]}`,
+      '& th, & td': {
         border: `1px solid ${theme.colors.gray[3]}`,
         padding: theme.spacing.xs,
-    },
-    '& th': {
+      },
+      '& th': {
         backgroundColor: theme.colors.gray[1],
         fontWeight: 'bold',
-    },
-    '& td:first-of-type': {
+      },
+      '& td:first-of-type': {
         width: '20%',
         fontWeight: 'bold',
-    },
-    '& td:last-of-type': {
+      },
+      '& td:last-of-type': {
         width: '80%',
+      },
     },
-},
-debugCheckbox: {
-    marginBottom: theme.spacing.md,
-},
-traceLogsContainer: {
-    maxHeight: '500px',
-    overflowY: 'auto',
-    backgroundColor: theme.colors.dark[9],
-    padding: theme.spacing.md,
-    borderRadius: theme.radius.sm,
-    fontFamily: '"JetBrains Mono", "Fira Code", "Source Code Pro", "IBM Plex Mono", "Roboto Mono", "Cascadia Code", Consolas, Monaco, "Courier New", monospace',
-    whiteSpace: 'pre-wrap',
-    fontSize: '16px',
-    '& span': {
+    debugCheckbox: {
+      marginBottom: theme.spacing.md,
+    },
+    traceLogsContainer: {
+      maxHeight: '500px',
+      overflowY: 'auto',
+      backgroundColor: theme.colors.dark[9],
+      padding: theme.spacing.md,
+      borderRadius: theme.radius.sm,
+      fontFamily: '"JetBrains Mono", "Fira Code", "Source Code Pro", "IBM Plex Mono", "Roboto Mono", "Cascadia Code", Consolas, Monaco, "Courier New", monospace',
+      whiteSpace: 'pre-wrap',
+      fontSize: '16px',
+      '& span': {
         display: 'inline'
-    },
-    '& .trace-message': {
+      },
+      '& .trace-message': {
         fontWeight: 'bold',
         color: '#ffffff',
-    }
-},
-viewToggle: {
-    marginBottom: theme.spacing.sm,
-},
-responseDataContainer: {
-    maxHeight: '500px',
-    overflowY: 'auto',
-    backgroundColor: 'white',
-    padding: theme.spacing.sm,
-    borderRadius: theme.radius.sm,
-    border: `1px solid ${theme.colors.gray[3]}`,
-},
-}));
+      }
+    },
+    viewToggle: {
+      marginBottom: theme.spacing.sm,
+    },
+    responseDataContainer: {
+      maxHeight: '500px',
+      overflowY: 'auto',
+      backgroundColor: 'white',
+      padding: theme.spacing.sm,
+      borderRadius: theme.radius.sm,
+      border: `1px solid ${theme.colors.gray[3]}`,
+    },
+  }));
 
-const { classes } = useStyles();
+  const { classes } = useStyles();
 
-return (
-<div>
-    <h2>RPC Endpoints</h2>
-    <Select
+  return (
+    <div>
+      <h2>RPC Endpoints</h2>
+      <Select
         label="Select an endpoint"
         placeholder="Choose an endpoint"
         data={endpoints.map(endpoint => ({ value: endpoint.name, label: `${endpoint.name} (${endpoint.version})` }))}
         value={selectedEndpoint}
         onChange={handleEndpointSelect}
         style={{ width: '100%', marginBottom: '1rem' }}
-    />
-    <Space h="md" />
-    <Accordion
+      />
+      <Space h="md" />
+      <Accordion
         classNames={{ item: classes.accordion }}
         variant="filled"
         radius="sm"
         value={accordionOpened ? 'example' : null}
         onChange={(value) => setAccordionOpened(value === 'example')}
-    >
+      >
         <Accordion.Item value="example">
-            <Accordion.Control>Example Request Payload</Accordion.Control>
-            <Accordion.Panel>
-                <Code block style={{ color: 'green' }}>
-                    <pre>
-                        {JSON.stringify(
-                            selectedEndpoint && selectedVersion
-                                ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
-                                : exampleRequestTemplates.default,
-                            null,
-                            2
-                        )}
-                    </pre>
-                </Code>
-                <Button
-                    onClick={() => {
-                        setRequestBody(
-                            JSON.stringify(
-                                selectedEndpoint && selectedVersion
-                                    ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
-                                    : exampleRequestTemplates.default,
-                                null,
-                                2
-                            )
-                        );
-                        setAccordionOpened(false);
-                    }}
-                    style={{ marginTop: '1rem' }}
-                >
-                    Copy to Request Body
-                </Button>
-            </Accordion.Panel>
+          <Accordion.Control>Example Request Payload</Accordion.Control>
+          <Accordion.Panel>
+            <Code block style={{ color: 'green' }}>
+              <pre>
+                {JSON.stringify(
+                  selectedEndpoint && selectedVersion
+                    ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
+                    : exampleRequestTemplates.default,
+                  null,
+                  2
+                )}
+              </pre>
+            </Code>
+            <Button
+              onClick={() => {
+                setRequestBody(
+                  JSON.stringify(
+                    selectedEndpoint && selectedVersion
+                      ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
+                      : exampleRequestTemplates.default,
+                    null,
+                    2
+                  )
+                );
+                setAccordionOpened(false);
+              }}
+              style={{ marginTop: '1rem' }}
+            >
+              Copy to Request Body
+            </Button>
+          </Accordion.Panel>
         </Accordion.Item>
-    </Accordion>
-    <Space h="md" />
-    <Textarea
+      </Accordion>
+      <Space h="md" />
+      <Textarea
         label="Request Body (JSON)"
         placeholder="Enter request body"
         value={requestBody}
@@ -195,110 +195,110 @@ return (
         style={{ width: '100%' }}
         autosize
         minRows={5}
-    />
-    <Space h="md" />
-    <Checkbox
+      />
+      <Space h="md" />
+      <Checkbox
         label="Enable Debug Mode"
         checked={debugMode}
         onChange={(event) => setDebugMode(event.currentTarget.checked)}
         disabled={!DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion || '')}
         className={classes.debugCheckbox}
-    />
-    <Button
+      />
+      <Button
         onClick={handleExecute}
         disabled={!selectedEndpoint || !requestBody || isLoading}
         leftIcon={isLoading ? <Loader size="xs" /> : null}
-    >
+      >
         {isLoading ? 'Executing...' : 'Execute'}
-    </Button>
-    {response && (
+      </Button>
+      {response && (
         <>
-            <Space h="md" />
-            <h3>Response:</h3>
-            <Switch
-                className={classes.viewToggle}
-                label="Show Trace Logs"
-                checked={showTraceLogs}
-                onChange={(event) => setShowTraceLogs(event.currentTarget.checked)}
-            />
-            <h4>Response Metadata:</h4>
-            <Accordion classNames={{ item: classes.accordion }}>
-                <Accordion.Item value="query-info">
-                    <Accordion.Control>
-                        <Text fw={700}>
-                            {showTraceLogs ? 'Query Trace Logs' : 'Query Metadata'}
-                        </Text>
-                    </Accordion.Control>
-                    <Accordion.Panel>
-                        {response.meta?.queryInfo ? (
-                            response.meta.queryInfo.map((queryInfo: QueryInfo, index: number) => (
-                                <div key={index}>
-                                    {showTraceLogs ? (
-                                        <>
-                                            <h4>Trace Logs</h4>
-                                            {queryInfo.traceLogs ? (
-                                                <div
-                                                    className={classes.traceLogsContainer}
-                                                    dangerouslySetInnerHTML={{
-                                                        __html: format_trace_log(queryInfo.traceLogs)
-                                                    }}
-                                                />
-                                            ) : (
-                                                <Text>No trace logs available</Text>
-                                            )}
-                                        </>
+          <Space h="md" />
+          <h3>Response:</h3>
+          <Switch
+            className={classes.viewToggle}
+            label="Show Trace Logs"
+            checked={showTraceLogs}
+            onChange={(event) => setShowTraceLogs(event.currentTarget.checked)}
+          />
+          <h4>Response Metadata:</h4>
+          <Accordion classNames={{ item: classes.accordion }}>
+            <Accordion.Item value="query-info">
+              <Accordion.Control>
+                <Text fw={700}>
+                  {showTraceLogs ? 'Query Trace Logs' : 'Query Metadata'}
+                </Text>
+              </Accordion.Control>
+              <Accordion.Panel>
+                {response.meta?.queryInfo ? (
+                  response.meta.queryInfo.map((queryInfo: QueryInfo, index: number) => (
+                    <div key={index}>
+                      {showTraceLogs ? (
+                        <>
+                          <h4>Trace Logs</h4>
+                          {queryInfo.traceLogs ? (
+                            <div
+                              className={classes.traceLogsContainer}
+                              dangerouslySetInnerHTML={{
+                                __html: format_trace_log(queryInfo.traceLogs)
+                              }}
+                            />
+                          ) : (
+                            <Text>No trace logs available</Text>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          <h4>Query {index + 1}</h4>
+                          <Table className={classes.table}>
+                            <thead>
+                              <tr>
+                                <th>Attribute</th>
+                                <th>Value</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {Object.entries({ ...queryInfo.stats, ...queryInfo.metadata }).map(([key, value]) => (
+                                <tr key={key}>
+                                  <td>{key}</td>
+                                  <td>
+                                    {typeof value === 'object' ? (
+                                      <Code block>{JSON.stringify(value, null, 2)}</Code>
                                     ) : (
-                                        <>
-                                            <h4>Query {index + 1}</h4>
-                                            <Table className={classes.table}>
-                                                <thead>
-                                                    <tr>
-                                                        <th>Attribute</th>
-                                                        <th>Value</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    {Object.entries({ ...queryInfo.stats, ...queryInfo.metadata }).map(([key, value]) => (
-                                                        <tr key={key}>
-                                                            <td>{key}</td>
-                                                            <td>
-                                                                {typeof value === 'object' ? (
-                                                                    <Code block>{JSON.stringify(value, null, 2)}</Code>
-                                                                ) : (
-                                                                    String(value)
-                                                                )}
-                                                            </td>
-                                                        </tr>
-                                                    ))}
-                                                </tbody>
-                                            </Table>
-                                        </>
+                                      String(value)
                                     )}
-                                </div>
-                            ))
-                        ) : (
-                            <Text>No query info available</Text>
-                        )}
-                    </Accordion.Panel>
-                </Accordion.Item>
-            </Accordion>
-            <Space h="md" />
-            <h4>Response Data:</h4>
-            <div className={classes.responseDataContainer}>
-                <Code block>
-                    <pre>
-                        {JSON.stringify(
-                            (({ meta, ...rest }) => rest)(response),
-                            null,
-                            2
-                        )}
-                    </pre>
-                </Code>
-            </div>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </Table>
+                        </>
+                      )}
+                    </div>
+                  ))
+                ) : (
+                  <Text>No query info available</Text>
+                )}
+              </Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
+          <Space h="md" />
+          <h4>Response Data:</h4>
+          <div className={classes.responseDataContainer}>
+            <Code block>
+              <pre>
+                {JSON.stringify(
+                  (({ meta, ...rest }) => rest)(response),
+                  null,
+                  2
+                )}
+              </pre>
+            </Code>
+          </div>
         </>
-    )}
-</div>
-);
+      )}
+    </div>
+  );
 }
 
 export default RpcEndpoints;

--- a/snuba/admin/static/rpc_endpoints/index.tsx
+++ b/snuba/admin/static/rpc_endpoints/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Select, Button, Code, Space, Textarea, Accordion, createStyles, Loader, Checkbox, Text, Table, Switch } from '@mantine/core';
 import useApi from 'SnubaAdmin/api_client';
-import { format_trace_log } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
+import { TraceLog } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
 import { ExampleRequestAccordionProps, QueryInfo } from 'SnubaAdmin/rpc_endpoints/types';
 import { useStyles } from 'SnubaAdmin/rpc_endpoints/styles';
 import { fetchEndpointsList, executeEndpoint, getEndpointData } from 'SnubaAdmin/rpc_endpoints/utils';
@@ -183,12 +183,7 @@ function RpcEndpoints() {
                         <>
                           <h4>Trace Logs</h4>
                           {queryInfo.traceLogs ? (
-                            <div
-                              className={classes.traceLogsContainer}
-                              dangerouslySetInnerHTML={{
-                                __html: format_trace_log(queryInfo.traceLogs)
-                              }}
-                            />
+                            <TraceLog log={queryInfo.traceLogs} />
                           ) : (
                             <Text>No trace logs available</Text>
                           )}

--- a/snuba/admin/static/rpc_endpoints/index.tsx
+++ b/snuba/admin/static/rpc_endpoints/index.tsx
@@ -1,194 +1,254 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { Select, Button, Code, Space, Textarea, Accordion, createStyles, Loader, Checkbox, Text, Table } from '@mantine/core';
+import { Select, Button, Code, Space, Textarea, Accordion, createStyles, Loader, Checkbox, Text, Table, Switch } from '@mantine/core';
 import useApi from 'SnubaAdmin/api_client';
+import { format_trace_log } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
+import { QueryInfo } from 'SnubaAdmin/rpc_endpoints/types';
 
 const DEBUG_SUPPORTED_VERSIONS = ['v1'];
 
 function RpcEndpoints() {
-    const api = useApi();
-    const [endpoints, setEndpoints] = useState<Array<{ name: string, version: string }>>([]);
-    const [selectedEndpoint, setSelectedEndpoint] = useState<string | null>(null);
-    const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
-    const [requestBody, setRequestBody] = useState('');
-    const [response, setResponse] = useState<any | null>(null);
-    const exampleRequestTemplates: Record<string, Record<string, any>> = require('SnubaAdmin/rpc_endpoints/exampleRequestTemplates.json');
-    const [accordionOpened, setAccordionOpened] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
-    const [debugMode, setDebugMode] = useState(false);
+const api = useApi();
+const [endpoints, setEndpoints] = useState<Array<{ name: string, version: string }>>([]);
+const [selectedEndpoint, setSelectedEndpoint] = useState<string | null>(null);
+const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
+const [requestBody, setRequestBody] = useState('');
+const [response, setResponse] = useState<any | null>(null);
+const exampleRequestTemplates: Record<string, Record<string, any>> = require('SnubaAdmin/rpc_endpoints/exampleRequestTemplates.json');
+const [accordionOpened, setAccordionOpened] = useState(false);
+const [isLoading, setIsLoading] = useState(false);
+const [debugMode, setDebugMode] = useState(false);
+const [showTraceLogs, setShowTraceLogs] = useState(false);
 
-    const fetchEndpoints = useCallback(async () => {
-        try {
-            const fetchedEndpoints: [string, string][] = await api.getRpcEndpoints();
-            const formattedEndpoints = fetchedEndpoints.map((endpoint: [string, string]) => ({
-                name: endpoint[0],
-                version: endpoint[1]
-            }));
-            setEndpoints(formattedEndpoints);
-        } catch (error) {
-            console.error("Error fetching endpoints:", error);
-        }
-    }, []);
-
-    useEffect(() => {
-        fetchEndpoints();
-    }, []);
-
-    const handleEndpointSelect = (value: string | null) => {
-        setSelectedEndpoint(value);
-        const selectedEndpointData = endpoints.find(e => e.name === value);
-        setSelectedVersion(selectedEndpointData?.version || null);
-        setRequestBody('');
-        setResponse(null);
-    };
-
-    const handleExecute = async () => {
-        if (!selectedEndpoint || !selectedVersion) return;
-        setIsLoading(true);
-        try {
-            const parsedBody = JSON.parse(requestBody);
-            if (debugMode && DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion)) {
-                parsedBody.meta = parsedBody.meta || {};
-                parsedBody.meta.debug = true;
-            }
-            const result = await api.executeRpcEndpoint(selectedEndpoint, selectedVersion, parsedBody);
-            setResponse(result);
-        } catch (error: any) {
-            alert(`Error: ${error.message}`);
-            setResponse({ error: error.message });
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    const useStyles = createStyles((theme) => ({
-        accordion: {
-            '& .mantine-Accordion-control': {
-                backgroundColor: theme.colors.blue[1],
-                color: theme.colors.blue[7],
-                fontSize: theme.fontSizes.xs,
-                padding: '2px 4px',
-                lineHeight: 1.2,
-                borderBottom: `1px solid ${theme.colors.gray[3]}`,
-                cursor: 'pointer',
-                '&:hover': {
-                    backgroundColor: theme.colors.blue[2],
-                },
-            },
-        },
-        table: {
-            border: `1px solid ${theme.colors.gray[3]}`,
-            '& th, & td': {
-                border: `1px solid ${theme.colors.gray[3]}`,
-                padding: theme.spacing.xs,
-            },
-            '& th': {
-                backgroundColor: theme.colors.gray[1],
-                fontWeight: 'bold',
-            },
-            '& td:first-of-type': {
-                width: '20%',
-                fontWeight: 'bold',
-            },
-            '& td:last-of-type': {
-                width: '80%',
-            },
-        },
-        debugCheckbox: {
-            marginBottom: theme.spacing.md,
-        },
+const fetchEndpoints = useCallback(async () => {
+try {
+    const fetchedEndpoints: [string, string][] = await api.getRpcEndpoints();
+    const formattedEndpoints = fetchedEndpoints.map((endpoint: [string, string]) => ({
+        name: endpoint[0],
+        version: endpoint[1]
     }));
+    setEndpoints(formattedEndpoints);
+} catch (error) {
+    console.error("Error fetching endpoints:", error);
+}
+}, []);
 
-    const { classes } = useStyles();
+useEffect(() => {
+fetchEndpoints();
+}, []);
 
-    return (
-        <div>
-            <h2>RPC Endpoints</h2>
-            <Select
-                label="Select an endpoint"
-                placeholder="Choose an endpoint"
-                data={endpoints.map(endpoint => ({ value: endpoint.name, label: `${endpoint.name} (${endpoint.version})` }))}
-                value={selectedEndpoint}
-                onChange={handleEndpointSelect}
-                style={{ width: '100%', marginBottom: '1rem' }}
-            />
+const handleEndpointSelect = (value: string | null) => {
+setSelectedEndpoint(value);
+const selectedEndpointData = endpoints.find(e => e.name === value);
+setSelectedVersion(selectedEndpointData?.version || null);
+setRequestBody('');
+setResponse(null);
+setDebugMode(false);
+};
+
+const handleExecute = async () => {
+if (!selectedEndpoint || !selectedVersion) return;
+setIsLoading(true);
+try {
+    const parsedBody = JSON.parse(requestBody);
+    if (debugMode && DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion)) {
+        parsedBody.meta = parsedBody.meta || {};
+        parsedBody.meta.debug = true;
+    }
+    const result = await api.executeRpcEndpoint(selectedEndpoint, selectedVersion, parsedBody);
+    setResponse(result);
+} catch (error: any) {
+    alert(`Error: ${error.message}`);
+    setResponse({ error: error.message });
+} finally {
+    setIsLoading(false);
+}
+};
+
+const useStyles = createStyles((theme) => ({
+accordion: {
+    '& .mantine-Accordion-control': {
+        backgroundColor: theme.colors.blue[1],
+        color: theme.colors.blue[7],
+        fontSize: theme.fontSizes.xs,
+        padding: '2px 4px',
+        lineHeight: 1.2,
+        borderBottom: `1px solid ${theme.colors.gray[3]}`,
+        cursor: 'pointer',
+        fontWeight: 'bold',
+        '&:hover': {
+            backgroundColor: theme.colors.blue[2],
+        },
+    },
+},
+table: {
+    border: `1px solid ${theme.colors.gray[3]}`,
+    '& th, & td': {
+        border: `1px solid ${theme.colors.gray[3]}`,
+        padding: theme.spacing.xs,
+    },
+    '& th': {
+        backgroundColor: theme.colors.gray[1],
+        fontWeight: 'bold',
+    },
+    '& td:first-of-type': {
+        width: '20%',
+        fontWeight: 'bold',
+    },
+    '& td:last-of-type': {
+        width: '80%',
+    },
+},
+debugCheckbox: {
+    marginBottom: theme.spacing.md,
+},
+traceLogsContainer: {
+    maxHeight: '500px',
+    overflowY: 'auto',
+    backgroundColor: theme.colors.dark[9],
+    padding: theme.spacing.md,
+    borderRadius: theme.radius.sm,
+    fontFamily: '"JetBrains Mono", "Fira Code", "Source Code Pro", "IBM Plex Mono", "Roboto Mono", "Cascadia Code", Consolas, Monaco, "Courier New", monospace',
+    whiteSpace: 'pre-wrap',
+    fontSize: '16px',
+    '& span': {
+        display: 'inline'
+    },
+    '& .trace-message': {
+        fontWeight: 'bold',
+        color: '#ffffff',
+    }
+},
+viewToggle: {
+    marginBottom: theme.spacing.sm,
+},
+responseDataContainer: {
+    maxHeight: '500px',
+    overflowY: 'auto',
+    backgroundColor: 'white',
+    padding: theme.spacing.sm,
+    borderRadius: theme.radius.sm,
+    border: `1px solid ${theme.colors.gray[3]}`,
+},
+}));
+
+const { classes } = useStyles();
+
+return (
+<div>
+    <h2>RPC Endpoints</h2>
+    <Select
+        label="Select an endpoint"
+        placeholder="Choose an endpoint"
+        data={endpoints.map(endpoint => ({ value: endpoint.name, label: `${endpoint.name} (${endpoint.version})` }))}
+        value={selectedEndpoint}
+        onChange={handleEndpointSelect}
+        style={{ width: '100%', marginBottom: '1rem' }}
+    />
+    <Space h="md" />
+    <Accordion
+        classNames={{ item: classes.accordion }}
+        variant="filled"
+        radius="sm"
+        value={accordionOpened ? 'example' : null}
+        onChange={(value) => setAccordionOpened(value === 'example')}
+    >
+        <Accordion.Item value="example">
+            <Accordion.Control>Example Request Payload</Accordion.Control>
+            <Accordion.Panel>
+                <Code block style={{ color: 'green' }}>
+                    <pre>
+                        {JSON.stringify(
+                            selectedEndpoint && selectedVersion
+                                ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
+                                : exampleRequestTemplates.default,
+                            null,
+                            2
+                        )}
+                    </pre>
+                </Code>
+                <Button
+                    onClick={() => {
+                        setRequestBody(
+                            JSON.stringify(
+                                selectedEndpoint && selectedVersion
+                                    ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
+                                    : exampleRequestTemplates.default,
+                                null,
+                                2
+                            )
+                        );
+                        setAccordionOpened(false);
+                    }}
+                    style={{ marginTop: '1rem' }}
+                >
+                    Copy to Request Body
+                </Button>
+            </Accordion.Panel>
+        </Accordion.Item>
+    </Accordion>
+    <Space h="md" />
+    <Textarea
+        label="Request Body (JSON)"
+        placeholder="Enter request body"
+        value={requestBody}
+        onChange={(event) => setRequestBody(event.currentTarget.value)}
+        style={{ width: '100%' }}
+        autosize
+        minRows={5}
+    />
+    <Space h="md" />
+    <Checkbox
+        label="Enable Debug Mode"
+        checked={debugMode}
+        onChange={(event) => setDebugMode(event.currentTarget.checked)}
+        disabled={!DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion || '')}
+        className={classes.debugCheckbox}
+    />
+    <Button
+        onClick={handleExecute}
+        disabled={!selectedEndpoint || !requestBody || isLoading}
+        leftIcon={isLoading ? <Loader size="xs" /> : null}
+    >
+        {isLoading ? 'Executing...' : 'Execute'}
+    </Button>
+    {response && (
+        <>
             <Space h="md" />
-            <Accordion
-                classNames={{ item: classes.accordion }}
-                variant="filled"
-                radius="sm"
-                value={accordionOpened ? 'example' : null}
-                onChange={(value) => setAccordionOpened(value === 'example')}
-            >
-                <Accordion.Item value="example">
-                    <Accordion.Control>Example Request Payload</Accordion.Control>
+            <h3>Response:</h3>
+            <Switch
+                className={classes.viewToggle}
+                label="Show Trace Logs"
+                checked={showTraceLogs}
+                onChange={(event) => setShowTraceLogs(event.currentTarget.checked)}
+            />
+            <h4>Response Metadata:</h4>
+            <Accordion classNames={{ item: classes.accordion }}>
+                <Accordion.Item value="query-info">
+                    <Accordion.Control>
+                        <Text fw={700}>
+                            {showTraceLogs ? 'Query Trace Logs' : 'Query Metadata'}
+                        </Text>
+                    </Accordion.Control>
                     <Accordion.Panel>
-                        <Code block style={{ color: 'green' }}>
-                            <pre>
-                                {JSON.stringify(
-                                    selectedEndpoint && selectedVersion
-                                        ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
-                                        : exampleRequestTemplates.default,
-                                    null,
-                                    2
-                                )}
-                            </pre>
-                        </Code>
-                        <Button
-                            onClick={() => {
-                                setRequestBody(
-                                    JSON.stringify(
-                                        selectedEndpoint && selectedVersion
-                                            ? exampleRequestTemplates[selectedEndpoint]?.[selectedVersion] || exampleRequestTemplates.default
-                                            : exampleRequestTemplates.default,
-                                        null,
-                                        2
-                                    )
-                                );
-                                setAccordionOpened(false);
-                            }}
-                            style={{ marginTop: '1rem' }}
-                        >
-                            Copy to Request Body
-                        </Button>
-                    </Accordion.Panel>
-                </Accordion.Item>
-            </Accordion>
-            <Space h="md" />
-            <Textarea
-                label="Request Body (JSON)"
-                placeholder="Enter request body"
-                value={requestBody}
-                onChange={(event) => setRequestBody(event.currentTarget.value)}
-                style={{ width: '100%' }}
-                autosize
-                minRows={5}
-            />
-            <Space h="md" />
-            <Checkbox
-                label="Enable Debug Mode"
-                checked={debugMode}
-                onChange={(event) => setDebugMode(event.currentTarget.checked)}
-                disabled={!DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion || '')}
-                className={classes.debugCheckbox}
-            />
-            <Button
-                onClick={handleExecute}
-                disabled={!selectedEndpoint || !requestBody || isLoading}
-                leftIcon={isLoading ? <Loader size="xs" /> : null}
-            >
-                {isLoading ? 'Executing...' : 'Execute'}
-            </Button>
-            {response && (
-                <>
-                    <Space h="md" />
-                    <h3>Response:</h3>
-                    <Accordion classNames={{ item: classes.accordion }}>
-                        <Accordion.Item value="query-info">
-                            <Accordion.Control>Query Metadata</Accordion.Control>
-                            <Accordion.Panel>
-                                {response.meta?.queryInfo ? (
-                                    response.meta.queryInfo.map((queryInfo: any, index: number) => (
-                                        <div key={index}>
+                        {response.meta?.queryInfo ? (
+                            response.meta.queryInfo.map((queryInfo: QueryInfo, index: number) => (
+                                <div key={index}>
+                                    {showTraceLogs ? (
+                                        <>
+                                            <h4>Trace Logs</h4>
+                                            {queryInfo.traceLogs ? (
+                                                <div
+                                                    className={classes.traceLogsContainer}
+                                                    dangerouslySetInnerHTML={{
+                                                        __html: format_trace_log(queryInfo.traceLogs)
+                                                    }}
+                                                />
+                                            ) : (
+                                                <Text>No trace logs available</Text>
+                                            )}
+                                        </>
+                                    ) : (
+                                        <>
                                             <h4>Query {index + 1}</h4>
                                             <Table className={classes.table}>
                                                 <thead>
@@ -212,29 +272,33 @@ function RpcEndpoints() {
                                                     ))}
                                                 </tbody>
                                             </Table>
-                                        </div>
-                                    ))
-                                ) : (
-                                    <Text>No query info available</Text>
-                                )}
-                            </Accordion.Panel>
-                        </Accordion.Item>
-                    </Accordion>
-                    <Space h="md" />
-                    <h4>Response Data:</h4>
-                    <Code block>
-                        <pre>
-                            {JSON.stringify(
-                                (({ meta, ...rest }) => rest)(response),
-                                null,
-                                2
-                            )}
-                        </pre>
-                    </Code>
-                </>
-            )}
-        </div>
-    );
+                                        </>
+                                    )}
+                                </div>
+                            ))
+                        ) : (
+                            <Text>No query info available</Text>
+                        )}
+                    </Accordion.Panel>
+                </Accordion.Item>
+            </Accordion>
+            <Space h="md" />
+            <h4>Response Data:</h4>
+            <div className={classes.responseDataContainer}>
+                <Code block>
+                    <pre>
+                        {JSON.stringify(
+                            (({ meta, ...rest }) => rest)(response),
+                            null,
+                            2
+                        )}
+                    </pre>
+                </Code>
+            </div>
+        </>
+    )}
+</div>
+);
 }
 
 export default RpcEndpoints;

--- a/snuba/admin/static/rpc_endpoints/styles.ts
+++ b/snuba/admin/static/rpc_endpoints/styles.ts
@@ -1,0 +1,68 @@
+import { createStyles } from '@mantine/core';
+
+export const useStyles = createStyles((theme) => ({
+  accordion: {
+    '& .mantine-Accordion-control': {
+      backgroundColor: theme.colors.blue[1],
+      color: theme.colors.blue[7],
+      fontSize: theme.fontSizes.xs,
+      padding: '2px 4px',
+      lineHeight: 1.2,
+      borderBottom: `1px solid ${theme.colors.gray[3]}`,
+      cursor: 'pointer',
+      fontWeight: 'bold',
+      '&:hover': {
+        backgroundColor: theme.colors.blue[2],
+      },
+    },
+  },
+  table: {
+    border: `1px solid ${theme.colors.gray[3]}`,
+    '& th, & td': {
+      border: `1px solid ${theme.colors.gray[3]}`,
+      padding: theme.spacing.xs,
+    },
+    '& th': {
+      backgroundColor: theme.colors.gray[1],
+      fontWeight: 'bold',
+    },
+    '& td:first-of-type': {
+      width: '20%',
+      fontWeight: 'bold',
+    },
+    '& td:last-of-type': {
+      width: '80%',
+    },
+  },
+  debugCheckbox: {
+    marginBottom: theme.spacing.md,
+  },
+  traceLogsContainer: {
+    maxHeight: '500px',
+    overflowY: 'auto',
+    backgroundColor: theme.colors.dark[9],
+    padding: theme.spacing.md,
+    borderRadius: theme.radius.sm,
+    fontFamily: '"JetBrains Mono", "Fira Code", "Source Code Pro", "IBM Plex Mono", "Roboto Mono", "Cascadia Code", Consolas, Monaco, "Courier New", monospace',
+    whiteSpace: 'pre-wrap',
+    fontSize: '16px',
+    '& span': {
+      display: 'inline'
+    },
+    '& .trace-message': {
+      fontWeight: 'bold',
+      color: '#ffffff',
+    }
+  },
+  viewToggle: {
+    marginBottom: theme.spacing.sm,
+  },
+  responseDataContainer: {
+    maxHeight: '500px',
+    overflowY: 'auto',
+    backgroundColor: 'white',
+    padding: theme.spacing.sm,
+    borderRadius: theme.radius.sm,
+    border: `1px solid ${theme.colors.gray[3]}`,
+  },
+}));

--- a/snuba/admin/static/rpc_endpoints/trace_formatter.tsx
+++ b/snuba/admin/static/rpc_endpoints/trace_formatter.tsx
@@ -7,7 +7,7 @@ const COLOR_DEBUG = '#ffff00';
 const COLOR_TRACE = '#ff6666';
 const COLOR_MESSAGE = '#ffffff';
 
-export function format_trace_log(log: string, width: number = 140): string {
+function format_trace_log(log: string, width: number = 140): string {
     if (!log?.trim()) {
         return '<span class="text-muted">No trace logs available</span>';
     }
@@ -84,3 +84,5 @@ function escapeHtml(text: string): string {
 
     return text.replace(/[&<>"']/g, char => htmlEntities[char]);
 }
+
+export { format_trace_log, stripHtml, escapeHtml, wrapText };

--- a/snuba/admin/static/rpc_endpoints/trace_formatter.tsx
+++ b/snuba/admin/static/rpc_endpoints/trace_formatter.tsx
@@ -1,0 +1,86 @@
+import { parseLogLine } from 'SnubaAdmin/tracing/util';
+
+const COLOR_HOST = '#00ffff';
+const COLOR_THREAD_ID = '#6666ff';
+const COLOR_QUERYID = '#ff66ff';
+const COLOR_DEBUG = '#ffff00';
+const COLOR_TRACE = '#ff6666';
+const COLOR_MESSAGE = '#ffffff';
+
+export function format_trace_log(log: string, width: number = 140): string {
+    if (!log?.trim()) {
+        return '<span class="text-muted">No trace logs available</span>';
+    }
+
+    const output: string[] = [];
+    const lines = log.split(/\n/);
+
+    for (const line of lines) {
+        if (!line.trim()) {
+            continue;
+        }
+
+        const parsedLine = parseLogLine(line);
+        if (!parsedLine) {
+            continue;
+        }
+
+        const { host, pid, query_id, log_level, message } = parsedLine;
+        const levelColor = log_level === 'Debug' ? COLOR_DEBUG : COLOR_TRACE;
+
+        const header = [
+            `<span style="color: ${COLOR_HOST}">[${host}]</span>`,
+            `<span style="color: ${COLOR_THREAD_ID}">[${pid}]</span>`,
+            `<span style="color: ${COLOR_QUERYID}">{${query_id}}</span>`,
+            `<span style="color: ${levelColor}">&lt;${log_level}&gt;</span>`,
+        ].join(' ');
+
+        const wrappedMessage = wrapText(
+            `<span style="color: ${COLOR_MESSAGE}; display: inline-block; font-weight: bold" class="trace-message">${escapeHtml(message)}</span>`,
+            width,
+            4
+        );
+
+        output.push(`${header}\n${wrappedMessage}`);
+    }
+
+    return output.join('\n\n');
+}
+
+function wrapText(text: string, width: number, indent: number = 0): string {
+    const words = text.split(' ');
+    const lines: string[] = [];
+    let currentLine = '';
+    const indentStr = ' '.repeat(indent);
+
+    for (const word of words) {
+        if (stripHtml(currentLine + ' ' + word).length > width) {
+            lines.push(currentLine);
+            currentLine = indentStr + word;
+        } else {
+            currentLine += (currentLine ? ' ' : '') + word;
+        }
+    }
+
+    if (currentLine) {
+        lines.push(currentLine);
+    }
+
+    return lines.join('\n');
+}
+
+function stripHtml(html: string): string {
+    return html.replace(/<[^>]*>/g, '');
+}
+
+function escapeHtml(text: string): string {
+    const htmlEntities: Record<string, string> = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+    };
+
+    return text.replace(/[&<>"']/g, char => htmlEntities[char]);
+}

--- a/snuba/admin/static/rpc_endpoints/trace_formatter.tsx
+++ b/snuba/admin/static/rpc_endpoints/trace_formatter.tsx
@@ -1,4 +1,7 @@
+import React from 'react';
 import { parseLogLine } from 'SnubaAdmin/tracing/util';
+import { StyledSpanProps, TraceLogProps } from 'SnubaAdmin/rpc_endpoints/types';
+import { useStyles } from 'SnubaAdmin/rpc_endpoints/styles';
 
 const COLOR_HOST = '#00ffff';
 const COLOR_THREAD_ID = '#6666ff';
@@ -7,82 +10,56 @@ const COLOR_DEBUG = '#ffff00';
 const COLOR_TRACE = '#ff6666';
 const COLOR_MESSAGE = '#ffffff';
 
-function format_trace_log(log: string, width: number = 140): string {
+const StyledSpan: React.FC<StyledSpanProps> = ({ color, children, className, style }) => (
+    <span style={{ color, ...style }} className={className}>
+        {children}
+    </span>
+);
+
+export const TraceLog: React.FC<TraceLogProps> = ({ log }) => {
+    const { classes } = useStyles();
+
     if (!log?.trim()) {
-        return '<span class="text-muted">No trace logs available</span>';
+        return <span className="text-muted">No trace logs available</span>;
     }
 
-    const output: string[] = [];
     const lines = log.split(/\n/);
-
-    for (const line of lines) {
+    const formattedLines = lines.map((line, index) => {
         if (!line.trim()) {
-            continue;
+            return null;
         }
 
         const parsedLine = parseLogLine(line);
         if (!parsedLine) {
-            continue;
+            return null;
         }
 
-        const { host, pid, query_id, log_level, message } = parsedLine;
+        const { host, pid, query_id, log_level, message, component } = parsedLine;
         const levelColor = log_level === 'Debug' ? COLOR_DEBUG : COLOR_TRACE;
 
-        const header = [
-            `<span style="color: ${COLOR_HOST}">[${host}]</span>`,
-            `<span style="color: ${COLOR_THREAD_ID}">[${pid}]</span>`,
-            `<span style="color: ${COLOR_QUERYID}">{${query_id}}</span>`,
-            `<span style="color: ${levelColor}">&lt;${log_level}&gt;</span>`,
-        ].join(' ');
-
-        const wrappedMessage = wrapText(
-            `<span style="color: ${COLOR_MESSAGE}; display: inline-block; font-weight: bold" class="trace-message">${escapeHtml(message)}</span>`,
-            width,
-            4
+        const header = (
+            <div key={`header-${index}`}>
+                <StyledSpan color={COLOR_HOST}>[{host}]</StyledSpan>{' '}
+                <StyledSpan color={COLOR_THREAD_ID}>[{pid}]</StyledSpan>{' '}
+                <StyledSpan color={COLOR_QUERYID}>{'{' + query_id + '}'}</StyledSpan>{' '}
+                <StyledSpan color={levelColor}>&lt;{log_level}&gt;</StyledSpan>{' '}
+                <StyledSpan color={COLOR_MESSAGE}>{component}:</StyledSpan>
+            </div>
         );
 
-        output.push(`${header}\n${wrappedMessage}`);
-    }
+        const messageComponent = (
+            <StyledSpan color="#ffffff" className="trace-message">
+                {message}
+            </StyledSpan>
+        );
 
-    return output.join('\n\n');
-}
+        return (
+            <div key={index} style={{ marginBottom: '1em' }}>
+                {header}
+                {messageComponent}
+            </div>
+        );
+    });
 
-function wrapText(text: string, width: number, indent: number = 0): string {
-    const words = text.split(' ');
-    const lines: string[] = [];
-    let currentLine = '';
-    const indentStr = ' '.repeat(indent);
-
-    for (const word of words) {
-        if (stripHtml(currentLine + ' ' + word).length > width) {
-            lines.push(currentLine);
-            currentLine = indentStr + word;
-        } else {
-            currentLine += (currentLine ? ' ' : '') + word;
-        }
-    }
-
-    if (currentLine) {
-        lines.push(currentLine);
-    }
-
-    return lines.join('\n');
-}
-
-function stripHtml(html: string): string {
-    return html.replace(/<[^>]*>/g, '');
-}
-
-function escapeHtml(text: string): string {
-    const htmlEntities: Record<string, string> = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;'
-    };
-
-    return text.replace(/[&<>"']/g, char => htmlEntities[char]);
-}
-
-export { format_trace_log, stripHtml, escapeHtml, wrapText };
+    return <div className={classes.traceLogsContainer}>{formattedLines}</div>;
+};

--- a/snuba/admin/static/rpc_endpoints/types.tsx
+++ b/snuba/admin/static/rpc_endpoints/types.tsx
@@ -1,0 +1,34 @@
+type TimingMarks = {
+    durationMs?: number;
+    marksMs?: Record<string, number>;
+    tags?: Record<string, string>;
+    timestamp?: number;
+};
+
+type QueryStats = {
+    rowsRead?: number;
+    columnsRead?: number;
+    blocks?: number;
+    progressBytes?: number;
+    maxThreads?: number;
+    timingMarks?: TimingMarks;
+};
+
+type QueryMetadata = {
+    sql?: string;
+    status?: string;
+    clickhouseTable?: string;
+    final?: boolean;
+    queryId?: string;
+    consistent?: boolean;
+    cacheHit?: boolean;
+    clusterName?: string;
+};
+
+type QueryInfo = {
+    stats: QueryStats;
+    metadata: QueryMetadata;
+    traceLogs: string;
+};
+
+export type { QueryInfo, QueryStats, QueryMetadata, TimingMarks };

--- a/snuba/admin/static/rpc_endpoints/types.tsx
+++ b/snuba/admin/static/rpc_endpoints/types.tsx
@@ -31,4 +31,17 @@ type QueryInfo = {
     traceLogs: string;
 };
 
-export type { QueryInfo, QueryStats, QueryMetadata, TimingMarks };
+interface EndpointData {
+    name: string;
+    version: string;
+}
+
+interface ExampleRequestAccordionProps {
+    selectedEndpoint: string | null;
+    selectedVersion: string | null;
+    exampleRequestTemplates: Record<string, Record<string, any>>;
+    setRequestBody: (value: string) => void;
+    classes: Record<string, string>;
+}
+
+export type { QueryInfo, QueryStats, QueryMetadata, TimingMarks, EndpointData, ExampleRequestAccordionProps };

--- a/snuba/admin/static/rpc_endpoints/types.tsx
+++ b/snuba/admin/static/rpc_endpoints/types.tsx
@@ -44,4 +44,16 @@ interface ExampleRequestAccordionProps {
     classes: Record<string, string>;
 }
 
-export type { QueryInfo, QueryStats, QueryMetadata, TimingMarks, EndpointData, ExampleRequestAccordionProps };
+interface TraceLogProps {
+    log: string;
+    width?: number;
+}
+
+interface StyledSpanProps {
+    color: string;
+    children: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+}
+
+export type { QueryInfo, QueryStats, QueryMetadata, TimingMarks, EndpointData, ExampleRequestAccordionProps, TraceLogProps, StyledSpanProps };

--- a/snuba/admin/static/rpc_endpoints/utils.ts
+++ b/snuba/admin/static/rpc_endpoints/utils.ts
@@ -1,0 +1,48 @@
+import { EndpointData } from 'SnubaAdmin/rpc_endpoints/types';
+
+export const DEBUG_SUPPORTED_VERSIONS = ['v1'];
+
+export async function fetchEndpointsList(
+  api: any
+): Promise<EndpointData[]> {
+  try {
+    const fetchedEndpoints: [string, string][] = await api.getRpcEndpoints();
+    return fetchedEndpoints.map((endpoint: [string, string]) => ({
+      name: endpoint[0],
+      version: endpoint[1]
+    }));
+  } catch (error) {
+    console.error("Error fetching endpoints:", error);
+    return [];
+  }
+}
+
+export async function executeEndpoint(
+  api: any,
+  selectedEndpoint: string | null,
+  selectedVersion: string | null,
+  requestBody: string,
+  debugMode: boolean
+): Promise<any> {
+  if (!selectedEndpoint || !selectedVersion) {
+    throw new Error('Endpoint and version must be selected');
+  }
+
+  try {
+    const parsedBody = JSON.parse(requestBody);
+    if (debugMode && DEBUG_SUPPORTED_VERSIONS.includes(selectedVersion)) {
+      parsedBody.meta = parsedBody.meta || {};
+      parsedBody.meta.debug = true;
+    }
+    return await api.executeRpcEndpoint(selectedEndpoint, selectedVersion, parsedBody);
+  } catch (error: any) {
+    throw new Error(error.message);
+  }
+}
+
+export function getEndpointData(
+  endpoints: EndpointData[],
+  endpointName: string
+): EndpointData | undefined {
+  return endpoints.find(e => e.name === endpointName);
+}

--- a/snuba/admin/static/rpc_endpoints/utils.ts
+++ b/snuba/admin/static/rpc_endpoints/utils.ts
@@ -36,7 +36,10 @@ export async function executeEndpoint(
     }
     return await api.executeRpcEndpoint(selectedEndpoint, selectedVersion, parsedBody);
   } catch (error: any) {
-    throw new Error(error.message);
+    if (error instanceof SyntaxError) {
+      throw new Error('Invalid JSON format in request body');
+    }
+    throw new Error(`Failed to execute endpoint: ${error.message}`);
   }
 }
 

--- a/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
+++ b/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
@@ -1,67 +1,46 @@
-import { escapeHtml, format_trace_log, stripHtml, wrapText } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TraceLog } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
 
-describe('trace_formatter', () => {
-  describe('format_trace_log', () => {
-    it('returns message for empty input', () => {
-      expect(format_trace_log('')).toBe('<span class="text-muted">No trace logs available</span>');
-      expect(format_trace_log('   ')).toBe('<span class="text-muted">No trace logs available</span>');
-    });
-
-    it('formats a single log line correctly', () => {
-      const input = '[ snuba-events-analytics-platform-z3-3-1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): Used generic exclusion search over index for part 20241007_444453_445838_6 with 507 steps';
-      const expected = [
-        '<span style="color: #00ffff">[snuba-events-analytics-platform-z3-3-1]</span>',
-        '<span style="color: #6666ff">[1087365]</span>',
-        '<span style="color: #ff66ff">{2a1a1deb-fa59-4b07-918d-1b7558e50fd5}</span>',
-        '<span style="color: #ff6666">&lt;Trace&gt;</span>'
-      ].join(' ') + '\n' +
-        '<span style="color: #ffffff; display: inline-block; font-weight: bold" class="trace-message">Used generic exclusion search over index for part 20241007_444453_445838_6 with 507 steps</span>';
-
-      expect(format_trace_log(input)).toBe(expected);
-    });
-
-    it('handles multiple log lines', () => {
-      const input = [
-        '[ snuba-events-analytics-platform-z3-3-1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): First message',
-        '[ snuba-events-analytics-platform-z3-3-1 ] [ 1786792 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): Second message'
-      ].join('\n');
-
-      const result = format_trace_log(input);
-      expect(result).toContain('[1087365]');
-      expect(result).toContain('[1786792]');
-      expect(result).toContain('First message');
-      expect(result).toContain('Second message');
-      expect(result).toContain('#ff6666');
-    });
-
-    it('respects width parameter for message wrapping', () => {
-      const input = '[ snuba-events-analytics-platform-z3-3-1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): ' + 'very long message '.repeat(10);
-      const result = format_trace_log(input, 40);
-      expect(result.split('\n').length).toBeGreaterThan(1);
-    });
+describe('TraceLog', () => {
+  it('renders empty state message when log is empty', () => {
+    const { getByText } = render(React.createElement(TraceLog, { log: "" }));
+    expect(getByText('No trace logs available')).toBeInTheDocument();
   });
 
-  describe('stripHtml', () => {
-    it('removes HTML tags', () => {
-      const input = '<span>test</span> <div>content</div>';
-      expect(stripHtml(input)).toBe('test content');
-    });
+  it('renders formatted log lines correctly', () => {
+    const sampleLog = '[ host1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> component: Test message';
+    const { getByText } = render(React.createElement(TraceLog, { log: sampleLog }));
+
+    expect(getByText(/host1/)).toBeInTheDocument();
+    expect(getByText(/1087365/)).toBeInTheDocument();
+    expect(getByText(/2a1a1deb-fa59-4b07-918d-1b7558e50fd5/)).toBeInTheDocument();
+    expect(getByText(/component/)).toBeInTheDocument();
+    expect(getByText(/Test message/)).toBeInTheDocument();
   });
 
-  describe('escapeHtml', () => {
-    it('escapes special characters', () => {
-      const input = '< > & " \'';
-      expect(escapeHtml(input)).toBe('&lt; &gt; &amp; &quot; &#39;');
-    });
+  it('handles multiple log lines', () => {
+    const multipleLines = [
+      '[ host1 ] [ 1111 ] {id-1} <Trace> first component: First message',
+      '[ host2 ] [ 2222 ] {id-2} <Debug> second component: Second message'
+    ].join('\n');
+
+    const { getByText } = render(React.createElement(TraceLog, { log: multipleLines }));
+
+    expect(getByText(/First message/)).toBeInTheDocument();
+    expect(getByText(/Second message/)).toBeInTheDocument();
+    expect(getByText(/first component/)).toBeInTheDocument();
+    expect(getByText(/second component/)).toBeInTheDocument();
+    expect(getByText(/host1/)).toBeInTheDocument();
+    expect(getByText(/host2/)).toBeInTheDocument();
   });
 
-  describe('wrapText', () => {
-    it('wraps text at specified width', () => {
-      const input = '<span>This is a long text that should wrap</span>';
-      const result = wrapText(input, 20, 2);
-      const lines = result.split('\n');
-      expect(lines.length).toBeGreaterThan(1);
-      expect(stripHtml(lines[1]).startsWith('  ')).toBe(true);
-    });
+  it('handles invalid log lines', () => {
+    const invalidLog = 'Invalid log line format\n[ host1 ] [ 1111 ] {id-1} <Trace> component: Valid message';
+    const { getByText, queryByText } = render(React.createElement(TraceLog, { log: invalidLog }));
+
+    expect(queryByText(/Invalid log line format/)).not.toBeInTheDocument();
+    expect(getByText(/Valid message/)).toBeInTheDocument();
   });
 });

--- a/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
+++ b/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { TraceLog } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
 
 describe('TraceLog', () => {

--- a/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
+++ b/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
@@ -5,19 +5,19 @@ import { TraceLog } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
 
 describe('TraceLog', () => {
   it('renders empty state message when log is empty', () => {
-    const { getByText } = render(React.createElement(TraceLog, { log: "" }));
-    expect(getByText('No trace logs available')).toBeInTheDocument();
+    const { queryByText } = render(React.createElement(TraceLog, { log: "" }));
+    expect(queryByText('No trace logs available')).toBeTruthy();
   });
 
   it('renders formatted log lines correctly', () => {
     const sampleLog = '[ host1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> component: Test message';
-    const { getByText } = render(React.createElement(TraceLog, { log: sampleLog }));
+    const { queryByText } = render(React.createElement(TraceLog, { log: sampleLog }));
 
-    expect(getByText(/host1/)).toBeInTheDocument();
-    expect(getByText(/1087365/)).toBeInTheDocument();
-    expect(getByText(/2a1a1deb-fa59-4b07-918d-1b7558e50fd5/)).toBeInTheDocument();
-    expect(getByText(/component/)).toBeInTheDocument();
-    expect(getByText(/Test message/)).toBeInTheDocument();
+    expect(queryByText(/host1/)).toBeTruthy();
+    expect(queryByText(/1087365/)).toBeTruthy();
+    expect(queryByText(/2a1a1deb-fa59-4b07-918d-1b7558e50fd5/)).toBeTruthy();
+    expect(queryByText(/component/)).toBeTruthy();
+    expect(queryByText(/Test message/)).toBeTruthy();
   });
 
   it('handles multiple log lines', () => {
@@ -26,21 +26,21 @@ describe('TraceLog', () => {
       '[ host2 ] [ 2222 ] {id-2} <Debug> second component: Second message'
     ].join('\n');
 
-    const { getByText } = render(React.createElement(TraceLog, { log: multipleLines }));
+    const { queryByText } = render(React.createElement(TraceLog, { log: multipleLines }));
 
-    expect(getByText(/First message/)).toBeInTheDocument();
-    expect(getByText(/Second message/)).toBeInTheDocument();
-    expect(getByText(/first component/)).toBeInTheDocument();
-    expect(getByText(/second component/)).toBeInTheDocument();
-    expect(getByText(/host1/)).toBeInTheDocument();
-    expect(getByText(/host2/)).toBeInTheDocument();
+    expect(queryByText(/First message/)).toBeTruthy();
+    expect(queryByText(/Second message/)).toBeTruthy();
+    expect(queryByText(/first component/)).toBeTruthy();
+    expect(queryByText(/second component/)).toBeTruthy();
+    expect(queryByText(/host1/)).toBeTruthy();
+    expect(queryByText(/host2/)).toBeTruthy();
   });
 
   it('handles invalid log lines', () => {
     const invalidLog = 'Invalid log line format\n[ host1 ] [ 1111 ] {id-1} <Trace> component: Valid message';
-    const { getByText, queryByText } = render(React.createElement(TraceLog, { log: invalidLog }));
+    const { queryByText } = render(React.createElement(TraceLog, { log: invalidLog }));
 
-    expect(queryByText(/Invalid log line format/)).not.toBeInTheDocument();
-    expect(getByText(/Valid message/)).toBeInTheDocument();
+    expect(queryByText(/Invalid log line format/)).toBeFalsy();
+    expect(queryByText(/Valid message/)).toBeTruthy();
   });
 });

--- a/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
+++ b/snuba/admin/static/tests/rpc_enpoints/trace_formatter.test.tsx
@@ -1,0 +1,67 @@
+import { escapeHtml, format_trace_log, stripHtml, wrapText } from 'SnubaAdmin/rpc_endpoints/trace_formatter';
+
+describe('trace_formatter', () => {
+  describe('format_trace_log', () => {
+    it('returns message for empty input', () => {
+      expect(format_trace_log('')).toBe('<span class="text-muted">No trace logs available</span>');
+      expect(format_trace_log('   ')).toBe('<span class="text-muted">No trace logs available</span>');
+    });
+
+    it('formats a single log line correctly', () => {
+      const input = '[ snuba-events-analytics-platform-z3-3-1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): Used generic exclusion search over index for part 20241007_444453_445838_6 with 507 steps';
+      const expected = [
+        '<span style="color: #00ffff">[snuba-events-analytics-platform-z3-3-1]</span>',
+        '<span style="color: #6666ff">[1087365]</span>',
+        '<span style="color: #ff66ff">{2a1a1deb-fa59-4b07-918d-1b7558e50fd5}</span>',
+        '<span style="color: #ff6666">&lt;Trace&gt;</span>'
+      ].join(' ') + '\n' +
+        '<span style="color: #ffffff; display: inline-block; font-weight: bold" class="trace-message">Used generic exclusion search over index for part 20241007_444453_445838_6 with 507 steps</span>';
+
+      expect(format_trace_log(input)).toBe(expected);
+    });
+
+    it('handles multiple log lines', () => {
+      const input = [
+        '[ snuba-events-analytics-platform-z3-3-1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): First message',
+        '[ snuba-events-analytics-platform-z3-3-1 ] [ 1786792 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): Second message'
+      ].join('\n');
+
+      const result = format_trace_log(input);
+      expect(result).toContain('[1087365]');
+      expect(result).toContain('[1786792]');
+      expect(result).toContain('First message');
+      expect(result).toContain('Second message');
+      expect(result).toContain('#ff6666');
+    });
+
+    it('respects width parameter for message wrapping', () => {
+      const input = '[ snuba-events-analytics-platform-z3-3-1 ] [ 1087365 ] {2a1a1deb-fa59-4b07-918d-1b7558e50fd5} <Trace> default.eap_spans_local (13c49dff-2011-4143-b8c9-3c5f732799e7) (SelectExecutor): ' + 'very long message '.repeat(10);
+      const result = format_trace_log(input, 40);
+      expect(result.split('\n').length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('stripHtml', () => {
+    it('removes HTML tags', () => {
+      const input = '<span>test</span> <div>content</div>';
+      expect(stripHtml(input)).toBe('test content');
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('escapes special characters', () => {
+      const input = '< > & " \'';
+      expect(escapeHtml(input)).toBe('&lt; &gt; &amp; &quot; &#39;');
+    });
+  });
+
+  describe('wrapText', () => {
+    it('wraps text at specified width', () => {
+      const input = '<span>This is a long text that should wrap</span>';
+      const result = wrapText(input, 20, 2);
+      const lines = result.split('\n');
+      expect(lines.length).toBeGreaterThan(1);
+      expect(stripHtml(lines[1]).startsWith('  ')).toBe(true);
+    });
+  });
+});

--- a/snuba/web/rpc/common/debug_info.py
+++ b/snuba/web/rpc/common/debug_info.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import re
+import textwrap
 from typing import List
 
 from sentry_protos.snuba.v1.request_common_pb2 import (
@@ -12,6 +16,22 @@ from snuba.query.query_settings import HTTPQuerySettings
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 
+COLOR_HOST = "\033[36m"  # Cyan
+COLOR_THREAD_ID = "\033[33m"  # Yellow
+COLOR_SESSION = "\033[35m"  # Magenta
+COLOR_DEBUG = "\033[32m"  # Green
+COLOR_TRACE = "\033[34m"  # Blue
+COLOR_MESSAGE = "\033[37m"  # White
+RESET = "\033[0m"
+
+LOG_PATTERNS = {
+    "host": re.compile(r"\[ (.*?) \]"),
+    "thread_id": re.compile(r"\[ (\d+) \]"),
+    "session": re.compile(r"\{(.*?)\}"),
+    "level": re.compile(r"<(\w+)>"),
+    "message": re.compile(r"> (.*)"),
+}
+
 
 def extract_response_meta(
     request_id: str,
@@ -19,6 +39,18 @@ def extract_response_meta(
     query_results: List[QueryResult],
     timers: List[Timer],
 ) -> ResponseMeta:
+    """
+    Extract metadata from query results for response.
+
+    Args:
+        request_id: Unique identifier for the request
+        debug: Whether debug mode is enabled
+        query_results: List of query results
+        timers: List of timing information
+
+    Returns:
+        ResponseMeta object containing query metadata
+    """
     query_info: List[QueryInfo] = []
 
     if not debug:
@@ -30,12 +62,14 @@ def extract_response_meta(
         result = getattr(query_result, "result", None) or {}
         profile = result.get("profile", {}) if isinstance(result, dict) else {}
         timer_data = timer.for_json()
+
         timing_marks = TimingMarks(
             marks_ms=timer_data.get("marks_ms", {}),
             duration_ms=int(timer_data.get("duration_ms", 0)),
             timestamp=int(timer_data.get("timestamp", 0)),
             tags=timer_data.get("tags", {}),
         )
+
         query_stats = QueryStats(
             rows_read=stats.get("result_rows", 0),
             columns_read=stats.get("result_cols", 0),
@@ -46,6 +80,7 @@ def extract_response_meta(
             .get("threads_used"),
             timing_marks=timing_marks,
         )
+
         query_metadata = QueryMetadata(
             sql=extra.get("sql", ""),
             status=(
@@ -62,6 +97,7 @@ def extract_response_meta(
             cache_hit=stats.get("cache_hit", False),
             cluster_name=stats.get("cluster_name", ""),
         )
+
         trace_logs = result.get("trace_output", "")
         query_info.append(
             QueryInfo(stats=query_stats, metadata=query_metadata, trace_logs=trace_logs)
@@ -71,8 +107,58 @@ def extract_response_meta(
 
 
 def setup_trace_query_settings() -> HTTPQuerySettings:
+    """
+    Configure query settings for tracing.
+
+    Returns:
+        HTTPQuerySettings configured for tracing
+    """
     query_settings = HTTPQuerySettings()
     query_settings.set_clickhouse_settings(
         {"send_logs_level": "trace", "log_profile_events": 1}
     )
     return query_settings
+
+
+def format_trace_log(log: str, width: int = 140) -> str:
+    """
+    Format a ClickHouse trace log with colored output and proper wrapping.
+
+    Args:
+        log: Raw trace log string
+        width: Maximum width for wrapped text lines
+
+    Returns:
+        Formatted string with ANSI colors and wrapped text
+    """
+    output = []
+    for line in log.splitlines():
+        if not line.strip():
+            continue
+
+        matches = {name: pattern.search(line) for name, pattern in LOG_PATTERNS.items()}
+
+        if not all(matches.values()):
+            continue
+
+        host = matches["host"].group(1)
+        thread_id = matches["thread_id"].group(1)
+        session = matches["session"].group(1)
+        level = matches["level"].group(1)
+        message = matches["message"].group(1).strip()
+
+        level_color = COLOR_DEBUG if level == "Debug" else COLOR_TRACE
+
+        header = (
+            f"{COLOR_HOST}[{host}]{RESET} "
+            f"{COLOR_THREAD_ID}[{thread_id}]{RESET} "
+            f"{COLOR_SESSION}{{{session}}}{RESET} "
+            f"<{level_color}{level}{RESET}>"
+        )
+
+        wrapped_message = textwrap.fill(
+            f"{COLOR_MESSAGE}{message}{RESET}", width=width, subsequent_indent=" " * 4
+        )
+        output.append(f"{header}\n{wrapped_message}")
+
+    return "\n\n".join(output)


### PR DESCRIPTION
This change enhances the RPC endpoints admin interface by adding trace log visualization capabilities. Key changes include:

- Add new trace log formatter with syntax highlighting and improved readability
- Introduce a toggle switch to alternate between query metadata and trace logs view
- Add new types for better TypeScript support
- Improve styling of response containers with proper scrolling
- Reset debug mode when switching endpoints
- Add proper monospace font styling for trace logs

The trace log visualization includes:
- Color-coded components (host, thread ID, query ID, log levels)
- Text wrapping for better readability
- Proper HTML escaping for security

This enhancement will help to better understand query execution and debug issues more effectively on EAP endpoints.



<img width="1728" alt="Screenshot 2024-10-29 at 11 04 12 AM" src="https://github.com/user-attachments/assets/1476c740-03e8-4448-af5e-fccc484e2510">
