### PR TITLE
chore(rpc-subscriptions): Remove timestamp rounding

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from enum import Enum
 from functools import partial
 from typing import (
@@ -217,20 +217,12 @@ class RPCSubscriptionData(_SubscriptionData[TimeSeriesRequest]):
         request_class = EndpointTimeSeries().request_class()()
         request_class.ParseFromString(base64.b64decode(self.time_series_request))
 
-        # TODO: update it to round to the lowest granularity
-        # rounded_ts = int(timestamp.replace(tzinfo=UTC).timestamp() / 15) * 15
-        rounded_ts = (
-            int(timestamp.replace(tzinfo=UTC).timestamp() / self.time_window_sec)
-            * self.time_window_sec
-        )
-        rounded_start = datetime.utcfromtimestamp(rounded_ts)
-
         start_time_proto = Timestamp()
         start_time_proto.FromDatetime(
-            rounded_start - timedelta(seconds=self.time_window_sec)
+            timestamp - timedelta(seconds=self.time_window_sec)
         )
         end_time_proto = Timestamp()
-        end_time_proto.FromDatetime(rounded_start)
+        end_time_proto.FromDatetime(timestamp)
         request_class.meta.start_timestamp.CopyFrom(start_time_proto)
         request_class.meta.end_timestamp.CopyFrom(end_time_proto)
 

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -174,7 +174,10 @@ class BaseSubscriptionTest:
             gen_span_message(self.base_time + timedelta(minutes=tick))
             for tick in range(self.minutes)
         ]
-        write_raw_unprocessed_events(spans_storage, messages)
+        extra_messages = [
+            gen_span_message(self.base_time - timedelta(hours=4)) for _ in range(2)
+        ]
+        write_raw_unprocessed_events(spans_storage, extra_messages + messages)
 
 
 def __entity_eq__(self: Entity, other: object) -> bool:

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -124,7 +124,7 @@ TESTS = [
                         ),
                     ],
                 ),
-                time_window_secs=3600,
+                time_window_secs=10800,
                 resolution_secs=60,
             ),
             EntityKey.EAP_SPANS,

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -28,7 +28,7 @@ from tests.web.rpc.v1.test_endpoint_time_series.test_endpoint_time_series import
     store_timeseries,
 )
 
-END_TIME = datetime.utcnow().replace(second=0, microsecond=0, tzinfo=UTC)
+END_TIME = datetime.utcnow().replace(tzinfo=UTC)
 START_TIME = END_TIME - timedelta(hours=1)
 
 


### PR DESCRIPTION
With this change https://github.com/getsentry/snuba/pull/6609 it's no longer 
required to round the timestamps to get back a single time bucket.