### PR TITLE
Align timeseries buckets

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -55,6 +55,11 @@ _VALID_GRANULARITY_SECS = set(
     ]
 )
 
+
+def _rewind(start_timestamp: int, granularity: int) -> int:
+    return (start_timestamp // granularity) * granularity
+
+
 _MAX_BUCKETS_IN_REQUEST = 1000
 
 
@@ -121,11 +126,14 @@ def _convert_result_timeseries(
         tuple[str, str], dict[int, Dict[str, Any]]
     ] = defaultdict(dict)
 
+    start_timestamp_seconds = _rewind(
+        request.meta.start_timestamp.seconds, request.granularity_secs
+    )
     query_duration = (
         request.meta.end_timestamp.seconds - request.meta.start_timestamp.seconds
     )
     time_buckets = [
-        Timestamp(seconds=(request.meta.start_timestamp.seconds) + secs)
+        Timestamp(seconds=(start_timestamp_seconds) + secs)
         for secs in range(0, query_duration, request.granularity_secs)
     ]
 

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -227,16 +227,17 @@ class TestTimeSeriesApi(BaseApiTest):
         ]
 
     def test_rachel(self) -> None:
-        start_timestamp_seconds = 1500
         # store a a test metric with a value of 1, every second of one hour
-        granularity_secs = 15
+        granularity_secs = 300
         query_duration = 60 * 30
         store_timeseries(
-            datetime.fromtimestamp(start_timestamp_seconds, tz=UTC),
+            BASE_TIME,
             1,
             3600,
             metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
         )
+
+        print(BASE_TIME.timestamp())
 
         message = TimeSeriesRequest(
             meta=RequestMeta(
@@ -244,9 +245,9 @@ class TestTimeSeriesApi(BaseApiTest):
                 organization_id=1,
                 cogs_category="something",
                 referrer="something",
-                start_timestamp=Timestamp(seconds=start_timestamp_seconds),
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp() + 1)),
                 end_timestamp=Timestamp(
-                    seconds=int(start_timestamp_seconds + query_duration)
+                    seconds=int(BASE_TIME.timestamp() + 1 + query_duration)
                 ),
             ),
             aggregations=[
@@ -266,7 +267,14 @@ class TestTimeSeriesApi(BaseApiTest):
             granularity_secs=granularity_secs,
         )
         response = EndpointTimeSeries().execute(message)
-        assert len(response.result_timeseries) != 0
+
+        print(response)
+        for ts in response.result_timeseries:
+            # expect ts.data_points to look like this: [, , , , , ]
+            for datapoint in ts.data_points:
+                assert datapoint != DataPoint()
+
+        assert False
 
     def test_with_group_by(self) -> None:
         store_timeseries(

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -226,7 +226,7 @@ class TestTimeSeriesApi(BaseApiTest):
             ),
         ]
 
-    def test_rachel(self) -> None:
+    def test_start_time_not_divisible_by_time_buckets_returns_valid_data(self) -> None:
         # store a a test metric with a value of 1, every second of one hour
         granularity_secs = 300
         query_duration = 60 * 30
@@ -237,8 +237,6 @@ class TestTimeSeriesApi(BaseApiTest):
             metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
         )
 
-        print(BASE_TIME.timestamp())
-
         message = TimeSeriesRequest(
             meta=RequestMeta(
                 project_ids=[1, 2, 3],
@@ -247,7 +245,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp() + 1)),
                 end_timestamp=Timestamp(
-                    seconds=int(BASE_TIME.timestamp() + 1 + query_duration)
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
             ),
             aggregations=[
@@ -273,8 +271,6 @@ class TestTimeSeriesApi(BaseApiTest):
             # expect ts.data_points to look like this: [, , , , , ]
             for datapoint in ts.data_points:
                 assert datapoint != DataPoint()
-
-        assert False
 
     def test_with_group_by(self) -> None:
         store_timeseries(

--- a/tests/web/rpc/v1/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series.py
@@ -226,6 +226,48 @@ class TestTimeSeriesApi(BaseApiTest):
             ),
         ]
 
+    def test_rachel(self) -> None:
+        start_timestamp_seconds = 1500
+        # store a a test metric with a value of 1, every second of one hour
+        granularity_secs = 15
+        query_duration = 60 * 30
+        store_timeseries(
+            datetime.fromtimestamp(start_timestamp_seconds, tz=UTC),
+            1,
+            3600,
+            metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
+        )
+
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=start_timestamp_seconds),
+                end_timestamp=Timestamp(
+                    seconds=int(start_timestamp_seconds + query_duration)
+                ),
+            ),
+            aggregations=[
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric"),
+                    label="sum",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_AVG,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric"),
+                    label="avg",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+            ],
+            granularity_secs=granularity_secs,
+        )
+        response = EndpointTimeSeries().execute(message)
+        assert len(response.result_timeseries) != 0
+
     def test_with_group_by(self) -> None:
         store_timeseries(
             BASE_TIME,


### PR DESCRIPTION
Fixes https://github.com/getsentry/projects/issues/364 by making `start_timestamp` divisible by `granularity`. This makes it so that our timebuckets line up properly.