### PR TITLE
chore(devservices): Bump devservices to 1.0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 clickhouse-driver==0.2.6
 confluent-kafka==2.7.0
 datadog==0.21.0
-devservices==1.0.12
+devservices==1.0.14
 flake8==7.0.0
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
Some various minor improvements: https://github.com/getsentry/devservices/releases/tag/1.0.14