### PR TITLE
fix: run sentry tests when RPC changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -2,7 +2,7 @@
 
 api_changes:
   - "snuba/datasets/configuration/**/*.yaml"
-  - "snuba/web/*.py"
+  - "snuba/web/**/*.py"
   - "snuba/query/**/*.py"
   - "snuba/snuba_migrations/**/*"
   - "snuba/cli/devserver.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,8 @@ jobs:
               tests/sentry/search/events \
               tests/sentry/event_manager \
               tests/sentry/api/endpoints/test_organization_profiling_functions.py \
+              tests/sentry/integrations/slack/test_unfurl.py \
+              tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py \
               tests/snuba/api/endpoints/test_organization_events_stats_mep.py \
               tests/sentry/sentry_metrics/querying \
               tests/snuba/test_snql_snuba.py \


### PR DESCRIPTION
This forces relevant sentry tests to run when we change RPC files.