### PR TITLE
feat(eap): AttributeNames "autocomplete" v1 API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ sqlparse==0.5.0
 google-api-python-client==2.88.0
 sentry-usage-accountant==0.0.10
 freezegun==1.2.2
-sentry-protos==0.1.30
+sentry-protos==0.1.31

--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -1,0 +1,137 @@
+import uuid
+from typing import Type
+
+from google.protobuf.json_format import MessageToDict
+from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
+    TraceItemAttributeNamesRequest,
+    TraceItemAttributeNamesResponse,
+)
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
+
+from snuba.attribution.appid import AppID
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.pluggable_dataset import PluggableDataset
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query.data_source.simple import Entity
+from snuba.query.dsl import column
+from snuba.query.logical import Query
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.reader import Row
+from snuba.request import Request as SnubaRequest
+from snuba.web import QueryResult
+from snuba.web.query import run_query
+from snuba.web.rpc import RPCEndpoint
+from snuba.web.rpc.common.common import base_conditions_and, treeify_or_and_conditions
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+
+
+def convert_to_snuba_request(req: TraceItemAttributeNamesRequest) -> SnubaRequest:
+    if req.limit > 1000:
+        raise BadSnubaRPCRequestException("Limit can be at most 1000")
+
+    if req.type == AttributeKey.Type.TYPE_STRING:
+        entity = Entity(
+            key=EntityKey("spans_str_attrs"),
+            schema=get_entity(EntityKey("spans_str_attrs")).get_data_model(),
+            sample=None,
+        )
+    elif req.type in (
+        AttributeKey.Type.TYPE_FLOAT,
+        AttributeKey.Type.TYPE_INT,
+        AttributeKey.Type.TYPE_BOOLEAN,
+    ):
+        entity = Entity(
+            key=EntityKey("spans_num_attrs"),
+            schema=get_entity(EntityKey("spans_num_attrs")).get_data_model(),
+            sample=None,
+        )
+    else:
+        raise BadSnubaRPCRequestException(f"Unknown attribute type: {req.type}")
+
+    # truncate_request_meta_to_day(request.meta)
+    # TODO: value substring filter
+    query = Query(
+        from_clause=entity,
+        selected_columns=[
+            SelectedExpression(
+                name="attr_key",
+                expression=column("attr_key"),
+            ),
+        ],
+        condition=base_conditions_and(req.meta),
+        order_by=[
+            OrderBy(
+                direction=OrderByDirection.ASC, expression=column("organization_id")
+            ),
+            OrderBy(direction=OrderByDirection.ASC, expression=column("attr_key")),
+        ],
+        groupby=[
+            column("organization_id", alias="organization_id"),
+            column("attr_key", alias="attr_key"),
+        ],
+        limit=req.limit,
+        offset=req.offset,
+    )
+    treeify_or_and_conditions(query)
+
+    return SnubaRequest(
+        id=uuid.uuid4(),
+        original_body=MessageToDict(req),
+        query=query,
+        query_settings=HTTPQuerySettings(),
+        attribution_info=AttributionInfo(
+            referrer=req.meta.referrer,
+            team="eap",
+            feature="eap",
+            tenant_ids={
+                "organization_id": req.meta.organization_id,
+                "referrer": req.meta.referrer,
+            },
+            app_id=AppID("eap"),
+            parent_api=EndpointTraceItemAttributeNames.config_key(),
+        ),
+    )
+
+
+def convert_to_response(query_res: QueryResult) -> TraceItemAttributeNamesResponse:
+    def t(row: Row) -> TraceItemAttributeNamesResponse.Attribute:
+        # our query to snuba only selected 1 column, attr_key
+        # so the result should only have 1 item per row
+        vals = row.values()
+        assert len(vals) == 1
+        attr_name = list(vals)[0]
+        return TraceItemAttributeNamesResponse.Attribute(
+            name=attr_name, type=AttributeKey.Type.TYPE_STRING
+        )
+
+    attributes = map(t, query_res.result["data"])
+    return TraceItemAttributeNamesResponse(attributes=attributes)
+
+
+class EndpointTraceItemAttributeNames(
+    RPCEndpoint[TraceItemAttributeNamesRequest, TraceItemAttributeNamesResponse]
+):
+    @classmethod
+    def version(cls) -> str:
+        return "v1"
+
+    @classmethod
+    def request_class(cls) -> Type[TraceItemAttributeNamesRequest]:
+        return TraceItemAttributeNamesRequest
+
+    @classmethod
+    def response_class(cls) -> Type[TraceItemAttributeNamesResponse]:
+        return TraceItemAttributeNamesResponse
+
+    def _execute(
+        self, req: TraceItemAttributeNamesRequest
+    ) -> TraceItemAttributeNamesResponse:
+        snuba_request = convert_to_snuba_request(req)
+        res = run_query(
+            dataset=PluggableDataset(name="eap", all_entities=[]),
+            request=snuba_request,
+            timer=self._timer,
+        )
+        return convert_to_response(res)

--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -95,7 +95,9 @@ def convert_to_snuba_request(req: TraceItemAttributeNamesRequest) -> SnubaReques
     )
 
 
-def convert_to_response(query_res: QueryResult) -> TraceItemAttributeNamesResponse:
+def convert_to_response(
+    query_res: QueryResult, attribute_type: AttributeKey.Type.ValueType
+) -> TraceItemAttributeNamesResponse:
     def t(row: Row) -> TraceItemAttributeNamesResponse.Attribute:
         # our query to snuba only selected 1 column, attr_key
         # so the result should only have 1 item per row
