### PR TITLE
fix: add a missing alias that was causing a warning

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -99,7 +99,7 @@ def convert_to_snuba_request(req: TraceItemAttributeNamesRequest) -> SnubaReques
         selected_columns=[
             SelectedExpression(
                 name="attr_key",
-                expression=column("attr_key"),
+                expression=column("attr_key", alias="attr_key"),
             ),
         ],
         condition=condition,


### PR DESCRIPTION
Solves https://github.com/getsentry/eap-planning/issues/138

