### PR TITLE
fix: a test is failing on master due to current-time dependencies

### DIFF
--- a/rust_snuba/src/mutations/clickhouse.rs
+++ b/rust_snuba/src/mutations/clickhouse.rs
@@ -211,6 +211,7 @@ struct MutationRow {
 #[cfg(test)]
 mod tests {
     use std::env;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use uuid::Uuid;
 
     use crate::mutations::parser::Update;
@@ -284,7 +285,11 @@ mod tests {
         let mut update = Update::default();
 
         let organization_id = 69;
-        let _sort_timestamp = 1727466947;
+        let curr_time_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        let _sort_timestamp = curr_time_unix as u32; //TODO year 2038 problem
         let trace_id = Uuid::parse_str("deadbeef-dead-beef-dead-beefdeadbeef").unwrap();
         let span_id = 16045690984833335023;
 


### PR DESCRIPTION
This test does something like this:

```
CREATE TABLE temp AS eap_spans_2_local;
INSERT INTO temp (some data)
-- irrelevant
SELECT * FROM temp
```

The problem is that eap_spans_2_local has a TTL of 90 days, so between steps 2 and 3, the data is deleted (the hardcoded timestamp is now more than 90 days old!)

This updates the timestamp used by the test to be recent, so that the data isn't TTL-d out before the test can use it.