### PR TITLE
feat: add a processor to ingest to new eap table

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -1,0 +1,333 @@
+use anyhow::Context;
+use chrono::DateTime;
+use seq_macro::seq;
+use serde::Serialize;
+use std::cmp::max;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use sentry_arroyo::backends::kafka::types::KafkaPayload;
+use serde_json::Value;
+
+use crate::config::ProcessorConfig;
+use crate::processors::spans::FromSpanMessage;
+use crate::processors::utils::enforce_retention;
+use crate::types::{InsertBatch, KafkaMessageMetadata};
+
+macro_rules! seq_attrs {
+    ($($tt:tt)*) => {
+        seq!(N in 0..20 {
+            $($tt)*
+        });
+    }
+}
+
+pub fn process_message(
+    payload: KafkaPayload,
+    _metadata: KafkaMessageMetadata,
+    config: &ProcessorConfig,
+) -> anyhow::Result<InsertBatch> {
+    if let Some(headers) = payload.headers() {
+        if let Some(ingest_in_eap) = headers.get("ingest_in_eap") {
+            if ingest_in_eap == b"false" {
+                return Ok(InsertBatch::skip());
+            }
+        }
+    }
+
+    let payload_bytes = payload.payload().context("Expected payload")?;
+    let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
+    let origin_timestamp = DateTime::from_timestamp(msg.received as i64, 0);
+    let mut span: EAPItem = msg.into();
+
+    span.retention_days = Some(max(
+        enforce_retention(span.retention_days, &config.env_config),
+        30,
+    ));
+
+    InsertBatch::from_rows([span], origin_timestamp)
+}
+
+seq_attrs! {
+#[derive(Debug, Default, Serialize)]
+pub(crate) struct AttributeMap {
+    attributes_bool: HashMap<String, bool>,
+    attributes_int: HashMap<String, i64>,
+    #(
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    attributes_string_~N: HashMap<String, String>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    attributes_float_~N: HashMap<String, f64>,
+    )*
+}
+}
+
+impl AttributeMap {
+    pub fn insert_str(&mut self, k: String, v: String) {
+        seq_attrs! {
+            let attr_str_buckets = [
+                #(
+                &mut self.attributes_string_~N,
+                )*
+            ];
+        };
+
+        attr_str_buckets[(fnv_1a(k.as_bytes()) as usize) % attr_str_buckets.len()].insert(k, v);
+    }
+
+    pub fn insert_float(&mut self, k: String, v: f64) {
+        seq_attrs! {
+            let attr_num_buckets = [
+                #(
+                &mut self.attributes_float_~N,
+                )*
+            ];
+        }
+
+        attr_num_buckets[(fnv_1a(k.as_bytes()) as usize) % attr_num_buckets.len()].insert(k, v);
+    }
+
+    pub fn insert_bool(&mut self, k: String, v: bool) {
+        self.attributes_bool.insert(k, v);
+    }
+
+    pub fn insert_int(&mut self, k: String, v: i64) {
+        self.attributes_int.insert(k, v);
+    }
+}
+
+#[derive(Debug, Default, Serialize, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub(crate) struct PrimaryKey {
+    pub organization_id: u64,
+    pub project_id: u64,
+    pub item_type: u8,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct EAPItem {
+    #[serde(flatten)]
+    primary_key: PrimaryKey,
+
+    trace_id: Uuid,
+    item_id: u128,
+    sampling_weight: u64,
+    retention_days: Option<u16>,
+
+    #[serde(flatten)]
+    attributes: AttributeMap,
+}
+
+fn fnv_1a(input: &[u8]) -> u32 {
+    const FNV_1A_PRIME: u32 = 16777619;
+    const FNV_1A_OFFSET_BASIS: u32 = 2166136261;
+
+    let mut res = FNV_1A_OFFSET_BASIS;
+    for byt in input {
+        res ^= *byt as u32;
+        res = res.wrapping_mul(FNV_1A_PRIME);
+    }
+
+    res
+}
+
+impl From<FromSpanMessage> for EAPItem {
+    fn from(from: FromSpanMessage) -> EAPItem {
+        let item_id = u128::from_str_radix(&from.span_id, 16).expect(&format!(
+            "Failed to parse span_id into u128. span_id: {}",
+            from.span_id
+        ));
+        let mut res = Self {
+            primary_key: PrimaryKey {
+                organization_id: from.organization_id,
+                project_id: from.project_id,
+                item_type: 1, // hardcoding "span" as type 1
+                timestamp: from.start_timestamp_ms,
+            },
+            trace_id: from.trace_id,
+            item_id,
+            sampling_weight: 1,
+            retention_days: from.retention_days,
+
+            ..Default::default()
+        };
+
+        {
+            if let Some(profile_id) = from.profile_id {
+                res.attributes.insert_str(
+                    "sentry.profile_id".to_owned(),
+                    profile_id.as_simple().to_string(),
+                );
+            }
+
+            if let Some(sentry_tags) = from.sentry_tags {
+                for (k, v) in sentry_tags {
+                    res.attributes.insert_str(format!("sentry.{k}"), v);
+                }
+            }
+
+            if let Some(tags) = from.tags {
+                for (k, v) in tags {
+                    res.attributes.insert_str(k, v);
+                }
+            }
+
+            let mut sampling_factor = 1.0;
+            if let Some(measurements) = from.measurements {
+                for (k, v) in measurements {
+                    match k.as_str() {
+                        "client_sample_rate" if v.value > 0.0 => sampling_factor *= v.value,
+                        "server_sample_rate" if v.value > 0.0 => sampling_factor *= v.value,
+                        _ => res.attributes.insert_float(k, v.value),
+                    }
+                }
+            }
+            // lower precision to compensate floating point errors
+            sampling_factor = (sampling_factor * 1e9).round() / 1e9;
+            res.sampling_weight = (1.0 / sampling_factor).round() as u64;
+
+            if let Some(data) = from.data {
+                for (k, v) in data {
+                    match v {
+                        Value::String(string) => res.attributes.insert_str(k, string),
+                        Value::Array(array) => res
+                            .attributes
+                            .insert_str(k, serde_json::to_string(&array).unwrap_or_default()),
+                        Value::Object(object) => res
+                            .attributes
+                            .insert_str(k, serde_json::to_string(&object).unwrap_or_default()),
+                        Value::Number(number) => {
+                            if number.is_i64() {
+                                res.attributes
+                                    .insert_int(k, number.as_i64().unwrap_or_default());
+                            } else if number.is_u64() {
+                                // as_i64() will return None if the u64 is too large
+                                res.attributes
+                                    .insert_int(k, number.as_i64().unwrap_or_default());
+                            } else {
+                                // it should be a float
+                                res.attributes
+                                    .insert_float(k, number.as_f64().unwrap_or_default())
+                            }
+                        }
+                        Value::Bool(b) => res.attributes.insert_bool(k, b),
+                        _ => (),
+                    }
+                }
+            }
+        }
+
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use super::*;
+
+    const SPAN_KAFKA_MESSAGE: &str = r#"
+{
+    "description": "/api/0/relays/projectconfigs/",
+    "duration_ms": 152,
+    "event_id": "d826225de75d42d6b2f01b957d51f18f",
+    "exclusive_time_ms": 0.228,
+    "is_segment": true,
+    "data": {
+        "sentry.environment": "development",
+        "sentry.release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
+        "thread.name": "uWSGIWorker1Core0",
+        "thread.id": "8522009600",
+        "sentry.segment.name": "/api/0/relays/projectconfigs/",
+        "sentry.sdk.name": "sentry.python.django",
+        "sentry.sdk.version": "2.7.0",
+        "my.float.field": 101.2,
+        "my.int.field": 2000,
+        "my.neg.field": -100,
+        "my.neg.float.field": -101.2,
+        "my.true.bool.field": true,
+        "my.false.bool.field": false
+    },
+    "measurements": {
+        "num_of_spans": {
+            "value": 50.0
+        },
+        "client_sample_rate": {
+            "value": 0.1
+        },
+        "server_sample_rate": {
+            "value": 0.2
+        }
+    },
+    "profile_id": "56c7d1401ea14ad7b4ac86de46baebae",
+    "organization_id": 1,
+    "origin": "auto.http.django",
+    "project_id": 1,
+    "received": 1721319572.877828,
+    "retention_days": 90,
+    "segment_id": "8873a98879faf06d",
+    "sentry_tags": {
+        "category": "http",
+        "environment": "development",
+        "op": "http.server",
+        "platform": "python",
+        "release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
+        "sdk.name": "sentry.python.django",
+        "sdk.version": "2.7.0",
+        "status": "ok",
+        "status_code": "200",
+        "thread.id": "8522009600",
+        "thread.name": "uWSGIWorker1Core0",
+        "trace.status": "ok",
+        "transaction": "/api/0/relays/projectconfigs/",
+        "transaction.method": "POST",
+        "transaction.op": "http.server",
+        "user": "ip:127.0.0.1"
+    },
+    "span_id": "8873a98879faf06d",
+    "tags": {
+        "http.status_code": "200",
+        "relay_endpoint_version": "3",
+        "relay_id": "88888888-4444-4444-8444-cccccccccccc",
+        "relay_no_cache": "False",
+        "relay_protocol_version": "3",
+        "relay_use_post_or_schedule": "True",
+        "relay_use_post_or_schedule_rejected": "version",
+        "server_name": "D23CXQ4GK2.local",
+        "spans_over_limit": "False"
+    },
+    "trace_id": "d099bf9ad5a143cf8f83a98081d0ed3b",
+    "start_timestamp_ms": 1721319572616,
+    "start_timestamp_precise": 1721319572.616648,
+    "end_timestamp_precise": 1721319572.768806
+}
+    "#;
+
+    #[test]
+    fn test_fnv_1a() {
+        assert_eq!(fnv_1a("test".as_bytes()), 2949673445)
+    }
+
+    #[test]
+    fn test_valid_span() {
+        let payload = KafkaPayload::new(None, None, Some(SPAN_KAFKA_MESSAGE.as_bytes().to_vec()));
+        let meta = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: DateTime::from(SystemTime::now()),
+        };
+        process_message(payload, meta, &ProcessorConfig::default())
+            .expect("The message should be processed");
+    }
+
+    #[test]
+    fn test_serialization() {
+        let msg: FromSpanMessage = serde_json::from_slice(SPAN_KAFKA_MESSAGE.as_bytes()).unwrap();
+        let item: EAPItem = msg.into();
+        insta::with_settings!({sort_maps => true}, {
+            insta::assert_json_snapshot!(item)
+        });
+    }
+}

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -1,3 +1,4 @@
+mod eap_items;
 pub(crate) mod eap_spans;
 mod errors;
 mod functions;
