### PR TITLE
feat(devservices): Add devservices ci validation job

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -8,3 +8,7 @@ api_changes:
   - "snuba/cli/devserver.py"
   - "rust_snuba/src/processors/*"
   - "snuba/datasets/processors/*"
+
+devservices_changes:
+  - 'devservices/**'
+  - '.github/workflows/ci.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     # Map a step output to a job output
     outputs:
       api_changes: ${{ steps.changes.outputs.api_changes }}
+      devservices_changes: ${{ steps.changes.outputs.devservices }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v2
 
@@ -448,3 +449,15 @@ jobs:
           # finally, nightly
           docker tag ${IMAGE_URL} getsentry/snuba:nightly
           docker push getsentry/snuba:nightly
+
+    validate-devservices-config:
+      runs-on: ubuntu-24.04
+      needs: files-changed
+      if: ${{ needs.files-changed.outputs.devservices_changes == 'true' }}
+      steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        name: Checkout repository
+      - uses: getsentry/action-validate-devservices-config@049567d407bbf73e3b0cad39dae7bc9447fc7669
+        name: Validate devservices config
+        with:
+          requirements-file-path: requirements.txt


### PR DESCRIPTION
This validation job will only run if files are changed in the `devservices/` directory or the `.github/workflows/ci.yml` has been changed. It will ensure that the config files that live in the snuba devservices directory actually work, preventing potential breakages for devservices across repos that depend on snuba if invalid configs are merged.

Composite action used: https://github.com/getsentry/action-validate-devservices-config