### PR TITLE
feat(devservices): Add restart settings and use external devservices network

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -41,6 +41,7 @@ services:
       host.docker.internal: host-gateway
     networks:
       - devservices
+    restart: unless-stopped
 
   snuba:
     image: ghcr.io/getsentry/snuba:latest
@@ -71,6 +72,7 @@ services:
       host.docker.internal: host-gateway
     networks:
       - devservices
+    restart: unless-stopped
 
 volumes:
   clickhouse-data:
@@ -78,3 +80,4 @@ volumes:
 networks:
   devservices:
     name: devservices
+    external: true


### PR DESCRIPTION
This automatically restarts the containers defined in the config file when they crash, unless explicitly stopped. Also uses devservices as an external network to avoid race conditions involving creating/removing networks. 