### PR TITLE
chore: Bump Arroyo 2.19.2

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "sentry_arroyo"
-version = "2.19.1"
+version = "2.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419bc455b4b94ac1da370db42ec3e399f87d7f044e8790f0e52c12131aaaea2e"
+checksum = "8b4051763acf699b709031c58e264ad9c393339669648a0d4ae08c8214a923ad"
 dependencies = [
  "chrono",
  "coarsetime",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -53,7 +53,7 @@ data-encoding = "2.5.0"
 zstd = "0.12.3"
 serde_with = "3.8.1"
 seq-macro = "0.3"
-sentry_arroyo = "2.19.1"
+sentry_arroyo = "2.19.2"
 
 
 [dev-dependencies]


### PR DESCRIPTION
Namely, this bump will allow us to respect DLQ buffer limits even when there's no DLQ topic configured for the consumer, thus preventing unbounded DLQ buffer growth