### PR TITLE
feat(capman): Remove BytesScannedWindowAllocationPolicy from errors_ro

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -279,15 +279,6 @@ allocation_policies:
         getsentry.tasks.backfill_grouping_records:
           max_threads: 7
           concurrent_limit: 60
-  - name: BytesScannedWindowAllocationPolicy
-    args:
-      required_tenant_types:
-        - organization_id
-        - referrer
-      default_config_overrides:
-        is_enforced: 1
-        throttled_thread_number: 1
-        org_limit_bytes_scanned: 10000000
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -374,17 +374,6 @@ def test_db_query_success() -> None:
                 "quota_unit": NO_UNITS,
                 "suggestion": NO_SUGGESTION,
             },
-            "BytesScannedWindowAllocationPolicy": {
-                "can_run": True,
-                "max_threads": 10,
-                "explanation": {"storage_key": "StorageKey.ERRORS_RO"},
-                "is_throttled": False,
-                "throttle_threshold": 10000000,
-                "rejection_threshold": MAX_THRESHOLD,
-                "quota_used": 0,
-                "quota_unit": "bytes",
-                "suggestion": "The feature, organization/project is scanning too many bytes, this usually means they are abusing that API",
-            },
         },
     }
 


### PR DESCRIPTION
It has been disabled the last three days and survived peak traffic just fine. For more info see the [policy consolidation](https://www.notion.so/sentry/CapMan-Visibility-Project-c16b375ed2ee43c19cd2fa163fc93332?pvs=4#185824a1f34b4ff6b31fe1c6ea872aca) document