### PR TITLE
feat(subscriptions): Add a create subscription rpc endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ sqlparse==0.5.0
 google-api-python-client==2.88.0
 sentry-usage-accountant==0.0.11
 freezegun==1.2.2
-sentry-protos==0.1.31
+sentry-protos==0.1.34

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -312,21 +312,6 @@ class SnQLSubscriptionData(SubscriptionData):
                 "At least one Entity must have a timestamp column for subscriptions"
             )
 
-    def validate(self) -> None:
-        if self.time_window_sec < 60:
-            raise InvalidSubscriptionError(
-                "Time window must be greater than or equal to 1 minute"
-            )
-        elif self.time_window_sec > 60 * 60 * 24:
-            raise InvalidSubscriptionError(
-                "Time window must be less than or equal to 24 hours"
-            )
-
-        if self.resolution_sec < 60:
-            raise InvalidSubscriptionError(
-                "Resolution must be greater than or equal to 1 minute"
-            )
-
     def build_request(
         self,
         dataset: Dataset,

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -25,6 +25,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
     CreateSubscriptionRequest,
 )
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
@@ -173,6 +174,15 @@ class RPCSubscriptionData(SubscriptionData):
 
         if request.group_by:
             raise InvalidSubscriptionError("Group bys not supported.")
+
+        aggregation = request.aggregations[0]
+        if (
+            aggregation.extrapolation_mode
+            != ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED
+        ):
+            raise InvalidSubscriptionError(
+                f"Invalid extrapolation mode. Allowed extrapolation modes: {ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED}"
+            )
 
     def build_request(
         self,

--- a/snuba/subscriptions/rpc_helpers.py
+++ b/snuba/subscriptions/rpc_helpers.py
@@ -1,0 +1,59 @@
+import base64
+from datetime import UTC, datetime, timedelta
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+
+from snuba.reader import Result
+from snuba.web import QueryResult
+from snuba.web.rpc.v1.endpoint_time_series import EndpointTimeSeries
+
+
+def build_rpc_request(
+    timestamp: datetime,
+    time_window_sec: int,
+    time_series_request: str,
+) -> TimeSeriesRequest:
+
+    request_class = EndpointTimeSeries().request_class()()
+    request_class.ParseFromString(base64.b64decode(time_series_request))
+
+    # TODO: update it to round to the lowest granularity
+    # rounded_ts = int(timestamp.replace(tzinfo=UTC).timestamp() / 15) * 15
+    rounded_ts = (
+        int(timestamp.replace(tzinfo=UTC).timestamp() / time_window_sec)
+        * time_window_sec
+    )
+    rounded_start = datetime.utcfromtimestamp(rounded_ts)
+
+    start_time_proto = Timestamp()
+    start_time_proto.FromDatetime(rounded_start - timedelta(seconds=time_window_sec))
+    end_time_proto = Timestamp()
+    end_time_proto.FromDatetime(rounded_start)
+    request_class.meta.start_timestamp.CopyFrom(start_time_proto)
+    request_class.meta.end_timestamp.CopyFrom(end_time_proto)
+
+    request_class.granularity_secs = time_window_sec
+
+    return request_class
+
+
+def run_rpc_subscription_query(
+    request: TimeSeriesRequest,
+) -> QueryResult:
+    response = EndpointTimeSeries().execute(request)
+    if not response.result_timeseries:
+        result: Result = {
+            "meta": [],
+            "data": [{request.aggregations[0].label: 0}],
+            "trace_output": "",
+        }
+        return QueryResult(
+            result=result, extra={"stats": {}, "sql": "", "experiments": {}}
+        )
+
+    timeseries = response.result_timeseries[0]
+    data = [{timeseries.label: timeseries.data_points[0].data}]
+
+    result = {"meta": [], "data": data, "trace_output": ""}
+    return QueryResult(result=result, extra={"stats": {}, "sql": "", "experiments": {}})

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -1,16 +1,25 @@
 from datetime import datetime
 from uuid import UUID, uuid1
 
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import enforce_table_writer, get_entity
 from snuba.redis import RedisClientKey, get_redis_client
+from snuba.request import Request
 from snuba.subscriptions.data import (
     PartitionId,
+    RPCSubscriptionData,
+    SnQLSubscriptionData,
     SubscriptionData,
     SubscriptionIdentifier,
 )
 from snuba.subscriptions.partitioner import TopicSubscriptionDataPartitioner
+from snuba.subscriptions.rpc_helpers import (
+    build_rpc_request,
+    run_rpc_subscription_query,
+)
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import run_query
@@ -51,8 +60,17 @@ class SubscriptionCreator:
         return identifier
 
     def _test_request(self, data: SubscriptionData, timer: Timer) -> None:
-        request = data.build_request(self.dataset, datetime.utcnow(), None, timer)
-        run_query(self.dataset, request, timer)
+        request: Request | TimeSeriesRequest
+        if isinstance(data, SnQLSubscriptionData):
+            request = data.build_request(self.dataset, datetime.utcnow(), None, timer)
+            run_query(self.dataset, request, timer)
+        if isinstance(data, RPCSubscriptionData):
+            request = build_rpc_request(
+                datetime.utcnow(),
+                data.time_window_sec,
+                data.time_series_request,
+            )
+            run_rpc_subscription_query(request)
 
 
 class SubscriptionDeleter:

--- a/snuba/web/rpc/v1/create_subscription.py
+++ b/snuba/web/rpc/v1/create_subscription.py
@@ -1,0 +1,44 @@
+from typing import Type
+
+from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
+    CreateSubscriptionRequest as CreateSubscriptionRequestProto,
+)
+from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
+    CreateSubscriptionResponse,
+)
+
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.pluggable_dataset import PluggableDataset
+from snuba.web.rpc import RPCEndpoint
+
+
+class CreateSubscriptionRequest(
+    RPCEndpoint[CreateSubscriptionRequestProto, CreateSubscriptionResponse]
+):
+    @classmethod
+    def version(cls) -> str:
+        return "v1"
+
+    @classmethod
+    def request_class(cls) -> Type[CreateSubscriptionRequestProto]:
+        return CreateSubscriptionRequestProto
+
+    @classmethod
+    def response_class(cls) -> Type[CreateSubscriptionResponse]:
+        return CreateSubscriptionResponse
+
+    def _execute(
+        self, in_msg: CreateSubscriptionRequestProto
+    ) -> CreateSubscriptionResponse:
+        from snuba.subscriptions.data import RPCSubscriptionData
+        from snuba.subscriptions.subscription import SubscriptionCreator
+
+        dataset = PluggableDataset(name="eap", all_entities=[])
+        entity_key = EntityKey("eap_spans")
+
+        subscription = RPCSubscriptionData.from_proto(in_msg, entity_key=entity_key)
+        identifier = SubscriptionCreator(dataset, entity_key).create(
+            subscription, self._timer
+        )
+
+        return CreateSubscriptionResponse(subscription_id=str(identifier))

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -1,0 +1,109 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
+    CreateSubscriptionRequest as CreateSubscriptionRequestProto,
+)
+from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
+    CreateSubscriptionResponse,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.error_pb2 import Error
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    ExtrapolationMode,
+    Function,
+)
+
+from tests.base import BaseApiTest
+from tests.web.rpc.v1.test_endpoint_time_series import DummyMetric, store_timeseries
+
+END_TIME = datetime.utcnow().replace(second=0, microsecond=0, tzinfo=UTC)
+START_TIME = END_TIME - timedelta(hours=1)
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+class TestCreateSubscriptionApi(BaseApiTest):
+    def test_create_valid_subscription(self) -> None:
+        store_timeseries(
+            START_TIME,
+            1,
+            3600,
+            metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
+        )
+
+        message = CreateSubscriptionRequestProto(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                ),
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ],
+                granularity_secs=300,
+            ),
+            time_window_secs=300,
+            resolution_secs=60,
+        )
+        response = self.app.post(
+            "/rpc/CreateSubscriptionRequest/v1", data=message.SerializeToString()
+        )
+        assert response.status_code == 200
+        response_class = CreateSubscriptionResponse()
+        response_class.ParseFromString(response.data)
+        assert response_class.subscription_id
+
+    def test_create_invalid_subscription(self) -> None:
+        store_timeseries(
+            START_TIME,
+            1,
+            3600,
+            metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
+        )
+
+        message = CreateSubscriptionRequestProto(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                ),
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ],
+                granularity_secs=172800,
+            ),
+            time_window_secs=172800,
+            resolution_secs=60,
+        )
+        response = self.app.post(
+            "/rpc/CreateSubscriptionRequest/v1", data=message.SerializeToString()
+        )
+        assert response.status_code == 500
+        error = Error()
+        error.ParseFromString(response.data)
+        assert (
+            error.message
+            == "internal error occurred while executing this RPC call: Time window must be less than or equal to 24 hours"
+        )

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -28,6 +28,125 @@ END_TIME = datetime.utcnow().replace(second=0, microsecond=0, tzinfo=UTC)
 START_TIME = END_TIME - timedelta(hours=1)
 
 
