### PR TITLE
feat(devservices): Use https for repo links

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -10,13 +10,13 @@ x-sentry-service-config:
       remote:
         repo_name: sentry-shared-redis
         branch: main
-        repo_link: git@github.com:getsentry/sentry-shared-redis.git
+        repo_link: https://github.com/getsentry/sentry-shared-redis.git
     kafka:
       description: Shared instance of kafka used by sentry services
       remote:
         repo_name: sentry-shared-kafka
         branch: main
-        repo_link: git@github.com:getsentry/sentry-shared-kafka.git
+        repo_link: https://github.com/getsentry/sentry-shared-kafka.git
     snuba:
       description: Service that provides a rich data model on top of Clickhouse together with a fast ingestion consumer and a query optimizer
   modes:


### PR DESCRIPTION
We decided to move forwards with https for these reasons:

1. devservices should not commit changes and should only care about configuration files in read only mode
2. It is not easy to integrate ssh authentication for CI
3. devservices will prompt for ssh key locally if ssh authentication is not set up