### PR TITLE
fix(uptime): add offset to trace item resolver for uptime checks

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_trace_item_table.py
@@ -162,9 +162,12 @@ def _build_query(request: TraceItemTableRequest) -> Query:
         # protobuf sets limit to 0 by default if it is not set,
         # give it a default value that will actually return data
         limit=request.limit if request.limit > 0 else _DEFAULT_ROW_LIMIT,
-        having=aggregation_filter_to_expression(request.aggregation_filter)
-        if request.HasField("aggregation_filter")
-        else None,
+        having=(
+            aggregation_filter_to_expression(request.aggregation_filter)
+            if request.HasField("aggregation_filter")
+            else None
+        ),
+        offset=request.page_token.offset,
     )
     treeify_or_and_conditions(res)
     apply_virtual_columns(res, request.virtual_column_contexts)


### PR DESCRIPTION
seems like we weren't using the request offset for uptime checks. this PR fixes.