### PR TITLE
fix: bug with translation of key in exists filter

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -357,7 +357,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
     if item_filter.HasField("exists_filter"):
         k = item_filter.exists_filter.key
         if k.name in NORMALIZED_COLUMNS.keys():
-            return f.isNotNull(column(k.name))
+            return f.isNotNull(attribute_key_to_expression(k))
         if k.type == AttributeKey.Type.TYPE_STRING:
             return f.mapContains(column("attr_str"), literal(k.name))
         else:


### PR DESCRIPTION
if you have the following filter in your `TraceItemTableRequest`
`exists(sentry.duration_ms)`
it will get translated to `isNotNull(sentry.duration_ms)`
which causes a clickhouse error bc that column doesnt actually exists, everywhere else is is translated to `duration_ms AS sentry.duration_ms`

so this PR fixes that bug by translating these special columns properly by using the `attribute_key_to_expression` function that is used everywhere else.

honestly I dont know many internal details of this function so im slightly worried that there will be edge cases that could break things. but based on the name of the function and how i see it used elsewhere in the codebase, I will assume that if the tests pass with this change then its fine.

this bug is blocking https://github.com/getsentry/snuba/pull/6817