### PR TITLE
feat(snuba-admin): Use AST and Query Tree generated by EXPLAIN query for system query validation

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -49,23 +49,6 @@ def _run_sql_query_on_host(
     return query_result
 
 
-SYSTEM_QUERY_RE = re.compile(
-    r"""
-        ^ # Start
-        (SELECT|select)
-        \s
-        (?P<select_statement>[\w\s\',()*+\-\/:]+|\*)
-        \s
-        (FROM|from)
-        \s
-        system.[a-z_]+
-        (?P<extra>\s[\w\s,=()*+<>'%"\-\/:]+)?
-        ;? # Optional semicolon
-        $ # End
-    """,
-    re.VERBOSE,
-)
-
 DESCRIBE_QUERY_RE = re.compile(
     r"""
         ^ # Start
@@ -129,13 +112,62 @@ ALTER_QUERY_RE = re.compile(
 )
 
 
-def is_query_select(sql_query: str) -> bool:
+def is_query_using_only_system_tables(
+    clickhouse_host: str,
+    clickhouse_port: int,
+    storage_name: str,
+    sql_query: str,
+) -> bool:
     """
-    Simple validation to ensure query is a select command
+    Run the EXPLAIN QUERY TREE on the given sql_query and check that the only tables
+    in the query are system tables.
     """
-    sql_query = " ".join(sql_query.split())
-    match = SYSTEM_QUERY_RE.match(sql_query)
-    return True if match else False
+    sql_query = sql_query[:-1] if sql_query.endswith(";") else sql_query
+    explain_query_tree_query = (
+        f"EXPLAIN QUERY TREE {sql_query} SETTINGS allow_experimental_analyzer = 1"
+    )
+    explain_query_tree_result = _run_sql_query_on_host(
+        clickhouse_host, clickhouse_port, storage_name, explain_query_tree_query, False
+    )
+
+    for line in explain_query_tree_result.results:
+        line = line[0].strip()
+        # We don't allow table functions for now as the clickhouse analyzer isn't good enough yet to resolve those tables
+        if line.startswith("TABLE_FUNCTION"):
+            return False
+        if line.startswith("TABLE"):
+            match = re.search(r"table_name:\s*(\S+)", line, re.IGNORECASE)
+            if match:
+                table_name = match.group(1)
+                if not table_name.startswith("system."):
+                    return False
+
+    return True
+
+
+def is_valid_system_query(
+    clickhouse_host: str, clickhouse_port: int, storage_name: str, sql_query: str
+) -> bool:
+    """
+    Validation based on Query Tree and AST to ensure the query is a valid select query.
+    """
+    explain_ast_query = f"EXPLAIN AST {sql_query}"
+    disallowed_ast_nodes = ["AlterQuery", "AlterCommand", "DropQuery", "InsertQuery"]
+    explain_ast_result = _run_sql_query_on_host(
+        clickhouse_host, clickhouse_port, storage_name, explain_ast_query, False
+    )
+
+    print(explain_ast_result.results)
+
+    for node in disallowed_ast_nodes:
+        if any(
+            line[0].lstrip().startswith(node) for line in explain_ast_result.results
+        ):
+            return False
+
+    return is_query_using_only_system_tables(
+        clickhouse_host, clickhouse_port, storage_name, sql_query
+    )
 
 
 def is_query_show(sql_query: str) -> bool:
@@ -200,19 +232,30 @@ def run_system_query_on_host_with_sql(
         if not can_sudo:
             raise UnauthorizedForSudo()
 
-    if is_query_select(system_query_sql):
-        validate_system_query(system_query_sql)
-    elif is_query_describe(system_query_sql):
-        pass
-    elif is_query_show(system_query_sql):
-        pass
-    elif sudo_mode and (
-        is_system_command(system_query_sql)
-        or is_query_alter(system_query_sql)
-        or is_query_optimize(system_query_sql)
+    def is_valid_query(
+        clickhouse_host: str,
+        clickhouse_port: int,
+        storage_name: str,
+        system_query_sql: str,
+        sudo_mode: bool,
+    ) -> bool:
+        if not sudo_mode and is_valid_system_query(
+            clickhouse_host, clickhouse_port, storage_name, system_query_sql
+        ):
+            return True
+        if is_query_describe(system_query_sql) or is_query_show(system_query_sql):
+            return True
+        if sudo_mode and (
+            is_system_command(system_query_sql)
+            or is_query_alter(system_query_sql)
+            or is_query_optimize(system_query_sql)
+        ):
+            return True
+        return False
+
+    if not is_valid_query(
+        clickhouse_host, clickhouse_port, storage_name, system_query_sql, sudo_mode
     ):
-        pass
-    else:
         raise InvalidCustomQuery("Query is invalid")
 
     try:
@@ -240,36 +283,3 @@ def run_system_query_on_host_with_sql(
                 },
                 notify=sudo_mode,
             )
-
-
-def validate_system_query(sql_query: str) -> None:
-    """
-    Simple validation to ensure query only attempts to access system tables and not
-    any others. Will be replaced by AST parser eventually.
-
-    Raises InvalidCustomQuery if query is invalid or not allowed.
-    """
-    sql_query = " ".join(sql_query.split())
-
-    disallowed_keywords = ["select", "insert", "join"]
-
-    match = SYSTEM_QUERY_RE.match(sql_query)
-
-    if match is None:
-        raise InvalidCustomQuery("Query is invalid")
-
-    select_statement = match.group("select_statement")
-
-    # Extremely quick and dirty way of ensuring there is not a nested select, insert or a join
-    for kw in disallowed_keywords:
-        if kw in select_statement.lower():
-            raise InvalidCustomQuery(f"{kw} is not allowed here")
-
-    extra = match.group("extra")
-
-    # Unfortunately "extra" is pretty permissive right now, just ensure
-    # there is no attempt to do a select, insert or join in there
-    if extra is not None:
-        for kw in disallowed_keywords:
-            if kw in extra.lower():
-                raise InvalidCustomQuery(f"{kw} is not allowed here")

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -122,7 +122,7 @@ def is_query_using_only_system_tables(
     Run the EXPLAIN QUERY TREE on the given sql_query and check that the only tables
     in the query are system tables.
     """
-    sql_query = sql_query[:-1] if sql_query.endswith(";") else sql_query
+    sql_query = sql_query.strip().rstrip(";") if sql_query.endswith(";") else sql_query
     explain_query_tree_query = (
         f"EXPLAIN QUERY TREE {sql_query} SETTINGS allow_experimental_analyzer = 1"
     )

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -51,6 +51,7 @@ from snuba.admin.user import AdminUser
         """,
     ],
 )
+@pytest.mark.clickhouse_db
 def test_is_valid_system_query(sql_query: str) -> None:
     assert is_valid_system_query(
         settings.CLUSTERS[0]["host"],
@@ -92,6 +93,7 @@ def test_is_valid_system_query(sql_query: str) -> None:
         """,
     ],
 )
