### PR TITLE
chore(discover): Add trace response code to context array

### DIFF
--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -424,9 +424,14 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         # Only top level scalar values within a context are written to the table. `data` is
         # always a dict, so pop it from the context and move some values into the top level.
         transaction_data = transaction_ctx.pop("data", None) or {}
-        if isinstance(transaction_data, dict) and "thread.id" in transaction_data:
-            # The thread.id can be either a str/int. Make sure to always convert to a str.
-            transaction_ctx["thread_id"] = str(transaction_data["thread.id"])
+        if isinstance(transaction_data, dict):
+            if "thread.id" in transaction_data:
+                # The thread.id can be either a str/int. Make sure to always convert to a str.
+                transaction_ctx["thread_id"] = str(transaction_data["thread.id"])
+            if "http.response.status_code" in transaction_data:
+                transaction_ctx["http.response.status_code"] = str(
+                    transaction_data["http.response.status_code"]
+                )
 
         # The hash and exclusive_time is being stored in the spans columns
         # so there is no need to store it again in the context array.


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/issues/81418
Looks like some SDKs don't send a response context which
is where we currently read http.status code from. This information
is also found in the data dict on the trace context in most SDKs,
so adding promoting that to the contexts array so users can
query/aggregate on this data. 