### PR TITLE
ref(lw-deletes): add project_id killswitch and some logging

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -94,6 +94,7 @@ delete_allocation_policies:
     args:
       required_tenant_types:
         - referrer
+        - project_id
       default_config_overrides:
         is_enforced: 1
 

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -94,7 +94,6 @@ delete_allocation_policies:
     args:
       required_tenant_types:
         - referrer
-        - project_id
       default_config_overrides:
         is_enforced: 1
 

--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -18,9 +18,11 @@ from snuba.attribution.attribution_info import AttributionInfo
 from snuba.datasets.storage import WritableTableStorage
 from snuba.lw_deletions.batching import BatchStepCustom, ValuesBatch
 from snuba.lw_deletions.formatters import Formatter
+from snuba.query.allocation_policies import AllocationPolicyViolations
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state import get_int_config
 from snuba.utils.metrics import MetricsBackend
+from snuba.web import QueryException
 from snuba.web.bulk_delete_query import construct_or_conditions, construct_query
 from snuba.web.delete_query import (
     ConditionsType,
@@ -46,6 +48,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
     ) -> None:
         self.__next_step = next_step
         self.__storage = storage
+        self.__storage_name = storage.get_storage_key().value
         self.__cluster_name = self.__storage.get_cluster().get_clickhouse_cluster_name()
         self.__tables = storage.get_deletion_settings().tables
         self.__formatter: Formatter = formatter
@@ -62,11 +65,17 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
 
         try:
             self._execute_delete(conditions)
-        except TooManyOngoingMutationsError:
+        except TooManyOngoingMutationsError as err:
             # backpressure is applied while we wait for the
             # currently ongoing mutations to finish
             self.__metrics.increment("too_many_ongoing_mutations")
+            logger.warning(str(err), exc_info=True)
             raise MessageRejected
+        except QueryException as err:
+            cause = err.__cause__
+            if isinstance(cause, AllocationPolicyViolations):
+                self.__metrics.increment("allocation_policy_violation")
+                raise MessageRejected
 
         self.__next_step.submit(message)
 

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -211,7 +211,7 @@ def delete_from_tables(
 
     storage_name = storage.get_storage_key().value
     project_id = attribution_info.tenant_ids.get("project_id")
-    if project_id and should_use_killswitch(storage_name, project_id):
+    if project_id and should_use_killswitch(storage_name, str(project_id)):
         return result
 
     delete_query: DeleteQueryMessage = {
@@ -232,8 +232,8 @@ def construct_or_conditions(conditions: Sequence[ConditionsType]) -> Expression:
     return combine_or_conditions([_construct_condition(cond) for cond in conditions])
 
 
-def should_use_killswitch(storage_name: str, project_id: int):
+def should_use_killswitch(storage_name: str, project_id: str) -> bool:
     killswitch_config = get_str_config(
         f"lw_deletes_killswitch_{storage_name}", default=""
     )
-    return str(project_id) in killswitch_config
+    return project_id in killswitch_config if killswitch_config else False

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -20,6 +20,7 @@ from snuba.query.dsl import literal
 from snuba.query.exceptions import InvalidQueryException, NoRowsToDeleteException
 from snuba.query.expressions import Expression
 from snuba.reader import Result
+from snuba.state import get_str_config
 from snuba.utils.metrics.util import with_span
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.schemas import ColumnValidator, InvalidColumnType
@@ -208,9 +209,14 @@ def delete_from_tables(
     if highest_rows_to_delete == 0:
         return result
 
+    storage_name = storage.get_storage_key().value
+    project_id = attribution_info.tenant_ids.get("project_id")
+    if project_id and should_use_killswitch(storage_name, project_id):
+        return result
+
     delete_query: DeleteQueryMessage = {
         "rows_to_delete": highest_rows_to_delete,
-        "storage_name": storage.get_storage_key().value,
+        "storage_name": storage_name,
         "conditions": conditions,
         "tenant_ids": attribution_info.tenant_ids,
     }
@@ -224,3 +230,10 @@ def construct_or_conditions(conditions: Sequence[ConditionsType]) -> Expression:
     into OR conditions for a bulk delete
     """
     return combine_or_conditions([_construct_condition(cond) for cond in conditions])
+
+
+def should_use_killswitch(storage_name: str, project_id: int):
+    killswitch_config = get_str_config(
+        f"lw_deletes_killswitch_{storage_name}", default=""
+    )
+    return str(project_id) in killswitch_config


### PR DESCRIPTION
This PR has a couple improvements and additions to the lw delete pipeline, the main one being the killswitch for the project. 

Most storages should have the `project_id` as one of the allowed columns so the assumption right now is that they do and so the killswitch will work for that case. If we add more storages in the future that don't have that, we can update the killswitch logic. The config will be based on the storage:

`lw_deletes_killswitch_search_issues`

The killswitch is added at the API level because the moment it's produced to the consumer it's batched with other messages, most likely with other `project_id`'s. Another option would be to add another strategy step prior to the batch step that filters based on the killswitch, but I felt like not producing to the topic at all made more sense right now. 