### PR TITLE
chore(api): Do not log healthcheck error if downfile exists

### DIFF
--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -107,7 +107,8 @@ def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
     payload = json.dumps(body)
     if status != 200:
         metrics.increment("healthcheck_failed", tags=metric_tags)
-        logger.error(f"Snuba health check failed! Tags: {metric_tags}")
+        if not down_file_exists:
+            logger.error(f"Snuba health check failed! Tags: {metric_tags}")
 
     if status != 200 or down_file_exists:
         logger.info(payload)

--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -107,8 +107,10 @@ def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
     payload = json.dumps(body)
     if status != 200:
         metrics.increment("healthcheck_failed", tags=metric_tags)
-        if not down_file_exists:
-            logger.error(f"Snuba health check failed! Tags: {metric_tags}")
+        if down_file_exists:
+            logger.error("Snuba health check failed! Tags: %s", metric_tags)
+        else:
+            logger.info("Snuba health check failed! Tags: %s", metric_tags)
 
     if status != 200 or down_file_exists:
         logger.info(payload)

--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -112,9 +112,6 @@ def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
         else:
             logger.info("Snuba health check failed! Tags: %s", metric_tags)
 
-    if status != 200 or down_file_exists:
-        logger.info(payload)
-
     metrics.timing(
         "healthcheck.latency",
         time.time() - start,


### PR DESCRIPTION
Kubernetes tells the old snuba pods to mark itself as unhealthy, so that
envoy stops sending traffic to it.

Snuba reports itself as unhealthy to Sentry.

Gocd checks Sentry for new errors.

Gocd stalls the deployment because there are new errors.
