### PR TITLE
deps: replace python-jose with pyjwt

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,6 @@ time-machine==2.13.0
 # for typing
 mypy==1.1.1
 types-python-dateutil==2.8.19.14
-types-python-jose==3.3.0
 types-pyyaml==6.0.12.20240808
 types-requests==2.32.0.20240907
 types-setuptools==74.1.0.20240907

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ google-cloud-storage==2.18.0
 googleapis-common-protos==1.63.2
 google-api-core==2.19.1
 honcho==1.1.0
-python-jose[cryptography]==3.3.0
+pyjwt==2.10.1
 jsonschema==4.23.0
 fastjsonschema==2.16.2
 packaging==24.1

--- a/snuba/admin/jwt.py
+++ b/snuba/admin/jwt.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional
 
+import jwt
 import requests
 
 from snuba import settings
@@ -32,7 +33,12 @@ def validate_assertion(assertion: str) -> AdminUser:
 
     If not, an exception will be raised
     """
-    from jose import jwt
 
-    info = jwt.decode(assertion, _certs(), algorithms=["ES256"], audience=_audience())
+    info = jwt.decode(
+        assertion,
+        _certs(),
+        algorithms=["ES256"],
+        audience=_audience(),
+        options={"verify_aud": True},
+    )
     return AdminUser(email=info["email"], id=info["sub"])


### PR DESCRIPTION
python-jose has some unaddressed security vulnerabilities, with the latest release from 2021.
This PR swaps python-jose with PyJWT.

This will resolve the following dependabot alerts:
- https://github.com/getsentry/snuba/security/dependabot/50
- https://github.com/getsentry/snuba/security/dependabot/51