### PR TITLE
perf(final): add flag to skip cross-partition merging on FINAL

### DIFF
--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -129,6 +129,15 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
                     )
                 )
 
+        if (
+            set_final
+            and self.__replacer_state_name is not None
+            and self.__replacer_state_name == ReplacerState.ERRORS
+        ):
+            query_settings.push_clickhouse_setting(
+                "do_not_merge_across_partitions_select_final", 1
+            )
+
         self._set_query_final(query, set_final)
 
     def _initialize_tags(

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -53,6 +53,10 @@ class QuerySettings(ABC):
         pass
 
     @abstractmethod
+    def push_clickhouse_setting(self, key: str, value: Any) -> None:
+        pass
+
+    @abstractmethod
     def get_asynchronous(self) -> bool:
         pass
 
@@ -116,6 +120,9 @@ class HTTPQuerySettings(QuerySettings):
     def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
         self.__clickhouse_settings = settings
 
+    def push_clickhouse_setting(self, key: str, value: Any) -> None:
+        self.__clickhouse_settings[key] = value
+
     def get_asynchronous(self) -> bool:
         return self.__asynchronous
 
@@ -176,6 +183,9 @@ class SubscriptionQuerySettings(QuerySettings):
 
     def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
         self.__clickhouse_settings = settings
+
+    def push_clickhouse_setting(self, key: str, value: Any) -> None:
+        self.__clickhouse_settings[key] = value
 
     def get_asynchronous(self) -> bool:
         return False

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -138,12 +138,19 @@ def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> No
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
+    query_settings = HTTPQuerySettings()
     PostReplacementConsistencyEnforcer(
         "project_id", ReplacerState.ERRORS
-    ).process_query(query, HTTPQuerySettings())
+    ).process_query(query, query_settings)
 
     assert query.get_condition() == build_in("project_id", [2])
     assert query.get_from_clause().final
+    assert (
+        query_settings.get_clickhouse_settings()[
+            "do_not_merge_across_partitions_select_final"
+        ]
+        == 1
+    )
 
 
 @pytest.mark.redis_db


### PR DESCRIPTION
The errors table is partitioned by a key that never changes (timestamp of the event). Given that, we can pass [this ClickHouse query setting](https://clickhouse.com/docs/en/guides/replacing-merge-tree#exploiting-partitions-with-replacingmergetree) and hopefully see some reduced load/performance improvement on queries for groups/projects/etc. that have had replacements run on them. Based on the docs, the worst case seems like no improvement