### PR TITLE
fix(admin): add example RPC call for the endpoints missing it

### DIFF
--- a/snuba/admin/static/rpc_endpoints/exampleRequestTemplates.json
+++ b/snuba/admin/static/rpc_endpoints/exampleRequestTemplates.json
@@ -1,44 +1,50 @@
 {
-    "default": {},
-    "TraceItemAttributesRequest": {
-      "v1alpha": {
-          "meta": {
-              "project_ids": [1],
-              "organization_id": 1,
-              "cogs_category": "something",
-              "referrer": "something",
-              "start_timestamp": "2024-10-03T00:00:00Z",
-              "end_timestamp": "2024-10-06T00:00:00Z"
-          },
-          "limit": 10,
-          "offset": 0,
-          "type": "TYPE_STRING"
-      }
-    },
-    "AttributeValuesRequest": {
-      "v1alpha": {
-          "meta": {
-              "project_ids": [1],
-              "organization_id": 1,
-              "cogs_category": "something",
-              "referrer": "something",
-              "start_timestamp": "2024-10-03T00:00:00Z",
-              "end_timestamp": "2024-10-06T00:00:00Z"
-          },
-          "name": "http.status_code",
-          "limit": 5,
-          "offset": 0
-      }
-    },
-    "EndpointTraceItemTable": {
-      "v1": {
+  "default": {},
+  "TraceItemAttributesRequest": {
+    "v1alpha": {
       "meta": {
-        "project_ids": [1],
+        "project_ids": [
+          1
+        ],
         "organization_id": 1,
         "cogs_category": "something",
         "referrer": "something",
-        "start_timestamp":"2024-10-03T00:00:00Z",
-        "end_timestamp":"2024-10-31T00:00:00Z"
+        "start_timestamp": "2024-10-03T00:00:00Z",
+        "end_timestamp": "2024-10-06T00:00:00Z"
+      },
+      "limit": 10,
+      "offset": 0,
+      "type": "TYPE_STRING"
+    }
+  },
+  "AttributeValuesRequest": {
+    "v1alpha": {
+      "meta": {
+        "project_ids": [
+          1
+        ],
+        "organization_id": 1,
+        "cogs_category": "something",
+        "referrer": "something",
+        "start_timestamp": "2024-10-03T00:00:00Z",
+        "end_timestamp": "2024-10-06T00:00:00Z"
+      },
+      "name": "http.status_code",
+      "limit": 5,
+      "offset": 0
+    }
+  },
+  "EndpointTraceItemTable": {
+    "v1": {
+      "meta": {
+        "project_ids": [
+          1
+        ],
+        "organization_id": 1,
+        "cogs_category": "something",
+        "referrer": "something",
+        "start_timestamp": "2024-10-03T00:00:00Z",
+        "end_timestamp": "2024-10-31T00:00:00Z"
       },
       "columns": [
         {
@@ -58,16 +64,18 @@
           }
         }
       ],
-        "limit": 100
-      }
-    },
-    "AggregateBucketRequest": {
-      "v1alpha": {
+      "limit": 100
+    }
+  },
+  "AggregateBucketRequest": {
+    "v1alpha": {
       "meta": {
-       "project_ids": [1],
+        "project_ids": [
+          1
+        ],
         "organization_id": 1,
-        "start_timestamp":"2024-10-03T00:00:00Z",
-        "end_timestamp":"2024-10-04T00:00:00Z"
+        "start_timestamp": "2024-10-03T00:00:00Z",
+        "end_timestamp": "2024-10-04T00:00:00Z"
       },
       "key": {
         "name": "sentry.duration_ms",
@@ -75,6 +83,119 @@
       },
       "aggregate": "FUNCTION_P99",
       "granularity_secs": 900
+    }
+  },
+  "SpanSamplesRequest": {
+    "v1alpha": {
+      "meta": {
+        "project_ids": [
+          1
+        ],
+        "organization_id": 1,
+        "start_timestamp": "2024-10-03T00:00:00Z",
+        "end_timestamp": "2024-10-04T00:00:00Z"
+      },
+      "filter": {
+        "existsFilter": {
+          "key": {
+            "type": "TYPE_STRING",
+            "name": "color"
+          }
+        }
+      },
+      "keys": [
+        {
+          "type": "TYPE_STRING",
+          "name": "server_name"
+        }
+      ],
+      "limit": 61
+    }
+  },
+  "EndpointTraceItemAttributeNames": {
+    "v1": {
+      "meta": {
+        "project_ids": [
+          1
+        ],
+        "organization_id": 1,
+        "start_timestamp": "2024-10-03T00:00:00Z",
+        "end_timestamp": "2024-10-04T00:00:00Z"
+      },
+      "limit": 30,
+      "type": "TYPE_STRING"
+    }
+  },
+  "EndpointTimeSeries": {
+    "v1": {
+      "meta": {
+        "project_ids": [
+          1
+        ],
+        "organization_id": 1,
+        "start_timestamp": "2024-10-03T00:00:00Z",
+        "end_timestamp": "2024-10-04T00:00:00Z"
+      },
+      "aggregations": [
+        {
+          "aggregate": "FUNCTION_SUM",
+          "key": {
+            "type": "TYPE_FLOAT",
+            "name": "test_metric"
+          },
+          "label": "sum",
+          "extrapolationMode": "EXTRAPOLATION_MODE_NONE"
+        },
+        {
+          "aggregate": "FUNCTION_AVG",
+          "key": {
+            "type": "TYPE_FLOAT",
+            "name": "test_metric"
+          },
+          "label": "avg",
+          "extrapolationMode": "EXTRAPOLATION_MODE_NONE"
+        }
+      ],
+      "granularitySecs": "300"
+    }
+  },
+  "CreateSubscriptionRequest": {
+    "v1": {
+      "timeSeriesRequest": {
+        "meta": {
+          "project_ids": [
+            1
+          ],
+          "organization_id": 1,
+          "start_timestamp": "2024-10-03T00:00:00Z",
+          "end_timestamp": "2024-10-04T00:00:00Z"
+        },
+        "filter": {
+          "comparisonFilter": {
+            "key": {
+              "type": "TYPE_STRING",
+              "name": "foo"
+            },
+            "op": "OP_NOT_EQUALS",
+            "value": {
+              "valStr": "bar"
+            }
+          }
+        },
+        "aggregations": [
+          {
+            "aggregate": "FUNCTION_SUM",
+            "key": {
+              "type": "TYPE_FLOAT",
+              "name": "test_metric"
+            },
+            "label": "sum",
+            "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED"
+          }
+        ]
+      },
+      "timeWindowSecs": 300,
+      "resolutionSecs": 60
     }
   }
 }


### PR DESCRIPTION
this closes https://github.com/getsentry/eap-planning/issues/98

I added an example request to each of the following endpoints that were missing it. 
## used to look like
<img width="1036" alt="Screenshot 2024-12-04 at 3 37 22 PM" src="https://github.com/user-attachments/assets/441e3428-5e16-42a1-bede-fce430a9ab5f">

## now it looks like
<img width="791" alt="Screenshot 2024-12-04 at 3 37 39 PM" src="https://github.com/user-attachments/assets/e124a3a0-1cc9-4dab-b97f-e238e155ba0d">

I got the example request for each endpoint from one of its unit tests, I tried to pick a basic representative one. Here are all the endpoints I added example requests for, and a link to the test that I got the request from:
* [CreateSubscriptionRequest](https://github.com/getsentry/snuba/blob/b03c40e91c7b10af6d9794b576055eb9a6027b22/tests/subscriptions/test_scheduler_consumer.py#L165)
* [EndpointTraceItemAttributeNames](https://github.com/getsentry/snuba/blob/b03c40e91c7b10af6d9794b576055eb9a6027b22/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py#L89)
* [EndpointTimeSeries](https://github.com/getsentry/snuba/blob/b03c40e91c7b10af6d9794b576055eb9a6027b22/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py#L167)
* [SpanSamplesRequest](https://github.com/getsentry/snuba/blob/b03c40e91c7b10af6d9794b576055eb9a6027b22/tests/web/rpc/v1alpha/test_span_samples.py#L150)

All the new example RPC calls successfully send except for CreateSubscriptionRequest. 
It has a 400 error due to no meta field:
<img width="1014" alt="Screenshot 2024-12-04 at 3 19 48 PM" src="https://github.com/user-attachments/assets/4dc4e998-74d7-42c4-8bd6-9350831d6ede">
This is a bug that has been revealed by this PR but is unrelated to it so I plan to solve this as a follow up in a separate PR. https://github.com/getsentry/snuba/issues/6617

The PR diff makes it look like the entire file changed but thats just bc I ran a formatter on the JSON. Actually the only real changes are the additions from line 87 to the end.