### PR TITLE
chore(eap): Trim time range if going over 30 days

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -131,7 +131,7 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
             if (end - start).days > MAXIMUM_TIME_RANGE_IN_DAYS:
                 timestamp = Timestamp()
                 timestamp.FromDatetime(end - timedelta(days=MAXIMUM_TIME_RANGE_IN_DAYS))
-                in_msg.meta.start_timestamp.CopyFrom(timestamp)  # type: ignore
+                in_msg.meta.start_timestamp.CopyFrom(timestamp)
         try:
             out = self._execute(in_msg)
         except Exception as e:

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -121,10 +121,13 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
             span.description = self.config_key()
         self.__before_execute(in_msg)
         error = None
-        meta = getattr(in_msg, "meta", None)
-        if meta:
-            start = meta.start_timestamp.ToDatetime()
-            end = meta.end_timestamp.ToDatetime()
+        if (
+            hasattr(in_msg, "meta")
+            and hasattr(in_msg.meta, "start_timestamp")
+            and hasattr(in_msg.meta, "end_timestamp")
+        ):
+            start = in_msg.meta.start_timestamp.ToDatetime()
+            end = in_msg.meta.end_timestamp.ToDatetime()
             if (end - start).days > MAXIMUM_TIME_RANGE_IN_DAYS:
                 timestamp = Timestamp()
                 timestamp.FromDatetime(end - timedelta(days=MAXIMUM_TIME_RANGE_IN_DAYS))

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -128,7 +128,7 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
             if (end - start).days > MAXIMUM_TIME_RANGE_IN_DAYS:
                 timestamp = Timestamp()
                 timestamp.FromDatetime(end - timedelta(days=MAXIMUM_TIME_RANGE_IN_DAYS))
-                in_msg.meta.start_timestamp.CopyFrom(timestamp)
+                in_msg.meta.start_timestamp.CopyFrom(timestamp)  # type: ignore
         try:
             out = self._execute(in_msg)
         except Exception as e:

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -125,7 +125,7 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         if meta:
             start = meta.start_timestamp.ToDatetime()
             end = meta.end_timestamp.ToDatetime()
-            if (end - start).days > 30:
+            if (end - start).days > MAXIMUM_TIME_RANGE_IN_DAYS:
                 timestamp = Timestamp()
                 timestamp.FromDatetime(end - timedelta(days=MAXIMUM_TIME_RANGE_IN_DAYS))
                 in_msg.meta.start_timestamp.CopyFrom(timestamp)

--- a/tests/web/rpc/test_base.py
+++ b/tests/web/rpc/test_base.py
@@ -1,4 +1,3 @@
-import random
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -133,15 +132,10 @@ _BASE_TIME = datetime.now(tz=UTC).replace(
     second=0,
     microsecond=0,
 )
