### PR TITLE
ci: provide arm64 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,51 +445,6 @@ jobs:
           image_url: ${{ needs.snuba-image.outputs.image_tag }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  publish-to-dockerhub:
-    name: Publish Snuba to DockerHub
-    runs-on: ubuntu-20.04
-    if: ${{ (github.ref_name == 'master') }}
-    steps:
-      - uses: actions/checkout@v4 # v3.1.0
-      - name: Pull the test image
-        id: image_pull
-        env:
-          IMAGE_URL: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.sha }}
-        shell: bash
-        run: |
-          echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
-          echo "Polling for $IMAGE_URL"
-          timeout 20m bash -c 'until docker pull "$IMAGE_URL" 2>/dev/null; do sleep 10; done'
-      - name: Get short SHA for docker tag
-        id: short_sha
-        shell: bash
-        run: |
-          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          if [[ -z "$SHORT_SHA" ]]; then
-            echo "Short SHA empty? Re-running rev-parse."
-            git rev-parse --short "$GITHUB_SHA"
-          else
-            echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
-          fi
-      - name: Push built docker image
-        shell: bash
-        env:
-          SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
-          IMAGE_URL: us-central1-docker.pkg.dev/sentryio/snuba/image:${{ github.sha }}
-        run: |
-          # only login if the password is set
-          if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
-          # We push 3 tags to Dockerhub:
-          # first, the full sha of the commit
-          docker tag ${IMAGE_URL} getsentry/snuba:${GITHUB_SHA}
-          docker push getsentry/snuba:${GITHUB_SHA}
-          # second, the short sha of the commit
-          docker tag ${IMAGE_URL} getsentry/snuba:${SHORT_SHA}
-          docker push getsentry/snuba:${SHORT_SHA}
-          # finally, nightly
-          docker tag ${IMAGE_URL} getsentry/snuba:nightly
-          docker push getsentry/snuba:nightly
-
   validate-devservices-config:
     runs-on: ubuntu-24.04
     needs: files-changed

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,40 +1,114 @@
+name: image
+
 on:
   pull_request:
   push:
     branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build-image:
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
+
+    runs-on: |-
+      ${{fromJson('{
+        "amd64": "ubuntu-20.04",
+        "arm64": "ubuntu-22.04-arm"
+      }')[matrix.arch] }}
+    env:
+      IMG_VERSIONED: ghcr.io/getsentry/snuba:${{ matrix.arch }}-${{ github.sha }}
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
-      env:
-        GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event_name != 'pull_request'
+      - name: Docker Login
+        run: docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
 
-    - run: docker buildx create --driver docker-container --use
+      - name: build versioned image
+        run: |
+          set -euxo pipefail
+          docker buildx build \
+              --build-arg TARGETARCH=${{ matrix.arch }} \
+              --platform linux/${{ matrix.arch }} \
+              --tag "$IMG_VERSIONED" \
+              --target application \
+              .
 
-    - name: build
-      run: |
-        set -euxo pipefail
+      - name: push all images
+        if: ${{ (github.ref_name == 'master') }}
+        run: |
+          docker push "$IMG_VERSIONED"
 
-        if [ ${{ github.event_name }} = 'push' ]; then
-          args=(
-            --tag ghcr.io/getsentry/snuba:latest
-            --tag ghcr.io/getsentry/snuba:amd64-latest
-            --push
-          )
-        else
-          args=()
-        fi
+  assemble:
+    needs: build-image
+    if: ${{ (github.ref_name == 'master') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Docker Login
+        run: docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
 
-        docker buildx build \
-          --pull \
-          --platform linux/amd64 \
-          --cache-from ghcr.io/getsentry/snuba:latest \
-          --cache-to type=inline \
-          --tag ghcr.io/getsentry/snuba:${{ github.sha }} \
-          --target application \
-          "${args[@]}" \
-          .
+      - name: Assemble Sha Image
+        run: |
+          docker manifest create \
+            'ghcr.io/getsentry/snuba:${{ github.sha }}' \
+            'ghcr.io/getsentry/snuba:arm64-${{ github.sha }}' \
+            'ghcr.io/getsentry/snuba:amd64-${{ github.sha }}'
+          docker manifest push ghcr.io/getsentry/snuba:${{ github.sha }}
+      - name: Assemble Latest Image
+        run: |
+          docker manifest create \
+            'ghcr.io/getsentry/snuba:latest' \
+            'ghcr.io/getsentry/snuba:arm64-${{ github.sha }}' \
+            'ghcr.io/getsentry/snuba:amd64-${{ github.sha }}'
+          docker manifest push ghcr.io/getsentry/snuba:latest
+
+  publish-to-dockerhub:
+    needs: assemble
+    name: Publish Snuba to DockerHub
+    runs-on: ubuntu-20.04
+    if: ${{ (github.ref_name == 'master') }}
+    steps:
+      - uses: actions/checkout@v4 # v3.1.0
+      - name: Pull the test image
+        id: image_pull
+        env:
+          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
+        shell: bash
+        run: |
+          echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
+          echo "Polling for $IMAGE_URL"
+          timeout 20m bash -c 'until docker pull "$IMAGE_URL" 2>/dev/null; do sleep 10; done'
+      - name: Get short SHA for docker tag
+        id: short_sha
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          if [[ -z "$SHORT_SHA" ]]; then
+            echo "Short SHA empty? Re-running rev-parse."
+            git rev-parse --short "$GITHUB_SHA"
+          else
+            echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          fi
+      - name: Push built docker image
+        shell: bash
+        env:
+          SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
+          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
+        run: |
+          # only login if the password is set
+          if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
+          # We push 3 tags to Dockerhub:
+          # first, the full sha of the commit
+          docker tag ${IMAGE_URL} getsentry/snuba:${GITHUB_SHA}
+          docker push getsentry/snuba:${GITHUB_SHA}
+          # second, the short sha of the commit
+          docker tag ${IMAGE_URL} getsentry/snuba:${SHORT_SHA}
+          docker push getsentry/snuba:${SHORT_SHA}
+          # finally, nightly
+          docker tag ${IMAGE_URL} getsentry/snuba:nightly
+          docker push getsentry/snuba:nightly


### PR DESCRIPTION
Effort for https://github.com/getsentry/self-hosted/issues/1585

This PR changed the DockerHub publishing workflow. We don't depend on the GCB anymore. Rather, we depend on GHCR now.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
