### PR TITLE
feat(eap-api): support in conditions in TraceItemFilter

### DIFF
--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -217,6 +217,10 @@ def in_cond(
     return binary_condition("in", lhs, rhs, alias)
 
 
+def not_cond(expr: Expression, alias: Optional[str] = None) -> FunctionCall:
+    return FunctionCall(alias, "not", (expr,))
+
+
 # aggregate functions
 def count(column: Optional[Column] = None, alias: Optional[str] = None) -> FunctionCall:
     return FunctionCall(alias, "count", (column,) if column else ())

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -14,7 +14,15 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 from snuba.query import Query
 from snuba.query.conditions import combine_and_conditions, combine_or_conditions
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import and_cond, column, in_cond, literal, literals_array, or_cond
+from snuba.query.dsl import (
+    and_cond,
+    column,
+    in_cond,
+    literal,
+    literals_array,
+    not_cond,
+    or_cond,
+)
 from snuba.query.expressions import Expression, FunctionCall, SubscriptableReference
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 
@@ -267,12 +275,33 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 "comparison does not have a right hand side"
             )
 
-        v_expression = {
-            "val_bool": literal(v.val_bool),
-            "val_str": literal(v.val_str),
-            "val_float": literal(v.val_float),
-            "val_int": literal(v.val_int),
-        }[value_type]
+        match value_type:
+            case "val_bool":
+                v_expression: Expression = literal(v.val_bool)
+            case "val_str":
+                v_expression = literal(v.val_str)
+            case "val_float":
+                v_expression = literal(v.val_float)
+            case "val_int":
+                v_expression = literal(v.val_int)
+            case "val_null":
+                v_expression = literal(None)
+            case "val_str_array":
+                v_expression = literals_array(
+                    None, list(map(lambda x: literal(x), v.val_str_array.values))
+                )
+            case "val_int_array":
+                v_expression = literals_array(
+                    None, list(map(lambda x: literal(x), v.val_int_array.values))
+                )
+            case "val_float_array":
+                v_expression = literals_array(
+                    None, list(map(lambda x: literal(x), v.val_float_array.values))
+                )
+            case default:
+                raise NotImplementedError(
+                    f"translation of AttributeValue type {default} is not implemented"
+                )
 
         if op == ComparisonFilter.OP_EQUALS:
             return f.equals(k_expression, v_expression)
@@ -298,6 +327,10 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             return f.greater(k_expression, v_expression)
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
+        if op == ComparisonFilter.OP_IN:
+            return in_cond(k_expression, v_expression)
+        if op == ComparisonFilter.OP_NOT_IN:
+            return not_cond(in_cond(k_expression, v_expression))
 
         raise BadSnubaRPCRequestException(
             f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -18,8 +18,10 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeValue,
     ExtrapolationMode,
     Function,
+    StrArray,
 )
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
     ComparisonFilter,
     TraceItemFilter,
 )
@@ -483,10 +485,29 @@ class TestTimeSeriesApi(BaseApiTest):
                 ),
             ],
             filter=TraceItemFilter(
-                comparison_filter=ComparisonFilter(
-                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="customer"),
-                    op=ComparisonFilter.OP_EQUALS,
-                    value=AttributeValue(val_str="bob"),
+                and_filter=AndFilter(
+                    filters=[
+                        TraceItemFilter(
+                            comparison_filter=ComparisonFilter(
+                                key=AttributeKey(
+                                    type=AttributeKey.TYPE_STRING, name="customer"
+                                ),
+                                op=ComparisonFilter.OP_EQUALS,
+                                value=AttributeValue(val_str="bob"),
+                            )
+                        ),
+                        TraceItemFilter(
+                            comparison_filter=ComparisonFilter(
+                                key=AttributeKey(
+                                    type=AttributeKey.TYPE_STRING, name="customer"
+                                ),
+                                op=ComparisonFilter.OP_IN,
+                                value=AttributeValue(
+                                    val_str_array=StrArray(values=["bob", "alice"])
+                                ),
+                            )
+                        ),
+                    ]
                 )
             ),
             granularity_secs=granularity_secs,


### PR DESCRIPTION
This closes this ticket https://github.com/getsentry/eap-planning/issues/119

A request to the timeseries endpoint was failing due to its in condition. I was able to reproduce this bug locally and determine that its being caused because arrays and in conditions werent implemented yet. I implemented them and the test it now passing.