### PR TITLE
fix(admin): make profile events optional for trace queries

### DIFF
--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -107,10 +107,24 @@ function QueryDisplay(props: {
             options={storages}
           />
         </div>
-        <ExecuteButton
-          onClick={executeQuery}
-          disabled={!query.storage || !query.sql}
-        />
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <Switch
+            checked={query.gather_profile_events ?? true}
+            onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+              setQuery((prevQuery) => ({
+                ...prevQuery,
+                gather_profile_events: evt.currentTarget.checked,
+              }))
+            }
+            onLabel="PROFILE"
+            offLabel="NO PROFILE"
+            size="md"
+          />
+          <ExecuteButton
+            onClick={executeQuery}
+            disabled={!query.storage || !query.sql}
+          />
+        </div>
       </div>
       <div>
         <h2>Query results</h2>

--- a/snuba/admin/static/tracing/types.tsx
+++ b/snuba/admin/static/tracing/types.tsx
@@ -1,6 +1,7 @@
-type TracingRequest = {
-  storage: string;
+export type TracingRequest = {
   sql: string;
+  storage: string;
+  gather_profile_events?: boolean;
 };
 
 type TracingResult = {

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -496,7 +496,12 @@ def clickhouse_trace_query() -> Response:
 
         query_trace = run_query_and_get_trace(storage, raw_sql)
 
-        gather_profile_events(query_trace, storage)
+        try:
+            gather_profile_events(query_trace, storage)
+        except Exception:
+            logger.warning(
+                "Error gathering profile events, returning trace anyway", exc_info=True
+            )
         return make_response(jsonify(asdict(query_trace)), 200)
     except InvalidCustomQuery as err:
         return make_response(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -496,12 +496,14 @@ def clickhouse_trace_query() -> Response:
 
         query_trace = run_query_and_get_trace(storage, raw_sql)
 
-        try:
-            gather_profile_events(query_trace, storage)
-        except Exception:
-            logger.warning(
-                "Error gathering profile events, returning trace anyway", exc_info=True
-            )
+        if req.get("gather_profile_events", True):
+            try:
+                gather_profile_events(query_trace, storage)
+            except Exception:
+                logger.warning(
+                    "Error gathering profile events, returning trace anyway",
+                    exc_info=True,
+                )
         return make_response(jsonify(asdict(query_trace)), 200)
     except InvalidCustomQuery as err:
         return make_response(


### PR DESCRIPTION
Sometimes the system.query_log table doesn't exist in the environment. Right now that breaks the entire tool. Gathering profile events can also be quite slow and for long queries it can time out. Allow it to be optional in the UI