### PR TITLE
fix(devservices): Add orchestrator devservices label to clickhouse

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -46,6 +46,8 @@ services:
       host.docker.internal: host-gateway
     networks:
       - devservices
+    labels:
+      - orchestrator=devservices
     restart: unless-stopped
 
   snuba:


### PR DESCRIPTION
This adds missing label to be used by purge for clickhouse