### PR TITLE
fix(EAP): fix bug with unassigned labels

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -183,7 +183,7 @@ def _get_page_token(
 
 def _apply_labels_to_columns(in_msg: TraceItemTableRequest) -> TraceItemTableRequest:
     def _apply_label_to_column(column: Column) -> None:
-        if column.label:
+        if column.label != "":
             return
 
         if column.HasField("key"):

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -183,7 +183,7 @@ def _get_page_token(
 
 def _apply_labels_to_columns(in_msg: TraceItemTableRequest) -> TraceItemTableRequest:
     def _apply_label_to_column(column: Column) -> None:
-        if column.label != "":
+        if column.label != "" and column.label is not None:
             return
 
         if column.HasField("key"):

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -628,7 +628,7 @@ class TestTraceItemTable(BaseApiTest):
         with pytest.raises(BadSnubaRPCRequestException):
             EndpointTraceItemTable().execute(message)
 
-    def test_order_by_aggregation(self, setup_teardown) -> None:
+    def test_order_by_aggregation(self, setup_teardown: Any) -> None:
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
         message = TraceItemTableRequest(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -745,9 +745,21 @@ class TestUtils:
                         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
                     )
                 ),
+                Column(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_AVG,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="custom_measurement"
+                        ),
+                        label="avg(custom_measurement_2)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                    label=None,  # type: ignore
+                ),
             ],
             order_by=[],
             limit=5,
         )
         _apply_labels_to_columns(message)
         assert message.columns[0].label == "avg(custom_measurement)"
+        assert message.columns[1].label == "avg(custom_measurement_2)"


### PR DESCRIPTION
protobuf sets the label as an empty string by default which is truthy in python. hence we were not actually bubbling up labels correctly. this fixes the bug