### PR TITLE
feat(devservices): Remove devservices from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ click==8.1.3
 clickhouse-driver==0.2.6
 confluent-kafka==2.3.0
 datadog==0.21.0
-devservices==0.0.4
 flake8==5.0.4
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
Now that we have a clear update command for devservices that bumps the version in place, let's get rid of this. It removes ambiguity between using venv installs and global binary installs through PATH.

Installation instructions here:
https://github.com/getsentry/devservices?tab=readme-ov-file#installation