### PR TITLE
fix(eap): use TDigestWeighted instead of TDigest for perncetile confidence calculation

### DIFF
--- a/snuba/web/rpc/common/aggregation.py
+++ b/snuba/web/rpc/common/aggregation.py
@@ -371,8 +371,9 @@ def _get_possible_percentiles_expression(
         aggregation, {"granularity": str(granularity), "width": str(width)}
     )
     alias_dict = {"alias": alias} if alias else {}
-    return cf.quantilesTDigest(*possible_percentiles)(
+    return cf.quantilesTDigestWeighted(*possible_percentiles)(
         field,
+        sampling_weight_column,
         **alias_dict,
     )
 


### PR DESCRIPTION
In order to calculate the correct percentiles, we need to use the weighted TDigest - the current implementation uses the unweighted TDigest to calculate percentiles from all samples, but when the percentile estimate calculation is using the TDigest in the weighted variant, the system will basically mark everything as unreliable except from outliers. 

Contributes to https://github.com/getsentry/projects/issues/530
