### PR TITLE
Remove vector deployment again

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -48,13 +48,12 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="search-issues-consumer" \
   --container-name="snuba-admin" \
   --container-name="spans-consumer" \
-  --container-name="test-eap-mutations-vector" \
   --container-name="transactions-consumer-new" \
   --container-name="transactions-subscriptions-executor" \
   --container-name="transactions-subscriptions-scheduler" \
   --container-name="uptime-results-consumer" \
-  # https://getsentry.atlassian.net/browse/SRE-630
-  # Prepare to move to consistent image name
+  ## https://getsentry.atlassian.net/browse/SRE-630
+  ## Prepare to move to consistent image name
   --container-name="snuba" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \


### PR DESCRIPTION
It seems the deploy.sh script syntax has changed under our feet causing #6947 to fail validation




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
