### PR TITLE
ref(clickhouse-24.3): allow_suspicious_primary_key for eap migration

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -147,8 +147,9 @@ class CreateTable(SqlOperation):
         columns: Sequence[Column[MigrationModifiers]],
         engine: TableEngine,
         target: OperationTarget = OperationTarget.UNSET,
+        settings: Optional[Mapping[str, Any]] = None,
     ):
-        super().__init__(storage_set, target=target)
+        super().__init__(storage_set, target=target, settings=settings)
         self.table_name = table_name
         self.__columns = columns
         self.engine = engine

--- a/snuba/snuba_migrations/events_analytics_platform/0014_span_attribute_table_smaller.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0014_span_attribute_table_smaller.py
@@ -170,6 +170,10 @@ GROUP BY
                 ),
                 columns=self.num_columns,
                 target=OperationTarget.LOCAL,
+                # Without this setting this migration fails in CH 24.3. This table
+                # gets remove in a later migration when it is rewritten so it's only
+                # needed for this version of the table
+                settings={"allow_suspicious_primary_key": 1},
             ),
             operations.CreateTable(
                 storage_set=self.storage_set_key,


### PR DESCRIPTION
**context**
When testing out the newest clickhouse version 24.3, it was found that this clickhouse change https://github.com/ClickHouse/ClickHouse/pull/61399, meant that the `0014_span_attribute_table_smaller` migration failed for version `24.3`. 

The `allow_suspicious_primary_key` setting allows us to ignore this, but we don't want to enable it everywhere because we don't want future tables to be created incorrectly. 

I'm editing a past migration so that the setting is only used this particular migration, which shouldn't matter much since this table gets dropped in [`0018_drop_unused_span_tables`](https://github.com/getsentry/snuba/blob/0293a3988d56cad70659d2d88cbff4808f6c9783/snuba/snuba_migrations/events_analytics_platform/0018_drop_unused_span_tables.py#L23). 

This will unblock https://github.com/getsentry/snuba/pull/6246