### PR TITLE
Consolidate migrations label into labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,0 @@
-migrations:
-- snuba/migrations/group_loader.py
-- snuba/migrations/groups.py
-- snuba/snuba_migrations/**/*
-- snuba/migrations/system_migrations/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,7 +17,7 @@ jobs:
 
 labels:
   migrations:
-  - snuba/migrations/group_loader.py
-  - snuba/migrations/groups.py
-  - snuba/snuba_migrations/**/*
-  - snuba/migrations/system_migrations/*
+    - snuba/migrations/group_loader.py
+    - snuba/migrations/groups.py
+    - snuba/snuba_migrations/**/*
+    - snuba/migrations/system_migrations/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,3 +14,10 @@ jobs:
     - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+labels:
+  migrations:
+  - snuba/migrations/group_loader.py
+  - snuba/migrations/groups.py
+  - snuba/snuba_migrations/**/*
+  - snuba/migrations/system_migrations/*


### PR DESCRIPTION
Even after merging https://github.com/getsentry/snuba/pull/6504, the labeler stage is failing when dependabot makes the changes. This is because we had two `labeler.yml` files. The deleted file just adds a label `migrations` when some specific files are touched. This PR combines that functionality into existing labeler workflow so that we have one `labeler.yml` file.