### PR TITLE
refactor: Remove hardcoded spans dataset references

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -1,30 +1,14 @@
 from datetime import datetime, timedelta
-from typing import Final, Mapping, Sequence, Set
 
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
-    AttributeKey,
-    VirtualColumnContext,
-)
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
-    ComparisonFilter,
-    TraceItemFilter,
-)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemName
 
 from snuba.query import Query
 from snuba.query.conditions import combine_and_conditions, combine_or_conditions
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import (
-    and_cond,
-    column,
-    in_cond,
-    literal,
-    literals_array,
-    not_cond,
-    or_cond,
-)
-from snuba.query.expressions import Expression, FunctionCall, SubscriptableReference
-from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+from snuba.query.dsl import and_cond, column, in_cond, literal, literals_array
+from snuba.query.expressions import Expression, FunctionCall
+from snuba.web.rpc.common.trace_item_types import SnubaRPCBridge
+from snuba.web.rpc.common.trace_item_types.spans import SpansSnubaRPCBridge
 
 
 def truncate_request_meta_to_day(meta: RequestMeta) -> None:
@@ -72,282 +56,6 @@ def treeify_or_and_conditions(query: Query) -> None:
     query.transform_expressions(transform)
 
 
-# These are the columns which aren't stored in attr_str_ nor attr_num_ in clickhouse
-NORMALIZED_COLUMNS: Final[Mapping[str, AttributeKey.Type.ValueType]] = {
-    "sentry.organization_id": AttributeKey.Type.TYPE_INT,
-    "sentry.project_id": AttributeKey.Type.TYPE_INT,
-    "sentry.service": AttributeKey.Type.TYPE_STRING,
-    "sentry.span_id": AttributeKey.Type.TYPE_STRING,  # this is converted by a processor on the storage
-    "sentry.parent_span_id": AttributeKey.Type.TYPE_STRING,  # this is converted by a processor on the storage
-    "sentry.segment_id": AttributeKey.Type.TYPE_STRING,  # this is converted by a processor on the storage
-    "sentry.segment_name": AttributeKey.Type.TYPE_STRING,
-    "sentry.is_segment": AttributeKey.Type.TYPE_BOOLEAN,
-    "sentry.duration_ms": AttributeKey.Type.TYPE_FLOAT,
-    "sentry.exclusive_time_ms": AttributeKey.Type.TYPE_FLOAT,
-    "sentry.retention_days": AttributeKey.Type.TYPE_INT,
-    "sentry.name": AttributeKey.Type.TYPE_STRING,
-    "sentry.sampling_weight": AttributeKey.Type.TYPE_FLOAT,
-    "sentry.sampling_factor": AttributeKey.Type.TYPE_FLOAT,
-    "sentry.timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
-    "sentry.start_timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
-    "sentry.end_timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
-}
-
-TIMESTAMP_COLUMNS: Final[Set[str]] = {
-    "sentry.timestamp",
-    "sentry.start_timestamp",
-    "sentry.end_timestamp",
-}
-
-
-def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
-    def _build_label_mapping_key(attr_key: AttributeKey) -> str:
-        return attr_key.name + "_" + AttributeKey.Type.Name(attr_key.type)
-
-    if attr_key.type == AttributeKey.Type.TYPE_UNSPECIFIED:
-        raise BadSnubaRPCRequestException(
-            f"attribute key {attr_key.name} must have a type specified"
-        )
-    alias = _build_label_mapping_key(attr_key)
-
-    if attr_key.name == "sentry.trace_id":
-        if attr_key.type == AttributeKey.Type.TYPE_STRING:
-            return f.CAST(column("trace_id"), "String", alias=alias)
-        raise BadSnubaRPCRequestException(
-            f"Attribute {attr_key.name} must be requested as a string, got {attr_key.type}"
-        )
-
-    if attr_key.name in TIMESTAMP_COLUMNS:
-        if attr_key.type == AttributeKey.Type.TYPE_STRING:
-            return f.CAST(
-                column(attr_key.name[len("sentry.") :]), "String", alias=alias
-            )
-        if attr_key.type == AttributeKey.Type.TYPE_INT:
-            return f.CAST(column(attr_key.name[len("sentry.") :]), "Int64", alias=alias)
-        if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
-            return f.CAST(
-                column(attr_key.name[len("sentry.") :]), "Float64", alias=alias
-            )
-        raise BadSnubaRPCRequestException(
-            f"Attribute {attr_key.name} must be requested as a string, float, or integer, got {attr_key.type}"
-        )
-
-    if attr_key.name in NORMALIZED_COLUMNS:
-        if NORMALIZED_COLUMNS[attr_key.name] == attr_key.type:
-            return column(attr_key.name[len("sentry.") :], alias=attr_key.name)
-        raise BadSnubaRPCRequestException(
-            f"Attribute {attr_key.name} must be requested as {NORMALIZED_COLUMNS[attr_key.name]}, got {attr_key.type}"
-        )
-
-    # End of special handling, just send to the appropriate bucket
-    if attr_key.type == AttributeKey.Type.TYPE_STRING:
-        return SubscriptableReference(
-            alias=alias, column=column("attr_str"), key=literal(attr_key.name)
-        )
-    if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
-        return SubscriptableReference(
-            alias=alias, column=column("attr_num"), key=literal(attr_key.name)
-        )
-    if attr_key.type == AttributeKey.Type.TYPE_INT:
-        return f.CAST(
-            SubscriptableReference(
-                alias=None, column=column("attr_num"), key=literal(attr_key.name)
-            ),
-            "Int64",
-            alias=alias,
-        )
-    if attr_key.type == AttributeKey.Type.TYPE_BOOLEAN:
-        return f.CAST(
-            SubscriptableReference(
-                alias=None,
-                column=column("attr_num"),
-                key=literal(attr_key.name),
-            ),
-            "Boolean",
-            alias=alias,
-        )
-    raise BadSnubaRPCRequestException(
-        f"Attribute {attr_key.name} had an unknown or unset type: {attr_key.type}"
-    )
-
-
-def apply_virtual_columns(
-    query: Query, virtual_column_contexts: Sequence[VirtualColumnContext]
-) -> None:
-    """Injects virtual column mappings into the clickhouse query. Works with NORMALIZED_COLUMNS on the table or
-    dynamic columns in attr_str
-
-    attr_num not supported because mapping on floats is a bad idea
-
-    Example:
-
-        SELECT
-          project_name AS `project_name`,
-          attr_str['release'] AS `release`,
-          attr_str['sentry.sdk.name'] AS `sentry.sdk.name`,
-        ... rest of query
-
-        contexts:
-            [   {from_column_name: project_id, to_column_name: project_name, value_map: {1: "sentry", 2: "snuba"}} ]
-
-
-        Query will be transformed into:
-
-        SELECT
-        -- see the project name column transformed and the value mapping injected
-          transform( CAST( project_id, 'String'), array( '1', '2'), array( 'sentry', 'snuba'), 'unknown') AS `project_name`,
-        --
-          attr_str['release'] AS `release`,
-          attr_str['sentry.sdk.name'] AS `sentry.sdk.name`,
-        ... rest of query
-
-    """
-
-    if not virtual_column_contexts:
-        return
-
-    mapped_column_to_context = {c.to_column_name: c for c in virtual_column_contexts}
-
-    def transform_expressions(expression: Expression) -> Expression:
-        # virtual columns will show up as `attr_str[virtual_column_name]` or `attr_num[virtual_column_name]`
-        if not isinstance(expression, SubscriptableReference):
-            return expression
-
-        if expression.column.column_name != "attr_str":
-            return expression
-        context = mapped_column_to_context.get(str(expression.key.value))
-        if context:
-            attribute_expression = attribute_key_to_expression(
-                AttributeKey(
-                    name=context.from_column_name,
-                    type=NORMALIZED_COLUMNS.get(
-                        context.from_column_name, AttributeKey.TYPE_STRING
-                    ),
-                )
-            )
-            return f.transform(
-                f.CAST(attribute_expression, "String"),
-                literals_array(None, [literal(k) for k in context.value_map.keys()]),
-                literals_array(None, [literal(v) for v in context.value_map.values()]),
-                literal("unknown"),
-                alias=context.to_column_name,
-            )
-
-        return expression
-
-    query.transform_expressions(transform_expressions)
-
-
-def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression:
-    """
-    Trace Item Filters are things like (span.id=12345 AND start_timestamp >= "june 4th, 2024")
-    This maps those filters into an expression which can be used in a WHERE clause
-    :param item_filter:
-    :return:
-    """
-    if item_filter.HasField("and_filter"):
-        filters = item_filter.and_filter.filters
-        if len(filters) == 0:
-            return literal(True)
-        if len(filters) == 1:
-            return trace_item_filters_to_expression(filters[0])
-        return and_cond(*(trace_item_filters_to_expression(x) for x in filters))
-
-    if item_filter.HasField("or_filter"):
-        filters = item_filter.or_filter.filters
-        if len(filters) == 0:
-            raise BadSnubaRPCRequestException(
-                "Invalid trace item filter, empty 'or' clause"
-            )
-        if len(filters) == 1:
-            return trace_item_filters_to_expression(filters[0])
-        return or_cond(*(trace_item_filters_to_expression(x) for x in filters))
-
-    if item_filter.HasField("comparison_filter"):
-        k = item_filter.comparison_filter.key
-        k_expression = attribute_key_to_expression(k)
-        op = item_filter.comparison_filter.op
-        v = item_filter.comparison_filter.value
-
-        value_type = v.WhichOneof("value")
-        if value_type is None:
-            raise BadSnubaRPCRequestException(
-                "comparison does not have a right hand side"
-            )
-
-        match value_type:
-            case "val_bool":
-                v_expression: Expression = literal(v.val_bool)
-            case "val_str":
-                v_expression = literal(v.val_str)
-            case "val_float":
-                v_expression = literal(v.val_float)
-            case "val_int":
-                v_expression = literal(v.val_int)
-            case "val_null":
-                v_expression = literal(None)
-            case "val_str_array":
-                v_expression = literals_array(
-                    None, list(map(lambda x: literal(x), v.val_str_array.values))
-                )
-            case "val_int_array":
-                v_expression = literals_array(
-                    None, list(map(lambda x: literal(x), v.val_int_array.values))
-                )
-            case "val_float_array":
-                v_expression = literals_array(
-                    None, list(map(lambda x: literal(x), v.val_float_array.values))
-                )
-            case default:
-                raise NotImplementedError(
-                    f"translation of AttributeValue type {default} is not implemented"
-                )
-
-        if op == ComparisonFilter.OP_EQUALS:
-            return f.equals(k_expression, v_expression)
-        if op == ComparisonFilter.OP_NOT_EQUALS:
-            return f.notEquals(k_expression, v_expression)
-        if op == ComparisonFilter.OP_LIKE:
-            if k.type != AttributeKey.Type.TYPE_STRING:
-                raise BadSnubaRPCRequestException(
-                    "the LIKE comparison is only supported on string keys"
-                )
-            return f.like(k_expression, v_expression)
-        if op == ComparisonFilter.OP_NOT_LIKE:
-            if k.type != AttributeKey.Type.TYPE_STRING:
-                raise BadSnubaRPCRequestException(
-                    "the NOT LIKE comparison is only supported on string keys"
-                )
-            return f.notLike(k_expression, v_expression)
-        if op == ComparisonFilter.OP_LESS_THAN:
-            return f.less(k_expression, v_expression)
-        if op == ComparisonFilter.OP_LESS_THAN_OR_EQUALS:
-            return f.lessOrEquals(k_expression, v_expression)
-        if op == ComparisonFilter.OP_GREATER_THAN:
-            return f.greater(k_expression, v_expression)
-        if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
-            return f.greaterOrEquals(k_expression, v_expression)
-        if op == ComparisonFilter.OP_IN:
-            return in_cond(k_expression, v_expression)
-        if op == ComparisonFilter.OP_NOT_IN:
-            return not_cond(in_cond(k_expression, v_expression))
-
-        raise BadSnubaRPCRequestException(
-            f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"
-        )
-
-    if item_filter.HasField("exists_filter"):
-        k = item_filter.exists_filter.key
-        if k.name in NORMALIZED_COLUMNS.keys():
-            return f.isNotNull(column(k.name))
-        if k.type == AttributeKey.Type.TYPE_STRING:
-            return f.mapContains(column("attr_str"), literal(k.name))
-        else:
-            return f.mapContains(column("attr_num"), literal(k.name))
-
-    return literal(True)
-
-
 def project_id_and_org_conditions(meta: RequestMeta) -> Expression:
     return and_cond(
         in_cond(
@@ -388,3 +96,21 @@ def base_conditions_and(meta: RequestMeta, *other_exprs: Expression) -> Expressi
         ),
         *other_exprs,
     )
