### PR TITLE
fix(eap-api): `equal`, `not equal`, `in`, `not in` ignoring case

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -291,7 +291,11 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             case "val_bool":
                 v_expression: Expression = literal(v.val_bool)
             case "val_str":
-                v_expression = literal(v.val_str)
+                v_expression = (
+                    literal(v.val_str.lower())
+                    if item_filter.comparison_filter.ignore_case
+                    else literal(v.val_str)
+                )
             case "val_float":
                 v_expression = literal(v.val_float)
             case "val_double":

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -354,17 +354,21 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
         if op == ComparisonFilter.OP_IN:
-            return (
-                in_cond(f.lower(k_expression), f.lower(v_expression))
-                if item_filter.comparison_filter.ignore_case
-                else in_cond(k_expression, v_expression)
-            )
+            if item_filter.comparison_filter.ignore_case:
+                k_expression = f.lower(k_expression)
+                v_expression = literals_array(
+                    None,
+                    list(map(lambda x: literal(x.lower()), v.val_str_array.values)),
+                )
+            return in_cond(k_expression, v_expression)
         if op == ComparisonFilter.OP_NOT_IN:
-            return (
-                not_cond(in_cond(f.lower(k_expression), f.lower(v_expression)))
-                if item_filter.comparison_filter.ignore_case
-                else not_cond(in_cond(k_expression, v_expression))
-            )
+            if item_filter.comparison_filter.ignore_case:
+                k_expression = f.lower(k_expression)
+                v_expression = literals_array(
+                    None,
+                    list(map(lambda x: literal(x.lower()), v.val_str_array.values)),
+                )
+            return not_cond(in_cond(k_expression, v_expression))
 
         raise BadSnubaRPCRequestException(
             f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -291,11 +291,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             case "val_bool":
                 v_expression: Expression = literal(v.val_bool)
             case "val_str":
-                v_expression = (
-                    literal(v.val_str.lower())
-                    if item_filter.comparison_filter.ignore_case
-                    else literal(v.val_str)
-                )
+                v_expression = literal(v.val_str)
             case "val_float":
                 v_expression = literal(v.val_float)
             case "val_double":
@@ -326,9 +322,17 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 )
 
         if op == ComparisonFilter.OP_EQUALS:
-            return f.equals(k_expression, v_expression)
+            return (
+                f.equals(f.lower(k_expression), f.lower(v_expression))
+                if item_filter.comparison_filter.ignore_case
+                else f.equals(k_expression, v_expression)
+            )
         if op == ComparisonFilter.OP_NOT_EQUALS:
