### PR TITLE
feat(eap): use eap_items in timeseries endpoint

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -53,7 +53,9 @@ NORMALIZED_COLUMNS_EAP_ITEMS: Final[
         AttributeKey.Type.TYPE_INT,
         AttributeKey.Type.TYPE_STRING,
     ],
-    "sentry.trace_id": [AttributeKey.Type.TYPE_STRING],
+    "sentry.trace_id": [
+        AttributeKey.Type.TYPE_STRING
+    ],  # this gets converted from a uuid to a string in a storage processor
     "sentry.item_id": [AttributeKey.Type.TYPE_STRING],
 }
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -138,6 +138,11 @@ def attribute_key_to_expression_eap_items(attr_key: AttributeKey) -> Expression:
                 "Nullable(Int64)",
                 alias=alias,
             )
+        return SubscriptableReference(
+            column=column(PROTO_TYPE_TO_ATTRIBUTE_COLUMN[attr_key.type]),
+            key=literal(attr_key.name),
+            alias=alias,
+        )
 
     raise BadSnubaRPCRequestException(
         f"Attribute {attr_key.name} has an unknown type: {AttributeKey.Type.Name(attr_key.type)}"

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -1,10 +1,12 @@
-from typing import Final, Mapping, Sequence, Set
+from typing import Any, Final, Mapping, Sequence, Set
 
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeKey,
     VirtualColumnContext,
 )
 
+from snuba import state
 from snuba.query import Query
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal, literals_array
@@ -37,6 +39,156 @@ TIMESTAMP_COLUMNS: Final[Set[str]] = {
     "sentry.start_timestamp",
     "sentry.end_timestamp",
 }
+
+COLLUMN_PREFIX: str = "sentry."
+
+NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, Any]] = {
+    "sentry.organization_id": {AttributeKey.Type.TYPE_INT},
+    "sentry.project_id": {AttributeKey.Type.TYPE_INT},
+    "sentry.timestamp": {
+        AttributeKey.Type.TYPE_FLOAT,
+        AttributeKey.Type.TYPE_DOUBLE,
+        AttributeKey.Type.TYPE_INT,
+        AttributeKey.Type.TYPE_STRING,
+    },
+    "sentry.trace_id": {AttributeKey.Type.TYPE_STRING},
+    "sentry.item_id": {AttributeKey.Type.TYPE_STRING},
+}
+
+PROTO_TYPE_TO_CLICKHOUSE_TYPE: Final[Mapping[AttributeKey.Type.ValueType, str]] = {
+    AttributeKey.Type.TYPE_INT: "Int64",
+    AttributeKey.Type.TYPE_STRING: "String",
+    AttributeKey.Type.TYPE_DOUBLE: "Float64",
+    AttributeKey.Type.TYPE_FLOAT: "Float64",
+    AttributeKey.Type.TYPE_BOOLEAN: "Boolean",
+}
+
+PROTO_TYPE_TO_ATTRIBUTE_COLUMN: Final[Mapping[AttributeKey.Type.ValueType, str]] = {
+    AttributeKey.Type.TYPE_INT: "attributes_int",
+    AttributeKey.Type.TYPE_STRING: "attributes_string",
+    AttributeKey.Type.TYPE_DOUBLE: "attributes_float",
+    AttributeKey.Type.TYPE_FLOAT: "attributes_float",
+    AttributeKey.Type.TYPE_BOOLEAN: "attributes_bool",
+}
+
+
+def use_eap_items_table(request_meta: RequestMeta) -> bool:
+    use_eap_items_table_start_timestamp_seconds = state.get_int_config(
+        "use_eap_items_table_start_timestamp_seconds"
+    )
+    if (
+        state.get_config("use_eap_items_table", False)
+        and use_eap_items_table_start_timestamp_seconds is not None
+    ):
+        return (
+            request_meta.start_timestamp.seconds
+            >= use_eap_items_table_start_timestamp_seconds
+        )
+
+    return False
+
+
+def attribute_key_to_expression_eap_items(attr_key: AttributeKey) -> Expression:
+    alias = attr_key.name + "_" + AttributeKey.Type.Name(attr_key.type)
+    if attr_key.type == AttributeKey.Type.TYPE_UNSPECIFIED:
+        raise BadSnubaRPCRequestException(
+            f"attribute key {attr_key.name} must have a type specified"
+        )
+
+    if attr_key.name in NORMALIZED_COLUMNS_EAP_ITEMS:
+        if attr_key.type not in NORMALIZED_COLUMNS_EAP_ITEMS[attr_key.name]:
+            formatted_attribute_types = ", ".join(
+                map(AttributeKey.Type.Name, NORMALIZED_COLUMNS_EAP_ITEMS[attr_key.name])
+            )
+            raise BadSnubaRPCRequestException(
+                f"Attribute {attr_key.name} must be one of [{formatted_attribute_types}], got {AttributeKey.Type.Name(attr_key.type)}"
+            )
+
+        return f.CAST(
+            column(attr_key.name[len(COLLUMN_PREFIX) :]),
+            PROTO_TYPE_TO_CLICKHOUSE_TYPE[attr_key.type],
+            alias=alias,
+        )
+
+    if attr_key.type in PROTO_TYPE_TO_ATTRIBUTE_COLUMN:
+        return SubscriptableReference(
+            column=column(PROTO_TYPE_TO_ATTRIBUTE_COLUMN[attr_key.type]),
+            key=literal(attr_key.name),
+            alias=alias,
+        )
+
+    raise BadSnubaRPCRequestException(
+        f"Attribute {attr_key.name} has an unknown type: {AttributeKey.Type.Name(attr_key.type)}"
+    )
+
+
+def apply_virtual_columns_eap_items(
+    query: Query, virtual_column_contexts: Sequence[VirtualColumnContext]
+) -> None:
+    """Injects virtual column mappings into the clickhouse query. Works with NORMALIZED_COLUMNS on the table or
+    dynamic columns in attr_str
+
+    attr_num not supported because mapping on floats is a bad idea
+
+    Example:
+
+        SELECT
+          project_name AS `project_name`,
+          attr_str['release'] AS `release`,
+          attr_str['sentry.sdk.name'] AS `sentry.sdk.name`,
+        ... rest of query
+
+        contexts:
+            [   {from_column_name: project_id, to_column_name: project_name, value_map: {1: "sentry", 2: "snuba"}} ]
+
+
+        Query will be transformed into:
+
+        SELECT
+        -- see the project name column transformed and the value mapping injected
+          transform( CAST( project_id, 'String'), array( '1', '2'), array( 'sentry', 'snuba'), 'unknown') AS `project_name`,
+        --
+          attr_str['release'] AS `release`,
+          attr_str['sentry.sdk.name'] AS `sentry.sdk.name`,
+        ... rest of query
+
+    """
+
+    if not virtual_column_contexts:
+        return
+
+    mapped_column_to_context = {c.to_column_name: c for c in virtual_column_contexts}
+
+    def transform_expressions(expression: Expression) -> Expression:
+        # virtual columns will show up as `attr_str[virtual_column_name]` or `attr_num[virtual_column_name]`
+        if not isinstance(expression, SubscriptableReference):
+            return expression
+
+        if expression.column.column_name != "attributes_string":
+            return expression
+        context = mapped_column_to_context.get(str(expression.key.value))
+        if context:
+            attribute_expression = attribute_key_to_expression_eap_items(
+                AttributeKey(
+                    name=context.from_column_name,
+                    type=NORMALIZED_COLUMNS.get(
+                        context.from_column_name, AttributeKey.TYPE_STRING
+                    ),
+                )
+            )
+            return f.transform(
+                f.CAST(attribute_expression, "String"),
+                literals_array(None, [literal(k) for k in context.value_map.keys()]),
+                literals_array(None, [literal(v) for v in context.value_map.values()]),
+                literal(
+                    context.default_value if context.default_value != "" else "unknown"
+                ),
+                alias=context.to_column_name,
+            )
+
+        return expression
+
+    query.transform_expressions(transform_expressions)
 
 
 def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -77,8 +77,8 @@ PROTO_TYPE_TO_ATTRIBUTE_COLUMN: Final[Mapping[AttributeKey.Type.ValueType, str]]
 
 
 def use_eap_items_table(request_meta: RequestMeta) -> bool:
