### PR TITLE
fix(admin): Make clickhouse node info more retriable

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1401,7 +1401,11 @@ def get_job_logs(job_id: str) -> Response:
 @application.route("/clickhouse_node_info")
 @check_tool_perms(tools=[AdminTools.DATABASE_CLUSTERS])
 def clickhouse_node_info() -> Response:
-    return make_response(jsonify(get_node_info()), 200)
+    try:
+        node_info = get_node_info()
+        return make_response(jsonify(node_info), 200)
+    except Exception as e:
+        make_response(jsonify({"error": str(e)}), 500)
 
 
 @application.route("/clickhouse_system_settings")

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1405,7 +1405,7 @@ def clickhouse_node_info() -> Response:
         node_info = get_node_info()
         return make_response(jsonify(node_info), 200)
     except Exception as e:
-        make_response(jsonify({"error": str(e)}), 500)
+        return make_response(jsonify({"error": str(e)}), 500)
 
 
 @application.route("/clickhouse_system_settings")

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -426,7 +426,8 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
             ClickhouseNode(*host)
             for host in self.get_query_connection(ClickhouseClientSettings.QUERY)
             .execute(
-                f"select host_name, port, shard_num, replica_num from system.clusters where cluster={escape_string(cluster_name)}"
+                f"select host_name, port, shard_num, replica_num from system.clusters where cluster={escape_string(cluster_name)}",
+                retryable=True,
             )
             .results
         ]


### PR DESCRIPTION
Sometimes in snuba admin we fail to load the cluster info because one cluster rejected a connection, as we add more clusters, the probability of this will only increase. Add a retry to the function. WIll add caching of this info later as it's not needed to be fresh fetched all the time