### PR TITLE
test(runtime-config): Add some tests to make sure data is cached

### DIFF
--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -40,12 +40,56 @@ pub fn get_str_config(key: &str) -> Result<Option<String>, Error> {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     #[test]
     fn test_runtime_config() {
         crate::testutils::initialize_python();
-        let config = get_str_config("test");
+        let config = get_str_config("key0");
         assert_eq!(config.unwrap(), None);
+        CONFIG.write().clear();
+    }
+
+    #[test]
+    fn test_runtime_config_is_stored_in_cache() {
+        crate::testutils::initialize_python();
+        assert!(!CONFIG.read().contains_key("key1"));
+        let config = get_str_config("key1");
+        assert_eq!(config.unwrap(), None);
+        assert!(CONFIG.read().contains_key("key1"));
+        CONFIG.write().clear();
+    }
+
+    #[test]
+    fn test_runtime_config_retrieves_from_cache_within_deadline() {
+        {
+            CONFIG.write().insert(
+                "key2".to_string(),
+                (
+                    Some("value2".to_string()),
+                    Deadline::new(Duration::from_secs(10)),
+                ),
+            );
+        }
+        let config = get_str_config("key2");
+        assert_eq!(config.unwrap(), Some("value2".to_string()));
+        CONFIG.write().clear();
+    }
+
+    #[test]
+    fn test_runtime_config_invalidates_cache_outside_deadline() {
+        {
+            CONFIG.write().insert(
+                "key3".to_string(),
+                (
+                    Some("value3".to_string()),
+                    Deadline::new(Duration::from_secs(0)),
+                ),
+            );
+        }
+        let config = get_str_config("key3");
+        assert_eq!(config.unwrap(), None);
+        CONFIG.write().clear();
     }
 }


### PR DESCRIPTION
### Overview

We ran into an incident where we accidentally did not store runtime config into our cache and retrieved it from redis every time the get_runtime_config is called. This pr tries to add a couple of tests to assert the caching behaviour.