### PR TITLE
fix(test): run more relevant sentry CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,9 +377,11 @@ jobs:
               tests/sentry/integrations/slack/test_unfurl.py \
               tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py \
               tests/sentry/uptime/endpoints/test_organization_uptime_stats.py \
+              tests/snuba/api/endpoints/test_organization_traces.py \
               tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py \
               tests/snuba/api/endpoints/test_organization_events_ourlogs.py \
               tests/snuba/api/endpoints/test_organization_events_stats_mep.py \
+              tests/snuba/api/endpoints/test_project_trace_item_details.py \
               tests/sentry/sentry_metrics/querying \
               tests/snuba/test_snql_snuba.py \
               tests/snuba/test_metrics_layer.py \


### PR DESCRIPTION
We had another broken CI pipeline due to https://github.com/getsentry/snuba/pull/6932 - this ensures several more sentry tests are run on snuba changes.