### PR TITLE
chore: Allow 2h and 4h granularities in timeseries RPC

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -23,7 +23,9 @@ _VALID_GRANULARITY_SECS = set(
         15 * 60,
         30 * 60,  # minutes
         1 * 3600,
+        2 * 3600,
         3 * 3600,
+        4 * 3600,
         12 * 3600,
         24 * 3600,  # hours
     ]


### PR DESCRIPTION
Our other alerts support 2h and 4h time intervals, so for UX consistency 
we'd like to allowlist those granularities for EAP alerts

closes https://github.com/orgs/getsentry/projects/284?pane=issue&itemId=94947565