### PR TITLE
fix(admin): Allow KILL MUTATION commands in sudo mode

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -75,6 +75,18 @@ SHOW_QUERY_RE = re.compile(
     re.VERBOSE,
 )
 
+KILL_COMMAND_RE = re.compile(
+    r"""
+        ^
+        (KILL\sMUTATION\sWHERE)
+        \s
+        .*\s*=\s*.*
+        ;?
+        $
+    """,
+    re.IGNORECASE + re.VERBOSE,
+)
+
 SYSTEM_COMMAND_RE = re.compile(
     r"""
         ^
@@ -195,8 +207,9 @@ def is_system_command(sql_query: str) -> bool:
     Validates whether we are running something like SYSTEM STOP MERGES
     """
     sql_query = " ".join(sql_query.split())
-    match = SYSTEM_COMMAND_RE.match(sql_query)
-    return True if match else False
+    smatch = SYSTEM_COMMAND_RE.match(sql_query)
+    kmatch = KILL_COMMAND_RE.match(sql_query)
+    return True if smatch or kmatch else False
 
 
 def is_query_optimize(sql_query: str) -> bool:

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -6,9 +6,6 @@ from snuba import settings
 from snuba.admin.auth_roles import ROLES, Role
 from snuba.admin.clickhouse.system_queries import (
     UnauthorizedForSudo,
-    is_query_alter,
-    is_query_optimize,
-    is_system_command,
     is_valid_system_query,
     run_system_query_on_host_with_sql,
     validate_query,
@@ -112,6 +109,8 @@ def test_invalid_system_query(sql_query: str) -> None:
     [
         ("SYSSSSSSSTEM DO SOMETHING", False),
         ("SYSTEM STOP MERGES", True),
+        ("SYSTEM STOP TTL MERGES", True),
+        ("KILL MUTATION WHERE mutation_id='0000000000'", True),
         ("system STOP MerGes", True),
         ("system SHUTDOWN", False),
         ("system KILL", False),
@@ -124,12 +123,15 @@ def test_invalid_system_query(sql_query: str) -> None:
 )
 @pytest.mark.clickhouse_db
 def test_sudo_queries(sudo_query: str, expected: bool) -> None:
-    assert (
-        is_system_command(sudo_query)
-        or is_query_alter(sudo_query)
-        or is_query_optimize(sudo_query)
-    ) == expected
-    if not expected:
+    if expected:
+        validate_query(
+            settings.CLUSTERS[0]["host"],
+            int(settings.CLUSTERS[0]["port"]),
+            "errors",
+            sudo_query,
+            True,
+        )  # Should no-op
+    else:
         with pytest.raises(Exception):
             validate_query(
                 settings.CLUSTERS[0]["host"],


### PR DESCRIPTION
This is needed in order to stop bad mutations from overloading the cluster.