### PR TITLE
fix(errors): Extract parent_span_id properly

### DIFF
--- a/rust_snuba/src/processors/errors.rs
+++ b/rust_snuba/src/processors/errors.rs
@@ -177,6 +177,8 @@ struct TraceContext {
     span_id: Option<String>,
     #[serde(default)]
     trace_id: Option<Uuid>,
+    #[serde(default)]
+    parent_span_id: Option<String>,
     #[serde(flatten)]
     other: GenericContext,
 }
@@ -549,6 +551,11 @@ impl ErrorRow {
         if let Some(trace_id) = from_trace_context.trace_id {
             contexts_keys.push("trace.trace_id".to_owned());
             contexts_values.push(trace_id.simple().to_string());
+        }
+
+        if let Some(parent_span_id) = from_trace_context.parent_span_id {
+            contexts_keys.push("trace.parent_span_id".to_owned());
+            contexts_values.push(parent_span_id.to_string());
         }
 
         // Conditionally overwrite replay_id if it was provided on the contexts object.

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__events-.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__events-.snap
@@ -4,6 +4,13 @@ expression: diff
 ---
 [
     Change {
+        path: ".<anyOf:0>.2.data.contexts.<anyOf:0>.trace.<anyOf:0>",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "parent_span_id",
+        },
+    },
+    Change {
         path: ".<anyOf:1>.0",
         change: TypeRemove {
             removed: Number,


### PR DESCRIPTION
It seems searching by parent span id in errors was broken for a long
time, but nobody noticed?
