### PR TITLE
chore(tests): Clean up which sentry tests are run on snuba PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,10 +366,11 @@ jobs:
         if: needs.files-changed.outputs.api_changes == 'true'
         working-directory: sentry
         run: |
-          pytest -k 'not __In' tests/snuba \
+          pytest -k 'not __In' \
+              tests/snuba \
+              tests/sentry/snuba \
               tests/sentry/eventstream/kafka \
               tests/sentry/post_process_forwarder \
-              tests/sentry/snuba \
               tests/sentry/eventstore/snuba \
               tests/sentry/search/events \
               tests/sentry/event_manager \
@@ -377,16 +378,9 @@ jobs:
               tests/sentry/integrations/slack/test_unfurl.py \
               tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py \
               tests/sentry/uptime/endpoints/test_organization_uptime_stats.py \
-              tests/snuba/api/endpoints/test_organization_traces.py \
-              tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py \
-              tests/snuba/api/endpoints/test_organization_events_ourlogs.py \
-              tests/snuba/api/endpoints/test_organization_events_stats_mep.py \
-              tests/snuba/api/endpoints/test_project_trace_item_details.py \
-              tests/sentry/sentry_metrics/querying \
-              tests/snuba/test_snql_snuba.py \
-              tests/snuba/test_metrics_layer.py \
+              tests/sentry/api/endpoints/test_organization_traces.py \
               tests/sentry/api/endpoints/test_organization_spans_fields.py \
-              tests/snuba/api/endpoints/test_organization_events_span_indexed.py \
+              tests/sentry/sentry_metrics/querying \
               -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 
       - name: Run CI module tests


### PR DESCRIPTION
There was a lot of duplication - we run all tests in tests/sentry/snuba and tests/snuba, so nothing in there needs to be explicitly added