### PR TITLE
fix(vscode): update deprecated vscode workspace settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-python.black-formatter",
+        "ms-python.mypy-type-checker",
+        "ms-python.flake8"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,11 +56,7 @@
     "editor.formatOnSave": true
   },
 
-  "python.linting.mypyEnabled": true,
-  "python.linting.flake8Enabled": true,
-  "python.formatting.provider": "black",
-  // https://github.com/DonJayamanne/pythonVSCode/issues/992
-  "python.pythonPath": ".venv/bin/python",
+  "python.defaultInterpreterPath": ".venv/bin/python",
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,


### PR DESCRIPTION
Changes
1. The following vscode settings
```
"python.linting.mypyEnabled": true,
"python.linting.flake8Enabled": true,
"python.formatting.provider": "black",
```
have been deprecated in favor of using the extensions, [see here](https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions#linting-and-formatting-settings-deprecation). I don't think they even do anything anymore. So I removed them and added their corresponding extensions to the workspace extension recommendations.

2. `python.pythonPath` settings has been deprecated and I'm pretty sure it doesnt do anything anymore. `python.defaultInterpreterPath` should be used instead so I replaced it with that. See here https://devblogs.microsoft.com/python/python-in-visual-studio-code-july-2021-release/#selecting-a-python-interpreter-no-longer-modifies-workspace-settings