### PR TITLE
chore: Bump Arroyo to 2.19.1

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "sentry_arroyo"
-version = "2.19.0"
+version = "2.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742eaedce02dd900432c55d216d3d9316a1a31af836e5d4cf27e8a97bbd5a501"
+checksum = "419bc455b4b94ac1da370db42ec3e399f87d7f044e8790f0e52c12131aaaea2e"
 dependencies = [
  "chrono",
  "coarsetime",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -53,7 +53,7 @@ data-encoding = "2.5.0"
 zstd = "0.12.3"
 serde_with = "3.8.1"
 seq-macro = "0.3"
-sentry_arroyo = "2.19.0"
+sentry_arroyo = "2.19.1"
 
 
 [dev-dependencies]


### PR DESCRIPTION
Bump Arroyo dependency to latest