### PR TITLE
fix(storage): correctly name storage key

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/uptime_monitor_checks.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/uptime_monitor_checks.yaml
@@ -2,7 +2,7 @@ version: v1
 kind: writable_storage
 name: uptime_monitor_checks
 storage:
-  key: events_analytics_platform
+  key: uptime_monitor_checks
   set_key: events_analytics_platform
 readiness_state: experimental
 schema:


### PR DESCRIPTION
should be `uptime_monitor_checks` for the key. aligns with how `eap_spans` works. this fixes s4s deployment error here: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22mattrobenolt-kube%22%0Aresource.labels.location%3D%22us-west1-c%22%0Aresource.labels.cluster_name%3D%22primary%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name%3D%22snuba-uptime-results-consumer-67d755db8c-wz6c8%22%20severity%3E%3DDEFAULT;storageScope=project;pinnedLogId=2025-01-08T23:34:40.996910078Z%2Fgl78637r4sgdqea5;cursorTimestamp=2025-01-08T23:34:40.996894468Z;aroundTime=2025-01-08T23:34:40.996910078Z;duration=PT1H?hl=en&inv=1&invt=AbmVdg&project=mattrobenolt-kube