### PR TITLE
fix(ci): Enable third-party contributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,13 +160,13 @@ jobs:
           load: true
           target: testing
           tags: |
-            ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
-            ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
+            ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+            ghcr.io/getsentry/snuba-ci:latest
           cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest
           # cache-to is re-implemented using the next step, to run conditionally for contributors
           outputs: type=docker,dest=/tmp/snuba-ci.tar
 
@@ -177,11 +177,11 @@ jobs:
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # Useful to speed up CI
-          docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
-          docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
+          docker push ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+          docker push ghcr.io/getsentry/snuba-ci:${{ github.sha }}
           if [ "${{ steps.branch.outputs.branch }}" == 'master' ]; then
             # The latest tag should only be published on `master`
-            docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
+            docker push ghcr.io/getsentry/snuba-ci:latest
           fi
 
       - name: Publish snuba-ci image to artifacts
@@ -226,23 +226,23 @@ jobs:
 
       - name: Docker Snuba Rust tests
         run: |
-          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-rust
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-rust
         if: ${{ matrix.snuba_settings == 'test_rust' }}
 
       - name: Docker Snuba tests
         run: |
-          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}
 
       - name: Docker Snuba Multi-Node Tests
         run: |
-          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml up -d
-          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml up -d
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test_distributed_migrations' }}
 
       - name: Docker Snuba Init Tests
         run: |
-          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=test_initialization TEST_LOCATION=test_initialization docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_initialization TEST_LOCATION=test_initialization docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' }}
 
       - name: Upload test results to Codecov
@@ -329,7 +329,7 @@ jobs:
             -e REDIS_DB=1 \
             --name sentry_snuba \
             --network sentry \
-            ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
+            ghcr.io/getsentry/snuba-ci:${{ github.sha }}
           docker exec sentry_snuba snuba migrations migrate --force
 
       - name: Run snuba tests
@@ -397,7 +397,7 @@ jobs:
       - name: Docker Snuba Test other ClickHouse versions
         run: |
           export CLICKHOUSE_IMAGE=ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:${{matrix.version}}
-          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test
 
       - name: Upload to codecov
         run: |
@@ -414,7 +414,7 @@ jobs:
         uses: getsentry/action-self-hosted-e2e-tests@main
         with:
           project_name: snuba
-          docker_repo: ${{ github.repository_owner }}/snuba
+          docker_repo: getsentry/snuba
           image_url: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.event.pull_request.head.sha || github.sha }}
           docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
 
@@ -454,11 +454,11 @@ jobs:
           if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
           # We push 3 tags to Dockerhub:
           # first, the full sha of the commit
-          docker tag ${IMAGE_URL} ${{ github.repository_owner }}/snuba:${GITHUB_SHA}
-          docker push ${{ github.repository_owner }}/snuba:${GITHUB_SHA}
+          docker tag ${IMAGE_URL} getsentry/snuba:${GITHUB_SHA}
+          docker push getsentry/snuba:${GITHUB_SHA}
           # second, the short sha of the commit
-          docker tag ${IMAGE_URL} ${{ github.repository_owner }}/snuba:${SHORT_SHA}
-          docker push ${{ github.repository_owner }}/snuba:${SHORT_SHA}
+          docker tag ${IMAGE_URL} getsentry/snuba:${SHORT_SHA}
+          docker push getsentry/snuba:${SHORT_SHA}
           # finally, nightly
-          docker tag ${IMAGE_URL} ${{ github.repository_owner }}/snuba:nightly
-          docker push ${{ github.repository_owner }}/snuba:nightly
+          docker tag ${IMAGE_URL} getsentry/snuba:nightly
+          docker push getsentry/snuba:nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,12 +168,8 @@ jobs:
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
           # cache-to is re-implemented using the next step, to run conditionally for contributors
-
+          #
       - name: Publish images for cache
-        if: steps.branch.outputs.branch == 'master' || github.event.pull_request.head.repo.full_name == github.repository
-        # outside contributors won't be able to push to the docker registry
-        # ignore the failures in this step
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # Useful to speed up CI
           docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,9 +386,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Registry login
+      - name: Download snuba-ci image from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: snuba-ci
+          path: /tmp
+
+      - name: Load snuba-ci image
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker load --input /tmp/snuba-ci.tar
+          docker image ls -a
 
       - name: Docker set up
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,13 +161,13 @@ jobs:
           load: true
           target: testing
           tags: |
-            ghcr.io/getsentry/snuba-ci:${{ github.sha }}
-            ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
-            ghcr.io/getsentry/snuba-ci:latest
+            ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
+            ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
           cache-from: |
-            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
-            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
-            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
           # cache-to is re-implemented using the next step, to run conditionally for contributors
 
       - name: Publish images for cache
@@ -177,11 +177,11 @@ jobs:
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # Useful to speed up CI
-          docker push ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
-          docker push ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
+          docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
           if [ "${{ steps.branch.outputs.branch }}" == 'master' ]; then
             # The latest tag should only be published on `master`
-            docker push ghcr.io/getsentry/snuba-ci:latest
+            docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
           fi
 
   tests:
@@ -212,23 +212,23 @@ jobs:
 
       - name: Docker Snuba Rust tests
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-rust
+          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-rust
         if: ${{ matrix.snuba_settings == 'test_rust' }}
 
       - name: Docker Snuba tests
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}
 
       - name: Docker Snuba Multi-Node Tests
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml up -d
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml up -d
+          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test_distributed_migrations' }}
 
       - name: Docker Snuba Init Tests
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_initialization TEST_LOCATION=test_initialization docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_initialization TEST_LOCATION=test_initialization docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' }}
 
       - name: Upload test results to Codecov
