### PR TITLE
chore(uptime): move uptime storage to partial

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/uptime_monitor_checks.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/uptime_monitor_checks.yaml
@@ -4,7 +4,7 @@ name: uptime_monitor_checks
 storage:
   key: uptime_monitor_checks
   set_key: events_analytics_platform
-readiness_state: experimental
+readiness_state: partial
 schema:
   columns:
     [


### PR DESCRIPTION
moves uptime storage to partial in snuba -- want to start testing this in our SaaS regions.