### PR TITLE
build(rs): Add `protobuf` to brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,2 @@
-# necessary for rust-snuba
-brew 'cmake'
+brew 'cmake'  # for rust-snuba
+brew 'protobuf'  # for rust-snuba > sentry_protos


### PR DESCRIPTION
As of a few versions ago, `protoc` is required by `sentry_protos`. It can be
installed through homebrew.

