### PR TITLE
fix(scripts): Grab everything in the path

### DIFF
--- a/scripts/copy_tables.py
+++ b/scripts/copy_tables.py
@@ -21,9 +21,9 @@ def _get_client(
 
 
 def get_regex_match(curr_create_table_statement: str) -> str:
-    match = re.search(r"\/clickhouse([a-z\/\-{}_]*)", curr_create_table_statement)
+    match = re.search(r"'(\/clickhouse/.*)'", curr_create_table_statement)
     assert match is not None
-    return match.group(0)
+    return match.group(1)
 
 
 def verify_zk_replica_path(

--- a/scripts/copy_tables.py
+++ b/scripts/copy_tables.py
@@ -21,7 +21,7 @@ def _get_client(
 
 
 def get_regex_match(curr_create_table_statement: str) -> str:
-    match = re.search(r"'(\/clickhouse/.*)'", curr_create_table_statement)
+    match = re.search(r"'(\/clickhouse\/.*?)'", curr_create_table_statement)
     assert match is not None
     return match.group(1)
 

--- a/tests/test_copy_tables.py
+++ b/tests/test_copy_tables.py
@@ -13,6 +13,10 @@ from scripts import copy_tables
             "ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/transactions-{shard}/transactions_local', '{replica}')",
             "/clickhouse/tables/transactions-{shard}/transactions_local",
         ),
+        (
+            "ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/transactions-{shard}/transactions_2_CAPITAL_local', '{replica}')",
+            "/clickhouse/tables/transactions-{shard}/transactions_2_CAPITAL_local",
+        ),
     ],
 )
 def test_copy_tables_regex(table_statement: str, expected_match: str) -> None:


### PR DESCRIPTION
Input  looks like this. We need to grab the path inside the string.
```
CREATE TABLE somedb.sometable (column TYPE, ...) 
ENGINE = MergeTree('/clickhouse/tables/clustername/{shard}/default/tablename', '{replica}', sign)
```
Instead of trying to grab specific classes of characters (after all, we can't know if our table names have capitals, numbers or else), we'll simply grab everything between the two single quotes.