### PR TITLE
ref(deletes): add lw-deletions-search-issues-consumer to deploy.sh

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -53,6 +53,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="eap-spans-consumer" \
   --container-name="eap-mutations-consumer" \
   --container-name="eap-spans-profiled-consumer" \
+  --container-name="lw-deletions-search-issues-consumer" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \


### PR DESCRIPTION
replicas are still set to `0` right now, and will only be enabled in S4S in the near future. 

ops PR to set replicas to `1` for S4S: https://github.com/getsentry/ops/pull/12839