### PR TITLE
feat: implement aggregate filters on EndpointTraceItemTable

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
@@ -7,10 +7,6 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Any, Dict, List, Optional
 
-from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
-    AggregationComparisonFilter,
-    AggregationFilter,
-)
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     ExtrapolationMode,
@@ -20,7 +16,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
 
 from snuba.query.dsl import CurriedFunctions as cf
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import and_cond, column, or_cond
+from snuba.query.dsl import column
 from snuba.query.expressions import (
     CurriedFunctionCall,
     Expression,
@@ -652,44 +648,3 @@ def aggregation_to_expression(aggregation: AttributeAggregation) -> Expression:
         )
 
     return agg_func_expr
-
-
-def aggregation_filter_to_expression(agg_filter: AggregationFilter) -> Expression:
-    op_to_expr = {
-        AggregationComparisonFilter.OP_LESS_THAN: f.less,
-        AggregationComparisonFilter.OP_GREATER_THAN: f.greater,
-        AggregationComparisonFilter.OP_LESS_THAN_OR_EQUALS: f.lessOrEquals,
-        AggregationComparisonFilter.OP_GREATER_THAN_OR_EQUALS: f.greaterOrEquals,
-        AggregationComparisonFilter.OP_EQUALS: f.equals,
-        AggregationComparisonFilter.OP_NOT_EQUALS: f.notEquals,
-    }
-
-    match agg_filter.WhichOneof("value"):
-        case "comparison_filter":
-            op_expr = op_to_expr.get(agg_filter.comparison_filter.op)
-            if op_expr is None:
-                raise BadSnubaRPCRequestException(
-                    f"Unsupported aggregation filter op: {AggregationComparisonFilter.Op.Name(agg_filter.comparison_filter.op)}"
-                )
-            return op_expr(
-                aggregation_to_expression(agg_filter.comparison_filter.aggregation),
-                agg_filter.comparison_filter.val,
-            )
-        case "and_filter":
-            return and_cond(
-                *(
-                    aggregation_filter_to_expression(x)
-                    for x in agg_filter.and_filter.filters
-                )
-            )
-        case "or_filter":
-            return or_cond(
-                *(
-                    aggregation_filter_to_expression(x)
-                    for x in agg_filter.or_filter.filters
-                )
-            )
-        case default:
-            raise BadSnubaRPCRequestException(
-                f"Unsupported aggregation filter type: {default}"
-            )

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/aggregation.py
@@ -686,7 +686,7 @@ def aggregation_filter_to_expression(agg_filter: AggregationFilter) -> Expressio
             return or_cond(
                 *(
                     aggregation_filter_to_expression(x)
-                    for x in agg_filter.and_filter.filters
+                    for x in agg_filter.or_filter.filters
                 )
             )
         case default:

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -42,6 +42,7 @@ from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.resolvers import ResolverTraceItemTable
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.aggregation import (
     ExtrapolationContext,
+    aggregation_filter_to_expression,
     aggregation_to_expression,
     get_average_sample_rate_column,
     get_confidence_interval_column,
@@ -147,6 +148,7 @@ def _build_query(request: TraceItemTableRequest) -> Query:
         # protobuf sets limit to 0 by default if it is not set,
         # give it a default value that will actually return data
         limit=request.limit if request.limit > 0 else _DEFAULT_ROW_LIMIT,
+        having=aggregation_filter_to_expression(request.aggregation_filter),
     )
     treeify_or_and_conditions(res)
     apply_virtual_columns(res, request.virtual_column_contexts)

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -148,7 +148,9 @@ def _build_query(request: TraceItemTableRequest) -> Query:
         # protobuf sets limit to 0 by default if it is not set,
         # give it a default value that will actually return data
         limit=request.limit if request.limit > 0 else _DEFAULT_ROW_LIMIT,
-        having=aggregation_filter_to_expression(request.aggregation_filter),
+        having=aggregation_filter_to_expression(request.aggregation_filter)
+        if request.HasField("aggregation_filter")
+        else None,
     )
     treeify_or_and_conditions(res)
     apply_virtual_columns(res, request.virtual_column_contexts)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1303,6 +1303,8 @@ class TestTraceItemTable(BaseApiTest):
     def test_bad_aggregation_filter(self, setup_teardown: Any) -> None:
         """
         This test ensures that an error is raised when the aggregation filter is invalid.
+        It tests a case where AttributeAggregation is set improperly.
+        And it tests a case where an and filter has only one filter.
         """
         # first I write new messages with different value of kylestags,
         # theres a different number of messages for each tag so that
@@ -1366,6 +1368,31 @@ class TestTraceItemTable(BaseApiTest):
                     val=350,
                 )
             ),
