### PR TITLE
feat(profiler): Update formatting of Heaptrack output file

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -19,7 +19,8 @@ else
 fi
 
 if [ -n "${ENABLE_HEAPTRACK:-}" ]; then
-  set -- heaptrack "$@"
+  file_path="./profiled_data/profile_$(date '+%Y%m%d_%H%M%S')"
+  set -- heaptrack -o "${file_path}" "$@"
 fi
 
 exec "$@"

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -19,7 +19,7 @@ else
 fi
 
 if [ -n "${ENABLE_HEAPTRACK:-}" ]; then
-  file_path="./profiled_data/profile_$(date '+%Y%m%d_%H%M%S')"
+  file_path="./profiler_data/profile_$(date '+%Y%m%d_%H%M%S')"
   set -- heaptrack -o "${file_path}" "$@"
 fi
 


### PR DESCRIPTION
Since Heaptrack performs continuous profiling of the Rust consumer, we will want to track the profiler's output for various profiling runs that happen. A profiling run happens for every consumer process that is started.  

Adds timestamp and ensures Heaptrack writes to a formatted file for each profiling run. This will also make analysis easier as we will know which file corresponds to which date and time.
