### PR TITLE
fix(optimize): make tests and optimize use UTC timestamps

### DIFF
--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -5,7 +5,7 @@ import threading
 import time
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Mapping, Optional, Sequence
 
 import structlog
@@ -347,7 +347,7 @@ def optimize_partitions(
     """
 
     for partition in partitions:
-        if cutoff_time is not None and datetime.now() > cutoff_time:
+        if cutoff_time is not None and datetime.now(UTC) > cutoff_time:
             logger.info(
                 f"Optimize job is running past provided cutoff time"
                 f" {cutoff_time}. Cancelling.",

--- a/snuba/clickhouse/optimize/optimize_scheduler.py
+++ b/snuba/clickhouse/optimize/optimize_scheduler.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import MutableSequence, Sequence
 
 from snuba import settings
@@ -42,7 +42,7 @@ class OptimizeScheduler:
 
     def __init__(self, default_parallel_threads: int) -> None:
         self.__default_parallel_threads = default_parallel_threads
-        self.__last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
+        self.__last_midnight = (datetime.now(UTC) + timedelta(minutes=10)).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
         self.__parallel_start_time = self.__last_midnight + timedelta(
@@ -95,7 +95,8 @@ class OptimizeScheduler:
         reached.
         """
         num_threads = get_num_threads(self.__default_parallel_threads)
-        current_time = datetime.now()
+        current_time = datetime.now(UTC)
+
         if current_time >= self.__full_job_end_time:
             raise OptimizedSchedulerTimeout(
                 f"Optimize job cutoff time exceeded "

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Callable, Mapping
 from unittest.mock import Mock, patch
 
@@ -24,8 +24,9 @@ from tests.helpers import write_processed_messages
 
 redis_client = get_redis_client(RedisClientKey.REPLACEMENTS_STORE)
 
-last_midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-
+last_midnight = (
+    datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(UTC)
+)
 
 test_data = [
     pytest.param(


### PR DESCRIPTION
There are different expectations in the tests and application of optimize for whether UTC or local TZ times are being used. Fixing them to UTC fixes unreliable tests (at least those failing in my environment and @xurui-c )