### PR TITLE
hotfix(ci): Set image_tag correctly (again)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -56,7 +56,6 @@ jobs:
     needs: build
     name: Publish Snuba to DockerHub
     runs-on: ubuntu-20.04
-    if: ${{ (github.ref_name == 'master') }}
     steps:
       - uses: actions/checkout@v4 # v3.1.0
       - name: Pull the test image
@@ -78,6 +77,7 @@ jobs:
             echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           fi
       - name: Push built docker image
+        if: ${{ (github.ref_name == 'master') }}
         shell: bash
         env:
           SHORT_SHA: ${{ steps.short_sha.outputs.sha }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build:
     outputs:
-      image_tag: ${{ steps.get_image_tag.image_tag }}
+      image_tag: ${{ steps.get_image_tag.outputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -21,15 +21,23 @@ jobs:
       run: |
         set -euxo pipefail
 
+        args=()
+
         if [ ${{ github.event_name }} = 'push' ]; then
-          args=(
+          args+=(
             --tag ghcr.io/getsentry/snuba:latest
             --tag ghcr.io/getsentry/snuba:amd64-latest
             --cache-to type=registry,ref=ghcr.io/getsentry/snuba:buildcache,mode=max
             --push
           )
-        else
-          args=()
+        fi
+
+        if [ ${{ github.event.pull_request.head.repo.full_name }} = ${{ github.repository }} ]; then
+          # TODO: we should use github artifacts to send images between jobs, like in ci.yml
+          # otherwise third-party PRs will break
+          args+=(
+            --push
+          )
         fi
 
         docker buildx build \

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,7 +13,6 @@ jobs:
     - run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
       env:
         GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event_name != 'pull_request'
 
     - run: docker buildx create --driver docker-container --use
 


### PR DESCRIPTION
It seems that image_tag was silently empty, which causes the e2e tests
to pull snuba master for testing.

meanwhile pushing to dockerhub fails on master.