@@ -315,7 +315,7 @@ jobs:
             -e REDIS_DB=1 \
             --name sentry_snuba \
             --network sentry \
-            ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }}
           docker exec sentry_snuba snuba migrations migrate --force
 
       - name: Run snuba tests
@@ -383,7 +383,7 @@ jobs:
       - name: Docker Snuba Test other ClickHouse versions
         run: |
           export CLICKHOUSE_IMAGE=ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:${{matrix.version}}
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test
 
       - name: Upload to codecov
         run: |
@@ -400,7 +400,7 @@ jobs:
         uses: getsentry/action-self-hosted-e2e-tests@main
         with:
           project_name: snuba
-          docker_repo: getsentry/snuba
+          docker_repo: ${{ github.repository_owner }}/snuba
           image_url: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.event.pull_request.head.sha || github.sha }}
           docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
 
@@ -440,11 +440,11 @@ jobs:
           if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
           # We push 3 tags to Dockerhub:
           # first, the full sha of the commit
-          docker tag ${IMAGE_URL} getsentry/snuba:${GITHUB_SHA}
-          docker push getsentry/snuba:${GITHUB_SHA}
+          docker tag ${IMAGE_URL} ${{ github.repository_owner }}/snuba:${GITHUB_SHA}
+          docker push ${{ github.repository_owner }}/snuba:${GITHUB_SHA}
           # second, the short sha of the commit
-          docker tag ${IMAGE_URL} getsentry/snuba:${SHORT_SHA}
-          docker push getsentry/snuba:${SHORT_SHA}
+          docker tag ${IMAGE_URL} ${{ github.repository_owner }}/snuba:${SHORT_SHA}
+          docker push ${{ github.repository_owner }}/snuba:${SHORT_SHA}
           # finally, nightly
-          docker tag ${IMAGE_URL} getsentry/snuba:nightly
-          docker push getsentry/snuba:nightly
+          docker tag ${IMAGE_URL} ${{ github.repository_owner }}/snuba:nightly
+          docker push ${{ github.repository_owner }}/snuba:nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,6 @@ jobs:
 
       - name: Build snuba docker image for CI
         uses: docker/build-push-action@v6
-        if: github.repository_owner == 'getsentry'
         with:
           context: .
           # push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,9 +286,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Registry login
+      - name: Download snuba-ci image from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: snuba-ci
+          path: /tmp
+
+      - name: Load snuba-ci image
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker load --input /tmp/snuba-ci.tar
+          docker image ls -a
 
       - name: Checkout sentry
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,11 @@ jobs:
           fi
 
       - name: Publish snuba-ci image to artifacts
+      # we publish to github artifacts separately so that third-party
+      # contributions also work, as all the test jobs need this image.
+      # otherwise third-party contributors would have to provide a working,
+      # authenticated GHCR, which seems impossible to ensure in the general
+      # case.
         uses: actions/upload-artifact@v4
         with:
           name: snuba-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,12 @@ jobs:
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
           # cache-to is re-implemented using the next step, to run conditionally for contributors
-          #
+
       - name: Publish images for cache
+        if: steps.branch.outputs.branch == 'master' || github.event.pull_request.head.repo.full_name == github.repository
+        # outside contributors won't be able to push to the docker registry
+        # ignore the failures in this step
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           # Useful to speed up CI
           docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,9 @@ jobs:
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ steps.branch.outputs.branch }}
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
           # cache-to is re-implemented using the next step, to run conditionally for contributors
+          outputs: type=docker,dest=/tmp/snuba-ci.tar
 
-      - name: Publish images for cache
+      - name: Publish snuba-ci image to registry
         if: steps.branch.outputs.branch == 'master' || github.event.pull_request.head.repo.full_name == github.repository
         # outside contributors won't be able to push to the docker registry
         # ignore the failures in this step
@@ -182,6 +183,13 @@ jobs:
             # The latest tag should only be published on `master`
             docker push ghcr.io/${{ github.repository_owner }}/snuba-ci:latest
           fi
+
+      - name: Publish snuba-ci image to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: snuba-ci
+          path: /tmp/snuba-ci.tar
+
 
   tests:
     needs: [linting, snuba-image]
@@ -201,9 +209,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Registry login
+      - name: Download snuba-ci image from artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: snuba-ci
+          path: /tmp
+
+      - name: Load snuba-ci image
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker load --input /tmp/snuba-ci.tar
+          docker image ls -a
 
       - name: Docker set up
         run: |
@@ -211,23 +226,23 @@ jobs:
 
       - name: Docker Snuba Rust tests
         run: |
-          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-rust
+          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-rust
         if: ${{ matrix.snuba_settings == 'test_rust' }}
 
       - name: Docker Snuba tests
         run: |
-          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}
 
       - name: Docker Snuba Multi-Node Tests
         run: |
-          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml up -d
+          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml up -d
           SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test_distributed_migrations' }}
 
       - name: Docker Snuba Init Tests
         run: |
-          SNUBA_IMAGE=ghcr.io/${{ github.repository_owner }}/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_initialization TEST_LOCATION=test_initialization docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=snuba-ci SNUBA_SETTINGS=test_initialization TEST_LOCATION=test_initialization docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' }}
 
       - name: Upload test results to Codecov


### PR DESCRIPTION
we have had two external contributions recently:

* #6575
* #6719 

neither of the contributors can iterate properly on their changes because our CI is actually busted for PRs launched from forks