### PR TITLE
fix(admin): Allow special characters in SYSTEM/OPTIMIZE queries

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -93,7 +93,7 @@ SYSTEM_COMMAND_RE = re.compile(
         (SYSTEM)
         \s
         (?!SHUTDOWN\b)(?!KILL\b)
-        [\w\s]+
+        [\w\s'-_]+
         ;? # Optional semicolon
         $
     """,
@@ -104,7 +104,7 @@ OPTIMIZE_QUERY_RE = re.compile(
     r"""^
         (OPTIMIZE\sTABLE)
         \s
-        [\w\s]+
+        [\w\s_-']+
         ;? # Optional semicolon
         $
     """,

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -93,7 +93,7 @@ SYSTEM_COMMAND_RE = re.compile(
         (SYSTEM)
         \s
         (?!SHUTDOWN\b)(?!KILL\b)
-        [\w\s'-_]+
+        [\w\s'\-_]+
         ;? # Optional semicolon
         $
     """,
@@ -104,7 +104,7 @@ OPTIMIZE_QUERY_RE = re.compile(
     r"""^
         (OPTIMIZE\sTABLE)
         \s
-        [\w\s_-']+
+        [\w\s_\-']+
         ;? # Optional semicolon
         $
     """,

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -110,6 +110,7 @@ def test_invalid_system_query(sql_query: str) -> None:
         ("SYSSSSSSSTEM DO SOMETHING", False),
         ("SYSTEM STOP MERGES", True),
         ("SYSTEM STOP TTL MERGES", True),
+        ("SYSTEM STOP TTL MERGES ON CLUSTER 'snuba-spans'", True),
         ("KILL MUTATION WHERE mutation_id='0000000000'", True),
         ("system STOP MerGes", True),
         ("system SHUTDOWN", False),


### PR DESCRIPTION
These queries sometimes have to reference table names or clusters with quotes or other special
characters.