### PR TITLE
chore(ci): Bump sentry-related dependencies more aggressively

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,15 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 10
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      timezone: America/Los_Angeles
+      time: '9:30'
+    groups:
+      sentry-dependencies:
+        patterns:
+          - 'sentry-sdk'
+          - 'sentry-arroyo'


### PR DESCRIPTION
Open PRs to update sentry-sdk, sentry-arroyo at once, and with at most 1
day delay. It should not actually create PRs every day because it's only
two dependencies that get released rarely.

context: we were behind a few arroyo versions. when we had to bump the arroyo version during incident response for INC-1003, we got held up on breaking changes that had been released a few days ago but not been bumped in snuba.

sentry-kafka-schemas is not there because its release speed is way too
high.
