### PR TITLE
hotfix(ci): Fix missing image sha output

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -40,9 +40,6 @@ jobs:
           "${args[@]}" \
           .
 
-    - run: |
-        echo 'image_tag=ghcr.io/getsentry/snuba:${{ github.sha }}' >> "$GITHUB_OUTPUT"
-
   publish-to-dockerhub:
     needs: build
     name: Publish Snuba to DockerHub
@@ -53,7 +50,7 @@ jobs:
       - name: Pull the test image
         id: image_pull
         env:
-          IMAGE_URL: ${{ needs.build.outputs.image_tag }}
+          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
         shell: bash
         run: |
           docker pull "$IMAGE_URL"
@@ -72,7 +69,7 @@ jobs:
         shell: bash
         env:
           SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
-          IMAGE_URL: ${{ needs.build.outputs.image_tag }}
+          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
         run: |
           # only login if the password is set
           if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
@@ -97,5 +94,5 @@ jobs:
         uses: getsentry/self-hosted@master
         with:
           project_name: snuba
-          image_url: ${{ needs.build.outputs.image_tag }}
+          image_url: ghcr.io/getsentry/snuba:${{ github.sha }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
 jobs:
   build:
+    outputs:
+      image_tag: ${{ steps.get_image_tag.image_tag }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -40,8 +42,8 @@ jobs:
           "${args[@]}" \
           .
 
-    - run: |
-        echo 'image_tag=ghcr.io/getsentry/snuba:${{ github.sha }}' >> "$GITHUB_OUTPUT"
+    - id: get_image_tag
+      run: echo 'image_tag=ghcr.io/getsentry/snuba:${{ github.sha }}' >> "$GITHUB_OUTPUT"
 
   publish-to-dockerhub:
     needs: build

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -40,6 +40,9 @@ jobs:
           "${args[@]}" \
           .
 
+    - run: |
+        echo 'image_tag=ghcr.io/getsentry/snuba:${{ github.sha }}' >> "$GITHUB_OUTPUT"
+
   publish-to-dockerhub:
     needs: build
     name: Publish Snuba to DockerHub
@@ -50,7 +53,7 @@ jobs:
       - name: Pull the test image
         id: image_pull
         env:
-          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
+          IMAGE_URL: ${{ needs.build.outputs.image_tag }}
         shell: bash
         run: |
           docker pull "$IMAGE_URL"
@@ -69,7 +72,7 @@ jobs:
         shell: bash
         env:
           SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
-          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
+          IMAGE_URL: ${{ needs.build.outputs.image_tag }}
         run: |
           # only login if the password is set
           if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
@@ -94,5 +97,5 @@ jobs:
         uses: getsentry/self-hosted@master
         with:
           project_name: snuba
-          image_url: ghcr.io/getsentry/snuba:${{ github.sha }}
+          image_url: ${{ needs.build.outputs.image_tag }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The output of the build job has not been properly declared. ~Instead of
getting it to work, let's just hardcode the image, it's actually
simpler.~ It turns out that the e2e-test job does not have access to the right github.sha for some reason, probably because it doesn't check out the snuba repo?