+
+
+TRACE_ITEM_NAMES_TO_SNUBA_BRIDGES = {
+    TraceItemName.TRACE_ITEM_NAME_EAP_SPANS: SpansSnubaRPCBridge()
+}
+
+
+def trace_item_name_to_snuba_bridge(name: TraceItemName.ValueType) -> SnubaRPCBridge:
+    if name == TraceItemName.TRACE_ITEM_NAME_UNSPECIFIED:
+        # TODO to avoid a backwards-incompatible change, assume spans
+        # raise BadSnubaRPCRequestException("you must specify a dataset to query (TraceItemName)")
+        return TRACE_ITEM_NAMES_TO_SNUBA_BRIDGES[
+            TraceItemName.TRACE_ITEM_NAME_EAP_SPANS
+        ]
+
+    if name in TRACE_ITEM_NAMES_TO_SNUBA_BRIDGES:
+        return TRACE_ITEM_NAMES_TO_SNUBA_BRIDGES[name]
+    raise NotImplementedError(f"dataset {name} is not implemented")

--- a/snuba/web/rpc/common/trace_item_types/__init__.py
+++ b/snuba/web/rpc/common/trace_item_types/__init__.py
@@ -1,0 +1,187 @@
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    VirtualColumnContext,
+)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    ComparisonFilter,
+    TraceItemFilter,
+)
+
+from snuba.query import Expression, Query
+from snuba.query.data_source.simple import Entity
+from snuba.query.dsl import Functions as f
+from snuba.query.dsl import (
+    and_cond,
+    in_cond,
+    literal,
+    literals_array,
+    not_cond,
+    or_cond,
+)
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+
+
+class SnubaRPCBridge(ABC):
+    """
+    Classes that implement this abstract class are used to map RPC data to/from snuba data
+    in a dataset-specific way.
+
+    For example, the RPC filter 'exists(trace_id)' might go to `mapContains(attr_str, trace_id)` in one
+    dataset, and `trace_id is not null` in another.
+    """
+
+    @abstractmethod
+    def attribute_key_to_expression(self, attr_key: AttributeKey) -> Expression:
+        pass
+
+    @abstractmethod
+    def get_snuba_entity(self) -> Entity:
+        pass
+
+    @abstractmethod
+    def _attribute_key_exists_expression(self, attr_key: AttributeKey) -> Expression:
+        pass
+
+    def trace_item_filters_to_expression(
+        self, item_filter: TraceItemFilter
+    ) -> Expression:
+        """
+        Trace Item Filters are things like (span.id=12345 AND start_timestamp >= "june 4th, 2024")
+        This maps those filters into an expression which can be used in a WHERE clause
+        :param item_filter: the RPC-formatted filters
+        :return: a snuba expression that can be sent onwards to clickhouse
+        """
+        if item_filter.HasField("and_filter"):
+            filters = item_filter.and_filter.filters
+            if len(filters) == 0:
+                return literal(True)
+            if len(filters) == 1:
+                return self.trace_item_filters_to_expression(filters[0])
+            return and_cond(
+                *(self.trace_item_filters_to_expression(x) for x in filters)
+            )
+
+        if item_filter.HasField("or_filter"):
+            filters = item_filter.or_filter.filters
+            if len(filters) == 0:
+                raise BadSnubaRPCRequestException(
+                    "Invalid trace item filter, empty 'or' clause"
+                )
+            if len(filters) == 1:
+                return self.trace_item_filters_to_expression(filters[0])
+            return or_cond(*(self.trace_item_filters_to_expression(x) for x in filters))
+
+        if item_filter.HasField("comparison_filter"):
+            k = item_filter.comparison_filter.key
+            k_expression = self.attribute_key_to_expression(k)
+            op = item_filter.comparison_filter.op
+            v = item_filter.comparison_filter.value
+
+            value_type = v.WhichOneof("value")
+            if value_type is None:
+                raise BadSnubaRPCRequestException(
+                    "comparison does not have a right hand side"
+                )
+
+            match value_type:
+                case "val_bool":
+                    v_expression: Expression = literal(v.val_bool)
+                case "val_str":
+                    v_expression = literal(v.val_str)
+                case "val_float":
+                    v_expression = literal(v.val_float)
+                case "val_int":
+                    v_expression = literal(v.val_int)
+                case "val_null":
+                    v_expression = literal(None)
+                case "val_str_array":
+                    v_expression = literals_array(
+                        None, list(map(lambda x: literal(x), v.val_str_array.values))
+                    )
+                case "val_int_array":
+                    v_expression = literals_array(
+                        None, list(map(lambda x: literal(x), v.val_int_array.values))
+                    )
+                case "val_float_array":
+                    v_expression = literals_array(
+                        None, list(map(lambda x: literal(x), v.val_float_array.values))
+                    )
+                case default:
+                    raise NotImplementedError(
+                        f"translation of AttributeValue type {default} is not implemented"
+                    )
+
+            if op == ComparisonFilter.OP_EQUALS:
+                return f.equals(k_expression, v_expression)
+            if op == ComparisonFilter.OP_NOT_EQUALS:
+                return f.notEquals(k_expression, v_expression)
+            if op == ComparisonFilter.OP_LIKE:
+                if k.type != AttributeKey.Type.TYPE_STRING:
+                    raise BadSnubaRPCRequestException(
+                        "the LIKE comparison is only supported on string keys"
+                    )
+                return f.like(k_expression, v_expression)
+            if op == ComparisonFilter.OP_NOT_LIKE:
+                if k.type != AttributeKey.Type.TYPE_STRING:
+                    raise BadSnubaRPCRequestException(
+                        "the NOT LIKE comparison is only supported on string keys"
+                    )
+                return f.notLike(k_expression, v_expression)
+            if op == ComparisonFilter.OP_LESS_THAN:
+                return f.less(k_expression, v_expression)
+            if op == ComparisonFilter.OP_LESS_THAN_OR_EQUALS:
+                return f.lessOrEquals(k_expression, v_expression)
+            if op == ComparisonFilter.OP_GREATER_THAN:
+                return f.greater(k_expression, v_expression)
+            if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
+                return f.greaterOrEquals(k_expression, v_expression)
+            if op == ComparisonFilter.OP_IN:
+                return in_cond(k_expression, v_expression)
+            if op == ComparisonFilter.OP_NOT_IN:
+                return not_cond(in_cond(k_expression, v_expression))
+
+            raise BadSnubaRPCRequestException(
+                f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"
+            )
+
+        if item_filter.HasField("exists_filter"):
+            return self._attribute_key_exists_expression(item_filter.exists_filter.key)
+
+        return literal(True)
+
+    @abstractmethod
+    def apply_virtual_columns(
+        self, query: Query, virtual_column_contexts: Sequence[VirtualColumnContext]
+    ) -> None:
+        """Injects virtual column mappings into the clickhouse query. Works with NORMALIZED_COLUMNS on the table or
+        dynamic columns in attr_str
+
+        attr_num not supported because mapping on floats is a bad idea
+
+        Example:
+
+            SELECT
+              project_name AS `project_name`,
+              attr_str['release'] AS `release`,
+              attr_str['sentry.sdk.name'] AS `sentry.sdk.name`,
+            ... rest of query
+
+            contexts:
+                [   {from_column_name: project_id, to_column_name: project_name, value_map: {1: "sentry", 2: "snuba"}} ]
+
+
+            Query will be transformed into:
+
+            SELECT
+            -- see the project name column transformed and the value mapping injected
+              transform( CAST( project_id, 'String'), array( '1', '2'), array( 'sentry', 'snuba'), 'unknown') AS `project_name`,
+            --
+              attr_str['release'] AS `release`,
+              attr_str['sentry.sdk.name'] AS `sentry.sdk.name`,
+            ... rest of query
+
+        """
+        pass

