### PR TITLE
ref(admin): Allow merge function in FROM clause

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -132,10 +132,11 @@ def is_query_using_only_system_tables(
 
     for line in explain_query_tree_result.results:
         line = line[0].strip()
-        # We don't allow table functions (except clusterAllReplicas) for now as the clickhouse analyzer isn't good enough yet to resolve those tables
+        # We don't allow table functions (except clusterAllReplicas/merge) for now as the clickhouse analyzer isn't good enough yet to resolve those tables
         if (
             line.startswith("TABLE_FUNCTION")
             and "table_function_name: clusterAllReplicas" not in line
+            and "table_function_name: merge" not in line
         ):
             return False
         if line.startswith("TABLE"):

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -51,6 +51,7 @@ from snuba.admin.user import AdminUser
             memory DESC
         """,
         "SELECT hostname(), avg(query_duration_ms) FROM clusterAllReplicas('default', system.query_log) GROUP BY hostname()",
+        "SELECT count() FROM merge('system', '.*settings')",
     ],
 )
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
This function creates a temporary merge table, which is very useful for doing things like querying
across all the different settings tables.