### PR TITLE
Run rustup toolchain install explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,11 +87,11 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; cd ./rust_snuba/; rustup show active-toolchain || rustup toolchain install
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \
     cd ./rust_snuba/; \
+    rustup show active-toolchain || rustup toolchain install; \
     maturin build --release --compatibility linux --locked
 
 FROM build_rust_snuba_base AS build_rust_snuba

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; rustup toolchain install 
+RUN set -ex; rustup toolchain install
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; rustup toolchain install --toolchain-file ./rust_snuba/rust-toolchain.toml
+RUN set -ex; cd ./rust_snuba/; rustup toolchain install
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ RUN set -ex; \
     echo '[registries.crates-io]' >> ~/.cargo/config; \
     echo 'protocol = "sparse"' >> ~/.cargo/config
 
+RUN set -ex; rustup toolchain install
+
 ENV PATH="/root/.cargo/bin/:${PATH}"
 
 FROM build_rust_snuba_base AS build_rust_snuba_deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
+RUN set -ex; cd ./rust_snuba/; rustup show active-toolchain 
 RUN set -ex; cd ./rust_snuba/; rustup install
 
 RUN set -ex; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; cd ./rust_snuba/; rustup show active-toolchain
-RUN set -ex; cd ./rust_snuba/; rustup install
+RUN set -ex; cd ./rust_snuba/ && rustup toolchain install
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; cd ./rust_snuba/; rustup toolchain install
+RUN set -ex; cd ./rust_snuba/; rustup install
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; rustup toolchain install
+RUN set -ex; rustup toolchain install --toolchain-file ./rust_snuba/rust-toolchain.toml
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; cd ./rust_snuba/; rustup show active-toolchain 
+RUN set -ex; cd ./rust_snuba/; rustup show active-toolchain
 RUN set -ex; cd ./rust_snuba/; rustup install
 
 RUN set -ex; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,7 @@ COPY --from=build_rust_snuba_deps /usr/src/snuba/rust_snuba/target/ ./rust_snuba
 COPY --from=build_rust_snuba_deps /root/.cargo/ /root/.cargo/
 RUN set -ex; \
     cd ./rust_snuba/; \
+    rustup show active-toolchain || rustup toolchain install; \
     maturin build --release --compatibility linux --locked
 
 # Install nodejs and yarn and build the admin UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; cd ./rust_snuba/ && rustup toolchain install stable
+RUN set -ex; cd ./rust_snuba/; rustup show active-toolchain || rustup toolchain install
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
-RUN set -ex; cd ./rust_snuba/ && rustup toolchain install
+RUN set -ex; cd ./rust_snuba/ && rustup toolchain install stable
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,6 @@ RUN set -ex; \
     echo '[registries.crates-io]' >> ~/.cargo/config; \
     echo 'protocol = "sparse"' >> ~/.cargo/config
 
-RUN set -ex; rustup toolchain install
-
 ENV PATH="/root/.cargo/bin/:${PATH}"
 
 FROM build_rust_snuba_base AS build_rust_snuba_deps
@@ -89,6 +87,7 @@ COPY ./rust_snuba/Cargo.toml ./rust_snuba/Cargo.toml
 COPY ./rust_snuba/rust-toolchain.toml ./rust_snuba/rust-toolchain.toml
 COPY ./rust_snuba/Cargo.lock ./rust_snuba/Cargo.lock
 COPY ./scripts/rust-dummy-build.sh ./scripts/rust-dummy-build.sh
+RUN set -ex; rustup toolchain install 
 
 RUN set -ex; \
     sh scripts/rust-dummy-build.sh; \


### PR DESCRIPTION
rustup will no longer automatically install the active toolchain if it is not installed. To ensure its installation, run `rustup toolchain install` with no arguments.

https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html



In the cloudbuild logs we see this happening which is breaking our builds

```
info: default host triple is x86_64-unknown-linux-gnu
info: skipping toolchain installation
```