@@ -68,6 +69,7 @@ define_processing_functions! {
     ("PolymorphicMetricsProcessor", "snuba-metrics", ProcessingFunctionType::ProcessingFunction(release_health_metrics::process_metrics_message)),
     ("ErrorsProcessor", "events", ProcessingFunctionType::ProcessingFunctionWithReplacements(errors::process_message_with_replacement)),
     ("ProfileChunksProcessor", "snuba-profile-chunks", ProcessingFunctionType::ProcessingFunction(profile_chunks::process_message)),
+    ("EAPItemsProcessor", "snuba-spans", ProcessingFunctionType::ProcessingFunction(eap_items::process_message)),
 }
 
 // COGS is recorded for these processors

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_items__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_items__tests__serialization.snap
@@ -1,42 +1,62 @@
 ---
 source: src/processors/eap_items.rs
-expression: span
+expression: item
 ---
 {
   "attributes_bool": {
     "my.false.bool.field": false,
-    "my.true.bool.field": true
+    "my.true.bool.field": true,
+    "sentry.is_segment": true
   },
   "attributes_float_1": {
-    "my.neg.float.field": -101.2
+    "my.true.bool.field": 1.0
   },
-  "attributes_float_11": {
-    "num_of_spans": 50.0
+  "attributes_float_14": {
+    "my.int.field": 2000.0
   },
   "attributes_float_17": {
     "my.float.field": 101.2
   },
+  "attributes_float_21": {
+    "my.neg.float.field": -101.2
+  },
+  "attributes_float_25": {
+    "sentry.exclusive_time_ms": 0.228,
+    "sentry.start_timestamp_precise": 1721319572.616648
+  },
+  "attributes_float_26": {
+    "sentry.is_segment": 1.0
+  },
+  "attributes_float_31": {
+    "num_of_spans": 50.0
+  },
+  "attributes_float_4": {
+    "sentry.end_timestamp_precise": 1721319572.768806
+  },
+  "attributes_float_5": {
+    "my.neg.field": -100.0,
+    "sentry.duration_ms": 152.0
+  },
+  "attributes_float_6": {
+    "my.false.bool.field": 0.0
+  },
+  "attributes_float_7": {
+    "sentry.received": 1721319572.877828
+  },
   "attributes_int": {
     "my.int.field": 2000,
-    "my.neg.field": -100
+    "my.neg.field": -100,
+    "sentry.duration_ms": 152
   },
   "attributes_string_0": {
-    "relay_protocol_version": "3",
-    "sentry.transaction": "/api/0/relays/projectconfigs/"
-  },
-  "attributes_string_1": {
-    "sentry.thread.name": "uWSGIWorker1Core0"
-  },
-  "attributes_string_10": {
-    "sentry.sdk.version": "2.7.0"
+    "relay_protocol_version": "3"
   },
   "attributes_string_11": {
-    "sentry.platform": "python",
-    "sentry.transaction.method": "POST",
-    "sentry.user": "ip:127.0.0.1"
+    "sentry.segment_id": "8873a98879faf06d",
+    "sentry.transaction.method": "POST"
   },
   "attributes_string_12": {
-    "relay_use_post_or_schedule_rejected": "version",
+    "sentry.event_id": "d826225de75d42d6b2f01b957d51f18f",
     "server_name": "D23CXQ4GK2.local"
   },
   "attributes_string_14": {
@@ -55,31 +75,54 @@ expression: span
   "attributes_string_19": {
     "sentry.op": "http.server"
   },
-  "attributes_string_3": {
-    "sentry.profile_id": "56c7d1401ea14ad7b4ac86de46baebae",
-    "sentry.thread.id": "8522009600"
+  "attributes_string_20": {
+    "sentry.transaction": "/api/0/relays/projectconfigs/"
   },
-  "attributes_string_4": {
+  "attributes_string_21": {
+    "sentry.thread.name": "uWSGIWorker1Core0"
+  },
+  "attributes_string_23": {
+    "sentry.profile_id": "56c7d1401ea14ad7b4ac86de46baebae"
+  },
+  "attributes_string_24": {
     "thread.id": "8522009600"
   },
-  "attributes_string_5": {
+  "attributes_string_25": {
     "http.status_code": "200",
     "sentry.release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
     "sentry.sdk.name": "sentry.python.django",
     "sentry.transaction.op": "http.server"
   },
-  "attributes_string_6": {
-    "relay_id": "88888888-4444-4444-8444-cccccccccccc",
-    "thread.name": "uWSGIWorker1Core0"
+  "attributes_string_26": {
+    "relay_id": "88888888-4444-4444-8444-cccccccccccc"
   },
-  "attributes_string_7": {
+  "attributes_string_27": {
     "sentry.trace.status": "ok"
   },
-  "attributes_string_8": {
+  "attributes_string_28": {
     "sentry.category": "http"
   },
-  "attributes_string_9": {
+  "attributes_string_29": {
     "sentry.environment": "development"
+  },
+  "attributes_string_3": {
+    "sentry.thread.id": "8522009600"
+  },
+  "attributes_string_30": {
+    "sentry.sdk.version": "2.7.0"
+  },
+  "attributes_string_31": {
+    "sentry.platform": "python",
+    "sentry.user": "ip:127.0.0.1"
+  },
+  "attributes_string_32": {
+    "relay_use_post_or_schedule_rejected": "version"
+  },
+  "attributes_string_38": {
+    "sentry.description": "/api/0/relays/projectconfigs/"
+  },
+  "attributes_string_6": {
+    "thread.name": "uWSGIWorker1Core0"
   },
   "item_id": 9832388815107059821,
   "item_type": 1,
@@ -87,6 +130,6 @@ expression: span
   "project_id": 1,
   "retention_days": 90,
   "sampling_weight": 50,
-  "timestamp": 1721319572616,
+  "timestamp": 3332654216,
   "trace_id": "d099bf9a-d5a1-43cf-8f83-a98081d0ed3b"
 }

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_items__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_items__tests__serialization.snap
@@ -1,0 +1,92 @@
+---
+source: src/processors/eap_items.rs
+expression: span
+---
+{
+  "attributes_bool": {
+    "my.false.bool.field": false,
+    "my.true.bool.field": true
+  },
+  "attributes_float_1": {
+    "my.neg.float.field": -101.2
+  },
+  "attributes_float_11": {
+    "num_of_spans": 50.0
+  },
+  "attributes_float_17": {
+    "my.float.field": 101.2
+  },
+  "attributes_int": {
+    "my.int.field": 2000,
+    "my.neg.field": -100
+  },
+  "attributes_string_0": {
+    "relay_protocol_version": "3",
+    "sentry.transaction": "/api/0/relays/projectconfigs/"
+  },
+  "attributes_string_1": {
+    "sentry.thread.name": "uWSGIWorker1Core0"
+  },
+  "attributes_string_10": {
+    "sentry.sdk.version": "2.7.0"
+  },
+  "attributes_string_11": {
+    "sentry.platform": "python",
+    "sentry.transaction.method": "POST",
+    "sentry.user": "ip:127.0.0.1"
+  },
+  "attributes_string_12": {
+    "relay_use_post_or_schedule_rejected": "version",
+    "server_name": "D23CXQ4GK2.local"
+  },
+  "attributes_string_14": {
+    "sentry.status": "ok"
+  },
+  "attributes_string_17": {
+    "relay_endpoint_version": "3",
+    "relay_no_cache": "False",
+    "relay_use_post_or_schedule": "True",
+    "spans_over_limit": "False"
+  },
+  "attributes_string_18": {
+    "sentry.segment.name": "/api/0/relays/projectconfigs/",
+    "sentry.status_code": "200"
+  },
+  "attributes_string_19": {
+    "sentry.op": "http.server"
+  },
+  "attributes_string_3": {
+    "sentry.profile_id": "56c7d1401ea14ad7b4ac86de46baebae",
+    "sentry.thread.id": "8522009600"
+  },
+  "attributes_string_4": {
+    "thread.id": "8522009600"
+  },
+  "attributes_string_5": {
+    "http.status_code": "200",
+    "sentry.release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",
+    "sentry.sdk.name": "sentry.python.django",
+    "sentry.transaction.op": "http.server"
+  },
+  "attributes_string_6": {
+    "relay_id": "88888888-4444-4444-8444-cccccccccccc",
+    "thread.name": "uWSGIWorker1Core0"
+  },
+  "attributes_string_7": {
+    "sentry.trace.status": "ok"
+  },
+  "attributes_string_8": {
+    "sentry.category": "http"
+  },
+  "attributes_string_9": {
+    "sentry.environment": "development"
+  },
+  "item_id": 9832388815107059821,
+  "item_type": 1,
+  "organization_id": 1,
+  "project_id": 1,
+  "retention_days": 90,
+  "sampling_weight": 50,
+  "timestamp": 1721319572616,
+  "trace_id": "d099bf9a-d5a1-43cf-8f83-a98081d0ed3b"
+}

--- a/snuba/datasets/processors/eap_items_processor.py
+++ b/snuba/datasets/processors/eap_items_processor.py
@@ -1,0 +1,6 @@
+from snuba.datasets.processors.rust_compat_processor import RustCompatProcessor
+
+
+class EAPItemsProcessor(RustCompatProcessor):
+    def __init__(self) -> None:
+        super().__init__("EAPItemsProcessor")


### PR DESCRIPTION
A new EAP clickhouse table was recently created https://github.com/getsentry/snuba/pull/6850
This PR creates a new processor aka kafka consumer that reads spans off the existing `snuba-spans` topic and writes them to the new table.