### PR TITLE
chore: increase timeout for some of the ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
     needs: [linting, snuba-image]
     name: Tests and code coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix:
         snuba_settings:


### PR DESCRIPTION
I noticed `test_distributed` in our CI has been failing sometimes due to timeout. This causes the deploy pipeline to fail needing manual intervention. This is a short-term fix that increases the timeout so this doesnt happen. Longer term we might want to see if we can reduce the time CI takes.

This change increases the timeout for `test, test_rust, test_distributed, test_distributed_migrations` from 30 minutes to 40 minutes. The only one that actually needs the increase is `test_distributed` but since theyre all together I had to do it for all of them. They run in parallel.