+        )
+        with pytest.raises(BadSnubaRPCRequestException):
+            EndpointTraceItemTable().execute(message)
+
+        # now do an and filter has only one filter
+        message.aggregation_filter.CopyFrom(
+            AggregationFilter(
+                and_filter=AggregationAndFilter(
+                    filters=[
+                        AggregationFilter(
+                            comparison_filter=AggregationComparisonFilter(
+                                aggregation=AttributeAggregation(
+                                    aggregate=Function.FUNCTION_SUM,
+                                    key=AttributeKey(
+                                        type=AttributeKey.TYPE_FLOAT,
+                                        name="my.float.field",
+                                    ),
+                                ),
+                                op=AggregationComparisonFilter.OP_LESS_THAN,
+                                val=350,
+                            )
+                        ),
+                    ]
+                )
+            )
         )
         with pytest.raises(BadSnubaRPCRequestException):
             EndpointTraceItemTable().execute(message)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -7,6 +7,8 @@ import pytest
 from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    AggregationComparisonFilter,
+    AggregationFilter,
     Column,
     TraceItemColumnValues,
     TraceItemTableRequest,
@@ -1039,6 +1041,90 @@ class TestTraceItemTable(BaseApiTest):
         )
         with pytest.raises(BadSnubaRPCRequestException):
             EndpointTraceItemTable().execute(message)
+
+    def test_aggregation_filter(self, setup_teardown: Any) -> None:
+        # first I write new messages with different value of kylestags,
+        # theres a different number of messages for each tag so that
+        # each will have a different sum value when i do aggregate
+        spans_storage = get_storage(StorageKey("eap_spans"))
+        msg_timestamp = BASE_TIME - timedelta(minutes=1)
+        messages = (
+            [gen_message(msg_timestamp, tags={"kylestag": "val1"}) for i in range(3)]
+            + [gen_message(msg_timestamp, tags={"kylestag": "val2"}) for i in range(12)]
+            + [gen_message(msg_timestamp, tags={"kylestag": "val3"}) for i in range(30)]
+        )
+        write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+            ),
+            filter=TraceItemFilter(
+                exists_filter=ExistsFilter(
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="kylestag")
+                )
+            ),
+            columns=[
+                Column(
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="kylestag")
+                ),
+                Column(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="my.float.field"
+                        ),
+                        label="sum(my.float.field)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                    ),
+                ),
+            ],
+            group_by=[AttributeKey(type=AttributeKey.TYPE_STRING, name="kylestag")],
+            order_by=[
+                TraceItemTableRequest.OrderBy(
+                    column=Column(
+                        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="kylestag")
+                    )
+                ),
+            ],
+            aggregation_filter=AggregationFilter(
+                comparison_filter=AggregationComparisonFilter(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="my.float.field"
+                        ),
+                    ),
+                    op=AggregationComparisonFilter.OP_GREATER_THAN,
+                    val=350,
+                )
+            ),
+        )
+        response = EndpointTraceItemTable().execute(message)
+        assert response.column_values == [
+            TraceItemColumnValues(
+                attribute_name="kylestag",
+                results=[
+                    AttributeValue(val_str="val2"),
+                    AttributeValue(val_str="val3"),
+                ],
+            ),
+            TraceItemColumnValues(
+                attribute_name="sum(my.float.field)",
+                results=[
+                    AttributeValue(val_float=1214.4),
+                    AttributeValue(val_float=3036),
+                ],
+            ),
+        ]
 
 
 class TestUtils:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1072,7 +1072,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -1164,7 +1164,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(
@@ -1327,7 +1327,7 @@ class TestTraceItemTable(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
-                trace_item_name=TraceItemName.TRACE_ITEM_NAME_EAP_SPANS,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(


### PR DESCRIPTION
This PR closes [this ticket](https://github.com/getsentry/eap-planning/issues/143)

It implements support for [this field in TraceItemTableRequest](https://github.com/getsentry/sentry-protos/blob/dc01de301c524ce75cea38750f1d5c3e6538cfcf/proto/sentry_protos/snuba/v1/endpoint_trace_item_table.proto#L40)

Aggregation filters can now be specified like [this one](https://github.com/getsentry/snuba/pull/6776/files#diff-95d7f61d81f5bafda1267a2fb8d7ea3b9368b23e34dc2d24de38fb40532f9a1dR1105-R1117)

```
AggregationFilter(
    comparison_filter=AggregationComparisonFilter(
        aggregation=AttributeAggregation(
            aggregate=Function.FUNCTION_SUM,
            key=AttributeKey(
                type=AttributeKey.TYPE_FLOAT, name="my.float.field"
            ),
        ),
        op=AggregationComparisonFilter.OP_GREATER_THAN,
        val=350,
    )
)
```
which translates to
`HAVING sum(my.float.field) > 350`
