### PR TITLE
fix(eap-api): return normalized fields for GetTraceEndpoint

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -176,7 +176,6 @@ def execute_query(
     # Apply clickhouse query setting overrides
     clickhouse_query_settings.update(query_settings.get_clickhouse_settings())
 
-    print("formatted_queryyyy", formatted_query)
     result = reader.execute(
         formatted_query,
         clickhouse_query_settings,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -176,6 +176,7 @@ def execute_query(
     # Apply clickhouse query setting overrides
     clickhouse_query_settings.update(query_settings.get_clickhouse_settings())
 
+    print("formatted_queryyyy", formatted_query)
     result = reader.execute(
         formatted_query,
         clickhouse_query_settings,

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -88,7 +88,6 @@ def _build_query(request: GetTraceRequest) -> Query:
             ),
         ]
         columns_to_exclude = ["retention_days", "sign", "attr_str", "attr_num"]
-        # print("bruhhhh", get_entity(EntityKey("eap_spans")).get_data_model().columns)
         selected_columns.extend(
             [
                 SelectedExpression(
@@ -98,8 +97,6 @@ def _build_query(request: GetTraceRequest) -> Query:
                 if col.name not in columns_to_exclude
             ]
         )
-
-        print("bruhh", selected_columns)
 
     entity = Entity(
         key=EntityKey("eap_spans"),
@@ -182,14 +179,24 @@ def _value_to_attribute(key: str, value: Any) -> tuple[AttributeKey, AttributeVa
                 val_double=value,
             ),
         )
-    elif isinstance(value, str) or isinstance(value, datetime):
+    elif isinstance(value, str):
         return (
             AttributeKey(
                 name=key,
                 type=AttributeKey.Type.TYPE_STRING,
             ),
             AttributeValue(
-                val_str=str(value),
+                val_str=value,
+            ),
+        )
+    elif isinstance(value, datetime):
+        return (
+            AttributeKey(
+                name=key,
+                type=AttributeKey.Type.TYPE_DOUBLE,
+            ),
+            AttributeValue(
+                val_double=value.timestamp(),
             ),
         )
     else:

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -86,6 +86,30 @@ def _build_query(request: GetTraceRequest) -> Query:
                 ),
             ),
         ]
+        selected_columns.extend(
+            [
+                SelectedExpression(name=col_name, expression=column(col_name))
+                for col_name in [
+                    "organization_id",
+                    "project_id",
+                    "service",
+                    "trace_id",
+                    "span_id",
+                    "parent_span_id",
+                    "segment_id",
+                    "segment_name",
+                    "is_segment",
+                    "_sort_timestamp",
+                    "start_timestamp",
+                    "end_timestamp",
+                    "duration_micro",
+                    "exclusive_time_micro",
+                    "name",
+                    "sampling_factor",
+                    "sampling_weight",
+                ]
+            ]
+        )
 
     entity = Entity(
         key=EntityKey("eap_spans"),

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -87,32 +87,19 @@ def _build_query(request: GetTraceRequest) -> Query:
                 ),
             ),
         ]
+        columns_to_exclude = ["retention_days", "sign", "attr_str", "attr_num"]
+        # print("bruhhhh", get_entity(EntityKey("eap_spans")).get_data_model().columns)
         selected_columns.extend(
             [
                 SelectedExpression(
-                    name=col_name, expression=column(col_name, alias=col_name)
+                    name=col.name, expression=column(col.name, alias=col.name)
                 )
-                for col_name in [
-                    "organization_id",
-                    "project_id",
-                    "service",
-                    "trace_id",
-                    "span_id",
-                    "parent_span_id",
-                    "segment_id",
-                    "segment_name",
-                    "is_segment",
-                    "_sort_timestamp",
-                    "start_timestamp",
-                    "end_timestamp",
-                    "duration_micro",
-                    "exclusive_time_micro",
-                    "name",
-                    "sampling_factor",
-                    "sampling_weight",
-                ]
+                for col in get_entity(EntityKey("eap_spans")).get_data_model().columns
+                if col.name not in columns_to_exclude
             ]
         )
