### PR TITLE
fix: bug in AttributeNames RPC endpoint, filter offset

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -172,7 +172,7 @@ class EndpointTraceItemAttributeNames(
         attributes = convert_to_attributes(res, req.type)
         page_token = (
             PageToken(offset=req.page_token.offset + len(attributes))
-            if req.page_token.HasField("offset")
+            if req.page_token.HasField("offset") or len(attributes) == 0
             else PageToken(
                 filter_offset=TraceItemFilter(
                     comparison_filter=ComparisonFilter(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
@@ -210,6 +210,26 @@ class TestTraceItemAttributeNames(BaseApiTest):
             done += at_a_time
         assert expected_attributes == []
 
+    def test_empty_results(self) -> None:
+        req = TraceItemAttributeNamesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(
+                    seconds=int((BASE_TIME - timedelta(days=1)).timestamp())
+                ),
+                end_timestamp=Timestamp(
+                    seconds=int((BASE_TIME + timedelta(days=1)).timestamp())
+                ),
+            ),
+            type=AttributeKey.Type.TYPE_STRING,
+            value_substring_match="this_definitely_doesnt_exist_93710",
+        )
+        res = EndpointTraceItemAttributeNames().execute(req)
+        assert res.attributes == []
+
     def test_page_token_offset_filter(self) -> None:
 
         expected_attributes = []


### PR DESCRIPTION
There is an index out of range error with filter offset when the attribute results are empty. This PR solves this bug.
The new test `test_empty_results` failed before (due to the bug), and now passes

here is the sentry issue it fixes: https://sentry.sentry.io/issues/6189483746/?project=300688&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=1h&stream_index=8

and it also closes this ticket https://github.com/getsentry/eap-planning/issues/138