### PR TITLE
feat(capman): Instead of flatly rejecting heavy projects, limit their bytes scanned on the query level

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -55,7 +55,7 @@ jobs:
   publish-to-dockerhub:
     needs: build
     name: Publish Snuba to DockerHub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # v3.1.0
       - name: Pull the test image

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -110,13 +110,13 @@ class QuotaAllowance:
     quota_unit: str
     suggestion: str
 
+    # sets this value:
+    # https://clickhouse.com/docs/operations/settings/settings#max_bytes_to_read
+    # 0 means unlimited
+    max_bytes_to_read: int = field(default=0)
+
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
-
-    def __lt__(self, other: QuotaAllowance) -> bool:
-        if self.can_run and not other.can_run:
-            return False
-        return self.max_threads < other.max_threads
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, QuotaAllowance):
@@ -124,6 +124,7 @@ class QuotaAllowance:
         return (
             self.can_run == other.can_run
             and self.max_threads == other.max_threads
+            and self.max_bytes_to_read == other.max_bytes_to_read
             and self.explanation == other.explanation
             and self.is_throttled == other.is_throttled
             and self.throttle_threshold == other.throttle_threshold

--- a/snuba/query/allocation_policies/bytes_scanned_rejecting_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_rejecting_policy.py
@@ -111,6 +111,18 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
                 int,
                 DEFAULT_THREADS_THROTTLE_DIVIDER,
             ),
+            AllocationPolicyConfig(
+                "limit_bytes_instead_of_rejecting",
+                "instead of rejecting a query, limit its bytes with max_bytes_to_read on clickhouse",
+                int,
+                0,
+            ),
+            AllocationPolicyConfig(
+                "max_bytes_to_read_scan_limit_divider",
+                "if limit_bytes_instead_of_rejecting is set and the scan limit is reached, scan_limit/ max_bytes_to_read_scan_limit_divider is how many bytes each query will be capped to",
+                float,
+                1.0,
+            ),
         ]
 
     def _are_tenant_ids_valid(
@@ -230,32 +242,72 @@ class BytesScannedRejectingPolicy(AllocationPolicy):
         granted_quota = granted_quotas[0]
         used_quota = scan_limit - granted_quota.granted
         if granted_quota.granted <= 0:
-            explanation[
-                "reason"
-            ] = f"""{customer_tenant_key} {customer_tenant_value} is over the bytes scanned limit of {scan_limit} for referrer {referrer}.
-            This policy is exceeded when a customer is abusing a specific feature in a way that puts load on clickhouse. If this is happening to
-            "many customers, that may mean the feature is written in an inefficient way"""
-            explanation["granted_quota"] = granted_quota.granted
-            explanation["limit"] = scan_limit
-            # This is technically a high cardinality tag value however these rejections
-            # should not happen often therefore it should be safe to output these rejections as metris
-            self.metrics.increment(
-                "bytes_scanned_rejection",
-                tags={
-                    "tenant": f"{customer_tenant_key}__{customer_tenant_value}__{referrer}"
-                },
-            )
-            return QuotaAllowance(
-                can_run=False,
-                max_threads=0,
-                explanation=explanation,
-                is_throttled=True,
-                throttle_threshold=throttle_threshold,
-                rejection_threshold=scan_limit,
-                quota_used=used_quota,
-                quota_unit=QUOTA_UNIT,
-                suggestion=SUGGESTION,
-            )
+            if self.get_config_value("limit_bytes_instead_of_rejecting"):
+                max_bytes_to_read = int(
+                    scan_limit
+                    / self.get_config_value("max_bytes_to_read_scan_limit_divider")
+                )
+                explanation[
+                    "reason"
+                ] = f"""{customer_tenant_key} {customer_tenant_value} is over the bytes scanned limit of {scan_limit} for referrer {referrer}.
+                The query will be limited to {max_bytes_to_read} bytes
+                """
+                explanation["granted_quota"] = granted_quota.granted
+                explanation["limit"] = scan_limit
+                # This is technically a high cardinality tag value however these rejections
+                # should not happen often therefore it should be safe to output these rejections as metris
+
+                self.metrics.increment(
+                    "bytes_scanned_limited",
+                    tags={
+                        "tenant": f"{customer_tenant_key}__{customer_tenant_value}__{referrer}"
+                    },
+                )
+                return QuotaAllowance(
+                    can_run=True,
+                    max_threads=max(
+                        1,
+                        self.max_threads
+                        // self.get_config_value("threads_throttle_divider"),
+                    ),
+                    max_bytes_to_read=max_bytes_to_read,
+                    explanation=explanation,
+                    is_throttled=True,
+                    throttle_threshold=throttle_threshold,
+                    rejection_threshold=scan_limit,
+                    quota_used=used_quota,
+                    quota_unit=QUOTA_UNIT,
+                    suggestion=SUGGESTION,
+                )
+
+            else:
+                explanation[
+                    "reason"
+                ] = f"""{customer_tenant_key} {customer_tenant_value} is over the bytes scanned limit of {scan_limit} for referrer {referrer}.
+                This policy is exceeded when a customer is abusing a specific feature in a way that puts load on clickhouse. If this is happening to
+                "many customers, that may mean the feature is written in an inefficient way"""
+                explanation["granted_quota"] = granted_quota.granted
+                explanation["limit"] = scan_limit
+                # This is technically a high cardinality tag value however these rejections
+                # should not happen often therefore it should be safe to output these rejections as metris
+
+                self.metrics.increment(
+                    "bytes_scanned_rejection",
+                    tags={
+                        "tenant": f"{customer_tenant_key}__{customer_tenant_value}__{referrer}"
+                    },
+                )
+                return QuotaAllowance(
+                    can_run=False,
+                    max_threads=0,
+                    explanation=explanation,
+                    is_throttled=True,
+                    throttle_threshold=throttle_threshold,
+                    rejection_threshold=scan_limit,
+                    quota_used=used_quota,
+                    quota_unit=QUOTA_UNIT,
+                    suggestion=SUGGESTION,
+                )
 
         # this checks to see if you reached the throttle threshold
         if granted_quota.granted < scan_limit - throttle_threshold:

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1404,12 +1404,13 @@ class TestSnQLApi(BaseApiTest):
                             "storage_key": "StorageKey.DOESNTMATTER",
                         },
                         "is_throttled": False,
