### PR TITLE
chore(tests): Fix the time for optimize test

### DIFF
--- a/tests/clickhouse/optimize/test_optimize_scheduler.py
+++ b/tests/clickhouse/optimize/test_optimize_scheduler.py
@@ -232,14 +232,15 @@ def test_get_next_schedule(
 
 
 def test_get_next_schedule_raises_exception() -> None:
-    optimize_scheduler = OptimizeScheduler(default_parallel_threads=1)
-    with time_machine.travel(
-        last_midnight
-        + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)
-        + timedelta(minutes=20),
-        tick=False,
-    ):
-        with pytest.raises(OptimizedSchedulerTimeout):
-            optimize_scheduler.get_next_schedule(
-                ["(90,'2022-03-28')", "(90,'2022-03-21')"]
-            )
+    with time_machine.travel(last_midnight, tick=False):
+        optimize_scheduler = OptimizeScheduler(default_parallel_threads=1)
+        with time_machine.travel(
+            last_midnight
+            + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)
+            + timedelta(minutes=20),
+            tick=False,
+        ):
+            with pytest.raises(OptimizedSchedulerTimeout):
+                optimize_scheduler.get_next_schedule(
+                    ["(90,'2022-03-28')", "(90,'2022-03-21')"]
+                )


### PR DESCRIPTION
The initial OptimizeScheduler instance could be created on a day's boundary. Fix the time so that the test always runs with the same parameters everytime.

Resolves https://github.com/getsentry/snuba/issues/6829.