### PR TITLE
chore(deps): bump relay from 0.9.2 to 0.9.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ redis==4.5.4
 sentry-arroyo==2.19.3
 sentry-kafka-schemas==0.1.122
 sentry-redis-tools==0.3.0
-sentry-relay==0.9.2
+sentry-relay==0.9.4
 sentry-sdk==2.18.0
 simplejson==3.17.6
 snuba-sdk==3.0.39


### PR DESCRIPTION
ref: https://github.com/getsentry/relay/issues/4175