### PR TITLE
fix: Fix tagging with new SDK version

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -7,7 +7,6 @@ from uuid import UUID
 
 import sentry_sdk
 from sentry_kafka_schemas.schema_types import snuba_queries_v1
-from sentry_sdk import Hub
 from usageaccountant import UsageUnit
 
 from snuba import environment, settings, state
@@ -188,7 +187,7 @@ def _add_tags(
     experiments: Optional[Mapping[str, Any]] = None,
     metadata: Optional[SnubaQueryMetadata] = None,
 ) -> None:
-    if Hub.current.scope.span:
+    if sentry_sdk.get_current_span():
         duration_group = timer.get_duration_group()
         sentry_sdk.set_tag("duration_group", duration_group)
         if duration_group == ">30s":

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -13,7 +13,6 @@ import rapidjson
 import sentry_sdk
 from clickhouse_driver.errors import ErrorCodes
 from sentry_kafka_schemas.schema_types import snuba_queries_v1
-from sentry_sdk import Hub
 from sentry_sdk.api import configure_scope
 
 from snuba import environment, settings, state
@@ -294,7 +293,7 @@ def execute_query_with_readthrough_caching(
     query_id: str,
     referrer: str,
 ) -> Result:
-    span = Hub.current.scope.span
+    span = sentry_sdk.get_current_span()
 
     if referrer in settings.BYPASS_CACHE_REFERRERS and state.get_config(
         "enable_bypass_cache_referrers"


### PR DESCRIPTION
The new version of the sentry-sdk checks for existing spans in a different way.
Fix this so that data is still tagged correctly.