### PR TITLE
chore(devservices): Bumping the version of devservices to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 clickhouse-driver==0.2.9
 confluent-kafka==2.7.0
 datadog==0.21.0
-devservices==1.0.16
+devservices==1.0.17
 flake8==7.0.0
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
Updating devservices to 1.0.17: https://github.com/getsentry/devservices/releases/tag/1.0.17