### PR TITLE
Use GitHub Container Registry instead of Google Container Registry for snuba builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,7 @@ jobs:
         uses: getsentry/self-hosted@master
         with:
           project_name: snuba
-          image_url: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.event.pull_request.head.sha || github.sha }}
+          image_url: ghcr.io/getsentry/snuba:${{ github.event.pull_request.head.sha || github.sha }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish-to-dockerhub:
@@ -450,7 +450,7 @@ jobs:
       - name: Pull the test image
         id: image_pull
         env:
-          IMAGE_URL: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.sha }}
+          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
         shell: bash
         run: |
           echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
@@ -471,7 +471,7 @@ jobs:
         shell: bash
         env:
           SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
-          IMAGE_URL: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.sha }}
+          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
         run: |
           # only login if the password is set
           if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi


### PR DESCRIPTION
Currently, the snuba image is stored in Google Container Registry instead of the Github Container Registry. This puts limits on the external contributor's change passing through the CI. It specifically fails in self-hosted CI check stage with the error:

```
Run echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
  echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
  echo "Polling for $IMAGE_URL"
  [ -n "$(docker images -q $IMAGE_URL)" ] || timeout 20m bash -c 'until docker pull "$IMAGE_URL" 2>/dev/null; do sleep 10; done'
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    IMAGE_URL: us-central1-docker.pkg.dev/sentryio/snuba/image:f15ec56c42edcdc542b31dae438e6e0d0e2bb133
We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out.
Polling for us-central1-docker.pkg.dev/sentryio/snuba/image:f15ec56c42edcdc542b31dae438e6e0d0e2bb133
Error: Process completed with exit code 124.
```

This PR moves the registry to Github Container Registry.