### PR TITLE
fix(rust): Honor exit code

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -47,7 +47,7 @@ pub fn consumer(
     batch_write_timeout_ms: Option<u64>,
     max_bytes_before_external_group_by: Option<usize>,
     max_dlq_buffer_length: Option<usize>,
-) {
+) -> usize {
     py.allow_threads(|| {
         consumer_impl(
             consumer_group,
@@ -68,7 +68,7 @@ pub fn consumer(
             mutations_mode,
             max_dlq_buffer_length,
         )
-    });
+    })
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Previously when a consumer would crash, we would exit with 0 instead of
1.

Now the consumer either exits with 0 or 1.
