### PR TITLE
feat(eap): Timeseries V1 RPC

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -271,7 +271,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
     :param item_filter:
     :return:
     """
-    if item_filter.and_filter:
+    if item_filter.HasField("and_filter"):
         filters = item_filter.and_filter.filters
         if len(filters) == 0:
             return literal(True)
@@ -279,7 +279,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             return trace_item_filters_to_expression(filters[0])
         return and_cond(*(trace_item_filters_to_expression(x) for x in filters))
 
-    if item_filter.or_filter:
+    if item_filter.HasField("or_filter"):
         filters = item_filter.or_filter.filters
         if len(filters) == 0:
             raise BadSnubaRPCRequestException(
@@ -289,7 +289,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             return trace_item_filters_to_expression(filters[0])
         return or_cond(*(trace_item_filters_to_expression(x) for x in filters))
 
-    if item_filter.comparison_filter:
+    if item_filter.HasField("comparison_filter"):
         k = item_filter.comparison_filter.key
         k_expression = attribute_key_to_expression(k)
         op = item_filter.comparison_filter.op
@@ -337,7 +337,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"
         )
 
-    if item_filter.exists_filter:
+    if item_filter.HasField("exists_filter"):
         k = item_filter.exists_filter.key
         if k.name in NORMALIZED_COLUMNS.keys():
             return f.isNotNull(column(k.name))
@@ -346,7 +346,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         else:
             return f.mapContains(column("attr_num"), literal(k.name))
 
-    raise Exception("Unknown filter: ", item_filter)
+    return literal(True)
 
 
 def project_id_and_org_conditions(meta: RequestMeta) -> Expression:

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -1,0 +1,24 @@
+from typing import Type
+from snuba.web.rpc import RPCEndpoint
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest, TimeSeriesResponse, DataPoint
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+
+
+
+
+class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
+
+    @classmethod
+    def version(cls):
+        return "v1"
+
+    @classmethod
+    def request_class(cls) -> Type[TimeSeriesRequest]:
+        return TimeSeriesRequest
+
+    @classmethod
+    def response_class(cls) -> Type[TimeSeriesResponse]:
+        return TimeSeriesResponse
+
+    def _execute(self, in_msg: TimeSeriesRequest) -> TimeSeriesResponse:
+        raise NotImplementedError

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -65,7 +65,6 @@ def _convert_result_timeseries(
                 result_timeseries[(group_by_key, col_name)] = TimeSeries(
                     group_by_attributes=group_by_map, label=col_name
                 )
-                # TODO: convert row time to timestamp
             result_timeseries_timestamp_to_row[(group_by_key, col_name)][
                 int(datetime.fromisoformat(row["time"]).timestamp())
             ] = row

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -50,7 +50,9 @@ def _convert_result_timeseries(
     result_timeseries: dict[tuple[str, str], TimeSeries] = {}
 
     # create a mapping for each timeseries of timestamp: row to fill data points not returned in the query
-    result_timeseries_timestamp_to_row = defaultdict(dict)
+    result_timeseries_timestamp_to_row: defaultdict[
+        tuple[str, str], dict[int, Dict[str, Any]]
+    ] = defaultdict(dict)
     query_duration = (
         request.meta.end_timestamp.seconds - request.meta.start_timestamp.seconds
     )
@@ -164,7 +166,7 @@ def _build_snuba_request(request: TimeSeriesRequest) -> SnubaRequest:
 
 class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
     @classmethod
-    def version(cls):
+    def version(cls) -> str:
         return "v1"
 
     @classmethod
@@ -195,7 +197,7 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
 
         return TimeSeriesResponse(
             result_timeseries=list(
-                _convert_result_timeseries(in_msg, res.result.get("data", {}))
+                _convert_result_timeseries(in_msg, res.result.get("data", []))
             ),
             meta=response_meta,
         )

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -1,13 +1,16 @@
 from typing import Type
-from snuba.web.rpc import RPCEndpoint
-from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest, TimeSeriesResponse, DataPoint
+
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    DataPoint,
+    TimeSeriesRequest,
+    TimeSeriesResponse,
+)
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 
-
+from snuba.web.rpc import RPCEndpoint
 
 
 class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
-
     @classmethod
     def version(cls):
         return "v1"
@@ -21,4 +24,4 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         return TimeSeriesResponse
 
     def _execute(self, in_msg: TimeSeriesRequest) -> TimeSeriesResponse:
-        raise NotImplementedError
+        return TimeSeriesResponse()

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -1,13 +1,143 @@
-from typing import Type
+import uuid
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, Iterable, Type
 
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     DataPoint,
+    TimeSeries,
     TimeSeriesRequest,
     TimeSeriesResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 
+from snuba.attribution.appid import AppID
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.pluggable_dataset import PluggableDataset
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query.data_source.simple import Entity
+from snuba.query.dsl import column
+from snuba.query.logical import Query
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.request import Request as SnubaRequest
+from snuba.web.query import run_query
 from snuba.web.rpc import RPCEndpoint
+from snuba.web.rpc.common.common import (
+    aggregation_to_expression,
+    attribute_key_to_expression,
+    base_conditions_and,
+    trace_item_filters_to_expression,
+    treeify_or_and_conditions,
+)
+from snuba.web.rpc.common.debug_info import (
+    extract_response_meta,
+    setup_trace_query_settings,
+)
+
+
+def _convert_result_timeseries(
+    request: TimeSeriesRequest, data: Iterable[Dict[str, Any]]
+) -> Iterable[TimeSeries]:
+    # to convert the results, I need to know which were the groupby columns and which ones
+    # were aggregations
+    aggregation_labels = set([agg.label for agg in request.aggregations])
+    group_by_labels = set([attr.name for attr in request.group_by])
+
+    result_timeseries = defaultdict(TimeSeries)
+    # create a mapping with (all the group by attribute key,val pairs as strs, label name)
+
+    for row in data:
+        group_by_map = {}
+
+        for col_name, col_value in row.items():
+            if col_name in group_by_labels:
+                group_by_map[col_name] = col_value
+
+        group_by_key = "|".join(str(group_by_map.items()))
+
+        for col_name in aggregation_labels:
+            time_series = result_timeseries[(group_by_key, col_name)]
+            time_series.label = col_name
+            time_series.buckets.append(
+                Timestamp(seconds=int(datetime.fromisoformat(row["time"]).timestamp()))
+            )
+            time_series.data_points.append(
+                DataPoint(data=float(row[col_name]), data_present=True)
+            )  # TODO: data not always present
+            if not time_series.group_by_attributes and group_by_map:
+                time_series.group_by_attributes.update(group_by_map)
+
+    return result_timeseries.values()
+
+
+def _build_query(request: TimeSeriesRequest) -> Query:
+    # TODO: This is hardcoded still
+    entity = Entity(
+        key=EntityKey("eap_spans"),
+        schema=get_entity(EntityKey("eap_spans")).get_data_model(),
+        sample=None,
+    )
+
+    aggregation_columns = [
+        SelectedExpression(
+            name=aggregation.label, expression=aggregation_to_expression(aggregation)
+        )
+        for aggregation in request.aggregations
+    ]
+
+    groupby_columns = [
+        SelectedExpression(
+            name=attr_key.name, expression=attribute_key_to_expression(attr_key)
+        )
+        for attr_key in request.group_by
+    ]
+
+    res = Query(
+        from_clause=entity,
+        selected_columns=[
+            SelectedExpression(name="time", expression=column("time", alias="time")),
+            *aggregation_columns,
+            *groupby_columns,
+        ],
+        granularity=request.granularity_secs,
+        condition=base_conditions_and(
+            request.meta, trace_item_filters_to_expression(request.filter)
+        ),
+        groupby=[
+            column("time"),
+            *[attribute_key_to_expression(attr_key) for attr_key in request.group_by],
+        ],
+        order_by=[OrderBy(expression=column("time"), direction=OrderByDirection.ASC)],
+    )
+    treeify_or_and_conditions(res)
+    return res
+
+
+def _build_snuba_request(request: TimeSeriesRequest) -> SnubaRequest:
+    query_settings = (
+        setup_trace_query_settings() if request.meta.debug else HTTPQuerySettings()
+    )
+
+    return SnubaRequest(
+        id=uuid.UUID(request.meta.request_id),
+        original_body=MessageToDict(request),
+        query=_build_query(request),
+        query_settings=query_settings,
+        attribution_info=AttributionInfo(
+            referrer=request.meta.referrer,
+            team="eap",
+            feature="eap",
+            tenant_ids={
+                "organization_id": request.meta.organization_id,
+                "referrer": request.meta.referrer,
+            },
+            app_id=AppID("eap"),
+            parent_api="eap_span_samples",
+        ),
+    )
 
 
 class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
@@ -24,4 +154,26 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         return TimeSeriesResponse
 
     def _execute(self, in_msg: TimeSeriesRequest) -> TimeSeriesResponse:
-        return TimeSeriesResponse()
+        # TODO: Move this to base
+        in_msg.meta.request_id = getattr(in_msg.meta, "request_id", None) or str(
+            uuid.uuid4()
+        )
+        snuba_request = _build_snuba_request(in_msg)
+        res = run_query(
+            dataset=PluggableDataset(name="eap", all_entities=[]),
+            request=snuba_request,
+            timer=self._timer,
+        )
+        response_meta = extract_response_meta(
+            in_msg.meta.request_id,
+            in_msg.meta.debug,
+            [res],
+            [self._timer],
+        )
+
+        return TimeSeriesResponse(
+            result_timeseries=list(
+                _convert_result_timeseries(in_msg, res.result.get("data", {}))
+            ),
+            meta=response_meta,
+        )

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -214,7 +214,7 @@ def _build_snuba_request(request: TimeSeriesRequest) -> SnubaRequest:
     )
 
 
-def _enforce_no_duplicate_labels(request: TimeSeriesRequest):
+def _enforce_no_duplicate_labels(request: TimeSeriesRequest) -> None:
     labels = set()
 
     for agg in request.aggregations:

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -209,7 +209,7 @@ def _validate_select_and_groupby(in_msg: TraceItemTableRequest) -> None:
     aggregation_present = any([c for c in in_msg.columns if c.HasField("aggregation")])
     if non_aggregted_columns != grouped_by_columns and aggregation_present:
         raise BadSnubaRPCRequestException(
-            f"Non aggregated columns should be in group_by. non_aggregted_columns: {non_aggregted_columns}, grouped_by_columns: {grouped_by_columns}"
+            f"Non aggregated columns should be in group_by. non_aggregated_columns: {non_aggregted_columns}, grouped_by_columns: {grouped_by_columns}"
         )
 
 

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -10,6 +10,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeries,
     TimeSeriesRequest,
 )
+from sentry_protos.snuba.v1.error_pb2 import Error
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
@@ -158,7 +159,10 @@ class TestTimeSeriesApi(BaseApiTest):
         response = self.app.post(
             "/rpc/EndpointTimeSeries/v1", data=message.SerializeToString()
         )
-        assert response.status_code == 200
+        if response.status_code != 200:
+            error = Error()
+            error.ParseFromString(response.data)
+            assert response.status_code == 200, (error.message, error.details)
 
     def test_sum(self) -> None:
         # store a a test metric with a value of 1, every second of one hour

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -1,0 +1,206 @@
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Callable, MutableMapping
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    DataPoint,
+    TimeSeries,
+    TimeSeriesRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    ExtrapolationMode,
+    Function,
+)
+
+from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.web.rpc.v1.endpoint_time_series import EndpointTimeSeries
+from tests.base import BaseApiTest
+from tests.helpers import write_raw_unprocessed_events
+
+
+def gen_message(
+    dt: datetime, tags: dict[str, str], numerical_attributes: dict[str, float]
+) -> MutableMapping[str, Any]:
+    return {
+        "description": "/api/0/relays/projectconfigs/",
+        "duration_ms": 152,
+        "event_id": "d826225de75d42d6b2f01b957d51f18f",
+        "exclusive_time_ms": 0.228,
+        "is_segment": True,
+        "data": {
+            "sentry.environment": "development",
+            "sentry.release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
+            "thread.name": "uWSGIWorker1Core0",
+            "thread.id": "8522009600",
+            "sentry.segment.name": "/api/0/relays/projectconfigs/",
+            "sentry.sdk.name": "sentry.python.django",
+            "sentry.sdk.version": "2.7.0",
+            **numerical_attributes,
+        },
+        "measurements": {
+            "num_of_spans": {"value": 50.0},
+            "client_sample_rate": {"value": 1},
+        },
+        "organization_id": 1,
+        "origin": "auto.http.django",
+        "project_id": 1,
+        "received": 1721319572.877828,
+        "retention_days": 90,
+        "segment_id": "8873a98879faf06d",
+        "sentry_tags": {
+            "category": "http",
+            "environment": "development",
+            "op": "http.server",
+            "platform": "python",
+            "release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
+            "sdk.name": "sentry.python.django",
+            "sdk.version": "2.7.0",
+            "status": "ok",
+            "status_code": "200",
+            "thread.id": "8522009600",
+            "thread.name": "uWSGIWorker1Core0",
+            "trace.status": "ok",
+            "transaction": "/api/0/relays/projectconfigs/",
+            "transaction.method": "POST",
+            "transaction.op": "http.server",
+            "user": "ip:127.0.0.1",
+        },
+        "span_id": uuid.uuid4().hex,
+        "tags": tags,
+        "trace_id": uuid.uuid4().hex,
+        "start_timestamp_ms": int(dt.timestamp()) * 1000,
+        "start_timestamp_precise": dt.timestamp(),
+        "end_timestamp_precise": dt.timestamp() + 1,
+    }
+
+
+BASE_TIME = datetime.utcnow().replace(
+    hour=8, minute=0, second=0, microsecond=0, tzinfo=UTC
+) - timedelta(hours=24)
+
+
+SecsFromSeriesStart = int
+
+
+@dataclass
+class DummyMetric:
+    name: str
+    get_value: Callable[[SecsFromSeriesStart], float]
+
+
+def store_timeseries(
+    start_datetime: datetime,
+    period_secs: int,
+    len_secs: int,
+    metrics: list[DummyMetric],
+    tags: dict[str, str] | None = None,
+) -> None:
+    tags = tags or {}
+    messages = []
+    for secs in range(0, len_secs, period_secs):
+        dt = start_datetime + timedelta(seconds=secs)
+        numerical_attributes = {m.name: m.get_value(secs) for m in metrics}
+        messages.append(gen_message(dt, tags, numerical_attributes))
+    spans_storage = get_storage(StorageKey("eap_spans"))
+    write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+class TestTimeSeriesApi(BaseApiTest):
+    def test_basic(self) -> None:
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=ts,
+                end_timestamp=ts,
+            ),
+            aggregations=[
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_AVG,
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_FLOAT, name="sentry.duration"
+                    ),
+                    label="p50",
+                ),
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_P95,
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_FLOAT, name="sentry.duration"
+                    ),
+                    label="p90",
+                ),
+            ],
+            granularity_secs=60,
+            group_by=[
+                AttributeKey(type=AttributeKey.TYPE_STRING, name="endpoint_name"),
+                AttributeKey(type=AttributeKey.TYPE_STRING, name="consumer_group"),
+            ],
+        )
+        response = self.app.post(
+            "/rpc/EndpointTimeSeries/v1", data=message.SerializeToString()
+        )
+        assert response.status_code == 200
+
+    def test_sum(self) -> None:
+        # store a a test metric with a value of 10, every second of one hour
+        store_timeseries(
+            BASE_TIME,
+            1,
+            3600,
+            metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
+        )
+
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp() + 60 * 30)),
+            ),
+            aggregations=[
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="my.int.field"),
+                    label="sum",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+            ],
+            granularity_secs=300,
+        )
+        response = EndpointTimeSeries().execute(message)
+        expected_buckets = [
+            Timestamp(seconds=int(BASE_TIME.timestamp()) + secs)
+            for secs in range(0, 60 * 30, 300)
+        ]
+
+        assert response.result_timeseries == [
+            TimeSeries(
+                label="sum",
+                buckets=expected_buckets,
+                data_points=[DataPoint(data=300, data_present=True)],
+            )
+        ]
+
+    def test_with_multiple_aggregations(self) -> None:
+        pass
+
+    def test_with_group_by(self) -> None:
+        pass
+
+    def test_with_no_data_present(self) -> None:
+        pass

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -26,7 +26,10 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
-from snuba.web.rpc.v1.endpoint_time_series import EndpointTimeSeries
+from snuba.web.rpc.v1.endpoint_time_series import (
+    EndpointTimeSeries,
+    _validate_time_buckets,
+)
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 
@@ -455,8 +458,60 @@ class TestTimeSeriesApi(BaseApiTest):
             ),
         ]
 
+    def test_with_unaligned_granularities(self) -> None:
+        query_offset = 5
+        query_duration = 1800 + query_offset
+        granularity_secs = 300
+        store_timeseries(
+            BASE_TIME,
+            1,
+            3600,
+            metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
+            tags={"customer": "bob"},
+        )
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp()) + query_duration
+                ),
+                debug=True,
+            ),
+            aggregations=[
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric"),
+                    label="sum",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+            ],
+            granularity_secs=granularity_secs,
+        )
 
-class TestBadRequests:
+        response = EndpointTimeSeries().execute(message)
+        expected_buckets = [
+            Timestamp(seconds=int(BASE_TIME.timestamp()) + secs)
+            for secs in range(
+                0, query_duration - query_offset + granularity_secs, granularity_secs
+            )
+        ]
+        assert response.result_timeseries == [
+            TimeSeries(
+                label="sum",
+                buckets=expected_buckets,
+                data_points=[
+                    DataPoint(data=300, data_present=True)
+                    for _ in range(len(expected_buckets))
+                ],
+            )
+        ]
+
+
+class TestUtils:
     def test_no_duplicate_labels(self) -> None:
         message = TimeSeriesRequest(
             meta=RequestMeta(
@@ -487,3 +542,66 @@ class TestBadRequests:
 
         with pytest.raises(BadSnubaRPCRequestException):
             EndpointTimeSeries().execute(message)
+
+    @pytest.mark.parametrize(
+        ("start_ts", "end_ts", "granularity"),
+        [
+            (BASE_TIME, BASE_TIME + timedelta(hours=1), 1),
+            (BASE_TIME, BASE_TIME + timedelta(hours=24), 15),
+            (BASE_TIME, BASE_TIME + timedelta(hours=1), 0),
+            (BASE_TIME + timedelta(hours=1), BASE_TIME, 0),
+            (BASE_TIME, BASE_TIME + timedelta(hours=1), 3 * 3600),
+        ],
+    )
+    def test_bad_granularity(
+        self, start_ts: datetime, end_ts: datetime, granularity: int
+    ) -> None:
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(start_ts.timestamp())),
+                end_timestamp=Timestamp(seconds=int(end_ts.timestamp())),
+                debug=True,
+            ),
+            aggregations=[
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric"),
+                    label="sum",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+            ],
+            granularity_secs=granularity,
+        )
+
+        with pytest.raises(BadSnubaRPCRequestException):
+            _validate_time_buckets(message)
+
+    def test_adjust_buckets(self) -> None:
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp()) + 65),
+                debug=True,
+            ),
+            aggregations=[
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric"),
+                    label="sum",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+            ],
+            granularity_secs=15,
+        )
+
+        _validate_time_buckets(message)
+        # add another bucket to fit into granularity_secs
+        assert message.meta.end_timestamp.seconds == int(BASE_TIME.timestamp()) + 75

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -144,10 +144,6 @@ class TestTimeSeriesApi(BaseApiTest):
                 ),
             ],
             granularity_secs=60,
-            group_by=[
-                AttributeKey(type=AttributeKey.TYPE_STRING, name="endpoint_name"),
-                AttributeKey(type=AttributeKey.TYPE_STRING, name="consumer_group"),
-            ],
         )
         response = self.app.post(
             "/rpc/EndpointTimeSeries/v1", data=message.SerializeToString()
@@ -175,7 +171,7 @@ class TestTimeSeriesApi(BaseApiTest):
             aggregations=[
                 AttributeAggregation(
                     aggregate=Function.FUNCTION_SUM,
-                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="my.int.field"),
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric"),
                     label="sum",
                     extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                 ),
@@ -187,12 +183,14 @@ class TestTimeSeriesApi(BaseApiTest):
             Timestamp(seconds=int(BASE_TIME.timestamp()) + secs)
             for secs in range(0, 60 * 30, 300)
         ]
-
         assert response.result_timeseries == [
             TimeSeries(
                 label="sum",
                 buckets=expected_buckets,
-                data_points=[DataPoint(data=300, data_present=True)],
+                data_points=[
+                    DataPoint(data=300, data_present=True)
+                    for _ in range(len(expected_buckets))
+                ],
             )
         ]
 

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -127,13 +127,14 @@ class TestTimeSeriesApi(BaseApiTest):
     def test_basic(self) -> None:
         ts = Timestamp()
         ts.GetCurrentTime()
+        tstart = Timestamp(seconds=ts.seconds - 3600)
         message = TimeSeriesRequest(
             meta=RequestMeta(
                 project_ids=[1, 2, 3],
                 organization_id=1,
                 cogs_category="something",
                 referrer="something",
-                start_timestamp=ts,
+                start_timestamp=tstart,
                 end_timestamp=ts,
             ),
             aggregations=[

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -13,15 +13,12 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableResponse,
 )
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
-from sentry_protos.snuba.v1.request_common_pb2 import (
-    PageToken,
-    RequestMeta,
-    ResponseMeta,
-)
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
     AttributeValue,
+    ExtrapolationMode,
     Function,
     VirtualColumnContext,
 )
@@ -186,7 +183,6 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -207,6 +203,7 @@ class TestTraceItemTable(BaseApiTest):
                     )
                 )
             ],
+            limit=61,
         )
         response = EndpointTraceItemTable().execute(message)
 
@@ -218,7 +215,6 @@ class TestTraceItemTable(BaseApiTest):
                 )
             ],
             page_token=PageToken(offset=60),
-            meta=ResponseMeta(request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480"),
         )
         assert response == expected_response
 
@@ -233,7 +229,6 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
             ),
             filter=TraceItemFilter(
                 or_filter=OrFilter(
@@ -299,7 +294,6 @@ class TestTraceItemTable(BaseApiTest):
                 ),
             ],
             page_token=PageToken(offset=60),
-            meta=ResponseMeta(request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480"),
         )
         assert response == expected_response
 
@@ -315,7 +309,6 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -386,7 +379,6 @@ class TestTraceItemTable(BaseApiTest):
                 ),
             ],
             page_token=PageToken(offset=limit),
-            meta=ResponseMeta(request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480"),
         )
         assert response.page_token == expected_response.page_token
         # make sure columns are ordered in the order they are requested
@@ -478,6 +470,7 @@ class TestTraceItemTable(BaseApiTest):
                             type=AttributeKey.TYPE_FLOAT, name="my.float.field"
                         ),
                         label="max(my.float.field)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                     ),
                 ),
                 Column(
@@ -487,6 +480,7 @@ class TestTraceItemTable(BaseApiTest):
                             type=AttributeKey.TYPE_FLOAT, name="my.float.field"
                         ),
                         label="avg(my.float.field)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                     ),
                 ),
             ],
@@ -551,6 +545,7 @@ class TestTraceItemTable(BaseApiTest):
                             type=AttributeKey.TYPE_FLOAT, name="my.float.field"
                         ),
                         label="max(my.float.field)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                     )
                 ),
             ],
@@ -597,6 +592,7 @@ class TestTraceItemTable(BaseApiTest):
                             type=AttributeKey.TYPE_FLOAT, name="eap.measurement"
                         ),
                         label="avg(eap.measurment)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                     )
                 ),
             ],
@@ -649,6 +645,7 @@ class TestTraceItemTable(BaseApiTest):
                             type=AttributeKey.TYPE_FLOAT, name="eap.measurement"
                         ),
                         label="avg(eap.measurment)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                     )
                 ),
             ],
@@ -662,6 +659,7 @@ class TestTraceItemTable(BaseApiTest):
                                 type=AttributeKey.TYPE_FLOAT, name="eap.measurement"
                             ),
                             label="avg(eap.measurment)",
+                            extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                         )
                     )
                 ),
@@ -708,6 +706,7 @@ class TestTraceItemTable(BaseApiTest):
                             type=AttributeKey.TYPE_FLOAT, name="custom_measurement"
                         ),
                         label="avg(custom_measurement)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                     )
                 ),
             ],

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -13,7 +13,11 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableResponse,
 )
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
-from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import (
+    PageToken,
+    RequestMeta,
+    ResponseMeta,
+)
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -183,6 +187,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -203,7 +208,6 @@ class TestTraceItemTable(BaseApiTest):
                     )
                 )
             ],
-            limit=61,
         )
         response = EndpointTraceItemTable().execute(message)
 
@@ -215,6 +219,7 @@ class TestTraceItemTable(BaseApiTest):
                 )
             ],
             page_token=PageToken(offset=60),
+            meta=ResponseMeta(request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480"),
         )
         assert response == expected_response
 
@@ -229,6 +234,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
             ),
             filter=TraceItemFilter(
                 or_filter=OrFilter(
@@ -294,6 +300,7 @@ class TestTraceItemTable(BaseApiTest):
                 ),
             ],
             page_token=PageToken(offset=60),
+            meta=ResponseMeta(request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480"),
         )
         assert response == expected_response
 
@@ -309,6 +316,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -379,6 +387,7 @@ class TestTraceItemTable(BaseApiTest):
                 ),
             ],
             page_token=PageToken(offset=limit),
+            meta=ResponseMeta(request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480"),
         )
         assert response.page_token == expected_response.page_token
         # make sure columns are ordered in the order they are requested
@@ -606,6 +615,7 @@ class TestTraceItemTable(BaseApiTest):
                                 type=AttributeKey.TYPE_FLOAT, name="my.float.field"
                             ),
                             label="max(my.float.field)",
+                            extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                         )
                     )
                 ),

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -242,7 +242,7 @@ class TestTraceItemTable(BaseApiTest):
                         TraceItemFilter(
                             comparison_filter=ComparisonFilter(
                                 key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
+                                    type=AttributeKey.TYPE_FLOAT,
                                     name="eap.measurement",
                                 ),
                                 op=ComparisonFilter.OP_LESS_THAN_OR_EQUALS,
@@ -252,7 +252,7 @@ class TestTraceItemTable(BaseApiTest):
                         TraceItemFilter(
                             comparison_filter=ComparisonFilter(
                                 key=AttributeKey(
-                                    type=AttributeKey.TYPE_STRING,
+                                    type=AttributeKey.TYPE_FLOAT,
                                     name="eap.measurement",
                                 ),
                                 op=ComparisonFilter.OP_GREATER_THAN,


### PR DESCRIPTION
This PR implements the basics of the timeseries API.

Supported:

* Aggregations on all attributes
* filters
* groupby
* zerofilling nonexistent data

To come in future PRs:

* Sample count
* extrapolation