### PR TITLE
fix(errors): Add input_format_skip_unknown_fields to errors

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -62,6 +63,7 @@ fn create_factory(
             python_class_name: python_class_name.into(),
             python_module: "test".into(),
         },
+        writer_options: HashMap::new(),
     };
 
     let processing_concurrency =

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -76,6 +76,7 @@ pub struct StorageConfig {
     pub clickhouse_table_name: String,
     pub clickhouse_cluster: ClickhouseConfig,
     pub message_processor: MessageProcessorConfig,
+    pub writer_options: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -107,7 +107,7 @@ pub fn consumer_impl(
 
     for storage in &consumer_config.storages {
         tracing::info!(
-            "Storage: {}, ClickHouse Table Name: {}, Message Processor: {:?}, ClickHouse host: {}, ClickHouse port: {}, ClickHouse HTTP port: {}, ClickHouse database: {}",
+            "Storage: {}, ClickHouse Table Name: {}, Message Processor: {:?}, ClickHouse host: {}, ClickHouse port: {}, ClickHouse HTTP port: {}, ClickHouse database: {}, ClickHouse writer options: {:?}",
             storage.name,
             storage.clickhouse_table_name,
             &storage.message_processor,
@@ -115,6 +115,7 @@ pub fn consumer_impl(
             storage.clickhouse_cluster.port,
             storage.clickhouse_cluster.http_port,
             storage.clickhouse_cluster.database,
+            storage.writer_options,
         );
     }
 

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -117,6 +117,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.storage_config.clickhouse_cluster.password,
             self.async_inserts,
             self.batch_write_timeout,
+            &self.storage_config.writer_options,
         );
 
         let accumulator = Arc::new(

--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -393,6 +393,8 @@ replacer_processor:
       contexts: []
     state_name: errors
     storage_key_str: errors
+writer_options:
+  input_format_skip_unknown_fields: 1
 stream_loader:
   processor: ErrorsProcessor
   default_topic: events

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -343,6 +343,9 @@ class TableWriter:
         """
         return self.__replacer_processor
 
+    def get_writer_options(self) -> ClickhouseWriterOptions:
+        return self.__writer_options
+
     def __update_writer_options(
         self,
         options: ClickhouseWriterOptions = None,


### PR DESCRIPTION
This will allow the consumer to insert fields that don't exist in the tables yet. This is needed for
adding a new field to a Nested column.

This is brought back from https://github.com/getsentry/snuba/pull/6788. There is a bug fix to ensure the types of the writer options.