### PR TITLE
chore(trace-item-types): Switch all trace_item_name references to trace_item_type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-rapidjson==1.8
 redis==4.5.4
 sentry-arroyo==2.19.4
 sentry-kafka-schemas==0.1.129
-sentry-protos==0.1.41
+sentry-protos==0.1.49
 sentry-redis-tools==0.3.0
 sentry-relay==0.9.4
 sentry-sdk==2.18.0

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -5,7 +5,7 @@ import sentry_sdk
 from google.protobuf.message import DecodeError
 from google.protobuf.message import Message as ProtobufMessage
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemName
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from snuba import environment
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -35,7 +35,7 @@ class TraceItemDataResolver(Generic[Tin, Tout], metaclass=RegisteredClass):
 
     @classmethod
     def config_key(cls) -> str:
-        return f"{cls.endpoint_name()}__{cls.trace_item_name()}"
+        return f"{cls.endpoint_name()}__{cls.trace_item_type()}"
 
     @classmethod
     def endpoint_name(cls) -> str:
@@ -44,17 +44,17 @@ class TraceItemDataResolver(Generic[Tin, Tout], metaclass=RegisteredClass):
         raise NotImplementedError
 
     @classmethod
-    def trace_item_name(cls) -> TraceItemName.ValueType:
-        return TraceItemName.TRACE_ITEM_NAME_UNSPECIFIED
+    def trace_item_type(cls) -> TraceItemType.ValueType:
+        return TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED
 
     @classmethod
