### PR TITLE
feat: improve internal error logging for rpc endpoints

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -159,6 +159,7 @@ def run_rpc_handler(
     except (RPCRequestException, QueryException) as e:
         return convert_rpc_exception_to_proto(e)
     except Exception as e:
+        sentry_sdk.capture_exception(e)
         return convert_rpc_exception_to_proto(
             RPCRequestException(
                 status_code=500,


### PR DESCRIPTION
I believe that when internal errors happen in our RPC endpoints, its not currently logged to sentry. This is bc internal errors are caught, translated into error protobufs, and sent back as a 500 response. Since the exceptions are caught they must be logged explicitly, thats what this PR does.

extra, optional:
https://sentry.sentry.io/performance/trace/a8133bb3ddb340deb9dab4dbbf912fe4/?node=txn-7d11c149497d4bd284d4bfe0d9173608&pageEnd=2024-12-28T07%3A43%3A21.936&pageStart=2024-12-27T07%3A43%3A21.936&timestamp=1735328601.721
you can see in this error trace that sentry gets a 500 internal error from snuba, but there is no associated snuba error logged