### PR TITLE
fix(consumer): Add quantized rebalancing as cli option

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -95,6 +95,7 @@ fn create_factory(
             physical_topic_name: "shared-resources-usage".to_string(),
             logical_topic_name: "shared-resources-usage".to_string(),
             broker_config: BrokerConfig::default(),
+            quantized_rebalance_consumer_group_delay_secs: None,
         },
         stop_at_timestamp: None,
         batch_write_timeout: None,

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -56,6 +56,7 @@ pub struct TopicConfig {
     pub logical_topic_name: String,
     #[serde(deserialize_with = "deserialize_broker_config")]
     pub broker_config: BrokerConfig,
+    pub quantized_rebalance_consumer_group_delay_secs: Option<u64>,
 }
 
 type RawBrokerConfig = HashMap<String, Value>;

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -235,7 +235,13 @@ pub fn consumer_impl(
 
     let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);
 
-    let rebalance_delay_secs = rebalancing::get_rebalance_delay_secs(consumer_group);
+    let mut rebalance_delay_secs = consumer_config
+        .raw_topic
+        .quantized_rebalance_consumer_group_delay_secs;
+    let config_rebalance_delay_secs = rebalancing::get_rebalance_delay_secs(consumer_group);
+    if let Some(secs) = config_rebalance_delay_secs {
+        rebalance_delay_secs = Some(secs);
+    }
     if let Some(secs) = rebalance_delay_secs {
         rebalancing::delay_kafka_rebalance(secs)
     }

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -178,6 +178,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     default=None,
     help="Optional timeout for batch writer client connecting and sending request to Clickhouse",
 )
+@click.option(
+    "--quantized-rebalance-consumer-group-delay-secs",
+    type=int,
+    default=None,
+    help="Quantized rebalancing means that during deploys, rebalancing is triggered across all pods within a consumer group at the same time. The value is used by the pods to align their group join/leave activity to some multiple of the delay",
+)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -208,7 +214,8 @@ def rust_consumer(
     stop_at_timestamp: Optional[int],
     batch_write_timeout_ms: Optional[int],
     mutations_mode: bool,
-    max_dlq_buffer_length: Optional[int]
+    max_dlq_buffer_length: Optional[int],
+    quantized_rebalance_consumer_group_delay_secs: Optional[int],
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -228,6 +235,7 @@ def rust_consumer(
         queued_min_messages=queued_min_messages,
         slice_id=slice_id,
         group_instance_id=group_instance_id,
+        quantized_rebalance_consumer_group_delay_secs=quantized_rebalance_consumer_group_delay_secs,
     )
 
     consumer_config_raw = json.dumps(asdict(consumer_config))

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Mapping, Optional, Sequence
 
 from snuba import settings
@@ -40,6 +40,7 @@ class TopicConfig:
     broker_config: Mapping[str, Any]
     logical_topic_name: str
     physical_topic_name: str
+    quantized_rebalance_consumer_group_delay_secs: Optional[int]
 
 
 @dataclass(frozen=True)
@@ -85,11 +86,7 @@ def _add_to_topic_broker_config(
     # copy the broker config to avoid modifying the original
     broker_config = {k: v for k, v in topic_config.broker_config.items()}
     broker_config[param_key] = param_value
-    return TopicConfig(
-        broker_config=broker_config,
-        logical_topic_name=topic_config.logical_topic_name,
-        physical_topic_name=topic_config.physical_topic_name,
-    )
+    return replace(topic_config, broker_config=broker_config)
 
 
 def _resolve_topic_config(
@@ -97,6 +94,7 @@ def _resolve_topic_config(
     topic_spec: Optional[KafkaTopicSpec],
     cli_param: Optional[str],
     slice_id: Optional[int],
+    quantized_rebalance_consumer_group_delay_secs: Optional[int] = None,
 ) -> Optional[TopicConfig]:
     if topic_spec is None:
         if cli_param is not None:
@@ -117,6 +115,7 @@ def _resolve_topic_config(
         broker_config=broker,
         logical_topic_name=logical_topic_name,
         physical_topic_name=physical_topic_name,
+        quantized_rebalance_consumer_group_delay_secs=quantized_rebalance_consumer_group_delay_secs,
     )
 
 
@@ -157,6 +156,7 @@ def resolve_consumer_config(
     queued_max_messages_kbytes: Optional[int] = None,
     queued_min_messages: Optional[int] = None,
     group_instance_id: Optional[str] = None,
+    quantized_rebalance_consumer_group_delay_secs: Optional[int] = None,
 ) -> ConsumerConfig:
     """
     Resolves the ClickHouse cluster and Kafka brokers, and the physical topic name
@@ -175,7 +175,11 @@ def resolve_consumer_config(
     default_topic_spec = stream_loader.get_default_topic_spec()
 
     resolved_raw_topic = _resolve_topic_config(
-        "main topic", default_topic_spec, raw_topic, slice_id
+        "main topic",
+        default_topic_spec,
+        raw_topic,
+        slice_id,
+        quantized_rebalance_consumer_group_delay_secs,
     )
 
     assert resolved_raw_topic is not None


### PR DESCRIPTION
This adds the quantized rebalancing as a cli option, so it can be specified in code instead of just
in the runtime config.