### PR TITLE
feat(consumer): add flag for custom envoy request timeout

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -99,6 +99,7 @@ fn create_factory(
         },
         stop_at_timestamp: None,
         batch_write_timeout: None,
+        custom_envoy_request_timeout: None,
     };
     Box::new(factory)
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -46,6 +46,7 @@ pub fn consumer(
     stop_at_timestamp: Option<i64>,
     batch_write_timeout_ms: Option<u64>,
     max_dlq_buffer_length: Option<usize>,
+    custom_envoy_request_timeout: Option<u64>,
 ) -> usize {
     py.allow_threads(|| {
         consumer_impl(
@@ -65,6 +66,7 @@ pub fn consumer(
             batch_write_timeout_ms,
             mutations_mode,
             max_dlq_buffer_length,
+            custom_envoy_request_timeout,
         )
     })
 }
@@ -87,6 +89,7 @@ pub fn consumer_impl(
     batch_write_timeout_ms: Option<u64>,
     mutations_mode: bool,
     max_dlq_buffer_length: Option<usize>,
+    custom_envoy_request_timeout: Option<u64>,
 ) -> usize {
     setup_logging();
 
@@ -281,6 +284,7 @@ pub fn consumer_impl(
             accountant_topic_config: consumer_config.accountant_topic,
             stop_at_timestamp,
             batch_write_timeout,
+            custom_envoy_request_timeout,
         };
 
         StreamProcessor::with_kafka(config, factory, topic, dlq_policy)

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -57,6 +57,7 @@ pub struct ConsumerStrategyFactory {
     pub accountant_topic_config: config::TopicConfig,
     pub stop_at_timestamp: Option<i64>,
     pub batch_write_timeout: Option<Duration>,
+    pub custom_envoy_request_timeout: Option<u64>,
 }
 
 impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
@@ -117,6 +118,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.storage_config.clickhouse_cluster.password,
             self.async_inserts,
             self.batch_write_timeout,
+            self.custom_envoy_request_timeout,
         );
 
         let accumulator = Arc::new(

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -311,6 +311,7 @@ mod tests {
             "",
             true,
             None,
+            None,
         );
 
         let mut batch = factory.new_batch();

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -60,11 +60,12 @@ impl BatchFactory {
             "X-ClickHouse-Database",
             HeaderValue::from_str(database).unwrap(),
         );
-        headers.insert(
-            "x-envoy-upstream-rq-per-try-timeout-ms",
-            HeaderValue::from_str(&custom_envoy_request_timeout.unwrap_or(10000).to_string())
-                .unwrap(),
-        );
+        if let Some(custom_envoy_request_timeout) = custom_envoy_request_timeout {
+            headers.insert(
+                "x-envoy-upstream-rq-per-try-timeout-ms",
+                HeaderValue::from_str(&custom_envoy_request_timeout.to_string()).unwrap(),
+            );
+        }
 
         let mut query_params = String::new();
         query_params.push_str("load_balancing=in_order&insert_distributed_sync=1");

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -179,6 +179,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     help="Optional timeout for batch writer client connecting and sending request to Clickhouse",
 )
 @click.option(
+    "--custom-envoy-request-timeout",
+    type=int,
+    default=None,
+    help="Optional request timeout value for Snuba -> Envoy -> Clickhouse connection",
+)
+@click.option(
     "--quantized-rebalance-consumer-group-delay-secs",
     type=int,
     default=None,
@@ -216,6 +222,7 @@ def rust_consumer(
     mutations_mode: bool,
     max_dlq_buffer_length: Optional[int],
     quantized_rebalance_consumer_group_delay_secs: Optional[int],
+    custom_envoy_request_timeout: Optional[int],
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -236,6 +243,7 @@ def rust_consumer(
         slice_id=slice_id,
         group_instance_id=group_instance_id,
         quantized_rebalance_consumer_group_delay_secs=quantized_rebalance_consumer_group_delay_secs,
+        custom_envoy_request_timeout=custom_envoy_request_timeout,
     )
 
     consumer_config_raw = json.dumps(asdict(consumer_config))
@@ -269,6 +277,7 @@ def rust_consumer(
         stop_at_timestamp,
         batch_write_timeout_ms,
         max_dlq_buffer_length,
+        custom_envoy_request_timeout,
     )
 
     sys.exit(exitcode)

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -157,6 +157,7 @@ def resolve_consumer_config(
     queued_min_messages: Optional[int] = None,
     group_instance_id: Optional[str] = None,
     quantized_rebalance_consumer_group_delay_secs: Optional[int] = None,
+    custom_envoy_request_timeout: Optional[int] = None,
 ) -> ConsumerConfig:
     """
     Resolves the ClickHouse cluster and Kafka brokers, and the physical topic name


### PR DESCRIPTION
This lets us pass a custom envoy request timeout value in the HTTP request that we send to ClickHouse for inserts. We have observed in production that Envoy made some INSERTs terminate prematurely, and this caused downstream issues as the consumer would crash and try to resubmit on a loop, screwing up the consistent insert rate

(For employees, INC-1035)