### PR TITLE
fix 0006_sorting_key_change migration

### DIFF
--- a/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
+++ b/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
@@ -38,11 +38,11 @@ def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
     # Update the timestamp column
     # Clickhouse 20 does not support altering a column in the primary key so we need to do it here
     new_timestamp_type = "`timestamp` DateTime CODEC(T64, ZSTD(1))"
-    assert new_create_table_statement.count(new_timestamp_type) == 0
-    assert new_create_table_statement.count("`timestamp` DateTime") == 1
-    new_create_table_statement = new_create_table_statement.replace(
-        "`timestamp` DateTime", new_timestamp_type
-    )
+    if new_create_table_statement.count(new_timestamp_type) == 0:
+        assert new_create_table_statement.count("`timestamp` DateTime") == 1
+        new_create_table_statement = new_create_table_statement.replace(
+            "`timestamp` DateTime", new_timestamp_type
+        )
     assert new_timestamp_type in new_create_table_statement
 
     # Create the new table


### PR DESCRIPTION
Taking over https://github.com/getsentry/snuba/pull/6203 (from @wolandspb) and creating this PR.

Verified that the assertion error below happens locally:

```
  File "/Users/meredithaheller/code/snuba/snuba/snuba_migrations/querylog/0006_sorting_key_change.py", line 41, in update_querylog_table
    assert new_create_table_statement.count(new_timestamp_type) == 0
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```