### PR TITLE
chore: Upgrade sentry-kafka-schemas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.5.4
 sentry-arroyo==2.17.6
-sentry-kafka-schemas==0.1.117
+sentry-kafka-schemas==0.1.122
 sentry-redis-tools==0.3.0
 sentry-relay==0.9.2
 sentry-sdk==2.18.0


### PR DESCRIPTION
This is to include [this change](https://github.com/getsentry/sentry-kafka-schemas/pull/353) and to unblock #6604.