### PR TITLE
feat(job-runner): surface errors to Snuba admin

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1369,7 +1369,20 @@ def get_job_specs() -> Response:
 @check_tool_perms(tools=[AdminTools.MANUAL_JOBS])
 def execute_job(job_id: str) -> Response:
     job_specs = list_job_specs()
-    return make_response(run_job(job_specs[job_id]), 200)
+    job_status = None
+    try:
+        job_status = run_job(job_specs[job_id])
+    except BaseException as e:
+        return make_response(
+            jsonify(
+                {
+                    "error": str(e),
+                }
+            ),
+            500,
+        )
+
+    return make_response(job_status, 200)
 
 
 @application.route("/job-specs/<job_id>/logs", methods=["GET"])

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -134,7 +134,7 @@ def run_job(job_spec: JobSpec) -> JobStatus:
         if not job_spec.is_async:
             current_job_status = _set_job_status(job_spec.job_id, JobStatus.FINISHED)
             job_logger.info("[runner] job execution finished")
-    except BaseException as e:
+    except Exception as e:
         current_job_status = _set_job_status(job_spec.job_id, JobStatus.FAILED)
         job_logger.error(f"[runner] job execution failed {e}")
         job_logger.info(f"[runner] exception {traceback.format_exc()}")

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -134,7 +134,7 @@ def run_job(job_spec: JobSpec) -> JobStatus:
         if not job_spec.is_async:
             current_job_status = _set_job_status(job_spec.job_id, JobStatus.FINISHED)
             job_logger.info("[runner] job execution finished")
-    except Exception as e:
+    except BaseException as e:
         current_job_status = _set_job_status(job_spec.job_id, JobStatus.FAILED)
         job_logger.error(f"[runner] job execution failed {e}")
         job_logger.info(f"[runner] exception {traceback.format_exc()}")

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -138,6 +138,7 @@ def run_job(job_spec: JobSpec) -> JobStatus:
         current_job_status = _set_job_status(job_spec.job_id, JobStatus.FAILED)
         job_logger.error(f"[runner] job execution failed {e}")
         job_logger.info(f"[runner] exception {traceback.format_exc()}")
+        raise e
     finally:
         _release_job_lock(job_spec.job_id)
 

--- a/tests/manual_jobs/test_job_statuses.py
+++ b/tests/manual_jobs/test_job_statuses.py
@@ -45,7 +45,8 @@ def test_job_with_exception_causes_failure() -> None:
     with patch.object(_JobLoader, "get_job_instance") as MockGetInstance:
         MockGetInstance.return_value = FailJob()
         assert get_job_status(JOB_ID) == JobStatus.NOT_STARTED
-        run_job(test_job_spec)
+        with pytest.raises(SerializableException):
+            run_job(test_job_spec)
         assert get_job_status(JOB_ID) == JobStatus.FAILED
 
 


### PR DESCRIPTION
Currently, errors are surfaced to GCP, and Snuba Admin just displays server error. I want to surface the actual error message to Snuba Admin as well