### PR TITLE
ref(rust): Remove unused CLI option max_bytes_before_external_group_by

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -98,7 +98,6 @@ fn create_factory(
         },
         stop_at_timestamp: None,
         batch_write_timeout: None,
-        max_bytes_before_external_group_by: None,
     };
     Box::new(factory)
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -45,7 +45,6 @@ pub fn consumer(
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
     batch_write_timeout_ms: Option<u64>,
-    max_bytes_before_external_group_by: Option<usize>,
     max_dlq_buffer_length: Option<usize>,
 ) {
     py.allow_threads(|| {
@@ -64,7 +63,6 @@ pub fn consumer(
             health_check_file,
             stop_at_timestamp,
             batch_write_timeout_ms,
-            max_bytes_before_external_group_by,
             mutations_mode,
             max_dlq_buffer_length,
         )
@@ -87,7 +85,6 @@ pub fn consumer_impl(
     health_check_file: Option<&str>,
     stop_at_timestamp: Option<i64>,
     batch_write_timeout_ms: Option<u64>,
-    max_bytes_before_external_group_by: Option<usize>,
     mutations_mode: bool,
     max_dlq_buffer_length: Option<usize>,
 ) -> usize {
@@ -287,7 +284,6 @@ pub fn consumer_impl(
             accountant_topic_config: consumer_config.accountant_topic,
             stop_at_timestamp,
             batch_write_timeout,
-            max_bytes_before_external_group_by,
         };
 
         StreamProcessor::with_kafka(config, factory, topic, dlq_policy)

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -57,7 +57,6 @@ pub struct ConsumerStrategyFactory {
     pub accountant_topic_config: config::TopicConfig,
     pub stop_at_timestamp: Option<i64>,
     pub batch_write_timeout: Option<Duration>,
-    pub max_bytes_before_external_group_by: Option<usize>,
 }
 
 impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
@@ -121,7 +120,6 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.storage_config.clickhouse_cluster.password,
             self.async_inserts,
             self.batch_write_timeout,
-            self.max_bytes_before_external_group_by,
         );
 
         let accumulator = Arc::new(

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -268,7 +268,6 @@ mod tests {
             "",
             false,
             None,
-            None,
         );
 
         let mut batch = factory.new_batch();
@@ -304,7 +303,6 @@ mod tests {
             "",
             true,
             None,
-            None,
         );
 
         let mut batch = factory.new_batch();
@@ -339,7 +337,6 @@ mod tests {
             "",
             false,
             None,
-            None,
         );
 
         let mut batch = factory.new_batch();
@@ -371,7 +368,6 @@ mod tests {
             "default",
             "",
             false,
-            None,
             None,
         );
 
@@ -409,7 +405,6 @@ mod tests {
             // pass in an unreasonably short timeout
             // which prevents the client request from reaching Clickhouse
             Some(Duration::from_millis(0)),
-            None,
         );
 
         let mut batch = factory.new_batch();
@@ -444,7 +439,6 @@ mod tests {
             true,
             // pass in a reasonable timeout
             Some(Duration::from_millis(1000)),
-            None,
         );
 
         let mut batch = factory.new_batch();

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -178,16 +178,6 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     default=None,
     help="Optional timeout for batch writer client connecting and sending request to Clickhouse",
 )
-@click.option(
-    "--max-bytes-before-external-group-by",
-    type=int,
-    default=None,
-    help="""
-    Allow batching on disk for GROUP BY queries. This is a test mitigation for whether a
-    materialized view is causing OOM on inserts. If successful, this should be set in storage config.
-    If not successful, this option should be removed.
-    """,
-)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -217,7 +207,6 @@ def rust_consumer(
     enforce_schema: bool,
     stop_at_timestamp: Optional[int],
     batch_write_timeout_ms: Optional[int],
-    max_bytes_before_external_group_by: Optional[int],
     mutations_mode: bool,
     max_dlq_buffer_length: Optional[int]
 ) -> None:
@@ -271,7 +260,6 @@ def rust_consumer(
         health_check_file,
         stop_at_timestamp,
         batch_write_timeout_ms,
-        max_bytes_before_external_group_by,
         max_dlq_buffer_length,
     )
 


### PR DESCRIPTION
depends on successful rollout of https://github.com/getsentry/ops/pull/13279
