### PR TITLE
fix(sdk): Fix transaction name with new Sentry SDK

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
 jsonschema2md==0.4.0
 fastjsonschema==2.16.2
-sentry-sdk==2.8.0
+sentry-sdk==2.18.0
 myst-parser==0.18.0
 sphinx==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ sentry-arroyo==2.17.6
 sentry-kafka-schemas==0.1.117
 sentry-redis-tools==0.3.0
 sentry-relay==0.9.2
-sentry-sdk==2.8.0
+sentry-sdk==2.18.0
 simplejson==3.17.6
 snuba-sdk==3.0.39
 structlog==22.3.0


### PR DESCRIPTION
The updated version of the SDK sets the transaction name with a different API.
Update the code to properly set the tags and transaction name.