-                        "throttle_threshold": MAX_THRESHOLD,
-                        "rejection_threshold": MAX_THRESHOLD,
+                        "throttle_threshold": 1000000000000,
+                        "rejection_threshold": 1000000000000,
                         "quota_used": 0,
-                        "quota_unit": NO_UNITS,
-                        "suggestion": NO_SUGGESTION,
-                    },
+                        "quota_unit": "no_units",
+                        "suggestion": "no_suggestion",
+                        "max_bytes_to_read": 0,
+                    }
                 },
                 "summary": {
                     "threads_used": 0,
@@ -1429,7 +1430,6 @@ class TestSnQLApi(BaseApiTest):
                     "throttled_by": {},
                 },
             }
-
             assert (
                 response.json["error"]["message"]
                 == f"Query on could not be run due to allocation policies, info: {info}"

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -318,6 +318,7 @@ def test_db_query_success() -> None:
             "ReferrerGuardRailPolicy": {
                 "can_run": True,
                 "max_threads": 10,
+                "max_bytes_to_read": 0,
                 "explanation": {
                     "reason": "within limit",
                     "policy": "referrer_guard_rail_policy",
@@ -334,6 +335,7 @@ def test_db_query_success() -> None:
             "ConcurrentRateLimitAllocationPolicy": {
                 "can_run": True,
                 "max_threads": 10,
+                "max_bytes_to_read": 0,
                 "explanation": {
                     "reason": "within limit",
                     "overrides": {},
@@ -349,6 +351,7 @@ def test_db_query_success() -> None:
             "BytesScannedRejectingPolicy": {
                 "can_run": True,
                 "max_threads": 10,
+                "max_bytes_to_read": 0,
                 "explanation": {
                     "reason": "within_limit",
                     "storage_key": "StorageKey.ERRORS_RO",
@@ -362,6 +365,7 @@ def test_db_query_success() -> None:
             },
             "CrossOrgQueryAllocationPolicy": {
                 "can_run": True,
+                "max_bytes_to_read": 0,
                 "max_threads": 10,
                 "explanation": {
                     "reason": "pass_through",
@@ -544,6 +548,7 @@ def test_apply_allocation_policies_quota_sets_throttle_policy() -> None:
                 "ThrottleAllocationPolicy1": {
                     "can_run": True,
                     "max_threads": 1,
+                    "max_bytes_to_read": 0,
                     "explanation": {
                         "reason": "ThrottleAllocationPolicy1 throttles all queries",
                         "storage_key": "StorageKey.DOESNTMATTER",
@@ -558,6 +563,7 @@ def test_apply_allocation_policies_quota_sets_throttle_policy() -> None:
                 "ThrottleAllocationPolicy2": {
                     "can_run": True,
                     "max_threads": 2,
+                    "max_bytes_to_read": 0,
                     "explanation": {
                         "reason": "ThrottleAllocationPolicy2 throttles all queries",
                         "storage_key": "StorageKey.DOESNTMATTER",
@@ -676,6 +682,7 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
             "details": {
                 "RejectAllocationPolicy": {
                     "can_run": False,
+                    "max_bytes_to_read": 0,
                     "explanation": {
                         "reason": "policy rejects all queries",
                         "storage_key": "StorageKey.DOESNTMATTER",
@@ -922,6 +929,7 @@ def test_allocation_policy_updates_quota() -> None:
                     "storage_key": "StorageKey.DOESNTMATTER",
                 },
                 "is_throttled": False,
+                "max_bytes_to_read": 0,
                 "throttle_threshold": MAX_QUERIES_TO_RUN,
                 "rejection_threshold": MAX_QUERIES_TO_RUN,
                 "quota_used": queries_run,


### PR DESCRIPTION
Sometimes large customers complain that they get throttled because someone scans all their data and then they're locked out for 10 minutes. Not a great experience

To ease the pain, still allow their queries to go through but give them a short leash using clickhouses `max_bytes_to_read` setting


By default this will not be turned on until a human is around to monitor it