### PR TITLE
fix: make snuba admin error messages more stable

### DIFF
--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -37,11 +37,7 @@ function QueryDisplay(props: {
     getRecentHistory(HISTORY_KEY)
   );
 
-  type QueryError = {
-    title: string;
-    body: string;
-  }
-  const [queryError, setQueryError] = useState<QueryError | null>(null);
+  const [queryError, setQueryError] = useState<Error | null>(null);
 
   useEffect(() => {
     props.api.getClickhouseNodes().then((res) => {
@@ -136,35 +132,14 @@ function QueryDisplay(props: {
 
   function getErrorDomElement() {
     if (queryError !== null) {
-      const bodyDOM = queryError.body.split("\n").map((line) => <React.Fragment>{line}< br /></React.Fragment>)
-      return <Alert title={queryError.title} color="red">{bodyDOM}</Alert>;
+      const bodyDOM = queryError.message.split("\n").map((line) => <React.Fragment>{line}< br /></React.Fragment>)
+      return <Alert title={queryError.name} color="red">{bodyDOM}</Alert>;
     }
     return "";
   }
 
-  function handleQueryError(error: any) {
-    try {
-      // this block assumes that the error is an object with an error property,
-      // if its not it will be caught by the catch block
-      const lines = error.error.split("\n");
-      if (lines.length > 1) {
-        setQueryError({
-          title: lines[0],
-          body: lines.slice(1).join("\n"),
-        })
-      } else {
-        setQueryError({
-          title: "Error",
-          body: lines[0]
-        });
-      }
-    } catch (e) {
-      if (typeof error === "object") {
-        setQueryError({ title: "Error", body: JSON.stringify(error) });
-      } else {
-        setQueryError({ title: "Error", body: error.toString() });
-      }
-    }
+  function handleQueryError(error: Error) {
+    setQueryError(error);
   }
 
   return (

--- a/snuba/admin/static/utils/execute_button.tsx
+++ b/snuba/admin/static/utils/execute_button.tsx
@@ -16,7 +16,7 @@ function ExecuteButton(props: {
   };
   let errorCallback = props.onError || defaultError;
 
-  function _convertAnyToError(err: any) {
+  function _convertAnyToError(err: any): Error {
     if (err instanceof Error) {
       return err;
     } else if (typeof err === 'object' && Object.keys(err).length == 1) {

--- a/snuba/admin/static/utils/execute_button.tsx
+++ b/snuba/admin/static/utils/execute_button.tsx
@@ -4,26 +4,29 @@ import { Button } from "@mantine/core";
 function ExecuteButton(props: {
   disabled: boolean;
   onClick: () => Promise<any>;
-  onError?: (error: any) => any;  // TODO: we should make the type of error we return more specific
+  onError?: (error: Error) => any;
   label?: string;
 }) {
   const [isExecuting, setIsExecuting] = useState<boolean>(false);
 
   let label = props.label || "Execute Query";
 
-  const defaultError = (err: any) => {
-    console.log("ERROR ", err);
-    let errmsg = err.toString();
-    if (typeof err === 'object' &&
-      err !== null &&
-      err.hasOwnProperty("error") &&
-      err.error.hasOwnProperty("message")) {
-      errmsg = err.error.message;
-    }
-    window.alert("An error occurred: " + errmsg)
-
+  const defaultError = (err: Error) => {
+    window.alert("An error occurred: " + err.message)
   };
   let errorCallback = props.onError || defaultError;
+
+  function _convertAnyToError(err: any) {
+    if (err instanceof Error) {
+      return err;
+    } else if (typeof err === 'object' && Object.keys(err).length == 1) {
+      return _convertAnyToError(err[Object.keys(err)[0]]);
+    } else if (typeof err === 'object') {
+      return new Error(JSON.stringify(err));
+    } else {
+      return new Error(err.toString());
+    }
+  }
 
   function executeQuery() {
     if (isExecuting) {
@@ -33,7 +36,9 @@ function ExecuteButton(props: {
     props
       .onClick()
       .catch((err: any) => {
-        errorCallback(err);
+        console.error("Error: ", err);
+        // convert error to Error object for easier handling
+        errorCallback(_convertAnyToError((err)));
       })
       .finally(() => {
         setIsExecuting(false);


### PR DESCRIPTION
this PR makes the error handling in snuba admin more robust to hopefully prevent errors messages from getting messed up in the UI as frequently.

it maintains the console error logging as backup.

## Major changes
* adds `_convertAnyToError` function that is responsible for converting any type object to an error object. This is the change that has most impact on the already existing messages. It replaces the logic that was in `defaultError` but is more robust.
* changes the type of `onError` property of execute button to `function(Error)` instead of `function(Any)`. this makes overriding the error handling behavior simpler to users of the button. I was the only user of this so it has no serious impacts.
