### PR TITLE
chore(docs): update references to devservices

### DIFF
--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -82,7 +82,7 @@ and, in another terminal::
     cd ../sentry
     git checkout master
     git pull
-    sentry devservices up --exclude=snuba
+    devservices up --exclude=snuba
 
 This will get the most recent version of Sentry on master, and bring up all snuba's dependencies.
 

--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -22,7 +22,7 @@ in ``~/.sentry/sentry.conf.py``::
 
 And then use::
 
-    sentry devservices up --exclude=snuba
+    devservices up --exclude=snuba
 
 Note that Snuba assumes that everything is running on UTC time. Otherwise
 you may experience issues with timezone mismatches.

--- a/docs/source/migrations/modes.rst
+++ b/docs/source/migrations/modes.rst
@@ -27,7 +27,7 @@ Enabling Local Mode
 In your local ``server.py``, set ``SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES``
 to False. This is the default setting, so configuration is already
 set up for local mode migrations. Start up the corresponding ClickHouse
-container (``sentry devservices up clickhouse``).
+container (``devservices up clickhouse``).
 
 Now, run migrations as expected (``snuba migrations migrate --force``).
 
@@ -36,7 +36,7 @@ Enabling Distributed Mode
 ============================
 
 In your local ``server.py``, set ``SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES``
-to True. Start up the corresponding ClickHouse container (``sentry devservices up clickhouse``).
+to True. Start up the corresponding ClickHouse container (``devservices up clickhouse``).
 Make sure that the Zookeeper container is also running; without it, distributed migrations
 will not work properly.
 

--- a/snuba/admin/README.md
+++ b/snuba/admin/README.md
@@ -14,7 +14,7 @@ snuba admin
 
 The server should be running on http://127.0.0.1:1219
 
-note: please ensure that sentry devservices are up via `sentry devservices up --exclude=snuba` from within the sentry repository
+note: please ensure that sentry devservices are up via `devservices up --exclude=snuba` from within the sentry repository
 
 # Developing the Javascript
 


### PR DESCRIPTION
- Updates references to `devservices` according to [the repo's](https://github.com/getsentry/devservices) original guidance - "`sentry devservices up` is deprecated. Please use `devservices up` instead."