-_REQUEST_ID = uuid.uuid4().hex
-_RELEASE_TAG = "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b"
-_SERVER_NAME = "D23CXQ4GK2.local"
 
 
 def gen_message(
     dt: datetime,
-    measurements: dict[str, dict[str, float]] | None = None,
-    tags: dict[str, str] | None = None,
 ) -> Mapping[str, Any]:
     return {
         "description": "/api/0/relays/projectconfigs/",
@@ -149,65 +143,15 @@ def gen_message(
         "event_id": "d826225de75d42d6b2f01b957d51f18f",
         "exclusive_time_ms": 0.228,
         "is_segment": True,
-        "data": {
-            "sentry.environment": "development",
-            "sentry.release": _RELEASE_TAG,
-            "thread.name": "uWSGIWorker1Core0",
-            "thread.id": "8522009600",
-            "sentry.segment.name": "/api/0/relays/projectconfigs/",
-            "sentry.sdk.name": "sentry.python.django",
-            "sentry.sdk.version": "2.7.0",
-            "my.float.field": 101.2,
-            "my.int.field": 2000,
-            "my.neg.field": -100,
-            "my.neg.float.field": -101.2,
-            "my.true.bool.field": True,
-            "my.false.bool.field": False,
-        },
-        "measurements": {
-            "num_of_spans": {"value": 50.0},
-            "eap.measurement": {"value": random.choice([1, 100, 1000])},
-        },
         "organization_id": 1,
         "origin": "auto.http.django",
         "project_id": 1,
         "received": 1721319572.877828,
         "retention_days": 90,
         "segment_id": "8873a98879faf06d",
-        "sentry_tags": {
-            "category": "http",
-            "environment": "development",
-            "op": "http.server",
-            "platform": "python",
-            "release": _RELEASE_TAG,
-            "sdk.name": "sentry.python.django",
-            "sdk.version": "2.7.0",
-            "status": "ok",
-            "status_code": "200",
-            "thread.id": "8522009600",
-            "thread.name": "uWSGIWorker1Core0",
-            "trace.status": "ok",
-            "transaction": "/api/0/relays/projectconfigs/",
-            "transaction.method": "POST",
-            "transaction.op": "http.server",
-            "user": "ip:127.0.0.1",
-        },
         "span_id": "123456781234567D",
-        "tags": {
-            "http.status_code": "200",
-            "relay_endpoint_version": "3",
-            "relay_id": "88888888-4444-4444-8444-cccccccccccc",
-            "relay_no_cache": "False",
-            "relay_protocol_version": "3",
-            "relay_use_post_or_schedule": "True",
-            "relay_use_post_or_schedule_rejected": "version",
-            "server_name": _SERVER_NAME,
-            "spans_over_limit": "False",
-            "color": random.choice(["red", "green", "blue"]),
-            "location": random.choice(["mobile", "frontend", "backend"]),
-        },
         "trace_id": uuid.uuid4().hex,
-        "start_timestamp_ms": int(dt.timestamp()) * 1000 - int(random.gauss(1000, 200)),
+        "start_timestamp_ms": int(dt.timestamp() * 1000),
         "start_timestamp_precise": dt.timestamp(),
         "end_timestamp_precise": dt.timestamp() + 1,
     }

--- a/tests/web/rpc/test_base.py
+++ b/tests/web/rpc/test_base.py
@@ -1,11 +1,28 @@
+import random
 import time
-from typing import Type
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any, Mapping, Type
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
-from snuba.web.rpc import RPCEndpoint, list_all_endpoint_names
+from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.web.rpc import (
+    MAXIMUM_TIME_RANGE_IN_DAYS,
+    RPCEndpoint,
+    list_all_endpoint_names,
+)
+from snuba.web.rpc.v1.endpoint_trace_item_table import EndpointTraceItemTable
 from tests.backends.metrics import TestingMetricsBackend
+from tests.helpers import write_raw_unprocessed_events
 
 
 class RPCException(Exception):
@@ -83,7 +100,9 @@ def test_metrics() -> None:
     ]
 
     metric_names_to_metric = {m.name: m for m in metrics_backend.calls}  # type: ignore
-    assert metric_names_to_metric["rpc.endpoint_timing"].value == pytest.approx(MyRPC.duration_millis, rel=10)  # type: ignore
+    assert metric_names_to_metric["rpc.endpoint_timing"].value == pytest.approx(
+        MyRPC.duration_millis, rel=10
+    )  # type: ignore
     assert metric_names_to_metric["rpc.request_success"].value == 1  # type: ignore
 
 
@@ -107,3 +126,128 @@ def test_list_all_endpoint_names() -> None:
     assert isinstance(endpoint_names, list)
     assert ("MyRPC", "v1") in endpoint_names
     assert ("ErrorRPC", "v1") in endpoint_names
