### PR TITLE
chore(devservices): Bumping the version of devservices to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 clickhouse-driver==0.2.6
 confluent-kafka==2.3.0
 datadog==0.21.0
-devservices==0.0.5
+devservices==1.0.3
 flake8==7.0.0
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
This change bumps the new devservices library to the latest version so snuba can make use of the newest features and bug fixes devservices has to offer. https://github.com/getsentry/devservices/releases/tag/1.0.3