### PR TITLE
fix(eap): Remove column processor preventing the use of an index

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -216,9 +216,6 @@ allocation_policies:
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
-  - processor: UUIDColumnProcessor
-    args:
-      columns: [trace_id]
   - processor: PrewhereProcessor
     args:
       prewhere_candidates:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_log.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_log.yaml
@@ -216,9 +216,6 @@ allocation_policies:
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
-  - processor: UUIDColumnProcessor
-    args:
-      columns: [trace_id]
   - processor: PrewhereProcessor
     args:
       prewhere_candidates:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_spans.yaml
@@ -104,7 +104,7 @@ query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: UUIDColumnProcessor
     args:
-      columns: [transaction_id, trace_id, profile_id]
+      columns: [transaction_id, profile_id]
   - processor: HexIntColumnProcessor
     args:
       columns: [span_id, parent_span_id, segment_id]

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -249,6 +249,8 @@ def _convert_results(
         ] = defaultdict(TraceAttribute)
         for attribute in request.attributes:
             value = row[_ATTRIBUTES[attribute.key][0]]
+            if attribute.key == TraceAttribute.Key.KEY_TRACE_ID:
+                value = uuid.UUID(value).hex
             type = _ATTRIBUTES[attribute.key][1]
             values[attribute.key] = TraceAttribute(
                 key=attribute.key,

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -8,7 +8,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
 from snuba.query import Query
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal, literals_array
-from snuba.query.expressions import Expression, SubscriptableReference
+from snuba.query.expressions import Expression, FunctionCall, SubscriptableReference
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 
 # These are the columns which aren't stored in attr_str_ nor attr_num_ in clickhouse
@@ -51,7 +51,11 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
 
     if attr_key.name == "sentry.trace_id":
         if attr_key.type == AttributeKey.Type.TYPE_STRING:
-            return f.CAST(column("trace_id"), "String", alias=alias)
+            return FunctionCall(
+                alias,
+                "toUUID",
+                column("trace_id"),
+            )
         raise BadSnubaRPCRequestException(
             f"Attribute {attr_key.name} must be requested as a string, got {attr_key.type}"
         )

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -54,7 +54,7 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
             return FunctionCall(
                 alias,
                 "toUUID",
-                column("trace_id"),
+                (column("trace_id"),),
             )
         raise BadSnubaRPCRequestException(
             f"Attribute {attr_key.name} must be requested as a string, got {attr_key.type}"

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -133,7 +133,11 @@ def _build_query(request: GetTraceRequest) -> Query:
                     "String",
                     alias="trace_id",
                 ),
-                literal(request.trace_id),
+                FunctionCall(
+                    "trace_id",
+                    "toUUID",
+                    literal(request.trace_id),
+                ),
             ),
         ),
         order_by=[

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -19,7 +19,6 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
-from snuba.query.dsl import Functions as f
 from snuba.query.dsl import and_cond, column, equals, literal
 from snuba.query.expressions import FunctionCall
 from snuba.query.logical import Query
@@ -128,13 +127,9 @@ def _build_query(request: GetTraceRequest) -> Query:
                 request.meta.end_timestamp.seconds,
             ),
             equals(
-                f.cast(
-                    column("trace_id"),
-                    "String",
-                    alias="trace_id",
-                ),
+                column("trace_id"),
                 FunctionCall(
-                    "trace_id",
+                    None,
                     "toUUID",
                     (literal(request.trace_id),),
                 ),

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -136,7 +136,7 @@ def _build_query(request: GetTraceRequest) -> Query:
                 FunctionCall(
                     "trace_id",
                     "toUUID",
-                    literal(request.trace_id),
+                    (literal(request.trace_id),),
                 ),
             ),
         ),

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -15,7 +15,7 @@ class TestCommon:
                 type=AttributeKey.TYPE_STRING,
                 name="sentry.trace_id",
             ),
-        ) == f.CAST(column("trace_id"), "String", alias="sentry.trace_id_TYPE_STRING")
+        ) == f.toUUID(column("trace_id"), alias="sentry.trace_id_TYPE_STRING")
 
     def test_timestamp_columns(self) -> None:
         for col in [

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -343,7 +343,6 @@ class TestGetTraces(BaseApiTest):
     def test_with_data_and_aggregated_fields_all_keys(
         self, setup_teardown: Any
     ) -> None:
-
         ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))
         three_hours_later = int((_BASE_TIME + timedelta(hours=3)).timestamp())
         start_timestamp_per_trace_id: dict[str, float] = defaultdict(lambda: 2 * 1e10)


### PR DESCRIPTION
This column will transform the `trace_id` expression to:
```
(cast(replaceAll(toString(trace_id), '-', ''), 'String') AS trace_id)
```

As a result, when this is in the `PREWHERE`, it will not use the bloom filter created for the `trace_id`. Disabling this query processor will make it use the index.