+TESTS_INVALID_RPC_SUBSCRIPTIONS = [
+    pytest.param(
+        CreateSubscriptionRequestProto(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                ),
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ],
+            ),
+            time_window_secs=172800,
+            resolution_secs=60,
+        ),
+        "Time window must be less than or equal to 24 hours",
+        id="Invalid subscription: time window",
+    ),
+    pytest.param(
+        CreateSubscriptionRequestProto(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                ),
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ],
+            ),
+            time_window_secs=300,
+            resolution_secs=60,
+        ),
+        "Multiple project IDs not supported",
+        id="Invalid subscription: multiple project ids",
+    ),
+    pytest.param(
+        CreateSubscriptionRequestProto(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                ),
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ],
+            ),
+            time_window_secs=300,
+            resolution_secs=60,
+        ),
+        "Exactly one aggregation required",
+        id="Invalid subscription: multiple aggregations",
+    ),
+    pytest.param(
+        CreateSubscriptionRequestProto(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                ),
+                group_by=[
+                    AttributeKey(type=AttributeKey.TYPE_STRING, name="device.class")
+                ],
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ],
+            ),
+            time_window_secs=300,
+            resolution_secs=60,
+        ),
+        "Group bys not supported",
+        id="Invalid subscription: group by",
+    ),
+]
+
+
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
 class TestCreateSubscriptionApi(BaseApiTest):
