### PR TITLE
ref(lw-deletes): concurrent allocation policy requires org id

### DIFF
--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -74,7 +74,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
         return AttributionInfo(
             app_id=AppID("lw-deletes"),
             # concurrent allocation policies requires project or org id
-            tenant_ids={"organization_id": 1},
+            tenant_ids={"project_id": 1},
             referrer="lw-deletes",
             team=None,
             feature=None,

--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -73,7 +73,8 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
     def _get_attribute_info(self) -> AttributionInfo:
         return AttributionInfo(
             app_id=AppID("lw-deletes"),
-            tenant_ids={},
+            # concurrent allocation policies requires project or org id
+            tenant_ids={"organization_id": 1},
             referrer="lw-deletes",
             team=None,
             feature=None,


### PR DESCRIPTION
Ran into `InvalidTenantsForAllocationPolicy` because I wasn't passing in a `project_id` or an `organization_id`

Used `project_id` since that is what I had specified in the storage definition https://github.com/getsentry/snuba/blob/90a2d471ec64dafe282b406452f5791ed5893123/snuba/datasets/configuration/issues/storages/search_issues.yaml#L97

FIXES [SNUBA-6H4](https://sentry.sentry.io/issues/6147044083/?project=300688)