### PR TITLE
fix(eap-api): fix TraceItemTable aliasing bug

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -177,20 +177,20 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
     if attr_key.type == AttributeKey.Type.TYPE_INT:
         return f.CAST(
             SubscriptableReference(
-                alias=alias,
-                column=column("attr_num"),
-                key=literal(attr_key.name),
+                column=column("attr_num"), key=literal(attr_key.name), alias=None
             ),
             "Int64",
+            alias=alias,
         )
     if attr_key.type == AttributeKey.Type.TYPE_BOOLEAN:
         return f.CAST(
             SubscriptableReference(
-                alias=alias,
+                alias=None,
                 column=column("attr_num"),
                 key=literal(attr_key.name),
             ),
             "Boolean",
+            alias=alias,
         )
     raise BadSnubaRPCRequestException(
         f"Attribute {attr_key.name} had an unknown or unset type: {attr_key.type}"

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -177,7 +177,7 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
     if attr_key.type == AttributeKey.Type.TYPE_INT:
         return f.CAST(
             SubscriptableReference(
-                column=column("attr_num"), key=literal(attr_key.name), alias=None
+                alias=None, column=column("attr_num"), key=literal(attr_key.name)
             ),
             "Int64",
             alias=alias,

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -71,20 +71,22 @@ class TestCommon:
             AttributeKey(type=AttributeKey.TYPE_INT, name="derp"),
         ) == f.CAST(
             SubscriptableReference(
-                alias="derp",
+                alias=None,
                 column=column("attr_num"),
                 key=literal("derp"),
             ),
             "Int64",
+            alias="derp",
         )
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="derp"),
         ) == f.CAST(
             SubscriptableReference(
-                alias="derp",
+                alias=None,
                 column=column("attr_num"),
                 key=literal("derp"),
             ),
             "Boolean",
+            alias="derp",
         )

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any, Mapping
 
 import pytest
-from google.protobuf.json_format import MessageToDict
+from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     Column,
@@ -762,6 +762,85 @@ class TestTraceItemTable(BaseApiTest):
         response = EndpointTraceItemTable().execute(message)
         assert response.column_values[0].attribute_name == "description"
         assert response.column_values[1].attribute_name == "count()"
+
+    def test_cast_bug(self, setup_teardown: Any) -> None:
+        """
+        This test was added because the following request was causing a bug. The test was added when the bug was fixed.
+
+        Specifically the bug was related to the 2nd and 3rd columns of the request:
+        "type": "TYPE_INT", "name": "attr_num[foo]
+        "type": "TYPE_BOOLEAN", "name": "attr_num[foo]
+        and how alias was added to CAST.
+        """
+
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = Timestamp(seconds=int((BASE_TIME - timedelta(hours=1)).timestamp()))
+        err_req = {
+            "meta": {
+                "organizationId": "1",
+                "referrer": "api.organization-events",
+                "projectIds": ["1"],
+                "startTimestamp": hour_ago.ToJsonString(),
+                "endTimestamp": ts.ToJsonString(),
+            },
+            "columns": [
+                {
+                    "key": {"type": "TYPE_STRING", "name": "sentry.name"},
+                    "label": "description",
+                },
+                {
+                    "key": {"type": "TYPE_INT", "name": "attr_num[foo]"},
+                    "label": "tags[foo,number]",
+                },
+                {
+                    "key": {"type": "TYPE_BOOLEAN", "name": "attr_num[foo]"},
+                    "label": "tags[foo,boolean]",
+                },
+                {
+                    "key": {"type": "TYPE_STRING", "name": "attr_str[foo]"},
+                    "label": "tags[foo,string]",
+                },
+                {
+                    "key": {"type": "TYPE_STRING", "name": "attr_str[foo]"},
+                    "label": "tags[foo]",
+                },
+                {
+                    "key": {"type": "TYPE_STRING", "name": "sentry.span_id"},
+                    "label": "id",
+                },
+                {
+                    "key": {"type": "TYPE_STRING", "name": "project.name"},
+                    "label": "project.name",
+                },
+            ],
+            "orderBy": [
+                {
+                    "column": {
+                        "key": {"type": "TYPE_STRING", "name": "sentry.name"},
+                        "label": "description",
+                    }
+                }
+            ],
+            "groupBy": [
+                {"type": "TYPE_STRING", "name": "sentry.name"},
+                {"type": "TYPE_INT", "name": "attr_num[foo]"},
+                {"type": "TYPE_BOOLEAN", "name": "attr_num[foo]"},
+                {"type": "TYPE_STRING", "name": "attr_str[foo]"},
+                {"type": "TYPE_STRING", "name": "attr_str[foo]"},
+                {"type": "TYPE_STRING", "name": "sentry.span_id"},
+                {"type": "TYPE_STRING", "name": "project.name"},
+            ],
+            "virtualColumnContexts": [
+                {
+                    "fromColumnName": "sentry.project_id",
+                    "toColumnName": "project.name",
+                    "valueMap": {"4554989665714177": "bar"},
+                }
+            ],
+        }
+        err_msg = ParseDict(err_req, TraceItemTableRequest())
+        # just ensuring it doesnt raise an exception
+        EndpointTraceItemTable().execute(err_msg)
 
 
 class TestUtils:


### PR DESCRIPTION
This PR fixes [this bug](https://github.com/getsentry/projects/issues/363)

The test in the PR successfully reproduce the bug, and began passing after my change.

The bug was caused because one of the SelectedColumns in the query object looked like this
```
CAST(attr_num['attr_num[foo]'] AS attr_num[foo],'Int64')
```
this caused an issue later on at `converters[column_name]` because there is only a converter for `attr_num[foo]` not for `CAST(attr_num['attr_num[foo]'] AS attr_num[foo], 'Int64')`.

My change moved the alias so the SelectedColumn now looks like
```
CAST(attr_num['attr_num[foo]'], 'Int64') AS attr_num[foo]
```
and bug fixed