### PR TITLE
fix(admin): Log more data when dealing with discover storage

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -31,8 +31,18 @@ def is_valid_node(
     nodes = [
         cluster.get_query_node(),
     ]
-    if storage_name != "discover":
+    try:
         nodes.extend([*cluster.get_local_nodes(), *cluster.get_distributed_nodes()])
+    except Exception as e:
+        raise InvalidNodeError(
+            f"Error getting nodes for storage {storage_name}",
+            extra_data={
+                "error": str(e),
+                "host": host,
+                "port": port,
+                "nodes": ",".join([node.host_name for node in nodes]),
+            },
+        )
 
     return any(node.host_name == host and node.port == port for node in nodes)
 


### PR DESCRIPTION
The discover storage has a different configuration from the other storages, since
it's a merge table. Instead of silently skipping nodes, attempt to connect
and log the resulting error (if any).