### PR TITLE
fix(inc-1013): account for explicitly None fields in contexts

### DIFF
--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -177,26 +177,26 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
     def _process_contexts(
         self, event_data: IssueEventData, processed: MutableMapping[str, Any]
     ) -> None:
-        contexts = event_data.get("contexts", {})
+        contexts = event_data.get("contexts", {}) or {}
 
         processed["contexts.key"], processed["contexts.value"] = extract_extra_contexts(
             contexts
         )
 
         # promote fields within contexts to a top-level column
-        trace = contexts.get("trace", {})
+        trace = contexts.get("trace", {}) or {}
         if trace.get("trace_id") is not None:
             trace_id = _unicodify(trace["trace_id"])
             if trace_id is not None:
                 processed["trace_id"] = ensure_uuid(trace_id)
 
-        profile = contexts.get("profile", {})
+        profile = contexts.get("profile", {}) or {}
         if profile.get("profile_id") is not None:
             profile_id = _unicodify(profile["profile_id"])
             if profile_id is not None:
                 processed["profile_id"] = ensure_uuid(profile_id)
 
-        replay = contexts.get("replay", {})
+        replay = contexts.get("replay", {}) or {}
         if replay.get("replay_id") is not None:
             replay_id = _unicodify(replay["replay_id"])
             if replay_id is not None:

--- a/tests/datasets/test_search_issues_processor.py
+++ b/tests/datasets/test_search_issues_processor.py
@@ -253,6 +253,23 @@ class TestSearchIssuesMessageProcessor:
         assert "sdk_name" in insert_row and insert_row["sdk_name"] == "python"
         assert "sdk_version" in insert_row and insert_row["sdk_version"] == "1.2.3"
 
+    def test_extract_context_null_dicts(self, message_base):
+        message_base["data"]["contexts"] = {
+            "trace": None,
+            "profile": None,
+            "replay": None,
+            "scalar": {"string": "scalar_value"},
+        }
+        processed = self.process_message(message_base)
+        self.assert_required_columns(processed)
+        insert_row = processed.rows[0]
+        assert "contexts.key" in insert_row and insert_row["contexts.key"] == [
+            "scalar.string"
+        ]
+        assert "contexts.value" in insert_row and insert_row["contexts.value"] == [
+            "scalar_value"
+        ]
+
     def test_extract_context_filters_non_dict(self, message_base):
         message_base["data"]["contexts"] = {
             "string": "blah",


### PR DESCRIPTION
In the logs of the consumer:

```
 if profile.get("profile_id") is not None:
^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

This means that the profile value was explicitly set to None in the payload. make the context handling account for that case
