### PR TITLE
chore(eap-spans): Increase the number of replicas to scan in parallel

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
@@ -119,6 +119,7 @@ query_processors:
         max_memory_usage: 5000000000
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
+        max_parallel_replicas: 3
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer


### PR DESCRIPTION
This will enable ClickHouse to split queries between all the replicas of a shard.