### PR TITLE
feat(consumers): rust consumer runtime config

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -125,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +640,16 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -2713,6 +2729,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cccf17a692ce51b86564334614d72dcae1def0fd5ecebc9f02956da74352b5"
+dependencies = [
+ "arc-swap",
+ "combine",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.6",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +2902,7 @@ dependencies = [
  "parking_lot",
  "procspawn",
  "pyo3",
+ "redis",
  "reqwest",
  "rust_arroyo",
  "schemars",
@@ -3323,6 +3357,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -54,6 +54,7 @@ data-encoding = "2.5.0"
 zstd = "0.12.3"
 serde_with = "3.8.1"
 seq-macro = "0.3"
+redis = "0.27.5"
 
 
 [patch.crates-io]

--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -4,13 +4,40 @@ use pyo3::prelude::{PyModule, Python};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use redis;
 use rust_arroyo::timer;
 use rust_arroyo::utils::timing::Deadline;
 
 static CONFIG: RwLock<BTreeMap<String, (Option<String>, Deadline)>> = RwLock::new(BTreeMap::new());
 
-/// Runtime config is cached for 10 seconds
 pub fn get_str_config(key: &str) -> Result<Option<String>, Error> {
+    let redis_host = std::env::var("REDIS_HOST").unwrap_or(String::from("127.0.0.1"));
+    let redis_port = std::env::var("REDIS_PORT").unwrap_or(String::from("6379"));
+    let redis_password = std::env::var("REDIS_PASSWORD").unwrap_or(String::from(""));
+    let redis_db = std::env::var("REDIS_DB").unwrap_or(String::from("1"));
+    let redis_ssl = std::env::var("REDIS_SSL").unwrap_or(String::from("1"));
+    let deadline = Deadline::new(Duration::from_secs(10));
+    let url = format!(
+        "redis://{}:{}@{}:{}/{}",
+        "default", redis_password, redis_host, redis_port, redis_db
+    );
+
+    if let Some(value) = CONFIG.read().get(key) {
+        let (config, deadline) = value;
+        if !deadline.has_elapsed() {
+            return Ok(config.clone());
+        }
+    }
+
+    let client = redis::Client::open(url)?;
+    let mut con = client.get_connection()?;
+
+    let configmap: HashMap<String, String> = client.hgetall("snuba-config");
+    return configmap.get(String::from(key));
+}
+
+/// Runtime config is cached for 10 seconds
+pub fn get_str_config_python(key: &str) -> Result<Option<String>, Error> {
     let deadline = Deadline::new(Duration::from_secs(10));
 
     if let Some(value) = CONFIG.read().get(key) {

--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -1,43 +1,30 @@
 use anyhow::Error;
 use parking_lot::RwLock;
-use pyo3::prelude::{PyModule, Python};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use redis;
-use rust_arroyo::timer;
+use redis::Commands;
+use std::collections::HashMap;
+
 use rust_arroyo::utils::timing::Deadline;
 
 static CONFIG: RwLock<BTreeMap<String, (Option<String>, Deadline)>> = RwLock::new(BTreeMap::new());
+static CONFIG_HASHSET_KEY: &str = "snuba-config";
 
-pub fn get_str_config(key: &str) -> Result<Option<String>, Error> {
+fn get_redis_client() -> Result<redis::Client, redis::RedisError> {
     let redis_host = std::env::var("REDIS_HOST").unwrap_or(String::from("127.0.0.1"));
     let redis_port = std::env::var("REDIS_PORT").unwrap_or(String::from("6379"));
     let redis_password = std::env::var("REDIS_PASSWORD").unwrap_or(String::from(""));
     let redis_db = std::env::var("REDIS_DB").unwrap_or(String::from("1"));
-    let redis_ssl = std::env::var("REDIS_SSL").unwrap_or(String::from("1"));
-    let deadline = Deadline::new(Duration::from_secs(10));
+    // TODO: handle SSL?
     let url = format!(
         "redis://{}:{}@{}:{}/{}",
         "default", redis_password, redis_host, redis_port, redis_db
     );
-
-    if let Some(value) = CONFIG.read().get(key) {
-        let (config, deadline) = value;
-        if !deadline.has_elapsed() {
-            return Ok(config.clone());
-        }
-    }
-
-    let client = redis::Client::open(url)?;
-    let mut con = client.get_connection()?;
-
-    let configmap: HashMap<String, String> = client.hgetall("snuba-config");
-    return configmap.get(String::from(key));
+    redis::Client::open(url)
 }
 
-/// Runtime config is cached for 10 seconds
-pub fn get_str_config_python(key: &str) -> Result<Option<String>, Error> {
+pub fn get_str_config(key: &str) -> Result<Option<String>, Error> {
     let deadline = Deadline::new(Duration::from_secs(10));
 
     if let Some(value) = CONFIG.read().get(key) {
@@ -46,33 +33,45 @@ pub fn get_str_config_python(key: &str) -> Result<Option<String>, Error> {
             return Ok(config.clone());
         }
     }
+    let client = get_redis_client()?;
+    let mut con = client.get_connection()?;
 
-    let rv = Python::with_gil(|py| {
-        let snuba_state = PyModule::import(py, "snuba.state")?;
-        let config = snuba_state
-            .getattr("get_str_config")?
-            .call1((key,))?
-            .extract::<Option<String>>()?;
+    let configmap: HashMap<String, String> = con.hgetall(CONFIG_HASHSET_KEY)?;
+    let val = match configmap.get(key) {
+        Some(val) => Some(val.clone()),
+        None => return Ok(None),
+    };
 
-        CONFIG
-            .write()
-            .insert(key.to_string(), (config.clone(), deadline));
-        Ok(CONFIG.read().get(key).unwrap().0.clone())
-    });
-
-    timer!("runtime_config.get_str_config", deadline.elapsed());
-
-    rv
+    CONFIG
+        .write()
+        .insert(key.to_string(), (val.clone(), deadline));
+    Ok(CONFIG.read().get(key).unwrap().0.clone())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn set_str_config(key: &str, val: &str) -> Result<(), Error> {
+        let client = get_redis_client()?;
+        let mut con = client.get_connection()?;
+        con.hset(CONFIG_HASHSET_KEY, key, val)?;
+        Ok(())
+    }
+
+    fn del_str_config(key: &str) -> Result<(), Error> {
+        let client = get_redis_client()?;
+        let mut con = client.get_connection()?;
+        con.hdel(CONFIG_HASHSET_KEY, key)?;
+        Ok(())
+    }
 
     #[test]
     fn test_runtime_config() {
-        crate::testutils::initialize_python();
+        del_str_config("test").unwrap();
         let config = get_str_config("test");
         assert_eq!(config.unwrap(), None);
+        set_str_config("test", "value").unwrap();
+        assert_eq!(get_str_config("test").unwrap(), Some(String::from("value")));
+        del_str_config("test").unwrap();
     }
 }


### PR DESCRIPTION
Our current setup is accessing runtime config by FFI'ing into the python module. This is not only ugly and a performance hit, but also makes local testing development difficult because the FFI semantics don't seem to be the same across machines. (For example, I can't get the `test_python` and `test_runtime_config` tests to work on my machine.

The fewer python dependencies we have the better

### Do not merge this yet, ops repo needs to be changed to pass the redis params in via env vars