--- a/snuba/web/rpc/common/trace_item_types/spans.py
+++ b/snuba/web/rpc/common/trace_item_types/spans.py
@@ -1,0 +1,171 @@
+from typing import Final, Mapping, Sequence, Set
+
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    VirtualColumnContext,
+)
+
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query import Expression, Query, SubscriptableReference
+from snuba.query.data_source.simple import Entity
+from snuba.query.dsl import Functions as f
+from snuba.query.dsl import column, literal, literals_array
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+from snuba.web.rpc.common.trace_item_types import SnubaRPCBridge
+
+# These are the columns which aren't stored in attr_str_ nor attr_num_ in clickhouse
+SPAN_NORMALIZED_COLUMNS: Final[Mapping[str, AttributeKey.Type.ValueType]] = {
+    "sentry.organization_id": AttributeKey.Type.TYPE_INT,
+    "sentry.project_id": AttributeKey.Type.TYPE_INT,
+    "sentry.service": AttributeKey.Type.TYPE_STRING,
+    "sentry.span_id": AttributeKey.Type.TYPE_STRING,  # this is converted by a processor on the storage
+    "sentry.parent_span_id": AttributeKey.Type.TYPE_STRING,  # this is converted by a processor on the storage
+    "sentry.segment_id": AttributeKey.Type.TYPE_STRING,  # this is converted by a processor on the storage
+    "sentry.segment_name": AttributeKey.Type.TYPE_STRING,
+    "sentry.is_segment": AttributeKey.Type.TYPE_BOOLEAN,
+    "sentry.duration_ms": AttributeKey.Type.TYPE_FLOAT,
+    "sentry.exclusive_time_ms": AttributeKey.Type.TYPE_FLOAT,
+    "sentry.retention_days": AttributeKey.Type.TYPE_INT,
+    "sentry.name": AttributeKey.Type.TYPE_STRING,
+    "sentry.sampling_weight": AttributeKey.Type.TYPE_FLOAT,
+    "sentry.sampling_factor": AttributeKey.Type.TYPE_FLOAT,
+    "sentry.timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
+    "sentry.start_timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
+    "sentry.end_timestamp": AttributeKey.Type.TYPE_UNSPECIFIED,
+}
+
+SPAN_TIMESTAMP_COLUMNS: Final[Set[str]] = {
+    "sentry.timestamp",
+    "sentry.start_timestamp",
+    "sentry.end_timestamp",
+}
+
+
+class SpansSnubaRPCBridge(SnubaRPCBridge):
+    def get_snuba_entity(self) -> Entity:
+        return Entity(
+            key=EntityKey("eap_spans"),
+            schema=get_entity(EntityKey("eap_spans")).get_data_model(),
+            sample=None,
+        )
+
+    def _attribute_key_exists_expression(self, attr_key: AttributeKey) -> Expression:
+        if attr_key.name in SPAN_NORMALIZED_COLUMNS.keys():
+            return f.isNotNull(column(attr_key.name))
+        if attr_key.type == AttributeKey.Type.TYPE_STRING:
+            return f.mapContains(column("attr_str"), literal(attr_key.name))
+        else:
+            return f.mapContains(column("attr_num"), literal(attr_key.name))
+
+    def attribute_key_to_expression(self, attr_key: AttributeKey) -> Expression:
+        if attr_key.type == AttributeKey.Type.TYPE_UNSPECIFIED:
+            raise BadSnubaRPCRequestException(
+                f"attribute key {attr_key.name} must have a type specified"
+            )
+        alias = attr_key.name + "_" + AttributeKey.Type.Name(attr_key.type)
+
+        if attr_key.name == "sentry.trace_id":
+            if attr_key.type == AttributeKey.Type.TYPE_STRING:
+                return f.CAST(column("trace_id"), "String", alias=alias)
+            raise BadSnubaRPCRequestException(
+                f"Attribute {attr_key.name} must be requested as a string, got {attr_key.type}"
+            )
+
+        if attr_key.name in SPAN_TIMESTAMP_COLUMNS:
+            if attr_key.type == AttributeKey.Type.TYPE_STRING:
+                return f.CAST(
+                    column(attr_key.name[len("sentry.") :]), "String", alias=alias
+                )
+            if attr_key.type == AttributeKey.Type.TYPE_INT:
+                return f.CAST(
+                    column(attr_key.name[len("sentry.") :]), "Int64", alias=alias
+                )
+            if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
+                return f.CAST(
+                    column(attr_key.name[len("sentry.") :]), "Float64", alias=alias
+                )
+            raise BadSnubaRPCRequestException(
+                f"Attribute {attr_key.name} must be requested as a string, float, or integer, got {attr_key.type}"
+            )
+
+        if attr_key.name in SPAN_NORMALIZED_COLUMNS:
+            if SPAN_NORMALIZED_COLUMNS[attr_key.name] == attr_key.type:
+                return column(attr_key.name[len("sentry.") :], alias=attr_key.name)
+            raise BadSnubaRPCRequestException(
+                f"Attribute {attr_key.name} must be requested as {SPAN_NORMALIZED_COLUMNS[attr_key.name]}, got {attr_key.type}"
+            )
+
+        # End of special handling, just send to the appropriate bucket
+        if attr_key.type == AttributeKey.Type.TYPE_STRING:
+            return SubscriptableReference(
+                alias=alias, column=column("attr_str"), key=literal(attr_key.name)
+            )
+        if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
+            return SubscriptableReference(
+                alias=alias, column=column("attr_num"), key=literal(attr_key.name)
+            )
+        if attr_key.type == AttributeKey.Type.TYPE_INT:
+            return f.CAST(
+                SubscriptableReference(
+                    alias=None, column=column("attr_num"), key=literal(attr_key.name)
+                ),
+                "Int64",
+                alias=alias,
+            )
+        if attr_key.type == AttributeKey.Type.TYPE_BOOLEAN:
+            return f.CAST(
+                SubscriptableReference(
+                    alias=None,
+                    column=column("attr_num"),
+                    key=literal(attr_key.name),
+                ),
+                "Boolean",
+                alias=alias,
+            )
+        raise BadSnubaRPCRequestException(
+            f"Attribute {attr_key.name} had an unknown or unset type: {attr_key.type}"
+        )
+
+    def apply_virtual_columns(
+        self, query: Query, virtual_column_contexts: Sequence[VirtualColumnContext]
+    ) -> None:
+        if not virtual_column_contexts:
+            return
+
+        mapped_column_to_context = {
+            c.to_column_name: c for c in virtual_column_contexts
+        }
+
+        def transform_expressions(expression: Expression) -> Expression:
+            # virtual columns will show up as `attr_str[virtual_column_name]` or `attr_num[virtual_column_name]`
+            if not isinstance(expression, SubscriptableReference):
+                return expression
+
+            if expression.column.column_name != "attr_str":
+                return expression
+            context = mapped_column_to_context.get(str(expression.key.value))
+            if context:
+                attribute_expression = self.attribute_key_to_expression(
+                    AttributeKey(
+                        name=context.from_column_name,
+                        type=SPAN_NORMALIZED_COLUMNS.get(
+                            context.from_column_name, AttributeKey.TYPE_STRING
+                        ),
+                    )
+                )
+                return f.transform(
+                    f.CAST(attribute_expression, "String"),
+                    literals_array(
+                        None, [literal(k) for k in context.value_map.keys()]
+                    ),
+                    literals_array(
+                        None, [literal(v) for v in context.value_map.values()]
+                    ),
+                    literal("unknown"),
+                    alias=context.to_column_name,
+                )
+
+            return expression
+
+        query.transform_expressions(transform_expressions)

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -11,140 +11,151 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
 
 from snuba.web.rpc.common.aggregation import (
     CUSTOM_COLUMN_PREFIX,
+    Aggregator,
     CustomColumnInformation,
     ExtrapolationMeta,
-    get_confidence_interval_column,
 )
