### PR TITLE
Checkout labeler code before updating it to v5

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
https://github.com/getsentry/snuba/commit/b8a94dbc73147ea8800ab5fcdb2c3c1d110577d8 reverted the `labeler` to `v4`. To update the `labeler` to `v5` (originally intended to be done through https://github.com/getsentry/snuba/pull/6496), just updating the version to `v5` is not sufficient. https://github.com/actions/labeler/issues/628 recommends to add the `checkout` action before updating the labeler to `v5`. 