### PR TITLE
ref(admin): Allow clusterAllReplicas in system queries

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -132,8 +132,11 @@ def is_query_using_only_system_tables(
 
     for line in explain_query_tree_result.results:
         line = line[0].strip()
-        # We don't allow table functions for now as the clickhouse analyzer isn't good enough yet to resolve those tables
-        if line.startswith("TABLE_FUNCTION"):
+        # We don't allow table functions (except clusterAllReplicas) for now as the clickhouse analyzer isn't good enough yet to resolve those tables
+        if (
+            line.startswith("TABLE_FUNCTION")
+            and "table_function_name: clusterAllReplicas" not in line
+        ):
             return False
         if line.startswith("TABLE"):
             match = re.search(r"table_name:\s*(\S+)", line, re.IGNORECASE)

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -50,6 +50,7 @@ from snuba.admin.user import AdminUser
         ORDER BY
             memory DESC
         """,
+        "SELECT hostname(), avg(query_duration_ms) FROM clusterAllReplicas('default', system.query_log) GROUP BY hostname()",
     ],
 )
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
This function is very handy for debugging, since it allows aggregating across all nodes in a single
query.