### PR TITLE
ref(ci): test_distributed only runs clickhouse_db tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,13 +207,20 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        snuba_settings:
-          [
-            "test",
-            "test_rust",
-            "test_distributed",
-            "test_distributed_migrations",
-          ]
+        include:
+          - snuba_settings: test
+            docker_target: snuba-test
+          - snuba_settings: test_rust
+            docker_target: snuba-test-rust
+          - snuba_settings: test_distributed
+            docker_target: snuba-test
+            pytest_addopts: '-m clickhouse_db'
+          - snuba_settings: test_distributed_migrations
+            docker_target: snuba-test
+            pytest_addopts: '-m clickhouse_db'
+          - snuba_settings: test
+            docker_target: snuba-test
+            pytest_addopts: test_initialization
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -233,26 +240,16 @@ jobs:
         run: |
           docker network create --attachable cloudbuild
 
-      - name: Docker Snuba Rust tests
-        run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-rust
-        if: ${{ matrix.snuba_settings == 'test_rust' }}
-
       - name: Docker Snuba tests
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
-        if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm -e 'PYTEST_ADDOPTS=${{ matrix.pytest_addopts }}' ${{ matrix.docker_target }}
+        if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings == 'test_distributed' || matrix.snuba_settings == 'test_rust' }}
 
       - name: Docker Snuba Multi-Node Tests
         run: |
           SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml up -d
           SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test_distributed_migrations' }}
-
-      - name: Docker Snuba Init Tests
-        run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.sha }} SNUBA_SETTINGS=test_initialization TEST_LOCATION=test_initialization docker compose -f docker-compose.gcb.yml run --rm snuba-test
-        if: ${{ matrix.snuba_settings == 'test' }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}


### PR DESCRIPTION
All of our tests are segmented by whether they need clickhouse to run or not. All the tests that do not need clickhouse don't need to be re-run in test_distributed.

Also refactor test matrix so we have fewer conditional steps.
