### PR TITLE
chore(eap-spans): Switch test to use new spans table

### DIFF
--- a/rust_snuba/src/mutations/clickhouse.rs
+++ b/rust_snuba/src/mutations/clickhouse.rs
@@ -299,7 +299,7 @@ mod tests {
         // build the mutation batch
         batch.0.insert(primary_key.clone(), update);
 
-        let test_client = ClickhouseTestClient::new("eap_spans".to_string())
+        let test_client = ClickhouseTestClient::new("eap_spans_2".to_string())
             .await
             .unwrap();
 


### PR DESCRIPTION
Before we can remove the table, we need to change the table to copy the schema from (https://github.com/getsentry/snuba/blob/e86fafbbcc6317ee6cb3d4dcb064aa8eb0dce90b/rust_snuba/src/mutations/clickhouse.rs#L238)