### PR TITLE
fix(eap): fix bug where we pass non str group by mapping to timeseries

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -142,7 +142,7 @@ def _convert_result_timeseries(
 
         for col_name, col_value in row.items():
             if col_name in group_by_labels:
-                group_by_map[col_name] = col_value
+                group_by_map[col_name] = str(col_value)
 
         group_by_key = "|".join([f"{k},{v}" for k, v in group_by_map.items()])
         for col_name in aggregation_labels:


### PR DESCRIPTION
Fixes https://github.com/getsentry/projects/issues/426
TimeSeries expects a mapping from str to str, so we have to convert the column value to a string first.