-            return f.notEquals(k_expression, v_expression)
+            return (
+                f.notEquals(f.lower(k_expression), f.lower(v_expression))
+                if item_filter.comparison_filter.ignore_case
+                else f.notEquals(k_expression, v_expression)
+            )
         if op == ComparisonFilter.OP_LIKE:
             if k.type != AttributeKey.Type.TYPE_STRING:
                 raise BadSnubaRPCRequestException(
@@ -350,9 +354,17 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
         if op == ComparisonFilter.OP_IN:
-            return in_cond(k_expression, v_expression)
+            return (
+                in_cond(f.lower(k_expression), f.lower(v_expression))
+                if item_filter.comparison_filter.ignore_case
+                else in_cond(k_expression, v_expression)
+            )
         if op == ComparisonFilter.OP_NOT_IN:
-            return not_cond(in_cond(k_expression, v_expression))
+            return (
+                not_cond(in_cond(f.lower(k_expression), f.lower(v_expression)))
+                if item_filter.comparison_filter.ignore_case
+                else not_cond(in_cond(k_expression, v_expression))
+            )
 
         raise BadSnubaRPCRequestException(
             f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"

--- a/snuba/web/rpc/v1/resolvers/R_ourlogs/common/trace_item_filters_to_expression.py
+++ b/snuba/web/rpc/v1/resolvers/R_ourlogs/common/trace_item_filters_to_expression.py
@@ -119,17 +119,21 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
         if op == ComparisonFilter.OP_IN:
-            return (
-                in_cond(f.lower(k_expression), f.lower(v_expression))
-                if item_filter.comparison_filter.ignore_case
-                else in_cond(k_expression, v_expression)
-            )
+            if item_filter.comparison_filter.ignore_case:
+                k_expression = f.lower(k_expression)
+                v_expression = literals_array(
+                    None,
+                    list(map(lambda x: literal(x.lower()), v.val_str_array.values)),
+                )
+            return in_cond(k_expression, v_expression)
         if op == ComparisonFilter.OP_NOT_IN:
-            return (
-                not_cond(in_cond(f.lower(k_expression), f.lower(v_expression)))
-                if item_filter.comparison_filter.ignore_case
-                else not_cond(in_cond(k_expression, v_expression))
-            )
+            if item_filter.comparison_filter.ignore_case:
+                k_expression = f.lower(k_expression)
+                v_expression = literals_array(
+                    None,
+                    list(map(lambda x: literal(x.lower()), v.val_str_array.values)),
+                )
+            return not_cond(in_cond(k_expression, v_expression))
 
         raise BadSnubaRPCRequestException(
             f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"

--- a/snuba/web/rpc/v1/resolvers/R_ourlogs/common/trace_item_filters_to_expression.py
+++ b/snuba/web/rpc/v1/resolvers/R_ourlogs/common/trace_item_filters_to_expression.py
@@ -15,6 +15,7 @@ from snuba.query.dsl import (
     or_cond,
 )
 from snuba.query.expressions import Expression
+from snuba.web.rpc.common.common import _check_non_string_values_cannot_ignore_case
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.resolvers.R_ourlogs.common.attribute_key_to_expression import (
     attribute_key_to_expression,
@@ -87,12 +88,14 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 )
 
         if op == ComparisonFilter.OP_EQUALS:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             return (
                 f.equals(f.lower(k_expression), f.lower(v_expression))
                 if item_filter.comparison_filter.ignore_case
                 else f.equals(k_expression, v_expression)
             )
         if op == ComparisonFilter.OP_NOT_EQUALS:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             return (
                 f.notEquals(f.lower(k_expression), f.lower(v_expression))
                 if item_filter.comparison_filter.ignore_case
@@ -119,6 +122,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
         if op == ComparisonFilter.OP_IN:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             if item_filter.comparison_filter.ignore_case:
                 k_expression = f.lower(k_expression)
                 v_expression = literals_array(
@@ -127,6 +131,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 )
             return in_cond(k_expression, v_expression)
         if op == ComparisonFilter.OP_NOT_IN:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             if item_filter.comparison_filter.ignore_case:
                 k_expression = f.lower(k_expression)
                 v_expression = literals_array(

--- a/snuba/web/rpc/v1/resolvers/R_ourlogs/common/trace_item_filters_to_expression.py
+++ b/snuba/web/rpc/v1/resolvers/R_ourlogs/common/trace_item_filters_to_expression.py
@@ -62,7 +62,11 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             case "val_bool":
                 v_expression: Expression = literal(v.val_bool)
             case "val_str":
-                v_expression = literal(v.val_str)
+                v_expression = (
+                    literal(v.val_str.lower())
+                    if item_filter.comparison_filter.ignore_case
+                    else literal(v.val_str)
+                )
             case "val_float":
                 v_expression = literal(v.val_float)
             case "val_int":

--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
@@ -244,7 +244,11 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             case "val_bool":
                 v_expression: Expression = literal(v.val_bool)
             case "val_str":
-                v_expression = literal(v.val_str)
+                v_expression = (
+                    literal(v.val_str.lower())
+                    if item_filter.comparison_filter.ignore_case
+                    else literal(v.val_str)
+                )
             case "val_float":
                 v_expression = literal(v.val_float)
             case "val_double":

--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
@@ -279,9 +279,17 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 )
 
         if op == ComparisonFilter.OP_EQUALS:
-            return f.equals(k_expression, v_expression)
+            return (
+                f.equals(f.lower(k_expression), f.lower(v_expression))
+                if item_filter.comparison_filter.ignore_case
+                else f.equals(k_expression, v_expression)
+            )
         if op == ComparisonFilter.OP_NOT_EQUALS:
-            return f.notEquals(k_expression, v_expression)
+            return (
+                f.notEquals(f.lower(k_expression), f.lower(v_expression))
+                if item_filter.comparison_filter.ignore_case
+                else f.notEquals(k_expression, v_expression)
+            )
         if op == ComparisonFilter.OP_LIKE:
             if k.type != AttributeKey.Type.TYPE_STRING:
                 raise BadSnubaRPCRequestException(
@@ -303,9 +311,17 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
         if op == ComparisonFilter.OP_IN:
-            return in_cond(k_expression, v_expression)
+            return (
+                in_cond(f.lower(k_expression), f.lower(v_expression))
+                if item_filter.comparison_filter.ignore_case
+                else in_cond(k_expression, v_expression)
+            )
         if op == ComparisonFilter.OP_NOT_IN:
-            return not_cond(in_cond(k_expression, v_expression))
+            return (
+                not_cond(in_cond(f.lower(k_expression), f.lower(v_expression)))
+                if item_filter.comparison_filter.ignore_case
+                else not_cond(in_cond(k_expression, v_expression))
+            )
 
         raise BadSnubaRPCRequestException(
             f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"

--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
@@ -24,6 +24,7 @@ from snuba.query.dsl import (
     or_cond,
 )
 from snuba.query.expressions import Expression, FunctionCall, SubscriptableReference
+from snuba.web.rpc.common.common import _check_non_string_values_cannot_ignore_case
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 
 
@@ -275,12 +276,14 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 )
 
         if op == ComparisonFilter.OP_EQUALS:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             return (
                 f.equals(f.lower(k_expression), f.lower(v_expression))
                 if item_filter.comparison_filter.ignore_case
                 else f.equals(k_expression, v_expression)
             )
         if op == ComparisonFilter.OP_NOT_EQUALS:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             return (
                 f.notEquals(f.lower(k_expression), f.lower(v_expression))
                 if item_filter.comparison_filter.ignore_case
@@ -307,6 +310,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
         if op == ComparisonFilter.OP_IN:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             if item_filter.comparison_filter.ignore_case:
                 k_expression = f.lower(k_expression)
                 v_expression = literals_array(
@@ -315,6 +319,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
                 )
             return in_cond(k_expression, v_expression)
         if op == ComparisonFilter.OP_NOT_IN:
+            _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
             if item_filter.comparison_filter.ignore_case:
                 k_expression = f.lower(k_expression)
                 v_expression = literals_array(

--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/common/common.py
@@ -244,11 +244,7 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
             case "val_bool":
                 v_expression: Expression = literal(v.val_bool)
             case "val_str":
-                v_expression = (
-                    literal(v.val_str.lower())
-                    if item_filter.comparison_filter.ignore_case
-                    else literal(v.val_str)
-                )
+                v_expression = literal(v.val_str)
             case "val_float":
                 v_expression = literal(v.val_float)
             case "val_double":
@@ -311,17 +307,21 @@ def trace_item_filters_to_expression(item_filter: TraceItemFilter) -> Expression
         if op == ComparisonFilter.OP_GREATER_THAN_OR_EQUALS:
             return f.greaterOrEquals(k_expression, v_expression)
         if op == ComparisonFilter.OP_IN:
-            return (
-                in_cond(f.lower(k_expression), f.lower(v_expression))
-                if item_filter.comparison_filter.ignore_case
-                else in_cond(k_expression, v_expression)
-            )
+            if item_filter.comparison_filter.ignore_case:
+                k_expression = f.lower(k_expression)
+                v_expression = literals_array(
+                    None,
+                    list(map(lambda x: literal(x.lower()), v.val_str_array.values)),
+                )
+            return in_cond(k_expression, v_expression)
         if op == ComparisonFilter.OP_NOT_IN:
-            return (
-                not_cond(in_cond(f.lower(k_expression), f.lower(v_expression)))
-                if item_filter.comparison_filter.ignore_case
-                else not_cond(in_cond(k_expression, v_expression))
-            )
+            if item_filter.comparison_filter.ignore_case:
+                k_expression = f.lower(k_expression)
+                v_expression = literals_array(
+                    None,
+                    list(map(lambda x: literal(x.lower()), v.val_str_array.values)),
+                )
+            return not_cond(in_cond(k_expression, v_expression))
 
         raise BadSnubaRPCRequestException(
             f"Invalid string comparison, unknown op: {item_filter.comparison_filter}"

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -521,3 +521,76 @@ class TestGetTraces(BaseApiTest):
             meta=ResponseMeta(request_id=_REQUEST_ID),
         )
         assert MessageToDict(response) == MessageToDict(expected_response)
+
+    def test_with_data_and_aggregated_fields_ignore_case(
+        self, setup_teardown: Any
+    ) -> None:
+        ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))
+        three_hours_later = int((_BASE_TIME + timedelta(hours=3)).timestamp())
+        start_timestamp_per_trace_id: dict[str, float] = defaultdict(lambda: 2 * 1e10)
+        for s in _SPANS:
+            start_timestamp_per_trace_id[s["trace_id"]] = min(
+                start_timestamp_per_trace_id[s["trace_id"]],
+                s["start_timestamp_precise"],
+            )
+        trace_id_per_start_timestamp: dict[float, str] = {
+            timestamp: trace_id
+            for trace_id, timestamp in start_timestamp_per_trace_id.items()
+        }
+        message = GetTracesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=ts,
+                end_timestamp=Timestamp(seconds=three_hours_later),
+                request_id=_REQUEST_ID,
+            ),
+            attributes=[
+                TraceAttribute(
+                    key=TraceAttribute.Key.KEY_START_TIMESTAMP,
+                    type=AttributeKey.TYPE_DOUBLE,
+                ),
+            ],
+            filters=[
+                GetTracesRequest.TraceFilter(
+                    item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                    filter=TraceItemFilter(
+                        comparison_filter=ComparisonFilter(
+                            key=AttributeKey(
+                                name="sentry.op",
+                                type=AttributeKey.TYPE_STRING,
+                            ),
+                            op=ComparisonFilter.OP_EQUALS,
+                            value=AttributeValue(val_str="DB"),
+                            ignore_case=True,
+                        ),
+                    ),
+                ),
+            ],
+        )
+        response = EndpointGetTraces().execute(message)
+        expected_response = GetTracesResponse(
+            traces=[
+                GetTracesResponse.Trace(
+                    attributes=[
+                        TraceAttribute(
+                            key=TraceAttribute.Key.KEY_START_TIMESTAMP,
+                            type=AttributeKey.TYPE_DOUBLE,
+                            value=AttributeValue(
+                                val_double=start_timestamp_per_trace_id[
+                                    trace_id_per_start_timestamp[start_timestamp]
+                                ],
+                            ),
+                        ),
+                    ],
+                )
+                for start_timestamp in reversed(
+                    sorted(trace_id_per_start_timestamp.keys())
+                )
+            ],
+            page_token=PageToken(offset=len(_TRACE_IDS)),
+            meta=ResponseMeta(request_id=_REQUEST_ID),
+        )
+        assert MessageToDict(response) == MessageToDict(expected_response)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -616,7 +616,7 @@ class TestTimeSeriesApi(BaseApiTest):
             1,
             3600,
             metrics=[DummyMetric("test_metric", get_value=lambda x: 1)],
-            tags={"customer": "bob"},
+            tags={"customer": "bOb"},
         )
 
         store_spans_timeseries(
@@ -624,7 +624,7 @@ class TestTimeSeriesApi(BaseApiTest):
             1,
             3600,
             metrics=[DummyMetric("test_metric", get_value=lambda x: 999)],
-            tags={"customer": "alice"},
+            tags={"customer": "aLiCe"},
         )
 
         message = TimeSeriesRequest(
@@ -663,7 +663,7 @@ class TestTimeSeriesApi(BaseApiTest):
                                     type=AttributeKey.TYPE_STRING, name="customer"
                                 ),
                                 op=ComparisonFilter.OP_EQUALS,
-                                value=AttributeValue(val_str="bOb"),
+                                value=AttributeValue(val_str="BoB"),
                                 ignore_case=True,
                             )
                         ),
@@ -674,7 +674,7 @@ class TestTimeSeriesApi(BaseApiTest):
                                 ),
                                 op=ComparisonFilter.OP_IN,
                                 value=AttributeValue(
-                                    val_str_array=StrArray(values=["bob", "ALICE"])
+                                    val_str_array=StrArray(values=["BOB", "AlIcE"])
                                 ),
                                 ignore_case=True,
                             )


### PR DESCRIPTION
https://github.com/getsentry/eap-planning/issues/127

The ticket asks for ignoring case for the values, not the keys themselves
1. equality on keys: "span.op" = "SPAN.OP" <-- we don't support this
2. equality on values: if span.op is pageload, then "pageload" = "PAGELOAD" <-- we support this