+@pytest.mark.clickhouse_db
 def test_invalid_system_query(sql_query: str) -> None:
     with pytest.raises(Exception):
         is_valid_system_query(

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -4,15 +4,13 @@ import pytest
 
 from snuba import settings
 from snuba.admin.auth_roles import ROLES, Role
-from snuba.admin.clickhouse.common import InvalidCustomQuery
 from snuba.admin.clickhouse.system_queries import (
     UnauthorizedForSudo,
     is_query_alter,
     is_query_optimize,
-    is_query_select,
     is_system_command,
+    is_valid_system_query,
     run_system_query_on_host_with_sql,
-    validate_system_query,
 )
 from snuba.admin.user import AdminUser
 
@@ -31,10 +29,35 @@ from snuba.admin.user import AdminUser
         "SELECT * FROM system.clusters LIMIT 100",  # limit
         "SELECT empty('str') FROM system.clusters LIMIT 100",  # literal str params
         "SELECT * FROM system.query_log WHERE event_time > toDateTime('2023-07-05 14:24:00') AND event_time < toDateTime('2023-07-05T14:34:00')",  # datetimes
+        """SELECT
+            count() as nb_query,
+            user,
+            query,
+            sum(memory_usage) AS memory,
+            normalized_query_hash
+        FROM
+            system.query_log
+        WHERE
+            (event_time >= (now() - toIntervalDay(1)))
+            AND query_kind = 'Select'
+            AND type = 'QueryFinish'
+            and user != 'monitoring-internal'
+        GROUP BY
+            normalized_query_hash,
+            query,
+            user
+        ORDER BY
+            memory DESC
+        """,
     ],
 )
-def test_valid_system_query(sql_query: str) -> None:
-    validate_system_query(sql_query)
+def test_is_valid_system_query(sql_query: str) -> None:
+    assert is_valid_system_query(
+        settings.CLUSTERS[0]["host"],
+        int(settings.CLUSTERS[0]["port"]),
+        "errors",
+        sql_query,
+    )
 
 
 @pytest.mark.parametrize(
@@ -47,34 +70,36 @@ def test_valid_system_query(sql_query: str) -> None:
         "SELECT 1; SELECT 2;"  # no multiple statements
         "SELECT * FROM system.clusters c INNER JOIN my_table m ON c.cluster == m.something",  # no join
         "SELECT * from system.as1",  # invalid system table format
+        """SELECT
+            count() as nb_query,
+            user,
+            query,
+            sum(memory_usage) AS memory,
+            normalized_query_hash
+        FROM
+            clusterAllReplicas(default, system.query_log)
+        WHERE
+            (event_time >= (now() - toIntervalDay(1)))
+            AND query_kind = 'Select'
+            AND type = 'QueryFinish'
+            and user != 'monitoring-internal'
+        GROUP BY
+            normalized_query_hash,
+            query,
+            user
+        ORDER BY
+            memory DESC;
+        """,
     ],
 )
 def test_invalid_system_query(sql_query: str) -> None:
-    with pytest.raises(InvalidCustomQuery):
-        validate_system_query(sql_query)
-
-
-select_sql = """
-SELECT
-    table,
-    query,
-    format,
-    query_id,
-    bytes,
-    flush_time,
-    flush_query_id
-FROM
-    system.asynchronous_insert_log
-WHERE
-    status = 'Ok'
-    AND database = 'default'
-    AND flush_time > now() - toIntervalMinute(10)
-ORDER BY table, flush_time
-"""
-
-
-def test_is_query_select() -> None:
-    assert is_query_select(select_sql) == True
+    with pytest.raises(Exception):
+        is_valid_system_query(
+            settings.CLUSTERS[0]["host"],
+            int(settings.CLUSTERS[0]["port"]),
+            "errors",
+            sql_query,
+        )
 
 
 @pytest.mark.parametrize(
@@ -98,8 +123,6 @@ def test_sudo_queries(sudo_query: str, expected: bool) -> None:
         or is_query_alter(sudo_query)
         or is_query_optimize(sudo_query)
     ) == expected
-    with pytest.raises(InvalidCustomQuery):
-        validate_system_query(sudo_query)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Instead of using regex for validating system queries, we can use AST/Query Tree output from CH EXPLAIN to check for dangerous queries. This approach is more maintainable and in the future when the new CH analyzer is no longer experimental, we can switch fully to using the Query Tree.