### PR TITLE
chore(deps): bump relay from 0.9.4 to 0.9.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ sentry-arroyo==2.19.4
 sentry-kafka-schemas==0.1.129
 sentry-protos==0.1.49
 sentry-redis-tools==0.3.0
-sentry-relay==0.9.4
+sentry-relay==0.9.5
 sentry-sdk==2.18.0
 simplejson==3.17.6
 snuba-sdk==3.0.39


### PR DESCRIPTION
ref: https://github.com/getsentry/relay/commit/bcd37995353e916bf10612b35c08fa2f99412195