### PR TITLE
fix(eap): fix table aliasing

### DIFF
--- a/snuba/pipeline/stages/query_execution.py
+++ b/snuba/pipeline/stages/query_execution.py
@@ -147,9 +147,6 @@ def _run_and_apply_column_names(
         concurrent_queries_gauge,
         cluster_name,
     )
-    import pdb
-
-    pdb.set_trace()
     alias_name_mapping: MutableMapping[str, list[str]] = {}
     for select_col in clickhouse_query.get_selected_columns():
         alias = select_col.expression.alias

--- a/snuba/pipeline/stages/query_execution.py
+++ b/snuba/pipeline/stages/query_execution.py
@@ -147,7 +147,9 @@ def _run_and_apply_column_names(
         concurrent_queries_gauge,
         cluster_name,
     )
+    import pdb
 
+    pdb.set_trace()
     alias_name_mapping: MutableMapping[str, list[str]] = {}
     for select_col in clickhouse_query.get_selected_columns():
         alias = select_col.expression.alias

--- a/snuba/pipeline/stages/query_execution.py
+++ b/snuba/pipeline/stages/query_execution.py
@@ -147,6 +147,7 @@ def _run_and_apply_column_names(
         concurrent_queries_gauge,
         cluster_name,
     )
+
     alias_name_mapping: MutableMapping[str, list[str]] = {}
     for select_col in clickhouse_query.get_selected_columns():
         alias = select_col.expression.alias

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -1,5 +1,6 @@
 import uuid
 from collections import defaultdict
+from dataclasses import replace
 from typing import Any, Callable, Dict, Iterable, Sequence, Type
 
 from google.protobuf.json_format import MessageToDict
@@ -81,6 +82,7 @@ def _build_query(request: TraceItemTableRequest) -> Query:
             )
         elif column.HasField("aggregation"):
             function_expr = aggregation_to_expression(column.aggregation)
+            function_expr = replace(function_expr, alias=column.label)
             selected_columns.append(
                 SelectedExpression(name=column.label, expression=function_expr)
             )

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -77,11 +77,15 @@ def _build_query(request: TraceItemTableRequest) -> Query:
     for column in request.columns:
         if column.HasField("key"):
             key_col = attribute_key_to_expression(column.key)
+            # The key_col expression alias may differ from the column label. That is okay
+            # the attribute key name is used in the groupby, the column label is just the name of
+            # the returned attribute value
             selected_columns.append(
                 SelectedExpression(name=column.label, expression=key_col)
             )
         elif column.HasField("aggregation"):
             function_expr = aggregation_to_expression(column.aggregation)
+            # aggregation label may not be set and the column label takes priority anyways.
             function_expr = replace(function_expr, alias=column.label)
             selected_columns.append(
                 SelectedExpression(name=column.label, expression=function_expr)

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -77,7 +77,7 @@ def _build_query(request: TraceItemTableRequest) -> Query:
         if column.HasField("key"):
             key_col = attribute_key_to_expression(column.key)
             selected_columns.append(
-                SelectedExpression(name=column.key.name, expression=key_col)
+                SelectedExpression(name=column.label, expression=key_col)
             )
         elif column.HasField("aggregation"):
             function_expr = aggregation_to_expression(column.aggregation)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -730,7 +730,7 @@ class TestTraceItemTable(BaseApiTest):
         measurement_avg = [v.val_float for v in response.column_values[0].results][0]
         assert measurement_avg == 420
 
-    def test_different_column_label_and_attr_name(self, setup_teardown: Any):
+    def test_different_column_label_and_attr_name(self, setup_teardown: Any) -> None:
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = Timestamp(seconds=int((BASE_TIME - timedelta(hours=1)).timestamp()))
         message = TraceItemTableRequest(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -730,6 +730,37 @@ class TestTraceItemTable(BaseApiTest):
         measurement_avg = [v.val_float for v in response.column_values[0].results][0]
         assert measurement_avg == 420
 
+    def test_failing_query(self, setup_teardown: Any):
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = Timestamp(seconds=int((BASE_TIME - timedelta(hours=1)).timestamp()))
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                organization_id=1,
+                project_ids=[1],
+                start_timestamp=hour_ago,
+                end_timestamp=ts,
+                referrer="something",
+                cogs_category="something",
+            ),
+            columns=[
+                Column(
+                    key=AttributeKey(name="sentry.name", type=AttributeKey.TYPE_STRING),
+                    label="description",
+                ),
+                Column(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_COUNT,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="sentry.duration_ms"
+                        ),
+                    ),
+                    label="count()",
+                ),
+            ],
+            group_by=[AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.name")],
+        )
+        EndpointTraceItemTable().execute(message)
+
 
 class TestUtils:
     def test_apply_labels_to_columns(self) -> None:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -730,7 +730,7 @@ class TestTraceItemTable(BaseApiTest):
         measurement_avg = [v.val_float for v in response.column_values[0].results][0]
         assert measurement_avg == 420
 
-    def test_failing_query(self, setup_teardown: Any):
+    def test_different_column_label_and_attr_name(self, setup_teardown: Any):
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = Timestamp(seconds=int((BASE_TIME - timedelta(hours=1)).timestamp()))
         message = TraceItemTableRequest(
@@ -759,7 +759,9 @@ class TestTraceItemTable(BaseApiTest):
             ],
             group_by=[AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.name")],
         )
-        EndpointTraceItemTable().execute(message)
+        response = EndpointTraceItemTable().execute(message)
+        assert response.column_values[0].attribute_name == "description"
+        assert response.column_values[1].attribute_name == "count()"
 
 
 class TestUtils:


### PR DESCRIPTION
Using the wrong value for selected expression name, also aggregations sometimes don't have a label, we can just inherit the column name