### PR TITLE
chore: Bump Arroyo to 2.19.5

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "sentry_arroyo"
-version = "2.19.4"
+version = "2.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccce96788e9fa5bab750a8d7dcc44b2d6557c41fcdfc0d899d4e893ef4f15264"
+checksum = "7d03985a340e70b0360d89727cd55fad4f065b6dcd13a41fbe69e4dca41bcbc1"
 dependencies = [
  "chrono",
  "coarsetime",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -53,7 +53,7 @@ data-encoding = "2.5.0"
 zstd = "0.12.3"
 serde_with = "3.8.1"
 seq-macro = "0.3"
-sentry_arroyo = "2.19.4"
+sentry_arroyo = "2.19.5"
 
 
 [dev-dependencies]


### PR DESCRIPTION
Bump to latest version, which includes important DLQ management fixes. 