### PR TITLE
fix(eap): remove effective sample size from confidence calculation for averages

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
@@ -508,53 +508,47 @@ def get_confidence_interval_column(
         ),
         # confidence interval = Z * \sqrt{\frac{N * (\sum_{i=1}^n w_ix_i^2 - \frac{(\sum_{i=1}^n w_ix_i)^2}{N})}{n * (N-1) c* (N-1)}}
         #          ┌────────────────────────────┐
-        #          │                  ₙ
-        #          │                  ⎲
-        #          │      ₙ         ( ⎳  wᵢxᵢ)²
-        #     ╲    │      ⎲     2    ⁱ⁼¹
-        #      ╲   │N * ( ⎳  wᵢxᵢ - ───────────)
-        #       ╲  │     ⁱ⁼¹             N
+        #          │              ₙ
+        #          │              ⎲
+        #          │  ₙ         ( ⎳  wᵢxᵢ)²
+        #     ╲    │  ⎲     2    ⁱ⁼¹
+        #      ╲   │( ⎳  wᵢxᵢ - ───────────)
+        #       ╲  │     ⁱ⁼¹         N
         # Z *    ╲ │────────────────────────────
-        #         ╲│     n * (N-1) c* (N-1)
+        #         ╲│              n * N
         Function.FUNCTION_AVG: f.multiply(
             z_value,
             f.sqrt(
                 f.divide(
+                    f.minus(
+                        f.sumIf(
+                            f.multiply(
+                                sampling_weight_column,
+                                f.multiply(field, field),
+                            ),
+                            get_field_existence_expression(aggregation),
+                        ),
+                        f.divide(
+                            f.multiply(
+                                f.sumIf(
+                                    f.multiply(sampling_weight_column, field),
+                                    get_field_existence_expression(aggregation),
+                                ),
+                                f.sumIf(
+                                    f.multiply(sampling_weight_column, field),
+                                    get_field_existence_expression(aggregation),
+                                ),
+                            ),
+                            column(f"{alias}_N"),
+                        ),
+                    ),
                     f.multiply(
                         f.sumIf(
                             sampling_weight_column,
                             get_field_existence_expression(aggregation),
                             alias=f"{alias}_N",
                         ),
-                        f.minus(
-                            f.sumIf(
-                                f.multiply(
-                                    sampling_weight_column,
-                                    f.multiply(field, field),
-                                ),
-                                get_field_existence_expression(aggregation),
-                            ),
-                            f.divide(
-                                f.multiply(
-                                    f.sumIf(
-                                        f.multiply(sampling_weight_column, field),
-                                        get_field_existence_expression(aggregation),
-                                    ),
-                                    f.sumIf(
-                                        f.multiply(sampling_weight_column, field),
-                                        get_field_existence_expression(aggregation),
-                                    ),
-                                ),
-                                column(f"{alias}_N"),
-                            ),
-                        ),
-                    ),
-                    f.multiply(
-                        column(_get_count_column_alias(aggregation)),
-                        f.multiply(
-                            f.minus(column(f"{alias}_N"), literal(1)),
-                            f.minus(column(f"{alias}_N"), literal(1)),
-                        ),
+                        f.minus(column(f"{alias}_N"), literal(1)),
                     ),
                 )
             ),

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
@@ -16,7 +16,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
 
 from snuba.query.dsl import CurriedFunctions as cf
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import column, literal
+from snuba.query.dsl import column
 from snuba.query.expressions import (
     CurriedFunctionCall,
     Expression,
@@ -548,7 +548,9 @@ def get_confidence_interval_column(
                             get_field_existence_expression(aggregation),
                             alias=f"{alias}_N",
                         ),
-                        f.minus(column(f"{alias}_N"), literal(1)),
+                        f.sumIf(
+                            sign_column, get_field_existence_expression(aggregation)
+                        ),
                     ),
                 )
             ),

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
@@ -506,7 +506,7 @@ def get_confidence_interval_column(
             ),
             **alias_dict,
         ),
-        # confidence interval = Z * \sqrt{\frac{N * (\sum_{i=1}^n w_ix_i^2 - \frac{(\sum_{i=1}^n w_ix_i)^2}{N})}{n * (N-1) c* (N-1)}}
+        # confidence interval = Z * \sqrt{\frac{\sum_{i=1}^n w_ix_i^2 - \frac{(\sum_{i=1}^n w_ix_i)^2}{N}}{n * N}}
         #          ┌────────────────────────────┐
         #          │              ₙ
         #          │              ⎲

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -474,14 +474,14 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
 
     def test_avg_unreliable(self) -> None:
         # store a test metric with a value of 1, every second for an hour
-        granularity_secs = 60
+        granularity_secs = 120
         query_duration = 3600
         store_timeseries(
             BASE_TIME,
             1,
             3600,
             # for each time interval we distribute the values from -55 to 64 to keep the avg close to 0
-            metrics=[DummyMetric("test_metric", get_value=lambda x: (x % 60) - 55)],
+            metrics=[DummyMetric("test_metric", get_value=lambda x: (x % 120) - 55)],
             measurements=[
                 DummyMeasurement(
                     "client_sample_rate",
@@ -522,7 +522,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 buckets=expected_buckets,
                 data_points=[
                     DataPoint(
-                        data=-25.5,  # (-55 + -54 + ... + -4) / 60 = -25.5
+                        data=4.5,  # (-55 + -54 + ... + 64) / 60 = 4.5
                         data_present=True,
                         reliability=Reliability.RELIABILITY_LOW,
                         avg_sampling_rate=0.0001,

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -473,15 +473,15 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         ]
 
     def test_avg_unreliable(self) -> None:
-        # store a a test metric with a value of 1, every second for an hour
-        granularity_secs = 120
+        # store a test metric with a value of 1, every second for an hour
+        granularity_secs = 60
         query_duration = 3600
         store_timeseries(
             BASE_TIME,
             1,
             3600,
             # for each time interval we distribute the values from -55 to 64 to keep the avg close to 0
-            metrics=[DummyMetric("test_metric", get_value=lambda x: (x % 120) - 55)],
+            metrics=[DummyMetric("test_metric", get_value=lambda x: (x % 60) - 55)],
             measurements=[
                 DummyMeasurement(
                     "client_sample_rate",
@@ -522,7 +522,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 buckets=expected_buckets,
                 data_points=[
                     DataPoint(
-                        data=4.5,  # (-55 + -54 + ... + 64) / 120 = 4.5
+                        data=-25.5,  # (-55 + -54 + ... + -4) / 60 = -25.5
                         data_present=True,
                         reliability=Reliability.RELIABILITY_LOW,
                         avg_sampling_rate=0.0001,

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -522,7 +522,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 buckets=expected_buckets,
                 data_points=[
                     DataPoint(
-                        data=4.5,  # (-55 + -54 + ... + 64) / 60 = 4.5
+                        data=4.5,  # (-55 + -54 + ... + 64) / 120 = 4.5
                         data_present=True,
                         reliability=Reliability.RELIABILITY_LOW,
                         avg_sampling_rate=0.0001,


### PR DESCRIPTION
After careful consideration, this PR removes the effective sample size and replaces it with the sample size itself. The reason is that for very large sample sizes, low sample rates and highly heterogeneous sample rates, this actually causes issues in the confidence interval calculations ([see Notion for more details](https://www.notion.so/sentry/2024-12-18-Confidence-Evaluation-15e8b10e4b5d80aa89eff6579b704ca2?pvs=4)). 
This change also has a positive effect on the stability of the calculations, as there were some issues with NULL results that are not present with this version of the formula, probably caused by some divide-by-zero issues in the query for some buckets.