### PR TITLE
feat: formula queries in EndpointTraceItemTable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-rapidjson==1.8
 redis==4.5.4
 sentry-arroyo==2.19.12
 sentry-kafka-schemas==0.1.129
-sentry-protos==0.1.57
+sentry-protos==0.1.58
 sentry-redis-tools==0.3.0
 sentry-relay==0.9.5
 sentry-sdk==2.18.0

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
@@ -298,7 +298,7 @@ class ResolverTimeSeriesEAPSpans(ResolverTimeSeries):
         return TraceItemType.TRACE_ITEM_TYPE_SPAN
 
     def resolve(self, in_msg: TimeSeriesRequest) -> TimeSeriesResponse:
-        if in_msg.HasField("expressions"):
+        if len(in_msg.expressions) > 0:
             raise BadSnubaRPCRequestException("expressions field not yet implemented")
 
         snuba_request = _build_snuba_request(in_msg)

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
@@ -37,6 +37,7 @@ from snuba.web.rpc.common.debug_info import (
     extract_response_meta,
     setup_trace_query_settings,
 )
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.resolvers import ResolverTimeSeries
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.aggregation import (
     ExtrapolationContext,
@@ -297,6 +298,9 @@ class ResolverTimeSeriesEAPSpans(ResolverTimeSeries):
         return TraceItemType.TRACE_ITEM_TYPE_SPAN
 
     def resolve(self, in_msg: TimeSeriesRequest) -> TimeSeriesResponse:
+        if in_msg.HasField("expressions"):
+            raise BadSnubaRPCRequestException("expressions field not yet implemented")
+
         snuba_request = _build_snuba_request(in_msg)
         res = run_query(
             dataset=PluggableDataset(name="eap", all_entities=[]),

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -7,6 +7,7 @@ from google.protobuf.json_format import MessageToDict
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     AggregationComparisonFilter,
     AggregationFilter,
+    Column,
     TraceItemColumnValues,
     TraceItemTableRequest,
     TraceItemTableResponse,
@@ -128,6 +129,72 @@ def _convert_order_by(
     return res
 
 
+def _get_reliability_context_columns(column: Column) -> list[SelectedExpression]:
+    """
+    extrapolated aggregates need to request extra columns to calculate the reliability of the result.
+    this function returns the list of columns that need to be requested.
+    """
+    if not column.HasField("aggregation"):
+        return []
+
+    if (
+        column.aggregation.extrapolation_mode
+        == ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED
+    ):
+        context_columns = []
+        confidence_interval_column = get_confidence_interval_column(column.aggregation)
+        if confidence_interval_column is not None:
+            context_columns.append(
+                SelectedExpression(
+                    name=confidence_interval_column.alias,
+                    expression=confidence_interval_column,
+                )
+            )
+
+        average_sample_rate_column = get_average_sample_rate_column(column.aggregation)
+        count_column = get_count_column(column.aggregation)
+        context_columns.append(
+            SelectedExpression(
+                name=average_sample_rate_column.alias,
+                expression=average_sample_rate_column,
+            )
+        )
+        context_columns.append(
+            SelectedExpression(name=count_column.alias, expression=count_column)
+        )
+        return context_columns
+    return []
+
+
+def _column_to_expression(column: Column) -> Expression:
+    """
+    Given a column protobuf object, translates it into a Expression object and returns it.
+    """
+    if column.HasField("key"):
+        return attribute_key_to_expression(column.key)
+    elif column.HasField("aggregation"):
+        function_expr = aggregation_to_expression(column.aggregation)
+        # aggregation label may not be set and the column label takes priority anyways.
+        function_expr = replace(function_expr, alias=column.label)
+        return function_expr
+    elif column.HasField("formula"):
+        op_to_expr = {
+            Column.BinaryFormula.OP_ADD: f.add,
+            Column.BinaryFormula.OP_SUBTRACT: f.subtract,
+            Column.BinaryFormula.OP_MULTIPLY: f.multiply,
+            Column.BinaryFormula.OP_DIVIDE: f.divide,
+        }
+        return op_to_expr[column.formula.op](
+            _column_to_expression(column.formula.left),
+            _column_to_expression(column.formula.right),
+        )
+
+    else:
+        raise BadSnubaRPCRequestException(
+            "Column is not one of: aggregate, attribute key, or formula"
+        )
+
+
 def _build_query(request: TraceItemTableRequest) -> Query:
     # TODO: This is hardcoded still
     entity = Entity(
@@ -138,54 +205,15 @@ def _build_query(request: TraceItemTableRequest) -> Query:
 
     selected_columns = []
     for column in request.columns:
-        if column.HasField("key"):
-            key_col = attribute_key_to_expression(column.key)
-            # The key_col expression alias may differ from the column label. That is okay
-            # the attribute key name is used in the groupby, the column label is just the name of
-            # the returned attribute value
-            selected_columns.append(
-                SelectedExpression(name=column.label, expression=key_col)
+        # The key_col expression alias may differ from the column label. That is okay
+        # the attribute key name is used in the groupby, the column label is just the name of
+        # the returned attribute value
+        selected_columns.append(
+            SelectedExpression(
+                name=column.label, expression=_column_to_expression(column)
             )
-        elif column.HasField("aggregation"):
-            function_expr = aggregation_to_expression(column.aggregation)
-            # aggregation label may not be set and the column label takes priority anyways.
-            function_expr = replace(function_expr, alias=column.label)
-            selected_columns.append(
-                SelectedExpression(name=column.label, expression=function_expr)
-            )
-
-            if (
-                column.aggregation.extrapolation_mode
-                == ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED
-            ):
-                confidence_interval_column = get_confidence_interval_column(
-                    column.aggregation
-                )
-                if confidence_interval_column is not None:
-                    selected_columns.append(
-                        SelectedExpression(
-                            name=confidence_interval_column.alias,
-                            expression=confidence_interval_column,
-                        )
-                    )
-
-                average_sample_rate_column = get_average_sample_rate_column(
-                    column.aggregation
-                )
-                count_column = get_count_column(column.aggregation)
-                selected_columns.append(
-                    SelectedExpression(
-                        name=average_sample_rate_column.alias,
-                        expression=average_sample_rate_column,
-                    )
-                )
-                selected_columns.append(
-                    SelectedExpression(name=count_column.alias, expression=count_column)
-                )
-        else:
-            raise BadSnubaRPCRequestException(
-                "Column is neither an aggregate or an attribute"
-            )
+        )
+        selected_columns.extend(_get_reliability_context_columns(column))
 
     res = Query(
         from_clause=entity,

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -187,6 +187,7 @@ def _column_to_expression(column: Column) -> Expression:
         return op_to_expr[column.formula.op](
             _column_to_expression(column.formula.left),
             _column_to_expression(column.formula.right),
+            alias=column.label,
         )
 
     else:
@@ -283,9 +284,11 @@ def _convert_results(
                 converters[column.label] = lambda x: AttributeValue(val_double=float(x))
         elif column.HasField("aggregation"):
             converters[column.label] = lambda x: AttributeValue(val_double=float(x))
+        elif column.HasField("formula"):
+            converters[column.label] = lambda x: AttributeValue(val_double=float(x))
         else:
             raise BadSnubaRPCRequestException(
-                "column is neither an attribute or aggregation"
+                "column is not one of: attribute, aggregation, or formula"
             )
 
     res: defaultdict[str, TraceItemColumnValues] = defaultdict(TraceItemColumnValues)

--- a/snuba/web/rpc/v1/resolvers/R_ourlogs/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_ourlogs/resolver_trace_item_table.py
@@ -78,7 +78,7 @@ def _build_query(request: TraceItemTableRequest) -> Query:
             )
         else:
             raise BadSnubaRPCRequestException(
-                "requested attribute is not a column (aggregation not supported for logs)"
+                "requested attribute is not a column (aggregation and formulanot supported for logs)"
             )
 
     res = Query(

--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_trace_item_table.py
@@ -144,6 +144,10 @@ def _build_query(request: TraceItemTableRequest) -> Query:
             selected_columns.append(
                 SelectedExpression(name=column.label, expression=function_expr)
             )
+        elif column.HasField("formula"):
+            raise BadSnubaRPCRequestException(
+                "formulas are not supported for uptime checks"
+            )
         else:
             raise BadSnubaRPCRequestException(
                 "Column is neither an aggregate or an attribute"

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -2307,7 +2307,11 @@ class TestTraceItemTable(BaseApiTest):
             ),
         ]
 
-    def test_formula(self, setup_teardown: Any) -> None:
+    def test_agg_formula(self, setup_teardown: Any) -> None:
+        """
+        ensures formulas of aggregates work
+        ex sum(my_attribute) / count(my_attribute)
+        """
         span_ts = BASE_TIME - timedelta(minutes=1)
         write_eap_span(span_ts, {"kyles_measurement": 6}, 10)
         write_eap_span(span_ts, {"kyles_measurement": 7}, 2)
@@ -2367,6 +2371,93 @@ class TestTraceItemTable(BaseApiTest):
                 attribute_name="sum(kyles_measurement) / count(kyles_measurement)",
                 results=[
                     AttributeValue(val_double=(74 / 12)),
+                ],
+            ),
+        ]
+
+    def test_non_agg_formula(self, setup_teardown: Any) -> None:
+        """
+        ensures formulas of non-aggregates work
+        ex: my_attribute + my_other_attribute
+        """
+        span_ts = BASE_TIME - timedelta(minutes=1)
+        write_eap_span(span_ts, {"kyles_measurement": -1, "my_other_attribute": 1}, 4)
+        write_eap_span(span_ts, {"kyles_measurement": 3, "my_other_attribute": 2}, 2)
+        write_eap_span(span_ts, {"kyles_measurement": 10, "my_other_attribute": 3}, 1)
+
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            filter=TraceItemFilter(
+                exists_filter=ExistsFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_DOUBLE, name="kyles_measurement"
+                    )
+                )
+            ),
+            columns=[
+                Column(
+                    formula=Column.BinaryFormula(
+                        op=Column.BinaryFormula.OP_ADD,
+                        left=Column(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_DOUBLE, name="kyles_measurement"
+                            )
+                        ),
+                        right=Column(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_DOUBLE, name="my_other_attribute"
+                            )
+                        ),
+                    ),
+                    label="kyles_measurement + my_other_attribute",
+                ),
+            ],
+            order_by=[
+                TraceItemTableRequest.OrderBy(
+                    column=Column(
+                        formula=Column.BinaryFormula(
+                            op=Column.BinaryFormula.OP_ADD,
+                            left=Column(
+                                key=AttributeKey(
+                                    type=AttributeKey.TYPE_DOUBLE,
+                                    name="kyles_measurement",
+                                )
+                            ),
+                            right=Column(
+                                key=AttributeKey(
+                                    type=AttributeKey.TYPE_DOUBLE,
+                                    name="my_other_attribute",
+                                )
+                            ),
+                        ),
+                        label="kyles_measurement + my_other_attribute",
+                    )
+                ),
+            ],
+            limit=50,
+        )
+        response = EndpointTraceItemTable().execute(message)
+        assert response.column_values == [
+            TraceItemColumnValues(
+                attribute_name="kyles_measurement + my_other_attribute",
+                results=[
+                    AttributeValue(val_double=0),
+                    AttributeValue(val_double=0),
+                    AttributeValue(val_double=0),
+                    AttributeValue(val_double=0),
+                    AttributeValue(val_double=5),
+                    AttributeValue(val_double=5),
+                    AttributeValue(val_double=13),
                 ],
             ),
         ]

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
@@ -722,7 +722,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
         """
         span_ts = BASE_TIME - timedelta(minutes=1)
         write_eap_span(span_ts, {"kyles_measurement": 6, "server_sample_rate": 0.5}, 10)
-        write_eap_span(span_ts, {"kyles_measurement": 7, "server_sample_rate": 0.2}, 2)
+        write_eap_span(span_ts, {"kyles_measurement": 7}, 2)
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -780,7 +780,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             TraceItemColumnValues(
                 attribute_name="sum(kyles_measurement) / count(kyles_measurement)",
                 results=[
-                    AttributeValue(val_double=(190 / 30)),
+                    AttributeValue(val_double=(134 / 22)),
                 ],
             ),
         ]


### PR DESCRIPTION
This PR implements support for formulas in the TraceItemTable endpoint. It is relevant to this ticket https://github.com/orgs/getsentry/projects/284/views/1?pane=issue&itemId=85243940&issue=getsentry%7Ceap-planning%7C27
It enables queries such as `sum(my_attribute) / count(my_attribute)` which werent possible before

## Major changes
* the column to expression conversion logic used to take place [here](https://github.com/getsentry/snuba/pull/6844/files#diff-e1e06d7f875a7c2870cc11bc4301dd6ab9fba73263c76260452c0b3176f66110L141-L187) I extracted this logic into 2 separate new functions: `_get_reliability_context_columns` and `_column_to_expression`. (i.e. the logic stayed the same but its not inside these functions)
* I then extended `_column_to_expression` to support formulas https://github.com/getsentry/snuba/pull/6844/files#diff-e1e06d7f875a7c2870cc11bc4301dd6ab9fba73263c76260452c0b3176f66110R180-R191
* I also had to extend the existing result conversion and order by logic to support formulas https://github.com/getsentry/snuba/pull/6844/files#diff-e1e06d7f875a7c2870cc11bc4301dd6ab9fba73263c76260452c0b3176f66110R287-R288

## Testing
I wrote 3 new tests for this feature: 
* one that tests a simple formula on aggregates `sum(my_attribute) / count(my_attribute)`
* one that is the same as above uses extrapolation, to ensure formulas work with extrapolation.
* one that tests formulas on attributes without aggregation `my_attribute + my_other_attribute`

## design decisions
* reliabilities dont work with formulas, if you do a formula on extrapolated aggregates you will not get any reliability information back. This decision was made because of the increased complexity it would add to support. If needed we can implement support for this in the future.
* I realized while implementing this that formulas using constants are not supported such as `my_attribute * 10` if we need support for this it must be implemented as a follow up. and will require further modification of our protobuf grammar.
* it only supports spans not uptime or logs