### PR TITLE
chore(deps) bump werkzeug from 2.2.3 to 3.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ sql-metadata==2.11.0
 typing-extensions==4.8.0
 urllib3==1.26.12
 pyuwsgi==2.0.23
-Werkzeug==2.2.3
+Werkzeug==3.0.5
 PyYAML==6.0
 sqlparse==0.5.0
 google-api-python-client==2.88.0


### PR DESCRIPTION
https://github.com/getsentry/snuba/security/dependabot/52