+
+
+_BASE_TIME = datetime.now(tz=UTC).replace(
+    minute=0,
+    second=0,
+    microsecond=0,
+)
+_REQUEST_ID = uuid.uuid4().hex
+_RELEASE_TAG = "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b"
+_SERVER_NAME = "D23CXQ4GK2.local"
+
+
+def gen_message(
+    dt: datetime,
+    measurements: dict[str, dict[str, float]] | None = None,
+    tags: dict[str, str] | None = None,
+) -> Mapping[str, Any]:
+    return {
+        "description": "/api/0/relays/projectconfigs/",
+        "duration_ms": 152,
+        "event_id": "d826225de75d42d6b2f01b957d51f18f",
+        "exclusive_time_ms": 0.228,
+        "is_segment": True,
+        "data": {
+            "sentry.environment": "development",
+            "sentry.release": _RELEASE_TAG,
+            "thread.name": "uWSGIWorker1Core0",
+            "thread.id": "8522009600",
+            "sentry.segment.name": "/api/0/relays/projectconfigs/",
+            "sentry.sdk.name": "sentry.python.django",
+            "sentry.sdk.version": "2.7.0",
+            "my.float.field": 101.2,
+            "my.int.field": 2000,
+            "my.neg.field": -100,
+            "my.neg.float.field": -101.2,
+            "my.true.bool.field": True,
+            "my.false.bool.field": False,
+        },
+        "measurements": {
+            "num_of_spans": {"value": 50.0},
+            "eap.measurement": {"value": random.choice([1, 100, 1000])},
+        },
+        "organization_id": 1,
+        "origin": "auto.http.django",
+        "project_id": 1,
+        "received": 1721319572.877828,
+        "retention_days": 90,
+        "segment_id": "8873a98879faf06d",
+        "sentry_tags": {
+            "category": "http",
+            "environment": "development",
+            "op": "http.server",
+            "platform": "python",
+            "release": _RELEASE_TAG,
+            "sdk.name": "sentry.python.django",
+            "sdk.version": "2.7.0",
+            "status": "ok",
+            "status_code": "200",
+            "thread.id": "8522009600",
+            "thread.name": "uWSGIWorker1Core0",
+            "trace.status": "ok",
+            "transaction": "/api/0/relays/projectconfigs/",
+            "transaction.method": "POST",
+            "transaction.op": "http.server",
+            "user": "ip:127.0.0.1",
+        },
+        "span_id": "123456781234567D",
+        "tags": {
+            "http.status_code": "200",
+            "relay_endpoint_version": "3",
+            "relay_id": "88888888-4444-4444-8444-cccccccccccc",
+            "relay_no_cache": "False",
+            "relay_protocol_version": "3",
+            "relay_use_post_or_schedule": "True",
+            "relay_use_post_or_schedule_rejected": "version",
+            "server_name": _SERVER_NAME,
+            "spans_over_limit": "False",
+            "color": random.choice(["red", "green", "blue"]),
+            "location": random.choice(["mobile", "frontend", "backend"]),
+        },
+        "trace_id": uuid.uuid4().hex,
+        "start_timestamp_ms": int(dt.timestamp()) * 1000 - int(random.gauss(1000, 200)),
+        "start_timestamp_precise": dt.timestamp(),
+        "end_timestamp_precise": dt.timestamp() + 1,
+    }
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_trim_time_range() -> None:
+    spans_storage = get_storage(StorageKey("eap_spans"))
+    write_raw_unprocessed_events(
+        spans_storage,
+        [
+            gen_message(
+                dt=_BASE_TIME - timedelta(days=i),
+            )
+            for i in range(90)
+        ],
+    )  # type: ignore
+    ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))
+    ninety_days_before = Timestamp(
+        seconds=int((_BASE_TIME - timedelta(days=90)).timestamp())
+    )
+    message = TraceItemTableRequest(
+        meta=RequestMeta(
+            project_ids=[1],
+            organization_id=1,
+            cogs_category="something",
+            referrer="something",
+            start_timestamp=ninety_days_before,
+            end_timestamp=ts,
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        ),
+        columns=[
+            Column(
+                key=AttributeKey(
+                    type=AttributeKey.TYPE_DOUBLE,
+                    name="sentry.duration_ms",
+                ),
+            )
+        ],
+    )
+    response = EndpointTraceItemTable().execute(message)
+    assert len(response.column_values[0].results) == MAXIMUM_TIME_RANGE_IN_DAYS

--- a/tests/web/rpc/test_base.py
+++ b/tests/web/rpc/test_base.py
@@ -100,9 +100,9 @@ def test_metrics() -> None:
     ]
 
     metric_names_to_metric = {m.name: m for m in metrics_backend.calls}  # type: ignore
-    assert metric_names_to_metric["rpc.endpoint_timing"].value == pytest.approx(
+    assert metric_names_to_metric["rpc.endpoint_timing"].value == pytest.approx(  # type: ignore
         MyRPC.duration_millis, rel=10
-    )  # type: ignore
+    )
     assert metric_names_to_metric["rpc.request_success"].value == 1  # type: ignore
 
 
@@ -218,14 +218,14 @@ def gen_message(
 def test_trim_time_range() -> None:
     spans_storage = get_storage(StorageKey("eap_spans"))
     write_raw_unprocessed_events(
-        spans_storage,
+        spans_storage,  # type: ignore
         [
             gen_message(
                 dt=_BASE_TIME - timedelta(days=i),
             )
             for i in range(90)
         ],
-    )  # type: ignore
+    )
     ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))
     ninety_days_before = Timestamp(
         seconds=int((_BASE_TIME - timedelta(days=90)).timestamp())


### PR DESCRIPTION
We need to trim the time range for the time being since we do receive queries longer than 30 days which we do not want to allow right now.

We trim to the more recent data since our product always queries for the more recent data.

We trim instead of returning an error to not break part of the UI where we can't fix querying for 90 days of data.

This is temporary and will be removed before GA.