-    def get_from_trace_item_name(
-        cls, trace_item_name: TraceItemName.ValueType
+    def get_from_trace_item_type(
+        cls, trace_item_type: TraceItemType.ValueType
     ) -> "Type[TraceItemDataResolver[Tin, Tout]]":
         return cast(
             Type["TraceItemDataResolver[Tin, Tout]"],
             getattr(cls, "_registry").get_class_from_name(
-                f"{cls.endpoint_name()}__{trace_item_name}"
+                f"{cls.endpoint_name()}__{trace_item_type}"
             ),
         )
 
@@ -84,7 +84,7 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         return f"{cls.__name__}__{cls.version()}"
 
     def get_resolver(
-        self, trace_item_name: TraceItemName.ValueType
+        self, trace_item_type: TraceItemType.ValueType
     ) -> TraceItemDataResolver[Tin, Tout]:
         raise NotImplementedError
 

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -9,7 +9,7 @@ from sentry_protos.snuba.v1.endpoint_get_traces_pb2 import (
     GetTracesResponse,
     TraceAttribute,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import PageToken, TraceItemName
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
@@ -218,7 +218,7 @@ def _select_supported_filters(
         return next(
             f.filter
             for f in filters
-            if f.item_name == TraceItemName.TRACE_ITEM_NAME_EAP_SPANS
+            if f.item_name == TraceItemType.TRACE_ITEM_TYPE_SPAN
         )
     except StopIteration:
         raise BadSnubaRPCRequestException("Only one span filter is supported.")

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -218,7 +218,7 @@ def _select_supported_filters(
         return next(
             f.filter
             for f in filters
-            if f.item_name == TraceItemType.TRACE_ITEM_TYPE_SPAN
+            if f.item_type == TraceItemType.TRACE_ITEM_TYPE_SPAN
         )
     except StopIteration:
         raise BadSnubaRPCRequestException("Only one span filter is supported.")

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -6,7 +6,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeriesRequest,
     TimeSeriesResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemName
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from snuba.web.rpc import RPCEndpoint, TraceItemDataResolver
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -87,9 +87,9 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         return TimeSeriesResponse
 
     def get_resolver(
-        self, trace_item_name: TraceItemName.ValueType
+        self, trace_item_type: TraceItemType.ValueType
     ) -> TraceItemDataResolver[TimeSeriesRequest, TimeSeriesResponse]:
-        return ResolverTimeSeries.get_from_trace_item_name(trace_item_name)(
+        return ResolverTimeSeries.get_from_trace_item_type(trace_item_type)(
             timer=self._timer, metrics_backend=self._metrics_backend
         )
 
@@ -102,7 +102,7 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         _validate_time_buckets(in_msg)
         # NOTE: EAP spans was the first TraceItem, we didn't enforce a trace item name originally so we default to it
         # for backwards compatibility
-        if in_msg.meta.trace_item_name == TraceItemName.TRACE_ITEM_NAME_UNSPECIFIED:
-            in_msg.meta.trace_item_name = TraceItemName.TRACE_ITEM_NAME_EAP_SPANS
-        resolver = self.get_resolver(in_msg.meta.trace_item_name)
+        if in_msg.meta.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
+            in_msg.meta.trace_item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
+        resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -103,5 +103,5 @@ class EndpointTraceItemTable(
         # for backwards compatibility
         if in_msg.meta.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
             in_msg.meta.trace_item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
-        resolver = self.get_resolver(in_msg.meta.trace_item_name)
+        resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -6,7 +6,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableRequest,
     TraceItemTableResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemName
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from snuba.web.rpc import RPCEndpoint, TraceItemDataResolver
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -81,9 +81,9 @@ class EndpointTraceItemTable(
         return TraceItemTableRequest
 
     def get_resolver(
-        self, trace_item_name: TraceItemName.ValueType
+        self, trace_item_type: TraceItemType.ValueType
     ) -> TraceItemDataResolver[TraceItemTableRequest, TraceItemTableResponse]:
-        return ResolverTraceItemTable.get_from_trace_item_name(trace_item_name)(
+        return ResolverTraceItemTable.get_from_trace_item_type(trace_item_type)(
             timer=self._timer, metrics_backend=self._metrics_backend
         )
 
@@ -101,7 +101,7 @@ class EndpointTraceItemTable(
         )
         # NOTE: EAP spans was the first TraceItem, we didn't enforce a trace item name originally so we default to it
         # for backwards compatibility
-        if in_msg.meta.trace_item_name == TraceItemName.TRACE_ITEM_NAME_UNSPECIFIED:
-            in_msg.meta.trace_item_name = TraceItemName.TRACE_ITEM_NAME_EAP_SPANS
+        if in_msg.meta.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
+            in_msg.meta.trace_item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
         resolver = self.get_resolver(in_msg.meta.trace_item_name)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeriesRequest,
     TimeSeriesResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemName
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
 
 from snuba.attribution.appid import AppID
@@ -292,8 +292,8 @@ def _build_snuba_request(request: TimeSeriesRequest) -> SnubaRequest:
 
 class ResolverTimeSeriesEAPSpans(ResolverTimeSeries):
     @classmethod
-    def trace_item_name(cls) -> TraceItemName.ValueType:
-        return TraceItemName.TRACE_ITEM_NAME_EAP_SPANS
+    def trace_item_type(cls) -> TraceItemType.ValueType:
+        return TraceItemType.TRACE_ITEM_TYPE_SPAN
 
     def resolve(self, in_msg: TimeSeriesRequest) -> TimeSeriesResponse:
         snuba_request = _build_snuba_request(in_msg)

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -9,7 +9,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableRequest,
     TraceItemTableResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import PageToken, TraceItemName
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeKey,
     AttributeValue,
@@ -233,8 +233,8 @@ def _get_page_token(
 
 class ResolverTraceItemTableEAPSpans(ResolverTraceItemTable):
     @classmethod
-    def trace_item_name(cls) -> TraceItemName.ValueType:
-        return TraceItemName.TRACE_ITEM_NAME_EAP_SPANS
+    def trace_item_type(cls) -> TraceItemType.ValueType:
+        return TraceItemType.TRACE_ITEM_TYPE_SPAN
 
     def resolve(self, in_msg: TraceItemTableRequest) -> TraceItemTableResponse:
         snuba_request = _build_snuba_request(in_msg)

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -295,7 +295,7 @@ class TestGetTraces(BaseApiTest):
             ),
             filters=[
                 GetTracesRequest.TraceFilter(
-                    item_name=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                    item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                     filter=TraceItemFilter(
                         comparison_filter=ComparisonFilter(
                             key=AttributeKey(
@@ -383,7 +383,7 @@ class TestGetTraces(BaseApiTest):
             ],
             filters=[
                 GetTracesRequest.TraceFilter(
-                    item_name=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                    item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                     filter=TraceItemFilter(
                         comparison_filter=ComparisonFilter(
                             key=AttributeKey(

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -18,7 +18,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
     PageToken,
     RequestMeta,
     ResponseMeta,
-    TraceItemName,
+    TraceItemType,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
@@ -295,7 +295,7 @@ class TestGetTraces(BaseApiTest):
             ),
             filters=[
                 GetTracesRequest.TraceFilter(
-                    item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                    item_name=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                     filter=TraceItemFilter(
                         comparison_filter=ComparisonFilter(
                             key=AttributeKey(
@@ -383,7 +383,7 @@ class TestGetTraces(BaseApiTest):
             ],
             filters=[
                 GetTracesRequest.TraceFilter(
-                    item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                    item_name=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                     filter=TraceItemFilter(
                         comparison_filter=ComparisonFilter(
                             key=AttributeKey(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -17,7 +17,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
     PageToken,
     RequestMeta,
     ResponseMeta,
-    TraceItemName,
+    TraceItemType,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
@@ -154,7 +154,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=ts,
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -193,7 +193,7 @@ class TestTraceItemTable(BaseApiTest):
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -241,7 +241,7 @@ class TestTraceItemTable(BaseApiTest):
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 or_filter=OrFilter(
@@ -324,7 +324,7 @@ class TestTraceItemTable(BaseApiTest):
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -420,7 +420,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -469,7 +469,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -552,7 +552,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(
@@ -593,7 +593,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -648,7 +648,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -720,7 +720,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(
@@ -752,7 +752,7 @@ class TestTraceItemTable(BaseApiTest):
                 end_timestamp=ts,
                 referrer="something",
                 cogs_category="something",
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(
@@ -794,7 +794,7 @@ class TestTraceItemTable(BaseApiTest):
                 "projectIds": ["1"],
                 "startTimestamp": hour_ago.ToJsonString(),
                 "endTimestamp": ts.ToJsonString(),
-                "traceItemName": "TRACE_ITEM_NAME_EAP_SPANS",
+                "traceItemType": "TRACE_ITEM_TYPE_SPAN",
             },
             "columns": [
                 {
@@ -985,7 +985,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(
@@ -1018,7 +1018,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(


### PR DESCRIPTION
In preparation for adding a log type, might as well do some renaming before it's being consumed anywhere.