@@ -103,7 +105,7 @@ def convert_to_response(query_res: QueryResult) -> TraceItemAttributeNamesRespon
         assert len(vals) == 1
         attr_name = list(vals)[0]
         return TraceItemAttributeNamesResponse.Attribute(
-            name=attr_name, type=AttributeKey.Type.TYPE_STRING
+            name=attr_name, type=attribute_type
         )
 
     attributes = map(t, query_res.result["data"])
@@ -134,4 +136,4 @@ class EndpointTraceItemAttributeNames(
             request=snuba_request,
             timer=self._timer,
         )
-        return convert_to_response(res)
+        return convert_to_response(res, req.type)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
@@ -1,0 +1,122 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any, Mapping
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
+    TraceItemAttributeNamesRequest,
+    TraceItemAttributeNamesResponse,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
+
+from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.web.rpc.v1.endpoint_trace_item_attribute_names import (
+    EndpointTraceItemAttributeNames,
+)
+from tests.base import BaseApiTest
+from tests.helpers import write_raw_unprocessed_events
+
+BASE_TIME = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) - timedelta(
+    hours=3
+)
+
+
+def populate_eap_spans_storage(num_rows: int) -> None:
+    """
+    Fills the eap_spans storage with num_rows rows of data
+    """
+
+    def generate_span_event_message(id: int) -> Mapping[str, Any]:
+        res = {
+            "description": "/api/0/relays/projectconfigs/",
+            "duration_ms": 152,
+            "event_id": "d826225de75d42d6b2f01b957d51f18f",
+            "exclusive_time_ms": 0.228,
+            "is_segment": True,
+            "data": {},
+            "measurements": {},
+            "organization_id": 1,
+            "origin": "auto.http.django",
+            "project_id": 1,
+            "received": 1721319572.877828,
+            "retention_days": 90,
+            "segment_id": "8873a98879faf06d",
+            "sentry_tags": {
+                "category": "http",
+            },
+            "span_id": uuid.uuid4().hex,
+            "tags": {
+                "http.status_code": "200",
+            },
+            "trace_id": uuid.uuid4().hex,
+            "start_timestamp_ms": int(BASE_TIME.timestamp() * 1000),
+            "start_timestamp_precise": BASE_TIME.timestamp(),
+            "end_timestamp_precise": BASE_TIME.timestamp() + 1,
+        }
+        for i in range(id * 10, id * 10 + 10):
+            res["tags"][f"a_tag_{i:03}"] = "blah"  # type: ignore
+            res["measurements"][f"b_measurement_{i:03}"] = {"value": 10}  # type: ignore
+        return res
+
+    spans_storage = get_storage(StorageKey("eap_spans"))
+    messages = [generate_span_event_message(i) for i in range(num_rows)]
+    write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
+    populate_eap_spans_storage(num_rows=3)
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+class TestTraceItemAttributeNames(BaseApiTest):
+    def test_basic(self) -> None:
+        req = TraceItemAttributeNamesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(
+                    seconds=int((BASE_TIME - timedelta(days=1)).timestamp())
+                ),
+                end_timestamp=Timestamp(
+                    seconds=int((BASE_TIME + timedelta(days=1)).timestamp())
+                ),
+            ),
+            limit=1000,
+            offset=0,
+            type=AttributeKey.Type.TYPE_STRING,
+            value_substring_match="",
+        )
+        res = EndpointTraceItemAttributeNames().execute(req)
+
+        expected = []
+        for i in range(30):
+            expected.append(
+                TraceItemAttributeNamesResponse.Attribute(
+                    name=f"a_tag_{str(i).zfill(3)}", type=AttributeKey.Type.TYPE_STRING
+                )
+            )
+        expected += [
+            TraceItemAttributeNamesResponse.Attribute(
+                name="http.status_code", type=AttributeKey.Type.TYPE_STRING
+            ),
+            TraceItemAttributeNamesResponse.Attribute(
+                name="sentry.category", type=AttributeKey.Type.TYPE_STRING
+            ),
+            TraceItemAttributeNamesResponse.Attribute(
+                name="sentry.name", type=AttributeKey.Type.TYPE_STRING
+            ),
+            TraceItemAttributeNamesResponse.Attribute(
+                name="sentry.segment_name", type=AttributeKey.Type.TYPE_STRING
+            ),
+            TraceItemAttributeNamesResponse.Attribute(
+                name="sentry.service", type=AttributeKey.Type.TYPE_STRING
+            ),
+        ]
+        assert res == TraceItemAttributeNamesResponse(attributes=expected)


### PR DESCRIPTION
This PR implements the endpoint for TraceItemAttributeNames. For context, please see [this diagram](https://www.notion.so/sentry/Qu-EAP-Querying-Events-Analytics-Platform-76629acc212b4ac486c63e7979f16076?pvs=4#66feb9128c2b4752a7921e47c0cb20fc) "attribute names" in green at the bottom. Also see [this ticket](https://github.com/getsentry/projects/issues/293).

This API allows you to query for the names of all attributes attached to spans for a given project and dates. The interface definition is here https://github.com/getsentry/sentry-protos/blob/main/proto/sentry_protos/snuba/v1/endpoint_trace_item_attributes.proto#L12-L28

## implementation
Its implemented in the following way at a high-level
1. receive a request from the user
2. convert that request into a `SnubaRequest`. This is an existing object we use for snuba requests, and is directly compatible to go through the existing snuba query pipeline. So thats what we do with it once its converted.
3. Convert the `QueryResult` into the proper result. Once the query pipeline gives us our result we convert it to the proper format our users expect and return it.