@@ -42,7 +161,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
         message = CreateSubscriptionRequestProto(
             time_series_request=TimeSeriesRequest(
                 meta=RequestMeta(
-                    project_ids=[1, 2, 3],
+                    project_ids=[1],
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
@@ -91,7 +210,12 @@ class TestCreateSubscriptionApi(BaseApiTest):
         assert subscription_data["request_name"] == "TimeSeriesRequest"
         assert subscription_data["request_version"] == "v1"
 
-    def test_create_invalid_subscription(self) -> None:
+    @pytest.mark.parametrize(
+        "create_subscription, error_message", TESTS_INVALID_RPC_SUBSCRIPTIONS
+    )
+    def test_create_invalid_subscription(
+        self, create_subscription: CreateSubscriptionRequestProto, error_message: str
+    ) -> None:
         store_timeseries(
             START_TIME,
             1,
@@ -99,36 +223,11 @@ class TestCreateSubscriptionApi(BaseApiTest):
             metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
         )
 
-        message = CreateSubscriptionRequestProto(
-            time_series_request=TimeSeriesRequest(
-                meta=RequestMeta(
-                    project_ids=[1, 2, 3],
-                    organization_id=1,
-                    cogs_category="something",
-                    referrer="something",
-                ),
-                aggregations=[
-                    AttributeAggregation(
-                        aggregate=Function.FUNCTION_SUM,
-                        key=AttributeKey(
-                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
-                        ),
-                        label="sum",
-                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
-                    ),
-                ],
-                granularity_secs=172800,
-            ),
-            time_window_secs=172800,
-            resolution_secs=60,
-        )
         response = self.app.post(
-            "/rpc/CreateSubscriptionRequest/v1", data=message.SerializeToString()
+            "/rpc/CreateSubscriptionRequest/v1",
+            data=create_subscription.SerializeToString(),
         )
         assert response.status_code == 500
         error = Error()
         error.ParseFromString(response.data)
-        assert (
-            error.message
-            == "internal error occurred while executing this RPC call: Time window must be less than or equal to 24 hours"
-        )
+        assert error_message in error.message

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -144,6 +144,32 @@ TESTS_INVALID_RPC_SUBSCRIPTIONS = [
         "Group bys not supported",
         id="Invalid subscription: group by",
     ),
+    pytest.param(
+        CreateSubscriptionRequestProto(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                ),
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ],
+            ),
+            time_window_secs=300,
+            resolution_secs=60,
+        ),
+        "Invalid extrapolation mode",
+        id="Invalid subscription: extrapolation mode",
+    ),
 ]
 
 
@@ -173,7 +199,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
                             type=AttributeKey.TYPE_FLOAT, name="test_metric"
                         ),
                         label="sum",
-                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
                     ),
                 ],
                 granularity_secs=300,

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -73,6 +73,8 @@ class TestCreateSubscriptionApi(BaseApiTest):
         entity_key = EntityKey("eap_spans")
 
         redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
+        # TODO[fix]: querying the redis client like this directly is temporary
+        # because we don't have decode support for rpc queries in the codec yet.
         stored_subscription_data = list(
             redis_client.hgetall(
                 f"subscriptions:{entity_key.value}:{partition}"


### PR DESCRIPTION
This PR adds the CreateSubscription RPC endpoint. To create an RPC subscription we need to:
1. Create an RPC subscription object from the CreateSubscription protobuf
2. Serialize the request (to put it into redis)
3. Validate it
4. Build it & run it before saving

It builds and runs subscription request outside the RPCSubscriptionData class
for now so that we don't have to update the entire subscription pipeline to use both
SnubaRequest and TimeseriesRequest types.