### PR TITLE
fix(eap-items): make sure we are not overriding sentry.description

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -150,7 +150,7 @@ impl From<FromSpanMessage> for EAPItem {
         {
             if let Some(description) = from.description {
                 res.attributes
-                    .insert_str("sentry.description".to_string(), description);
+                    .insert_str("sentry.raw_description".to_string(), description);
             }
 
             // insert int double writes as float and int


### PR DESCRIPTION
We have been overriding the `sentry.description` tag by writing the old `description` to `sentry.description`. Let's not do that.