### PR TITLE
feat(devservices): Support no workers option for containerized version of snuba

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -55,7 +55,9 @@ services:
     ports:
       - 127.0.0.1:1218:1218
       - 127.0.0.1:1219:1219
-    command: [devserver]
+    command:
+      - devserver
+      - --${SNUBA_NO_WORKERS:+no-workers}
     healthcheck:
       test: curl -f http://localhost:1218/health_envoy
       interval: 5s


### PR DESCRIPTION
This option should be supported as CI in sentry generally runs snuba devserver without workers. Currently, this is determined in sentry based on the `SENTRY_EVENTSTREAM` setting. This is a workaround for an issue that stems from our jumbled logic around configuration files and settings that we should discuss in the future. 