### PR TITLE
fix: replace CDC storage set with EVENTS

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -86,7 +86,7 @@ DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset()
 # Joins can be performed across storage sets in the same group.
 JOINABLE_STORAGE_SETS: FrozenSet[FrozenSet[StorageSetKey]] = frozenset(
     {
-        frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC}),
+        frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO}),
         frozenset(
             {
                 StorageSetKey.EVENTS,

--- a/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
+++ b/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
@@ -3,7 +3,7 @@ kind: cdc_storage
 name: groupassignees
 storage:
   key: groupassignees
-  set_key: cdc
+  set_key: events
 readiness_state: deprecate
 schema:
   columns:

--- a/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
+++ b/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
@@ -3,7 +3,7 @@ kind: cdc_storage
 name: groupedmessages
 storage:
   key: groupedmessages
-  set_key: cdc
+  set_key: events
 readiness_state: deprecate
 schema:
   columns:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -97,7 +97,6 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "ca_certs": os.environ.get("CLICKHOUSE_CA_CERTS"),
         "verify": os.environ.get("CLICKHOUSE_VERIFY"),
         "storage_sets": {
-            "cdc",
             "discover",
             "events",
             "events_ro",

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -16,7 +16,6 @@ CLUSTERS = [
         "ca_certs": os.environ.get("CLICKHOUSE_CA_CERTS"),
         "verify": os.environ.get("CLICKHOUSE_VERIFY"),
         "storage_sets": {
-            "cdc",
             "discover",
             "events",
             "events_ro",

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -38,7 +38,6 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "database": os.environ.get("CLICKHOUSE_DATABASE", "snuba_test"),
         "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8229)),
         "storage_sets": {
-            "cdc",
             "discover",
             "events",
             "events_ro",

--- a/snuba/snuba_migrations/events/0007_groupedmessages.py
+++ b/snuba/snuba_migrations/events/0007_groupedmessages.py
@@ -30,11 +30,11 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupedmessage_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    storage_set=StorageSetKey.CDC,
+                    storage_set=StorageSetKey.EVENTS,
                     version_column="offset",
                     order_by="(project_id, id)",
                     sample_by="id",
@@ -46,7 +46,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupedmessage_local",
             )
         ]
@@ -54,7 +54,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupedmessage_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
@@ -67,7 +67,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupedmessage_dist",
             )
         ]

--- a/snuba/snuba_migrations/events/0008_groupassignees.py
+++ b/snuba/snuba_migrations/events/0008_groupassignees.py
@@ -24,11 +24,11 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupassignee_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    storage_set=StorageSetKey.CDC,
+                    storage_set=StorageSetKey.EVENTS,
                     version_column="offset",
                     order_by="(project_id, group_id)",
                     unsharded=True,
@@ -39,7 +39,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupassignee_local",
             )
         ]
@@ -47,7 +47,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupassignee_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
@@ -60,7 +60,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC,
+                storage_set=StorageSetKey.EVENTS,
                 table_name="groupassignee_dist",
             )
         ]

--- a/snuba/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -37,7 +37,7 @@ def fix_order_by(_logger: logging.Logger) -> None:
 
     # Add the project_id column
     add_column_sql = operations.AddColumn(
-        storage_set=StorageSetKey.CDC,
+        storage_set=StorageSetKey.EVENTS,
         table_name=TABLE_NAME,
         column=Column("project_id", UInt(64)),
         after="record_deleted",
@@ -72,7 +72,7 @@ def fix_order_by(_logger: logging.Logger) -> None:
 
 
 def ensure_drop_temporary_tables(_logger: logging.Logger) -> None:
-    cluster = get_cluster(StorageSetKey.CDC)
+    cluster = get_cluster(StorageSetKey.EVENTS)
 
     if not cluster.is_single_node():
         return
@@ -80,13 +80,13 @@ def ensure_drop_temporary_tables(_logger: logging.Logger) -> None:
     clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
     clickhouse.execute(
         operations.DropTable(
-            storage_set=StorageSetKey.CDC,
+            storage_set=StorageSetKey.EVENTS,
             table_name=TABLE_NAME_NEW,
         ).format_sql()
     )
     clickhouse.execute(
         operations.DropTable(
-            storage_set=StorageSetKey.CDC,
+            storage_set=StorageSetKey.EVENTS,
             table_name=TABLE_NAME_OLD,
         ).format_sql()
     )

--- a/tests/clusters/test_storage_sets.py
+++ b/tests/clusters/test_storage_sets.py
@@ -3,16 +3,6 @@ from snuba.clusters.storage_sets import StorageSetKey, is_valid_storage_set_comb
 
 def test_storage_set_combination() -> None:
     assert (
-        is_valid_storage_set_combination(StorageSetKey.EVENTS, StorageSetKey.CDC)
-        is True
-    )
-    assert (
         is_valid_storage_set_combination(StorageSetKey.EVENTS, StorageSetKey.SESSIONS)
-        is False
-    )
-    assert (
-        is_valid_storage_set_combination(
-            StorageSetKey.EVENTS, StorageSetKey.CDC, StorageSetKey.SESSIONS
-        )
         is False
     )


### PR DESCRIPTION
Simple fix for `UndefinedClickhouseCluster
StorageSetKey.CDC is not defined in the CLUSTERS setting for this environment` errors like [SNUBA-7FY](https://sentry.sentry.io/issues/6337625497/?project=300688&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20CDC&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=2)

The `StorageSetKey.CDC` storages are already created on the events cluster anyway, so logically it makes sense to have these storage belong to `StorageSetKey.EVENTS`. 
It also means we have a migration that removes the tables, instead of leaving the tables or having to remove them manually