+
+        print("bruhh", selected_columns)
 
     entity = Entity(
         key=EntityKey("eap_spans"),

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -87,7 +87,14 @@ def _build_query(request: GetTraceRequest) -> Query:
                 ),
             ),
         ]
-        columns_to_exclude = ["retention_days", "sign", "attr_str", "attr_num"]
+        columns_to_exclude = [
+            "retention_days",
+            "sign",
+            "attr_str",
+            "attr_num",
+            "span_id",
+            "timestamp",
+        ]
         selected_columns.extend(
             [
                 SelectedExpression(

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from operator import attrgetter
 from typing import Any, Dict, Iterable
 
@@ -88,7 +89,9 @@ def _build_query(request: GetTraceRequest) -> Query:
         ]
         selected_columns.extend(
             [
-                SelectedExpression(name=col_name, expression=column(col_name))
+                SelectedExpression(
+                    name=col_name, expression=column(col_name, alias=col_name)
+                )
                 for col_name in [
                     "organization_id",
                     "project_id",
@@ -192,14 +195,14 @@ def _value_to_attribute(key: str, value: Any) -> tuple[AttributeKey, AttributeVa
                 val_double=value,
             ),
         )
-    elif isinstance(value, str):
+    elif isinstance(value, str) or isinstance(value, datetime):
         return (
             AttributeKey(
                 name=key,
                 type=AttributeKey.Type.TYPE_STRING,
             ),
             AttributeValue(
-                val_str=value,
+                val_str=str(value),
             ),
         )
     else:

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -42,6 +42,21 @@ from snuba.web.rpc.v1.resolvers import ResolverGetTrace
 _BUCKET_COUNT = 20
 
 
+NORMALIZED_COLUMNS_TO_INCLUDE = [
+    col.name
+    for col in get_entity(EntityKey("eap_spans")).get_data_model().columns
+    if col.name
+    not in [
+        "retention_days",
+        "sign",
+        "attr_str",
+        "attr_num",
+        "span_id",
+        "timestamp",
+    ]
+]
+
+
 def _build_query(request: GetTraceRequest) -> Query:
     selected_columns: list[SelectedExpression] = [
         SelectedExpression(
@@ -87,21 +102,12 @@ def _build_query(request: GetTraceRequest) -> Query:
                 ),
             ),
         ]
-        columns_to_exclude = [
-            "retention_days",
-            "sign",
-            "attr_str",
-            "attr_num",
-            "span_id",
-            "timestamp",
-        ]
         selected_columns.extend(
             [
                 SelectedExpression(
-                    name=col.name, expression=column(col.name, alias=col.name)
+                    name=col_name, expression=column(col_name, alias=col_name)
                 )
-                for col in get_entity(EntityKey("eap_spans")).get_data_model().columns
-                if col.name not in columns_to_exclude
+                for col_name in NORMALIZED_COLUMNS_TO_INCLUDE
             ]
         )
 

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -281,8 +281,6 @@ class TestGetTrace(BaseApiTest):
             ],
         )
 
-        breakpoint()
-
         assert list(
             [
                 attribute

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -266,7 +266,9 @@ class TestGetTrace(BaseApiTest):
                 ),
             ],
         )
-        assert MessageToDict(response) == MessageToDict(expected_response)
+        assert MessageToDict(response.item_groups[0]) == MessageToDict(
+            expected_response.item_groups[0]
+        )
 
     def test_with_specific_attributes(self, setup_teardown: Any) -> None:
         ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -42,6 +42,7 @@ _NORMALIZED_FIELDS_TO_EXCLUDE = [
     "sign",
     "attr_str",
     "attr_num",
+    "span_id",
     "timestamp",
 ]
 _NORMALIZED_FIELDS_TO_INCLUDE = [


### PR DESCRIPTION
Currently, if the user doesn't specify attributes to the GetTraceEndpoint, we won't return normalized fields; however, we should

https://github.com/getsentry/eap-planning/issues/187