### PR TITLE
chore(trace-item-types): throw an error if no trace item type is specified

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -100,9 +100,9 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         _enforce_no_duplicate_labels(in_msg)
         _validate_time_buckets(in_msg)
-        # NOTE: EAP spans was the first TraceItem, we didn't enforce a trace item name originally so we default to it
-        # for backwards compatibility
         if in_msg.meta.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
-            in_msg.meta.trace_item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
+            raise BadSnubaRPCRequestException(
+                "This endpoint requires meta.trace_item_type to be set (are you requesting spans? logs?)"
+            )
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -99,9 +99,9 @@ class EndpointTraceItemTable(
         in_msg.meta.request_id = getattr(in_msg.meta, "request_id", None) or str(
             uuid.uuid4()
         )
-        # NOTE: EAP spans was the first TraceItem, we didn't enforce a trace item name originally so we default to it
-        # for backwards compatibility
         if in_msg.meta.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
-            in_msg.meta.trace_item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
+            raise BadSnubaRPCRequestException(
+                "This endpoint requires meta.trace_item_type to be set (are you requesting spans? logs?)"
+            )
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/tests/manual_jobs/test_scrub_ips_from_eap_spans.py
+++ b/tests/manual_jobs/test_scrub_ips_from_eap_spans.py
@@ -15,6 +15,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
     PageToken,
     RequestMeta,
     ResponseMeta,
+    TraceItemType,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ExistsFilter, TraceItemFilter
@@ -212,6 +213,7 @@ def _generate_request(
             start_timestamp=Timestamp(seconds=hour_ago),
             end_timestamp=ts,
             request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
         ),
         filter=TraceItemFilter(
             exists_filter=ExistsFilter(

--- a/tests/manual_jobs/test_scrub_users_from_eap_spans.py
+++ b/tests/manual_jobs/test_scrub_users_from_eap_spans.py
@@ -15,6 +15,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
     PageToken,
     RequestMeta,
     ResponseMeta,
+    TraceItemType,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ExistsFilter, TraceItemFilter
@@ -211,6 +212,7 @@ def _generate_request(
             start_timestamp=Timestamp(seconds=hour_ago),
             end_timestamp=ts,
             request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
         ),
         filter=TraceItemFilter(
             exists_filter=ExistsFilter(

--- a/tests/manual_jobs/test_scrub_users_from_eap_spans_str_attrs.py
+++ b/tests/manual_jobs/test_scrub_users_from_eap_spans_str_attrs.py
@@ -9,7 +9,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeValuesRequest,
     TraceItemAttributeValuesResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.datasets.storages.factory import get_storage
@@ -254,6 +254,7 @@ COMMON_META = RequestMeta(
     referrer="something",
     start_timestamp=START_TS,
     end_timestamp=END_TS,
+    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
 )
 
 

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
     CreateSubscriptionRequest as CreateSubscriptionRequestProto,
 )
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -60,6 +60,7 @@ def build_rpc_subscription_data_from_proto(
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 aggregations=[
                     AttributeAggregation(

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -6,7 +6,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
     CreateSubscriptionRequest as CreateSubscriptionRequestProto,
 )
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -112,6 +112,7 @@ TESTS = [
                         organization_id=1,
                         cogs_category="something",
                         referrer="something",
+                        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                     ),
                     aggregations=[
                         AttributeAggregation(
@@ -142,6 +143,7 @@ TESTS = [
                         organization_id=1,
                         cogs_category="something",
                         referrer="something",
+                        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                     ),
                     aggregations=[
                         AttributeAggregation(

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -23,7 +23,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
     CreateSubscriptionRequest as CreateSubscriptionRequestProto,
 )
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -187,6 +187,7 @@ def test_scheduler_consumer_rpc_subscriptions(tmpdir: LocalPath) -> None:
                 organization_id=1,
                 cogs_category="something",
                 referrer="something",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -7,7 +7,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
     CreateSubscriptionRequest as CreateSubscriptionRequestProto,
 )
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -355,6 +355,7 @@ TESTS_CREATE_RPC_SUBSCRIPTIONS = [
                         organization_id=1,
                         cogs_category="something",
                         referrer="something",
+                        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                     ),
                     aggregations=[
                         AttributeAggregation(

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -10,7 +10,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
 )
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 from sentry_protos.snuba.v1.error_pb2 import Error
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -41,6 +41,7 @@ TESTS_INVALID_RPC_SUBSCRIPTIONS = [
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 aggregations=[
                     AttributeAggregation(
@@ -67,6 +68,7 @@ TESTS_INVALID_RPC_SUBSCRIPTIONS = [
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 aggregations=[
                     AttributeAggregation(
@@ -93,6 +95,7 @@ TESTS_INVALID_RPC_SUBSCRIPTIONS = [
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 aggregations=[
                     AttributeAggregation(
@@ -127,6 +130,7 @@ TESTS_INVALID_RPC_SUBSCRIPTIONS = [
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 group_by=[
                     AttributeKey(type=AttributeKey.TYPE_STRING, name="device.class")
@@ -156,6 +160,7 @@ TESTS_INVALID_RPC_SUBSCRIPTIONS = [
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 aggregations=[
                     AttributeAggregation(
@@ -195,6 +200,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
                     organization_id=1,
                     cogs_category="something",
                     referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 aggregations=[
                     AttributeAggregation(

--- a/tests/web/rpc/v1/test_debug_info.py
+++ b/tests/web/rpc/v1/test_debug_info.py
@@ -7,7 +7,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     Column,
     TraceItemTableRequest,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ExistsFilter, TraceItemFilter
 
@@ -36,6 +36,7 @@ class TestDebugInfo:
                 end_timestamp=ts,
                 request_id=request_id,
                 debug=debug,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             filter=TraceItemFilter(
                 exists_filter=ExistsFilter(

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeriesRequest,
 )
 from sentry_protos.snuba.v1.error_pb2 import Error
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -139,6 +139,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 referrer="something",
                 start_timestamp=tstart,
                 end_timestamp=ts,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -187,6 +188,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -259,6 +261,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
                 end_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp() + 60 * 30)),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -339,6 +342,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
                 end_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp() + 60 * 30)),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -392,6 +396,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -469,6 +474,7 @@ class TestTimeSeriesApi(BaseApiTest):
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
                 debug=True,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -596,6 +596,7 @@ class TestTimeSeriesApi(BaseApiTest):
                     seconds=int(BASE_TIME.timestamp()) + query_duration
                 ),
                 debug=True,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -647,6 +648,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration + 1)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -682,6 +684,7 @@ class TestTimeSeriesApi(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
                 end_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp() + 60 * 30)),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -723,6 +726,7 @@ class TestUtils:
                 referrer="something",
                 start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
                 end_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 debug=True,
             ),
             aggregations=[
@@ -767,6 +771,7 @@ class TestUtils:
                 start_timestamp=Timestamp(seconds=int(start_ts.timestamp())),
                 end_timestamp=Timestamp(seconds=int(end_ts.timestamp())),
                 debug=True,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -792,6 +797,7 @@ class TestUtils:
                 start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
                 end_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp()) + 65),
                 debug=True,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -10,7 +10,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeries,
     TimeSeriesRequest,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -154,6 +154,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -269,6 +270,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -325,6 +327,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -379,6 +382,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -438,6 +442,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -500,6 +505,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -559,6 +565,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(
@@ -618,6 +625,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 end_timestamp=Timestamp(
                     seconds=int(BASE_TIME.timestamp() + query_duration)
                 ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             aggregations=[
                 AttributeAggregation(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -943,6 +943,7 @@ class TestTraceItemTable(BaseApiTest):
                 "projectIds": ["1"],
                 "startTimestamp": hour_ago.ToJsonString(),
                 "endTimestamp": ts.ToJsonString(),
+                "traceItemType": "TRACE_ITEM_TYPE_SPAN",
             },
             "columns": [
                 {

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -181,6 +181,43 @@ class TestTraceItemTable(BaseApiTest):
             error_proto.ParseFromString(response.data)
         assert response.status_code == 200, error_proto
 
+    def test_errors_without_type(self) -> None:
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=ts,
+                end_timestamp=ts,
+            ),
+            filter=TraceItemFilter(
+                exists_filter=ExistsFilter(
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="color")
+                )
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="location"))
+            ],
+            order_by=[
+                TraceItemTableRequest.OrderBy(
+                    column=Column(
+                        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="location")
+                    )
+                )
+            ],
+            limit=10,
+        )
+        response = self.app.post(
+            "/rpc/EndpointTraceItemTable/v1", data=message.SerializeToString()
+        )
+        error_proto = ErrorProto()
+        if response.status_code != 200:
+            error_proto.ParseFromString(response.data)
+        assert response.status_code == 400, error_proto
+
     def test_with_data(self, setup_teardown: Any) -> None:
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
@@ -10,7 +10,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     Column,
     TraceItemTableRequest,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
@@ -150,6 +150,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(
@@ -260,6 +261,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(
@@ -318,6 +320,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
                 referrer="something",
                 start_timestamp=Timestamp(seconds=hour_ago),
                 end_timestamp=ts,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
             columns=[
                 Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="key")),


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/83530 made the sentry backend send trace_item_type with every request, so now we can get rid of this unspecified => span assumption

