### PR TITLE
chore(devservices): Bump devservices to 1.0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 clickhouse-driver==0.2.6
 confluent-kafka==2.3.0
 datadog==0.21.0
-devservices==1.0.8
+devservices==1.0.10
 flake8==7.0.0
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
picks up https://github.com/getsentry/devservices/releases/tag/1.0.10