### PR TITLE
init

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -1,6 +1,7 @@
 import os
 from typing import Generic, List, Tuple, Type, TypeVar, cast, final
 
+import sentry_sdk
 from google.protobuf.message import DecodeError
 from google.protobuf.message import Message as ProtobufMessage
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
@@ -67,6 +68,11 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
 
     @final
     def execute(self, in_msg: Tin) -> Tout:
+        scope = sentry_sdk.get_current_scope()
+        scope.set_transaction_name(self.config_key())
+        span = scope.span
+        if span is not None:
+            span.description = self.config_key()
         self.__before_execute(in_msg)
         error = None
         try:


### PR DESCRIPTION
this closes this ticket https://github.com/getsentry/eap-planning/issues/118

now the transaction name and span description will be specific to the rpc endpoint that its in