### PR TITLE
chore: Upgrade clickhouse-driver to 0.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 black==22.6.0
 blinker==1.5
 click==8.1.7
-clickhouse-driver==0.2.6
+clickhouse-driver==0.2.9
 confluent-kafka==2.7.0
 datadog==0.21.0
 devservices==1.0.16

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -206,11 +206,11 @@ class ClickhousePool(object):
                         result_data = query_execute()
 
                     profile_data = ClickhouseProfile(
-                        bytes=conn.last_query.profile_info.bytes or 0,
-                        progress_bytes=conn.last_query.progress.bytes or 0,
-                        blocks=conn.last_query.profile_info.blocks or 0,
-                        rows=conn.last_query.profile_info.rows or 0,
+                        blocks=getattr(conn.last_query.profile_info, "blocks", 0),
+                        bytes=getattr(conn.last_query.profile_info, "bytes", 0),
                         elapsed=conn.last_query.elapsed or 0.0,
+                        progress_bytes=getattr(conn.last_query.progress, "bytes", 0),
+                        rows=getattr(conn.last_query.profile_info, "rows", 0),
                     )
                     if with_column_types:
                         result = ClickhouseResult(


### PR DESCRIPTION
This will be needed to contact cluster based on ClickHouse 24.8.

https://github.com/getsentry/pypi/pull/1258