### PR TITLE
fix(clickhouse): Fix crash in clickhouse client due to invalid verify parameter

### DIFF
--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -308,7 +308,10 @@ class HTTPBatchWriter(BatchWriter[bytes]):
         self.__pool: HTTPSConnectionPool | HTTPConnectionPool
         if secure:
             self.__pool = HTTPSConnectionPool(
-                host, port, ca_certs=ca_certs, cert_reqs='REQUIRED' if verify else 'CERT_NONE'
+                host,
+                port,
+                ca_certs=ca_certs,
+                cert_reqs="REQUIRED" if verify else "CERT_NONE",
             )
         else:
             self.__pool = HTTPConnectionPool(host, port)

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -308,7 +308,7 @@ class HTTPBatchWriter(BatchWriter[bytes]):
         self.__pool: HTTPSConnectionPool | HTTPConnectionPool
         if secure:
             self.__pool = HTTPSConnectionPool(
-                host, port, ca_certs=ca_certs, verify=verify
+                host, port, ca_certs=ca_certs, cert_reqs='REQUIRED' if verify else 'CERT_NONE'
             )
         else:
             self.__pool = HTTPConnectionPool(host, port)


### PR DESCRIPTION
I tried to test new version with ssl clickhouse fix and got an error 

```
connectionpool.py", line 1069, in _new_conn
    return self.ConnectionCls(
TypeError: __init__() got an unexpected keyword argument 'verify'
```
after some investigation i found that urllib3 HTTPSConnectionPool does not have verify attr.

to reproduce just open python console and execute
```
>>> from urllib3.connectionpool import HTTPSConnectionPool
>>> pool2=HTTPSConnectionPool('......', 443, verify=False)
>>> print(pool2.request('GET', '/'))
```
to fix this need to replace verify to cert_reqs.
```
>>> pool2=HTTPSConnectionPool('....', 443, ca_certs='custom.pem', cert_reqs='REQUIRED')
>>> print(pool2.request('GET', '/').data)
b'Ok.\n'
```
also there is an replacement for verify == False
```
>>> pool2=HTTPSConnectionPool('...', 443, cert_reqs='CERT_NONE')
>>> print(pool2.request('GET', '/').data)
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
