### PR TITLE
fix(eap): Bad circular import in endpoint get traces

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_stats.py
@@ -37,11 +37,12 @@ from snuba.web.rpc.common.debug_info import (
     setup_trace_query_settings,
 )
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
-from snuba.web.rpc.v1.endpoint_get_traces import _DEFAULT_ROW_LIMIT
 from snuba.web.rpc.v1.resolvers import ResolverTraceItemStats
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.common import (
     attribute_key_to_expression,
 )
+
+_DEFAULT_ROW_LIMIT = 10_000
 
 MAX_BUCKETS = 100
 DEFAULT_BUCKETS = 10


### PR DESCRIPTION
```
{"timestamp":"2025-02-11T19:28:14.591943Z","level":"INFO","fields":{"message":"Starting consumer for \"outcomes_raw\"","storage":"outcomes_raw"},"target":"rust_snuba::consumer"}
19:28:14 subscriptions-scheduler-executor-transactions |     from snuba.subscriptions.codecs import SubscriptionScheduledTaskEncoder
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/subscriptions/codecs.py", line 13, in <module>
19:28:14 subscriptions-scheduler-executor-transactions |     from snuba.subscriptions.data import (
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/subscriptions/data.py", line 60, in <module>
19:28:14 subscriptions-scheduler-executor-transactions |     from snuba.web.rpc.v1.endpoint_time_series import EndpointTimeSeries
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/web/rpc/__init__.py", line 242, in <module>
19:28:14 subscriptions-scheduler-executor-transactions |     import_submodules_in_directory(module_path, f"snuba.web.rpc.{v}")
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/utils/registered_class.py", line 179, in import_submodules_in_directory
19:28:14 subscriptions-scheduler-executor-transactions |     imported_modules.append(importlib.import_module(module_str))
19:28:14 subscriptions-scheduler-executor-transactions |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
19:28:14 subscriptions-scheduler-executor-transactions |     return _bootstrap._gcd_import(name[level:], package, level)
19:28:14 subscriptions-scheduler-executor-transactions |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/web/rpc/v1/endpoint_get_traces.py", line 43, in <module>
19:28:14 subscriptions-scheduler-executor-transactions |     from snuba.web.rpc.v1.resolvers.R_eap_spans.common.common import (
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/web/rpc/v1/resolvers/__init__.py", line 94, in <module>
19:28:14 subscriptions-scheduler-executor-transactions |     import_submodules_in_directory(module_path, f"snuba.web.rpc.v1.resolvers.{v}")
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/utils/registered_class.py", line 179, in import_submodules_in_directory
19:28:14 subscriptions-scheduler-executor-transactions |     imported_modules.append(importlib.import_module(module_str))
19:28:14 subscriptions-scheduler-executor-transactions |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
19:28:14 subscriptions-scheduler-executor-transactions |     return _bootstrap._gcd_import(name[level:], package, level)
19:28:14 subscriptions-scheduler-executor-transactions |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
19:28:14 subscriptions-scheduler-executor-transactions |   File "/usr/src/snuba/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_stats.py", line 40, in <module>
19:28:14 subscriptions-scheduler-executor-transactions |     from snuba.web.rpc.v1.endpoint_get_traces import _DEFAULT_ROW_LIMIT
19:28:14 subscriptions-scheduler-executor-transactions | ImportError: cannot import name '_DEFAULT_ROW_LIMIT' from partially initialized module 'snuba.web.rpc.v1.endpoint_get_traces' (most likely due to a circular import) (/usr/src/snuba/snuba/web/rpc/v1/endpoint_get_traces.py)
```