### PR TITLE
build(deps): bump actions/dependency-review-action from 3.1.0 to 4.4.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Checkout Repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Dependency Review
-        uses: actions/dependency-review-action@6c5ccdad469c9f8a2996bfecaec55a631a347034 # v3.1.0
+        uses: actions/dependency-review-action@4081bf99e2866ebe428fc0477b69eb4fcda7220a # v4.4.0
         with:
           # Possible values: "critical", "high", "moderate", "low"
           fail-on-severity: high


### PR DESCRIPTION
`actions/dependency-review-action` released a [latest version 4.4.0](https://github.com/actions/dependency-review-action/releases/tag/v4.4.0) and this PR consumes that version. Dependabot created https://github.com/getsentry/snuba/pull/6480 but it does not seem to pass CI. Trying this PR.