### PR TITLE
chore(eap-spans): Take advantage of parallel reads

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
@@ -120,6 +120,7 @@ query_processors:
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
         max_parallel_replicas: 3
+        allow_experimental_parallel_reading_from_replicas: 1
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer


### PR DESCRIPTION
We'd like to enable this feature, despite being experimental, on this cluster since it would allow us to speed up querying significantly.

The plan is to enable this during LA and choose whether or not we'll keep it in EA or GA later on.