### PR TITLE
fix(eap): Remove static sample count thresholds

### DIFF
--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -138,12 +138,7 @@ class GenericExtrapolationContext(ExtrapolationContext):
             if self.value != 0
             else float("inf")
         )
-        is_reliable = calculate_reliability(
-            relative_confidence,
-            self.sample_count,
-            CONFIDENCE_INTERVAL_THRESHOLD,
-        )
-        if is_reliable:
+        if relative_confidence <= CONFIDENCE_INTERVAL_THRESHOLD:
             return Reliability.RELIABILITY_HIGH
         return Reliability.RELIABILITY_LOW
 
@@ -174,12 +169,7 @@ class PercentileExtrapolationContext(ExtrapolationContext):
             self.value / ci_lower if ci_lower != 0 else float("inf"),
             ci_upper / self.value if self.value != 0 else float("inf"),
         )
-        is_reliable = calculate_reliability(
-            relative_confidence,
-            self.sample_count,
-            CONFIDENCE_INTERVAL_THRESHOLD,
-        )
-        if is_reliable:
+        if relative_confidence <= CONFIDENCE_INTERVAL_THRESHOLD:
             return Reliability.RELIABILITY_HIGH
         return Reliability.RELIABILITY_LOW
 
@@ -601,21 +591,6 @@ def _calculate_approximate_ci_percentile_levels(
     lower_index = n * p - z_value * math.sqrt(n * p * (1 - p))
     upper_index = 1 + n * p + z_value * math.sqrt(n * p * (1 - p))
     return (lower_index / n, upper_index / n)
-
-
-def calculate_reliability(
-    relative_confidence: float,
-    sample_count: int,
-    confidence_interval_threshold: float,
-    sample_count_threshold: int = 100,
-) -> bool:
-    """
-    A reliability check to determine if the sample count is large enough to be reliable and the confidence interval is small enough.
-    """
-    if sample_count < sample_count_threshold:
-        return False
-
-    return relative_confidence <= confidence_interval_threshold
 
 
 def aggregation_to_expression(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
@@ -402,9 +402,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             0
         ]
         assert measurement_count == 5
-        assert (
-            measurement_reliability == Reliability.RELIABILITY_LOW
-        )  # low reliability due to low sample count
+        assert measurement_reliability == Reliability.RELIABILITY_HIGH
 
     def test_count_reliability(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
@@ -461,9 +459,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             0
         ]
         assert measurement_count == 5
-        assert (
-            measurement_reliability == Reliability.RELIABILITY_LOW
-        )  # low reliability due to low sample count
+        assert measurement_reliability == Reliability.RELIABILITY_HIGH
 
     def test_count_reliability_with_group_by_backward_compat(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
@@ -578,17 +574,13 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
         measurement_counts = [v.val_double for v in response.column_values[3].results]
         measurement_reliabilities = [v for v in response.column_values[3].reliabilities]
         assert measurement_counts == [5]
-        assert measurement_reliabilities == [
-            Reliability.RELIABILITY_LOW,
-        ]  # low reliability due to low sample count
+        assert measurement_reliabilities == [Reliability.RELIABILITY_HIGH]
 
         measurement_p90s = [v.val_double for v in response.column_values[4].results]
         measurement_reliabilities = [v for v in response.column_values[4].reliabilities]
         assert len(measurement_p90s) == 1
         assert measurement_p90s[0] == 4
-        assert measurement_reliabilities == [
-            Reliability.RELIABILITY_LOW,
-        ]  # low reliability due to low sample count
+        assert measurement_reliabilities == [Reliability.RELIABILITY_HIGH]
 
     def test_count_reliability_with_group_by(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
@@ -703,17 +695,13 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
         measurement_counts = [v.val_double for v in response.column_values[3].results]
         measurement_reliabilities = [v for v in response.column_values[3].reliabilities]
         assert measurement_counts == [5]
-        assert measurement_reliabilities == [
-            Reliability.RELIABILITY_LOW,
-        ]  # low reliability due to low sample count
+        assert measurement_reliabilities == [Reliability.RELIABILITY_HIGH]
 
         measurement_p90s = [v.val_double for v in response.column_values[4].results]
         measurement_reliabilities = [v for v in response.column_values[4].reliabilities]
         assert len(measurement_p90s) == 1
         assert measurement_p90s[0] == 4
-        assert measurement_reliabilities == [
-            Reliability.RELIABILITY_LOW,
-        ]  # low reliability due to low sample count
+        assert measurement_reliabilities == [Reliability.RELIABILITY_HIGH]
 
     def test_formula(self) -> None:
         """
@@ -873,7 +861,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
                 attribute_name="sum(custom_measurement)",
                 results=[AttributeValue(val_double=5), AttributeValue(is_null=True)],
                 reliabilities=[
-                    Reliability.RELIABILITY_LOW,
+                    Reliability.RELIABILITY_HIGH,
                     Reliability.RELIABILITY_UNSPECIFIED,
                 ],
             ),
@@ -882,7 +870,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
                 results=[AttributeValue(is_null=True), AttributeValue(val_double=5)],
                 reliabilities=[
                     Reliability.RELIABILITY_UNSPECIFIED,
-                    Reliability.RELIABILITY_LOW,
+                    Reliability.RELIABILITY_HIGH,
                 ],
             ),
         ]


### PR DESCRIPTION
The `reliability` flag is supposed to return the mathematical accuracy
based on the sample rate without other additional heuristics applied.
Currently, the calculation also compares the sample count with a static
threshold (count > 100) and returns _low reliability_ if the count is
below.

Going forward, any checks for a static sample count threshold will be
performed outside of the EAP.

Confidence calculation for aggregations other than AVG will be fixed in
follow-up PRs.

Requires https://github.com/getsentry/sentry/pull/85323
Ref https://github.com/getsentry/eap-planning/issues/192