### PR TITLE
consumer: Add flag to configure DLQ buffer limit

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -46,7 +46,7 @@ pub fn consumer(
     stop_at_timestamp: Option<i64>,
     batch_write_timeout_ms: Option<u64>,
     max_bytes_before_external_group_by: Option<usize>,
-    max_dlq_buffer_size: Option<usize>,
+    max_dlq_buffer_length: Option<usize>,
 ) {
     py.allow_threads(|| {
         consumer_impl(
@@ -66,7 +66,7 @@ pub fn consumer(
             batch_write_timeout_ms,
             max_bytes_before_external_group_by,
             mutations_mode,
-            max_dlq_buffer_size,
+            max_dlq_buffer_length,
         )
     });
 }
@@ -89,7 +89,7 @@ pub fn consumer_impl(
     batch_write_timeout_ms: Option<u64>,
     max_bytes_before_external_group_by: Option<usize>,
     mutations_mode: bool,
-    max_dlq_buffer_size: Option<usize>,
+    max_dlq_buffer_length: Option<usize>,
 ) -> usize {
     setup_logging();
 
@@ -209,7 +209,7 @@ pub fn consumer_impl(
                 max_invalid_ratio: None,
                 max_consecutive_count: None,
             },
-            max_dlq_buffer_size,
+            max_dlq_buffer_length,
         )
     });
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -46,6 +46,7 @@ pub fn consumer(
     stop_at_timestamp: Option<i64>,
     batch_write_timeout_ms: Option<u64>,
     max_bytes_before_external_group_by: Option<usize>,
+    max_dlq_buffer_size: Option<usize>,
 ) {
     py.allow_threads(|| {
         consumer_impl(
@@ -65,6 +66,7 @@ pub fn consumer(
             batch_write_timeout_ms,
             max_bytes_before_external_group_by,
             mutations_mode,
+            max_dlq_buffer_size,
         )
     });
 }
@@ -87,6 +89,7 @@ pub fn consumer_impl(
     batch_write_timeout_ms: Option<u64>,
     max_bytes_before_external_group_by: Option<usize>,
     mutations_mode: bool,
+    max_dlq_buffer_size: Option<usize>,
 ) -> usize {
     setup_logging();
 
@@ -206,7 +209,7 @@ pub fn consumer_impl(
                 max_invalid_ratio: None,
                 max_consecutive_count: None,
             },
-            None,
+            max_dlq_buffer_size,
         )
     });
 

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -150,6 +150,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
 )
 @click.option(
     "--max-dlq-buffer-size",
+    type=int,
     default=None,
     help="Set a per-partition limit to the size (length) of the DLQ buffer",
 )

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -149,6 +149,11 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     """,
 )
 @click.option(
+    "--max-dlq-buffer-size",
+    default=None,
+    help="Set a per-partition limit to the size (length) of the DLQ buffer",
+)
+@click.option(
     "--health-check-file",
     default=None,
     type=str,
@@ -212,7 +217,8 @@ def rust_consumer(
     stop_at_timestamp: Optional[int],
     batch_write_timeout_ms: Optional[int],
     max_bytes_before_external_group_by: Optional[int],
-    mutations_mode: bool
+    mutations_mode: bool,
+    max_dlq_buffer_size: Optional[int]
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -265,6 +271,7 @@ def rust_consumer(
         stop_at_timestamp,
         batch_write_timeout_ms,
         max_bytes_before_external_group_by,
+        max_dlq_buffer_size,
     )
 
     sys.exit(exitcode)

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -149,10 +149,10 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     """,
 )
 @click.option(
-    "--max-dlq-buffer-size",
+    "--max-dlq-buffer-length",
     type=int,
     default=None,
-    help="Set a per-partition limit to the size (length) of the DLQ buffer",
+    help="Set a per-partition limit to the length of the DLQ buffer",
 )
 @click.option(
     "--health-check-file",
@@ -219,7 +219,7 @@ def rust_consumer(
     batch_write_timeout_ms: Optional[int],
     max_bytes_before_external_group_by: Optional[int],
     mutations_mode: bool,
-    max_dlq_buffer_size: Optional[int]
+    max_dlq_buffer_length: Optional[int]
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -272,7 +272,7 @@ def rust_consumer(
         stop_at_timestamp,
         batch_write_timeout_ms,
         max_bytes_before_external_group_by,
-        max_dlq_buffer_size,
+        max_dlq_buffer_length,
     )
 
     sys.exit(exitcode)


### PR DESCRIPTION
Arroyo consumers maintain an in-memory buffer of messages that gets filled every time a new message is polled from rdkafka. Offsets get removed from the buffer when messages are committed. 

The buffer is kept around in order to populate the DLQ topic and replay invalid messages later. 

However, this buffer can grow unbounded since we haven't configured any cap on it. We have a hunch that this is also contributing to memory spikes on Arroyo Rust consumers. 

Add a flag to configure a limit. We seem to already [have the functionality ](https://github.com/getsentry/arroyo/blob/main/rust-arroyo/src/processing/dlq.rs#L413-L421)to actually set it in the DLQ buffer. 