### PR TITLE
Fix sampling weight calculation

### DIFF
--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -217,7 +217,7 @@ impl From<FromSpanMessage> for EAPSpan {
 
             // lower precision to compensate floating point errors
             res.sampling_factor = (res.sampling_factor * 1e9).round() / 1e9;
-            res.sampling_weight = (1.0 / res.sampling_factor) as u64;
+            res.sampling_weight = (1.0 / res.sampling_factor).round();
 
             if let Some(data) = from.data {
                 for (k, v) in data {

--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -217,7 +217,7 @@ impl From<FromSpanMessage> for EAPSpan {
 
             // lower precision to compensate floating point errors
             res.sampling_factor = (res.sampling_factor * 1e9).round() / 1e9;
-            res.sampling_weight = (1.0 / res.sampling_factor).round();
+            res.sampling_weight = (1.0 / res.sampling_factor).round() as u64;
 
             if let Some(data) = from.data {
                 for (k, v) in data {


### PR DESCRIPTION
Using numeric casting, we always round down which leads to the sampling weight being calculated less accurately. For example, a sample rate of 0.16666666666666666 results in a sampling weight of 5 instead of 6.