### PR TITLE
feat(uptime): Add uptime monitor checks consumer to deploy script

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -54,6 +54,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="eap-spans-profiled-consumer" \
   --container-name="eap-spans-subscriptions-scheduler" \
   --container-name="eap-spans-subscriptions-executor" \
+  --container-name="uptime-monitor-checks-consumer" \
   --container-name="lw-deletions-search-issues-consumer" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -54,7 +54,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="eap-spans-profiled-consumer" \
   --container-name="eap-spans-subscriptions-scheduler" \
   --container-name="eap-spans-subscriptions-executor" \
-  --container-name="uptime-monitor-checks-consumer" \
+  --container-name="uptime-results-consumer" \
   --container-name="lw-deletions-search-issues-consumer" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \


### PR DESCRIPTION
Add uptime monitor checks consumer to the deployment script to ensure it gets deployed along with other Snuba consumers.