### PR TITLE
fix(ci): Auth protoc to avoid rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
         name: Checkout code
       - name: Install protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run linter
         run: |
           make lint-rust format-rust-ci


### PR DESCRIPTION
Docker made their rate limits more aggressive this week, we need to auth to circumvent that issue.