### PR TITLE
feat(job-runner): allow `BaseException`s to terminate the program 

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1372,7 +1372,7 @@ def execute_job(job_id: str) -> Response:
     job_status = None
     try:
         job_status = run_job(job_specs[job_id])
-    except BaseException as e:
+    except Exception as e:
         return make_response(
             jsonify(
                 {


### PR DESCRIPTION
Catching BaseException without re-raising the exception is not a good idea. this will catch KeyboardInterrupt, which in turn makes it not possible to use Ctrl-C to kill the web server.

Let's change that