### PR TITLE
fix(ci): Load snuba-ci image again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,11 @@ jobs:
           # cache-to is re-implemented using the next step, to run conditionally for contributors
           outputs: type=docker,dest=/tmp/snuba-ci.tar
 
+      - name: Load snuba-ci image
+        run: |
+          docker load --input /tmp/snuba-ci.tar
+          docker image ls -a
+
       - name: Publish snuba-ci image to registry
         if: steps.branch.outputs.branch == 'master' || github.event.pull_request.head.repo.full_name == github.repository
         # outside contributors won't be able to push to the docker registry


### PR DESCRIPTION
followup to #6721 

It seems that by using `outputs:` in the previous step, we don't load
the image into docker but _only_ into the local filesystem. this breaks
docker push on master.
