### PR TITLE
fix(eap-api): Snuba can receive `val_double` in addition to `val_float`

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -284,6 +284,8 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 v_expression = literal(v.val_str)
             case "val_float":
                 v_expression = literal(v.val_float)
+            case "val_double":
+                v_expression = literal(v.val_double)
             case "val_int":
                 v_expression = literal(v.val_int)
             case "val_null":
@@ -299,6 +301,10 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             case "val_float_array":
                 v_expression = literals_array(
                     None, list(map(lambda x: literal(x), v.val_float_array.values))
+                )
+            case "val_double_array":
+                v_expression = literals_array(
+                    None, list(map(lambda x: literal(x), v.val_double_array.values))
                 )
             case default:
                 raise NotImplementedError(


### PR DESCRIPTION
Sentry sends RPC request containing `val_float` to Snuba (code [here](https://github.com/getsentry/sentry/blob/master/src/sentry/search/eap/spans.py#L336-L347)). Snuba receives the request. Snuba then sends response containing `val_float` to Sentry (code [here](https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py#L194-L197)). Sentry receives the response.

Plan:
1. update the receiving end of both Sentry and Snuba to support both `val_double` and `val_float`
2. after some time, replace the `val_float` in the sending end of both Sentry and Snuba to `val_double`. This replacement (instead of supporting both) is backward compatible because step 1 ensures that both receiving ends can handle either `val_float` or `val_double`
3. after some time, remove `val_float` from the receiving end of both Sentry and Snuba

Note: "after some time" means all instances of Sentry and Snuba have the updated code

This PR handles the Snuba side of step 1. PR for handling the Sentry side of step 1 is [here](https://github.com/getsentry/sentry/pull/83566)