+from snuba.web.rpc.common.trace_item_types.spans import SpansSnubaRPCBridge
 
 
-def test_generate_custom_column_alias() -> None:
-    custom_column_information_with_metadata = CustomColumnInformation(
-        custom_column_id="confidence_interval",
-        referenced_column="count",
-        metadata={"function_type": "count", "additional_metadata": "value"},
-    )
+class TestRPCAggregation:
+    @pytest.fixture
+    def bridge(self) -> SpansSnubaRPCBridge:
+        return SpansSnubaRPCBridge()
 
-    assert custom_column_information_with_metadata.to_alias() == (
-        CUSTOM_COLUMN_PREFIX
-        + "confidence_interval$count$function_type:count,additional_metadata:value"
-    )
+    @pytest.fixture
+    def aggregator(self) -> Aggregator:
+        return Aggregator(snuba_rpc_bridge=SpansSnubaRPCBridge())
 
-
-def test_generate_custom_column_alias_without_metadata() -> None:
-    custom_column_information_without_metadata = CustomColumnInformation(
-        custom_column_id="column_id",
-        referenced_column="count",
-        metadata={},
-    )
-
-    assert (
-        custom_column_information_without_metadata.to_alias()
-        == CUSTOM_COLUMN_PREFIX + "column_id$count"
-    )
-
-
-def test_generate_custom_column_alias_without_referenced_column() -> None:
-    custom_column_information_without_referenced_column = CustomColumnInformation(
-        custom_column_id="column_id",
-        referenced_column=None,
-        metadata={},
-    )
-
-    assert (
-        custom_column_information_without_referenced_column.to_alias()
-        == CUSTOM_COLUMN_PREFIX + "column_id"
-    )
-
-
-def test_get_custom_column_information() -> None:
-    alias = CUSTOM_COLUMN_PREFIX + "column_type$count$meta1:value1,meta2:value2"
-    custom_column_information = CustomColumnInformation.from_alias(alias)
-    assert custom_column_information == CustomColumnInformation(
-        custom_column_id="column_type",
-        referenced_column="count",
-        metadata={"meta1": "value1", "meta2": "value2"},
-    )
-
-
-def test_get_confidence_interval_column_for_non_extrapolatable_column() -> None:
-    assert (
-        get_confidence_interval_column(
-            AttributeAggregation(
-                aggregate=Function.FUNCTION_MIN,
-                key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test"),
-                label="min(test)",
-                extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
-            )
+    def test_generate_custom_column_alias(self) -> None:
+        custom_column_information_with_metadata = CustomColumnInformation(
+            custom_column_id="confidence_interval",
+            referenced_column="count",
+            metadata={"function_type": "count", "additional_metadata": "value"},
         )
-        is None
+
+        assert custom_column_information_with_metadata.to_alias() == (
+            CUSTOM_COLUMN_PREFIX
+            + "confidence_interval$count$function_type:count,additional_metadata:value"
+        )
+
+    def test_generate_custom_column_alias_without_metadata(self) -> None:
+        custom_column_information_without_metadata = CustomColumnInformation(
+            custom_column_id="column_id",
+            referenced_column="count",
+            metadata={},
+        )
+
+        assert (
+            custom_column_information_without_metadata.to_alias()
+            == CUSTOM_COLUMN_PREFIX + "column_id$count"
+        )
+
+    def test_generate_custom_column_alias_without_referenced_column(self) -> None:
+        custom_column_information_without_referenced_column = CustomColumnInformation(
+            custom_column_id="column_id",
+            referenced_column=None,
+            metadata={},
+        )
+
+        assert (
+            custom_column_information_without_referenced_column.to_alias()
+            == CUSTOM_COLUMN_PREFIX + "column_id"
+        )
+
+    def test_get_custom_column_information(self) -> None:
+        alias = CUSTOM_COLUMN_PREFIX + "column_type$count$meta1:value1,meta2:value2"
+        custom_column_information = CustomColumnInformation.from_alias(alias)
+        assert custom_column_information == CustomColumnInformation(
+            custom_column_id="column_type",
+            referenced_column="count",
+            metadata={"meta1": "value1", "meta2": "value2"},
+        )
+
+    def test_get_confidence_interval_column_for_non_extrapolatable_column(
+        self, aggregator
+    ) -> None:
+        assert (
+            aggregator.get_confidence_interval_column(
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_MIN,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test"),
+                    label="min(test)",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+                )
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        ("row_data", "column_name", "average_sample_rate", "reliability"),
+        [
+            (
+                {
+                    "time": "2024-4-20 16:20:00",
+                    "count(sentry.duration)": 100,
+                    "p95(sentry.duration)": 123456,
+                    CustomColumnInformation(
+                        custom_column_id="confidence_interval",
+                        referenced_column="count(sentry.duration)",
+                        metadata={"function_type": "count"},
+                    ).to_alias(): 20,
+                    CustomColumnInformation(
+                        custom_column_id="average_sample_rate",
+                        referenced_column="count(sentry.duration)",
+                        metadata={},
+                    ).to_alias(): 0.5,
+                    CustomColumnInformation(
+                        custom_column_id="count",
+                        referenced_column="count(sentry.duration)",
+                        metadata={},
+                    ).to_alias(): 120,
+                    "group_by_attr_1": "g1",
+                    "group_by_attr_2": "a1",
+                },
+                "count(sentry.duration)",
+                0.5,
+                Reliability.RELIABILITY_HIGH,
+            ),
+            (
+                {
+                    "time": "2024-4-20 16:20:00",
+                    "count(sentry.duration)": 100,
+                    "min(sentry.duration)": 123456,
+                    CustomColumnInformation(
+                        custom_column_id="confidence_interval",
+                        referenced_column="count(sentry.duration)",
+                        metadata={"function_type": "count"},
+                    ).to_alias(): 20,
+                    CustomColumnInformation(
+                        custom_column_id="average_sample_rate",
+                        referenced_column="count(sentry.duration)",
+                        metadata={},
+                    ).to_alias(): 0.5,
+                    CustomColumnInformation(
+                        custom_column_id="count",
+                        referenced_column="count(sentry.duration)",
+                        metadata={},
+                    ).to_alias(): 120,
+                    "group_by_attr_1": "g1",
+                    "group_by_attr_2": "a1",
+                },
+                "min(sentry.duration)",
+                0,
+                Reliability.RELIABILITY_UNSPECIFIED,
+            ),
+        ],
     )
-
-
-@pytest.mark.parametrize(
-    ("row_data", "column_name", "average_sample_rate", "reliability"),
-    [
-        (
-            {
-                "time": "2024-4-20 16:20:00",
-                "count(sentry.duration)": 100,
-                "p95(sentry.duration)": 123456,
-                CustomColumnInformation(
-                    custom_column_id="confidence_interval",
-                    referenced_column="count(sentry.duration)",
-                    metadata={"function_type": "count"},
-                ).to_alias(): 20,
-                CustomColumnInformation(
-                    custom_column_id="average_sample_rate",
-                    referenced_column="count(sentry.duration)",
-                    metadata={},
-                ).to_alias(): 0.5,
-                CustomColumnInformation(
-                    custom_column_id="count",
-                    referenced_column="count(sentry.duration)",
-                    metadata={},
-                ).to_alias(): 120,
-                "group_by_attr_1": "g1",
-                "group_by_attr_2": "a1",
-            },
-            "count(sentry.duration)",
-            0.5,
-            Reliability.RELIABILITY_HIGH,
-        ),
-        (
-            {
-                "time": "2024-4-20 16:20:00",
-                "count(sentry.duration)": 100,
-                "min(sentry.duration)": 123456,
-                CustomColumnInformation(
-                    custom_column_id="confidence_interval",
-                    referenced_column="count(sentry.duration)",
-                    metadata={"function_type": "count"},
-                ).to_alias(): 20,
-                CustomColumnInformation(
-                    custom_column_id="average_sample_rate",
-                    referenced_column="count(sentry.duration)",
-                    metadata={},
-                ).to_alias(): 0.5,
-                CustomColumnInformation(
-                    custom_column_id="count",
-                    referenced_column="count(sentry.duration)",
-                    metadata={},
-                ).to_alias(): 120,
-                "group_by_attr_1": "g1",
-                "group_by_attr_2": "a1",
-            },
-            "min(sentry.duration)",
-            0,
-            Reliability.RELIABILITY_UNSPECIFIED,
-        ),
-    ],
-)
-def test_get_extrapolation_meta(
-    row_data: dict[str, Any],
-    column_name: str,
-    average_sample_rate: float,
-    reliability: Reliability.ValueType,
-) -> None:
-    extrapolation_meta = ExtrapolationMeta.from_row(row_data, column_name)
-    assert extrapolation_meta.avg_sampling_rate == average_sample_rate
-    assert extrapolation_meta.reliability == reliability
+    def test_get_extrapolation_meta(
+        self,
+        row_data: dict[str, Any],
+        column_name: str,
+        average_sample_rate: float,
+        reliability: Reliability.ValueType,
+        aggregator: Aggregator,
+    ) -> None:
+        extrapolation_meta = ExtrapolationMeta.from_row(
+            aggregator, row_data, column_name
+        )
+        assert extrapolation_meta.avg_sampling_rate == average_sample_rate
+        assert extrapolation_meta.reliability == reliability


### PR DESCRIPTION
Preparing for when we add other datatypes to EAP, we have to remove hardcoded references to the spans table and its structure