### PR TITLE
feat(devservices): Add healthchecks to clickhouse and snuba

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -34,6 +34,11 @@ services:
       - 127.0.0.1:9000:9000
       - 127.0.0.1:9009:9009
       - 127.0.0.1:8123:8123
+    healthcheck:
+      test: wget -q -O - http://localhost:8123/ping
+      interval: 5s
+      timeout: 5s
+      retries: 3
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - ./clickhouse/config.xml:/etc/clickhouse-server/config.d/sentry.xml
@@ -49,6 +54,11 @@ services:
       - 127.0.0.1:1218:1218
       - 127.0.0.1:1219:1219
     command: [devserver]
+    healthcheck:
+      test: curl -f http://localhost:1218/health_envoy
+      interval: 5s
+      timeout: 5s
+      retries: 3
     environment:
       PYTHONUNBUFFERED: 1
       SNUBA_SETTINGS: docker


### PR DESCRIPTION
This adds healthchecks to clickhouse and snuba for devservices. This is required because we want devservices to properly understand when a container is healthy/unhealthy to help developers out when encountering issues with their local dev environment.