### PR TITLE
chore: Bump rust-toolchain

### DIFF
--- a/rust_snuba/rust-toolchain.toml
+++ b/rust_snuba/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.83.0"

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -246,20 +246,11 @@ pub fn consumer_impl(
     let processor = if mutations_mode {
         let mut_factory = MutConsumerStrategyFactory {
             storage_config: first_storage,
-            env_config,
-            logical_topic_name,
             max_batch_size,
             max_batch_time,
             processing_concurrency: ConcurrencyConfig::new(concurrency),
             clickhouse_concurrency: ConcurrencyConfig::new(clickhouse_concurrency),
-            async_inserts,
-            python_max_queue_depth,
-            use_rust_processor,
             health_check_file: health_check_file.map(ToOwned::to_owned),
-            enforce_schema,
-            physical_consumer_group: consumer_group.to_owned(),
-            physical_topic_name: Topic::new(&consumer_config.raw_topic.physical_topic_name),
-            accountant_topic_config: consumer_config.accountant_topic,
             batch_write_timeout,
         };
 

--- a/rust_snuba/src/metrics/global_tags.rs
+++ b/rust_snuba/src/metrics/global_tags.rs
@@ -36,7 +36,7 @@ where
     }
 }
 
-impl<'a, M> Middleware for AddGlobalTags<'a, M>
+impl<M> Middleware for AddGlobalTags<'_, M>
 where
     M: Middleware,
 {

--- a/rust_snuba/src/mutations/factory.rs
+++ b/rust_snuba/src/mutations/factory.rs
@@ -13,7 +13,7 @@ use sentry_arroyo::processing::strategies::run_task_in_threads::{
 };
 use sentry_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
 use sentry_arroyo::types::Message;
-use sentry_arroyo::types::{Partition, Topic};
+use sentry_arroyo::types::Partition;
 
 use crate::config;
 use crate::metrics::global_tags::set_global_tag;
@@ -25,20 +25,11 @@ use crate::mutations::synchronize::Synchronizer;
 
 pub struct MutConsumerStrategyFactory {
     pub storage_config: config::StorageConfig,
-    pub env_config: config::EnvConfig,
-    pub logical_topic_name: String,
     pub max_batch_size: usize,
     pub max_batch_time: Duration,
     pub processing_concurrency: ConcurrencyConfig,
     pub clickhouse_concurrency: ConcurrencyConfig,
-    pub async_inserts: bool,
-    pub python_max_queue_depth: Option<usize>,
-    pub use_rust_processor: bool,
     pub health_check_file: Option<String>,
-    pub enforce_schema: bool,
-    pub physical_consumer_group: String,
-    pub physical_topic_name: Topic,
-    pub accountant_topic_config: config::TopicConfig,
     pub batch_write_timeout: Option<Duration>,
 }
 

--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -354,7 +354,7 @@ mod tests {
     #[test]
     fn test_serialization() {
         let msg: FromSpanMessage = serde_json::from_slice(SPAN_KAFKA_MESSAGE.as_bytes()).unwrap();
-        let span: EAPSpan = msg.try_into().unwrap();
+        let span: EAPSpan = msg.into();
         insta::with_settings!({sort_maps => true}, {
             insta::assert_json_snapshot!(span)
         });

--- a/rust_snuba/src/processors/eap_spans.rs
+++ b/rust_snuba/src/processors/eap_spans.rs
@@ -40,7 +40,7 @@ pub fn process_message(
     let payload_bytes = payload.payload().context("Expected payload")?;
     let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
     let origin_timestamp = DateTime::from_timestamp(msg.received as i64, 0);
-    let mut span: EAPSpan = msg.try_into()?;
+    let mut span: EAPSpan = msg.into();
 
     span.retention_days = Some(enforce_retention(span.retention_days, &config.env_config));
 


### PR DESCRIPTION
Our version of Rust is severely out of date. This is not a problem but
now vscode's lsp starts to complain about it.

```
Failed to run proc-macro server from path /Users/jferge/.rustup/toolchains/1.74.1-aarch64-apple-darwin/libexec/rust-analyzer-proc-macro-srv, error: Custom { kind: Other, error: "The version of the proc-macro server (2) in your Rust toolchain is too old and no longer supported by your rust-analyzer which requiresversion 4 or higher.\nThis will prevent proc-macro expansion from working. Please consider updating your toolchain or downgrading your rust-analyzer to ensure compatibility with your current toolchain." }rust-analyzermacro-error
```

This bumps the rust version in prod as well, as the dockerfile uses this file to determine the rust version.