### PR TITLE
log(optimize): after optimize, log how long it took w/partition

### DIFF
--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -373,11 +373,13 @@ def optimize_partitions(
 
         start = time.time()
         clickhouse.execute(query, retryable=False)
+        duration = time.time() - start
         metrics.timing(
             "optimized_part",
-            time.time() - start,
+            duration,
             tags=_get_metrics_tags(table, clickhouse_host),
         )
+        logger.info(f"Optimized partition: {partition} in {duration}s")
 
 
 def is_busy_merging(clickhouse: ClickhousePool, database: str, table: str) -> bool:


### PR DESCRIPTION
For easier observability, and because we want to see if oldest parts take the longest consistently, log out which partitions take how long in optimize