-    if request_meta.referrer.startswith("force_use_eap_items_table"):
-        return True
+    if request_meta.referrer.startswith("force_use_eap_spans_table"):
+        return False
 
     use_eap_items_table_start_timestamp_seconds = state.get_int_config(
         "use_eap_items_table_start_timestamp_seconds"

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -40,7 +40,7 @@ TIMESTAMP_COLUMNS: Final[Set[str]] = {
     "sentry.end_timestamp",
 }
 
-COLLUMN_PREFIX: str = "sentry."
+COLUMN_PREFIX: str = "sentry."
 
 NORMALIZED_COLUMNS_EAP_ITEMS: Final[
     Mapping[str, Sequence[AttributeKey.Type.ValueType]]
@@ -109,7 +109,7 @@ def attribute_key_to_expression_eap_items(attr_key: AttributeKey) -> Expression:
             )
 
         return f.CAST(
-            column(attr_key.name[len(COLLUMN_PREFIX) :]),
+            column(attr_key.name[len(COLUMN_PREFIX) :]),
             PROTO_TYPE_TO_CLICKHOUSE_TYPE[attr_key.type],
             alias=alias,
         )

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, Mapping, Sequence, Set
+from typing import Final, Mapping, Sequence, Set
 
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
@@ -42,17 +42,19 @@ TIMESTAMP_COLUMNS: Final[Set[str]] = {
 
 COLLUMN_PREFIX: str = "sentry."
 
-NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, Any]] = {
-    "sentry.organization_id": {AttributeKey.Type.TYPE_INT},
-    "sentry.project_id": {AttributeKey.Type.TYPE_INT},
-    "sentry.timestamp": {
+NORMALIZED_COLUMNS_EAP_ITEMS: Final[
+    Mapping[str, Sequence[AttributeKey.Type.ValueType]]
+] = {
+    "sentry.organization_id": [AttributeKey.Type.TYPE_INT],
+    "sentry.project_id": [AttributeKey.Type.TYPE_INT],
+    "sentry.timestamp": [
         AttributeKey.Type.TYPE_FLOAT,
         AttributeKey.Type.TYPE_DOUBLE,
         AttributeKey.Type.TYPE_INT,
         AttributeKey.Type.TYPE_STRING,
-    },
-    "sentry.trace_id": {AttributeKey.Type.TYPE_STRING},
-    "sentry.item_id": {AttributeKey.Type.TYPE_STRING},
+    ],
+    "sentry.trace_id": [AttributeKey.Type.TYPE_STRING],
+    "sentry.item_id": [AttributeKey.Type.TYPE_STRING],
 }
 
 PROTO_TYPE_TO_CLICKHOUSE_TYPE: Final[Mapping[AttributeKey.Type.ValueType, str]] = {

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
@@ -2,7 +2,7 @@ import uuid
 from collections import defaultdict
 from dataclasses import replace
 from datetime import datetime
-from typing import Any, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable
 
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -15,8 +15,11 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeriesRequest,
     TimeSeriesResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    ExtrapolationMode,
+)
 
 from snuba.attribution.appid import AppID
 from snuba.attribution.attribution_info import AttributionInfo
@@ -51,6 +54,8 @@ from snuba.web.rpc.v1.resolvers.common.aggregation import (
 )
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.common import (
     attribute_key_to_expression,
+    attribute_key_to_expression_eap_items,
+    use_eap_items_table,
 )
 
 OP_TO_EXPR = {
@@ -59,6 +64,14 @@ OP_TO_EXPR = {
     ProtoExpression.BinaryFormula.OP_MULTIPLY: f.multiply,
     ProtoExpression.BinaryFormula.OP_DIVIDE: f.divide,
 }
+
+
+def _get_attribute_key_to_expression_function(
+    request_meta: RequestMeta,
+) -> Callable[[AttributeKey], Expression]:
+    if use_eap_items_table(request_meta):
+        return attribute_key_to_expression_eap_items
+    return attribute_key_to_expression
 
 
 def _convert_result_timeseries(
@@ -184,6 +197,7 @@ def _convert_result_timeseries(
 
 def _get_reliability_context_columns(
     expressions: Iterable[ProtoExpression],
+    request_meta: RequestMeta,
 ) -> list[SelectedExpression]:
     # this reliability logic ignores formulas, meaning formulas may not properly support reliability
     additional_context_columns = []
@@ -199,7 +213,9 @@ def _get_reliability_context_columns(
             aggregation.extrapolation_mode
             == ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED
         ):
-            confidence_interval_column = get_confidence_interval_column(aggregation)
+            confidence_interval_column = get_confidence_interval_column(
+                aggregation, _get_attribute_key_to_expression_function(request_meta)
+            )
             if confidence_interval_column is not None:
                 additional_context_columns.append(
                     SelectedExpression(
@@ -208,7 +224,9 @@ def _get_reliability_context_columns(
                     )
                 )
 
-            average_sample_rate_column = get_average_sample_rate_column(aggregation)
+            average_sample_rate_column = get_average_sample_rate_column(
+                aggregation, _get_attribute_key_to_expression_function(request_meta)
+            )
             additional_context_columns.append(
                 SelectedExpression(
                     name=average_sample_rate_column.alias,
@@ -216,7 +234,9 @@ def _get_reliability_context_columns(
                 )
             )
 
-        count_column = get_count_column(aggregation)
+        count_column = get_count_column(
+            aggregation, _get_attribute_key_to_expression_function(request_meta)
+        )
         additional_context_columns.append(
             SelectedExpression(name=count_column.alias, expression=count_column)
         )
@@ -226,7 +246,9 @@ def _get_reliability_context_columns(
 def _proto_expression_to_ast_expression(expr: ProtoExpression) -> Expression:
     match expr.WhichOneof("expression"):
         case "conditional_aggregation":
-            return aggregation_to_expression(expr.conditional_aggregation)
+            return aggregation_to_expression(
+                expr.conditional_aggregation, attribute_key_to_expression
+            )
         case "formula":
             formula_expr = OP_TO_EXPR[expr.formula.op](
                 _proto_expression_to_ast_expression(expr.formula.left),
@@ -240,11 +262,18 @@ def _proto_expression_to_ast_expression(expr: ProtoExpression) -> Expression:
 
 def _build_query(request: TimeSeriesRequest) -> Query:
     # TODO: This is hardcoded still
-    entity = Entity(
-        key=EntityKey("eap_spans"),
-        schema=get_entity(EntityKey("eap_spans")).get_data_model(),
-        sample=None,
-    )
+    if use_eap_items_table(request.meta):
+        entity = Entity(
+            key=EntityKey("eap_items"),
+            schema=get_entity(EntityKey("eap_items")).get_data_model(),
+            sample=None,
+        )
+    else:
+        entity = Entity(
+            key=EntityKey("eap_spans"),
+            schema=get_entity(EntityKey("eap_spans")).get_data_model(),
+            sample=None,
+        )
 
     aggregation_columns = [
         SelectedExpression(
@@ -254,11 +283,16 @@ def _build_query(request: TimeSeriesRequest) -> Query:
         for expr in request.expressions
     ]
 
-    additional_context_columns = _get_reliability_context_columns(request.expressions)
+    additional_context_columns = _get_reliability_context_columns(
+        request.expressions, request.meta
+    )
 
     groupby_columns = [
         SelectedExpression(
-            name=attr_key.name, expression=attribute_key_to_expression(attr_key)
+            name=attr_key.name,
+            expression=_get_attribute_key_to_expression_function(request.meta)(
+                attr_key
+            ),
         )
         for attr_key in request.group_by
     ]
@@ -301,12 +335,15 @@ def _build_query(request: TimeSeriesRequest) -> Query:
         condition=base_conditions_and(
             request.meta,
             trace_item_filters_to_expression(
-                request.filter, attribute_key_to_expression
+                request.filter, _get_attribute_key_to_expression_function(request.meta)
             ),
         ),
         groupby=[
             column("time_slot"),
-            *[attribute_key_to_expression(attr_key) for attr_key in request.group_by],
+            *[
+                _get_attribute_key_to_expression_function(request.meta)(attr_key)
+                for attr_key in request.group_by
+            ],
         ],
         order_by=[
             OrderBy(expression=column("time_slot"), direction=OrderByDirection.ASC)

--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_time_series.py
@@ -184,9 +184,7 @@ def _build_query(request: TimeSeriesRequest) -> Query:
                         name=expr.conditional_aggregation.label,
                         expression=aggregation_to_expression(
                             expr.conditional_aggregation,
-                            attribute_key_to_expression(
-                                expr.conditional_aggregation.key
-                            ),
+                            attribute_key_to_expression,
                         ),
                     )
                 )

--- a/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_uptime_checks/resolver_trace_item_table.py
@@ -68,9 +68,7 @@ def aggregation_filter_to_expression(agg_filter: AggregationFilter) -> Expressio
             return op_expr(
                 aggregation_to_expression(
                     agg_filter.comparison_filter.aggregation,
-                    attribute_key_to_expression(
-                        agg_filter.comparison_filter.aggregation.key
-                    ),
+                    attribute_key_to_expression,
                 ),
                 agg_filter.comparison_filter.val,
             )
@@ -121,9 +119,7 @@ def _convert_order_by(
                     direction=direction,
                     expression=aggregation_to_expression(
                         x.column.conditional_aggregation,
-                        attribute_key_to_expression(
-                            x.column.conditional_aggregation.key
-                        ),
+                        attribute_key_to_expression,
                     ),
                 )
             )
@@ -150,7 +146,7 @@ def _build_query(request: TraceItemTableRequest) -> Query:
         elif column.HasField("conditional_aggregation"):
             function_expr = aggregation_to_expression(
                 column.conditional_aggregation,
-                attribute_key_to_expression(column.conditional_aggregation.key),
+                attribute_key_to_expression,
             )
             # aggregation label may not be set and the column label takes priority anyways.
             function_expr = replace(function_expr, alias=column.label)

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -12,6 +12,7 @@ from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
+    AttributeKey,
     ExtrapolationMode,
     Function,
     Reliability,
@@ -42,7 +43,7 @@ _FLOATING_POINT_PRECISION = 9
 
 def _get_condition_in_aggregation(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[Any], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
 ) -> Expression:
     condition_in_aggregation: Expression = literal(True)
     if isinstance(aggregation, AttributeConditionalAggregation):
@@ -268,7 +269,7 @@ def get_attribute_confidence_interval_alias(
 
 def get_average_sample_rate_column(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[Any], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
 ) -> Expression:
     alias = CustomColumnInformation(
         custom_column_id="average_sample_rate",
@@ -304,7 +305,7 @@ def _get_count_column_alias(
 
 def get_count_column(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[Any], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
 ) -> Expression:
     field = attribute_key_to_expression(aggregation.key)
     return f.countIf(
@@ -338,7 +339,7 @@ def _get_possible_percentiles(
 def _get_possible_percentiles_expression(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
     percentile: float,
-    attribute_key_to_expression: Callable[[Any], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
     granularity: float = 0.005,
     width: float = 0.1,
 ) -> Expression:
@@ -368,7 +369,7 @@ def _get_possible_percentiles_expression(
 def get_extrapolated_function(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
     field: Expression,
-    attribute_key_to_expression: Callable[[Any], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
 ) -> CurriedFunctionCall | FunctionCall | None:
     sampling_weight_column = column("sampling_weight")
     alias = aggregation.label if aggregation.label else None
@@ -471,7 +472,7 @@ def get_extrapolated_function(
 
 def get_confidence_interval_column(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[Any], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
 ) -> Expression | None:
     """
     Returns the expression for calculating the upper confidence limit for a given aggregation. If the aggregation cannot be extrapolated, returns None.
@@ -702,7 +703,7 @@ def _calculate_approximate_ci_percentile_levels(
 
 def aggregation_to_expression(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[Any], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
 ) -> Expression:
     field = attribute_key_to_expression(aggregation.key)
     alias = aggregation.label if aggregation.label else None

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from bisect import bisect_left
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
     AttributeConditionalAggregation,
@@ -26,9 +26,6 @@ from snuba.web.rpc.common.common import (
     trace_item_filters_to_expression,
 )
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
-from snuba.web.rpc.v1.resolvers.R_eap_spans.common.common import (
-    attribute_key_to_expression,
-)
 
 sampling_weight_column = column("sampling_weight")
 
@@ -45,6 +42,7 @@ _FLOATING_POINT_PRECISION = 9
 
 def _get_condition_in_aggregation(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
+    attribute_key_to_expression: Callable[[Any], Expression],
 ) -> Expression:
     condition_in_aggregation: Expression = literal(True)
     if isinstance(aggregation, AttributeConditionalAggregation):
@@ -270,6 +268,7 @@ def get_attribute_confidence_interval_alias(
 
 def get_average_sample_rate_column(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
+    attribute_key_to_expression: Callable[[Any], Expression],
 ) -> Expression:
     alias = CustomColumnInformation(
         custom_column_id="average_sample_rate",
@@ -277,7 +276,9 @@ def get_average_sample_rate_column(
         metadata={},
     ).to_alias()
     field = attribute_key_to_expression(aggregation.key)
-    condition_in_aggregation = _get_condition_in_aggregation(aggregation)
+    condition_in_aggregation = _get_condition_in_aggregation(
+        aggregation, attribute_key_to_expression
+    )
     return f.divide(
         f.countIf(
             field,
@@ -303,13 +304,14 @@ def _get_count_column_alias(
 
 def get_count_column(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
+    attribute_key_to_expression: Callable[[Any], Expression],
 ) -> Expression:
     field = attribute_key_to_expression(aggregation.key)
     return f.countIf(
         field,
         and_cond(
             get_field_existence_expression(field),
-            _get_condition_in_aggregation(aggregation),
+            _get_condition_in_aggregation(aggregation, attribute_key_to_expression),
         ),
         alias=_get_count_column_alias(aggregation),
     )
@@ -336,6 +338,7 @@ def _get_possible_percentiles(
 def _get_possible_percentiles_expression(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
     percentile: float,
+    attribute_key_to_expression: Callable[[Any], Expression],
     granularity: float = 0.005,
     width: float = 0.1,
 ) -> Expression:
@@ -365,11 +368,14 @@ def _get_possible_percentiles_expression(
 def get_extrapolated_function(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
     field: Expression,
+    attribute_key_to_expression: Callable[[Any], Expression],
 ) -> CurriedFunctionCall | FunctionCall | None:
     sampling_weight_column = column("sampling_weight")
     alias = aggregation.label if aggregation.label else None
     alias_dict = {"alias": alias} if alias else {}
-    condition_in_aggregation = _get_condition_in_aggregation(aggregation)
+    condition_in_aggregation = _get_condition_in_aggregation(
+        aggregation, attribute_key_to_expression
+    )
     function_map_sample_weighted: dict[
         Function.ValueType, CurriedFunctionCall | FunctionCall
     ] = {
@@ -465,6 +471,7 @@ def get_extrapolated_function(
 
 def get_confidence_interval_column(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
+    attribute_key_to_expression: Callable[[Any], Expression],
 ) -> Expression | None:
     """
     Returns the expression for calculating the upper confidence limit for a given aggregation. If the aggregation cannot be extrapolated, returns None.
@@ -475,7 +482,9 @@ def get_confidence_interval_column(
     alias = get_attribute_confidence_interval_alias(aggregation)
     alias_dict = {"alias": alias} if alias else {}
 
-    condition_in_aggregation = _get_condition_in_aggregation(aggregation)
+    condition_in_aggregation = _get_condition_in_aggregation(
+        aggregation, attribute_key_to_expression
+    )
 
     function_map_confidence_interval = {
         # confidence interval = Z \cdot \sqrt{-log{(\frac{\sum_{i=1}^n \frac{1}{w_i}}{n})} \cdot \sum_{i=1}^n w_i^2 - w_i}
@@ -492,7 +501,13 @@ def get_confidence_interval_column(
             z_value,
             f.sqrt(
                 f.multiply(
-                    f.negate(f.log(get_average_sample_rate_column(aggregation))),
+                    f.negate(
+                        f.log(
+                            get_average_sample_rate_column(
+                                aggregation, attribute_key_to_expression
+                            )
+                        )
+                    ),
                     f.sumIf(
                         f.minus(
                             f.multiply(sampling_weight_column, sampling_weight_column),
@@ -639,11 +654,21 @@ def get_confidence_interval_column(
             ),
             **alias_dict,
         ),
-        Function.FUNCTION_P50: _get_possible_percentiles_expression(aggregation, 0.5),
-        Function.FUNCTION_P75: _get_possible_percentiles_expression(aggregation, 0.75),
-        Function.FUNCTION_P90: _get_possible_percentiles_expression(aggregation, 0.9),
-        Function.FUNCTION_P95: _get_possible_percentiles_expression(aggregation, 0.95),
-        Function.FUNCTION_P99: _get_possible_percentiles_expression(aggregation, 0.99),
+        Function.FUNCTION_P50: _get_possible_percentiles_expression(
+            aggregation, 0.5, attribute_key_to_expression
+        ),
+        Function.FUNCTION_P75: _get_possible_percentiles_expression(
+            aggregation, 0.75, attribute_key_to_expression
+        ),
+        Function.FUNCTION_P90: _get_possible_percentiles_expression(
+            aggregation, 0.9, attribute_key_to_expression
+        ),
+        Function.FUNCTION_P95: _get_possible_percentiles_expression(
+            aggregation, 0.95, attribute_key_to_expression
+        ),
+        Function.FUNCTION_P99: _get_possible_percentiles_expression(
+            aggregation, 0.99, attribute_key_to_expression
+        ),
     }
 
     return function_map_confidence_interval.get(aggregation.aggregate)
@@ -677,12 +702,14 @@ def _calculate_approximate_ci_percentile_levels(
 
 def aggregation_to_expression(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    field: Expression | None = None,
+    attribute_key_to_expression: Callable[[Any], Expression],
 ) -> Expression:
-    field = field or attribute_key_to_expression(aggregation.key)
+    field = attribute_key_to_expression(aggregation.key)
     alias = aggregation.label if aggregation.label else None
     alias_dict = {"alias": alias} if alias else {}
-    condition_in_aggregation = _get_condition_in_aggregation(aggregation)
+    condition_in_aggregation = _get_condition_in_aggregation(
+        aggregation, attribute_key_to_expression
+    )
     function_map: dict[Function.ValueType, CurriedFunctionCall | FunctionCall] = {
         Function.FUNCTION_SUM: f.sumIfOrNull(
             field,
@@ -738,7 +765,9 @@ def aggregation_to_expression(
         aggregation.extrapolation_mode
         == ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED
     ):
-        agg_func_expr = get_extrapolated_function(aggregation, field)
+        agg_func_expr = get_extrapolated_function(
+            aggregation, field, attribute_key_to_expression
+        )
     else:
         agg_func_expr = function_map.get(aggregation.aggregate)
         if agg_func_expr is not None:

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -16,6 +16,9 @@ from snuba.web.rpc.v1.resolvers.common.aggregation import (
     _get_closest_percentile_index,
     get_confidence_interval_column,
 )
+from snuba.web.rpc.v1.resolvers.R_eap_spans.common.common import (
+    attribute_key_to_expression,
+)
 
 
 def test_generate_custom_column_alias() -> None:
@@ -75,7 +78,8 @@ def test_get_confidence_interval_column_for_non_extrapolatable_column() -> None:
                 key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test"),
                 label="min(test)",
                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
-            )
+            ),
+            attribute_key_to_expression,
         )
         is None
     )

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -125,3 +125,11 @@ class TestCommon:
         assert not use_eap_items_table(
             RequestMeta(start_timestamp=Timestamp(seconds=9))
         )
+
+        snuba_set_config("use_eap_items_table", False)
+        assert use_eap_items_table(
+            RequestMeta(
+                start_timestamp=Timestamp(seconds=5),
+                referrer="force_use_eap_items_table.test",
+            )
+        )

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -127,9 +127,9 @@ class TestCommon:
         )
 
         snuba_set_config("use_eap_items_table", False)
-        assert use_eap_items_table(
+        assert not use_eap_items_table(
             RequestMeta(
                 start_timestamp=Timestamp(seconds=5),
-                referrer="force_use_eap_items_table.test",
+                referrer="force_use_eap_spans_table.test",
             )
         )

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -1,3 +1,6 @@
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.query.dsl import Functions as f
@@ -5,7 +8,9 @@ from snuba.query.dsl import column, literal
 from snuba.query.expressions import SubscriptableReference
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.common import (
     attribute_key_to_expression,
+    use_eap_items_table,
 )
+from tests.conftest import SnubaSetConfig
 
 
 class TestCommon:
@@ -109,4 +114,14 @@ class TestCommon:
             ),
             "Nullable(Boolean)",
             alias="derp_TYPE_BOOLEAN",
+        )
+
+    @pytest.mark.redis_db
+    def test_use_eap_items_table(self, snuba_set_config: SnubaSetConfig) -> None:
+        snuba_set_config("use_eap_items_table", True)
+        snuba_set_config("use_eap_items_table_start_timestamp_seconds", 10)
+
+        assert use_eap_items_table(RequestMeta(start_timestamp=Timestamp(seconds=10)))
+        assert not use_eap_items_table(
+            RequestMeta(start_timestamp=Timestamp(seconds=9))
         )

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -193,7 +193,9 @@ def get_attributes(span: Mapping[str, Any]) -> list[GetTraceResponse.Item.Attrib
 @pytest.fixture(autouse=False)
 def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     write_raw_unprocessed_events(spans_storage, _SPANS)  # type: ignore
+    write_raw_unprocessed_events(items_storage, _SPANS)  # type: ignore
 
 
 @pytest.mark.clickhouse_db

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -153,7 +153,9 @@ _SPANS = [
 @pytest.fixture(autouse=False)
 def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     write_raw_unprocessed_events(spans_storage, _SPANS)  # type: ignore
+    write_raw_unprocessed_events(items_storage, _SPANS)  # type: ignore
 
 
 @pytest.mark.clickhouse_db

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -42,6 +42,7 @@ from snuba.web.rpc.v1.endpoint_time_series import (
     _validate_time_buckets,
 )
 from tests.base import BaseApiTest
+from tests.conftest import SnubaSetConfig
 from tests.helpers import write_raw_unprocessed_events
 
 
@@ -129,7 +130,9 @@ def store_spans_timeseries(
         numerical_attributes = {m.name: m.get_value(secs) for m in metrics}
         messages.append(gen_span_message(dt, tags, numerical_attributes))
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+    write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
 
 @pytest.mark.clickhouse_db
@@ -1200,3 +1203,16 @@ class TestUtils:
         _validate_time_buckets(message)
         # add another bucket to fit into granularity_secs
         assert message.meta.end_timestamp.seconds == int(BASE_TIME.timestamp()) + 75
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
+    """
+    Run the tests again, but this time on the eap_items table as well to ensure it also works.
+    """
+
+    @pytest.fixture(autouse=True)
+    def use_readonly_table(self, snuba_set_config: SnubaSetConfig) -> None:
+        snuba_set_config("use_eap_items_table", True)
+        snuba_set_config("use_eap_items_table_start_timestamp_seconds", 0)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1213,6 +1213,8 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
     """
 
     @pytest.fixture(autouse=True)
-    def use_readonly_table(self, snuba_set_config: SnubaSetConfig) -> None:
+    def use_eap_items_table(
+        self, snuba_set_config: SnubaSetConfig, redis_db: None
+    ) -> None:
         snuba_set_config("use_eap_items_table", True)
         snuba_set_config("use_eap_items_table_start_timestamp_seconds", 0)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -764,6 +764,8 @@ class TestTimeSeriesApiWithExtrapolationEAPItems(TestTimeSeriesApiWithExtrapolat
     """
 
     @pytest.fixture(autouse=True)
-    def use_readonly_table(self, snuba_set_config: SnubaSetConfig) -> None:
+    def use_eap_items_table(
+        self, snuba_set_config: SnubaSetConfig, redis_db: None
+    ) -> None:
         snuba_set_config("use_eap_items_table", True)
         snuba_set_config("use_eap_items_table_start_timestamp_seconds", 0)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -24,6 +24,7 @@ from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.web.rpc.v1.endpoint_time_series import EndpointTimeSeries
 from tests.base import BaseApiTest
+from tests.conftest import SnubaSetConfig
 from tests.helpers import write_raw_unprocessed_events
 
 
@@ -123,7 +124,9 @@ def store_timeseries(
         measurements_dict = {m.name: {"value": m.get_value(secs)} for m in measurements}
         messages.append(gen_message(dt, tags, numerical_attributes, measurements_dict))
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+    write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
 
 @pytest.mark.clickhouse_db
@@ -751,3 +754,16 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 ],
             ),
         ]
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+class TestTimeSeriesApiWithExtrapolationEAPItems(TestTimeSeriesApiWithExtrapolation):
+    """
+    Run the tests again, but this time on the eap_items table as well to ensure it also works.
+    """
+
+    @pytest.fixture(autouse=True)
+    def use_readonly_table(self, snuba_set_config: SnubaSetConfig) -> None:
+        snuba_set_config("use_eap_items_table", True)
+        snuba_set_config("use_eap_items_table_start_timestamp_seconds", 0)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
@@ -73,8 +73,10 @@ def populate_eap_spans_storage(num_rows: int) -> None:
         return res
 
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     messages = [generate_span_event_message(i) for i in range(num_rows)]
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+    write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
 
 @pytest.fixture(autouse=True)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_stats.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_stats.py
@@ -116,6 +116,7 @@ BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timed
 @pytest.fixture(autouse=False)
 def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     start = BASE_TIME
     messages = [
         gen_message(
@@ -125,6 +126,7 @@ def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
         for i in range(120)
     ]
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+    write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
 
 @pytest.mark.clickhouse_db

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -183,9 +183,11 @@ BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timed
 @pytest.fixture(autouse=False)
 def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     start = BASE_TIME
     messages = [gen_message(start - timedelta(minutes=i)) for i in range(120)]
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+    write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
 
 @pytest.mark.clickhouse_db
@@ -1151,6 +1153,7 @@ class TestTraceItemTable(BaseApiTest):
 
     def test_aggregation_on_attribute_column_backward_compat(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         measurement_val = 420.0
         measurement = {"custom_measurement": {"value": measurement_val}}
@@ -1166,6 +1169,10 @@ class TestTraceItemTable(BaseApiTest):
         ]
         write_raw_unprocessed_events(
             spans_storage,  # type: ignore
+            messages_w_measurement + messages_no_measurement,
+        )
+        write_raw_unprocessed_events(
+            items_storage,  # type: ignore
             messages_w_measurement + messages_no_measurement,
         )
 
@@ -1202,6 +1209,7 @@ class TestTraceItemTable(BaseApiTest):
 
     def test_aggregation_on_attribute_column(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         measurement_val = 420.0
         measurement = {"custom_measurement": {"value": measurement_val}}
@@ -1217,6 +1225,10 @@ class TestTraceItemTable(BaseApiTest):
         ]
         write_raw_unprocessed_events(
             spans_storage,  # type: ignore
+            messages_w_measurement + messages_no_measurement,
+        )
+        write_raw_unprocessed_events(
+            items_storage,  # type: ignore
             messages_w_measurement + messages_no_measurement,
         )
 
@@ -1411,6 +1423,7 @@ class TestTraceItemTable(BaseApiTest):
     def test_same_column_name(self) -> None:
         dt = BASE_TIME - timedelta(minutes=5)
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         messages = [
             {
                 "description": "foo",
@@ -1441,7 +1454,7 @@ class TestTraceItemTable(BaseApiTest):
             }
         ]
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
-
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = Timestamp(seconds=int((BASE_TIME - timedelta(hours=1)).timestamp()))
         err_req = {
@@ -1597,6 +1610,7 @@ class TestTraceItemTable(BaseApiTest):
         # theres a different number of messages for each tag so that
         # each will have a different sum value when i do aggregate
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = (
             [gen_message(msg_timestamp, tags={"kylestag": "val1"}) for i in range(3)]
@@ -1604,6 +1618,7 @@ class TestTraceItemTable(BaseApiTest):
             + [gen_message(msg_timestamp, tags={"kylestag": "val3"}) for i in range(30)]
         )
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -1687,6 +1702,7 @@ class TestTraceItemTable(BaseApiTest):
         # theres a different number of messages for each tag so that
         # each will have a different sum value when i do aggregate
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = (
             [gen_message(msg_timestamp, tags={"kylestag": "val1"}) for i in range(3)]
@@ -1694,6 +1710,7 @@ class TestTraceItemTable(BaseApiTest):
             + [gen_message(msg_timestamp, tags={"kylestag": "val3"}) for i in range(30)]
         )
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -1772,8 +1789,8 @@ class TestTraceItemTable(BaseApiTest):
         """
         This test sums only if the traceitem contains kylestag = val2
         """
-
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = (
             [gen_message(msg_timestamp, tags={"kylestag": "val1"}) for i in range(3)]
@@ -1781,6 +1798,7 @@ class TestTraceItemTable(BaseApiTest):
             + [gen_message(msg_timestamp, tags={"kylestag": "val3"}) for i in range(3)]
         )
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -1852,6 +1870,7 @@ class TestTraceItemTable(BaseApiTest):
 
     def test_reliability_with_conditional_aggregation(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = [
             gen_message(
@@ -1862,6 +1881,7 @@ class TestTraceItemTable(BaseApiTest):
             ),
         ]
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -1966,6 +1986,7 @@ class TestTraceItemTable(BaseApiTest):
         # theres a different number of messages for each tag so that
         # each will have a different sum value when i do aggregate
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = (
             [gen_message(msg_timestamp, tags={"kylestag": "val1"}) for i in range(3)]
@@ -1973,6 +1994,7 @@ class TestTraceItemTable(BaseApiTest):
             + [gen_message(msg_timestamp, tags={"kylestag": "val3"}) for i in range(30)]
         )
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -2132,6 +2154,7 @@ class TestTraceItemTable(BaseApiTest):
         # theres a different number of messages for each tag so that
         # each will have a different sum value when i do aggregate
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = (
             [gen_message(msg_timestamp, tags={"kylestag": "val1"}) for i in range(3)]
@@ -2139,6 +2162,7 @@ class TestTraceItemTable(BaseApiTest):
             + [gen_message(msg_timestamp, tags={"kylestag": "val3"}) for i in range(30)]
         )
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -2297,6 +2321,7 @@ class TestTraceItemTable(BaseApiTest):
         # theres a different number of messages for each tag so that
         # each will have a different sum value when i do aggregate
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = (
             [gen_message(msg_timestamp, tags={"kylestag": "val1"}) for i in range(3)]
@@ -2304,6 +2329,7 @@ class TestTraceItemTable(BaseApiTest):
             + [gen_message(msg_timestamp, tags={"kylestag": "val3"}) for i in range(30)]
         )
         write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
@@ -130,6 +130,7 @@ BASE_TIME = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - timed
 class TestTraceItemTableWithExtrapolation(BaseApiTest):
     def test_aggregation_on_attribute_column_backward_compat(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         tags = {"custom_tag": "blah"}
         messages_w_measurement = [
@@ -151,6 +152,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             gen_message(start - timedelta(minutes=i), tags=tags) for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -243,6 +245,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
 
     def test_aggregation_on_attribute_column(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         messages_w_measurement = [
             gen_message(
@@ -262,6 +265,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             gen_message(start - timedelta(minutes=i)) for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -354,6 +358,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
 
     def test_conditional_aggregation_on_attribute_column(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         messages_w_measurement = [
             gen_message(
@@ -375,6 +380,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -446,6 +452,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
 
     def test_count_reliability_backward_compat(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         tags = {"custom_tag": "blah"}
         messages_w_measurement = [
@@ -465,6 +472,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             gen_message(start - timedelta(minutes=i), tags=tags) for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -503,6 +511,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
 
     def test_count_reliability(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         tags = {"custom_tag": "blah"}
         messages_w_measurement = [
@@ -522,6 +531,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             gen_message(start - timedelta(minutes=i), tags=tags) for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -560,6 +570,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
 
     def test_count_reliability_with_group_by_backward_compat(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         messages_w_measurement = [
             gen_message(
@@ -579,6 +590,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -681,6 +693,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
 
     def test_count_reliability_with_group_by(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         messages_w_measurement = [
             gen_message(
@@ -700,6 +713,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_w_measurement + messages_no_measurement)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
@@ -872,6 +886,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
 
     def test_aggregation_with_nulls(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
+        items_storage = get_storage(StorageKey("eap_items"))
         start = BASE_TIME
         messages_a = [
             gen_message(
@@ -896,6 +911,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
             for i in range(5)
         ]
         write_raw_unprocessed_events(spans_storage, messages_a + messages_b)  # type: ignore
+        write_raw_unprocessed_events(items_storage, messages_a + messages_b)  # type: ignore
 
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())

--- a/tests/web/rpc/v1/test_trace_item_attribute_values_v1.py
+++ b/tests/web/rpc/v1/test_trace_item_attribute_values_v1.py
@@ -78,6 +78,7 @@ def gen_message(tags: Mapping[str, str]) -> Mapping[str, Any]:
 @pytest.fixture(autouse=True)
 def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     spans_storage = get_storage(StorageKey("eap_spans"))
+    items_storage = get_storage(StorageKey("eap_items"))
     messages = [
         gen_message({"tag1": "herp", "tag2": "herp"}),
         gen_message({"tag1": "herpderp", "tag2": "herp"}),
@@ -88,6 +89,7 @@ def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
         gen_message({"tag1": "some_last_value"}),
     ]
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+    write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
 
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
This PR updates the timeseries endpoint for the eap_spans resolver to use the new eap_items table when the following conditions are met:
- the `use_eap_items_table` runtime config is set to `1`
- the start time of the query is greater than `use_eap_items_table_start_timestamp_seconds` (measured in UTC seconds)

The tests have also been updated to been run once on the eap_spans table and once on the eap_items table.