### PR TITLE
Revert "ref(ci): Disable self-hosted e2e CI due to resource constraints"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,21 +387,20 @@ jobs:
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
 
-  # TODO: Re-enable this once CI is stable, seems to be running into issues potentially with resource constraints
-  # self-hosted-end-to-end:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
+  self-hosted-end-to-end:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-  #   steps:
-  #     - name: Checkout Snuba
-  #       uses: actions/checkout@v4
-  #     - name: Run Sentry self-hosted e2e CI
-  #       uses: getsentry/action-self-hosted-e2e-tests@main
-  #       with:
-  #         project_name: snuba
-  #         docker_repo: getsentry/snuba
-  #         image_url: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.event.pull_request.head.sha || github.sha }}
-  #         docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+    steps:
+      - name: Checkout Snuba
+        uses: actions/checkout@v4
+      - name: Run Sentry self-hosted e2e CI
+        uses: getsentry/action-self-hosted-e2e-tests@main
+        with:
+          project_name: snuba
+          docker_repo: getsentry/snuba
+          image_url: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.event.pull_request.head.sha || github.sha }}
+          docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
 
   publish-to-dockerhub:
     name: Publish Snuba to DockerHub


### PR DESCRIPTION
Reverts getsentry/snuba#6620

It looks like this issue was entirely on Github since the CI check is now passing everywhere. So, re-enabling this