### PR TITLE
ref(deletes): add ConditionsType

### DIFF
--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -26,6 +26,7 @@ from snuba.utils.schemas import ColumnValidator, InvalidColumnType
 from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.topics import Topic
 from snuba.web.delete_query import (
+    ConditionsType,
     DeletesNotEnabledError,
     _construct_condition,
     _enforce_max_rows,
@@ -35,8 +36,6 @@ from snuba.web.delete_query import (
 
 metrics = MetricsWrapper(environment.metrics, "snuba.delete")
 logger = logging.getLogger(__name__)
-
-ConditionsType = Mapping[str, Sequence[str | int | float]]
 
 
 class DeleteQueryMessage(TypedDict):
@@ -219,7 +218,7 @@ def delete_from_tables(
     return result
 
 
-def construct_or_conditions(conditions: Sequence[Dict[str, Any]]) -> Expression:
+def construct_or_conditions(conditions: Sequence[ConditionsType]) -> Expression:
     """
     Combines multiple AND conditions: (equals(project_id, 1) AND in(group_id, (2, 3, 4, 5))
     into OR conditions for a bulk delete

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -1,6 +1,6 @@
 import typing
 import uuid
-from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
 from snuba import settings
 from snuba.attribution import get_app_id
@@ -35,6 +35,8 @@ from snuba.utils.schemas import ColumnValidator, InvalidColumnType
 from snuba.web import QueryException, QueryExtraData, QueryResult
 from snuba.web.db_query import _apply_allocation_policies_quota
 
+ConditionsType = Mapping[str, Sequence[str | int | float]]
+
 
 class DeletesNotEnabledError(Exception):
     pass
@@ -47,7 +49,7 @@ class TooManyOngoingMutationsError(Exception):
 @with_span()
 def delete_from_storage(
     storage: WritableTableStorage,
-    columns: Dict[str, list[Any]],
+    columns: ConditionsType,
     attribution_info: Mapping[str, Any],
 ) -> dict[str, Result]:
     """
@@ -108,7 +110,7 @@ def delete_from_storage(
 def _delete_from_table(
     storage: WritableTableStorage,
     table: str,
-    conditions: Dict[str, Any],
+    conditions: ConditionsType,
     attribution_info: AttributionInfo,
 ) -> Result:
     cluster_name = storage.get_cluster().get_clickhouse_cluster_name()
@@ -345,7 +347,7 @@ def _execute_query(
         )
 
 
-def _construct_condition(columns: Dict[str, Any]) -> Expression:
+def _construct_condition(columns: ConditionsType) -> Expression:
     and_conditions = []
     for col, values in columns.items():
         if len(values) == 1:


### PR DESCRIPTION
Adds better typing to the delete pipeline as well separates some code out from https://github.com/getsentry/snuba/pull/6510. To avoid circular imports, it's easier to have `bulk_delete_query` file almost import from `delete_query`, and never have `delete_query` import from `bulk_delete_query` (where the ConditionsType was before)