### PR TITLE
ref(migrations): add revert command

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -133,7 +133,7 @@ def migrate(
     "--readiness-state",
     multiple=True,
     type=click.Choice([r.value for r in ReadinessState], case_sensitive=False),
-    default=None,
+    default=(),
 )
 @click.argument("through", default="all")
 @click.option("--force", is_flag=True)
@@ -178,9 +178,11 @@ def revert(
     try:
         if group:
             migration_group = MigrationGroup(group)
+        elif through != "all":
+            raise click.ClickException(
+                "A migration group must be specified when 'through' is not 'all'."
+            )
         else:
-            if through != "all":
-                raise click.ClickException("Need migration group")
             migration_group = None
         runner.reverse_all(
             through=through,

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -127,6 +127,76 @@ def migrate(
 
 
 @migrations.command()
+@click.option("-g", "--group", default=None)
+@click.option(
+    "-r",
+    "--readiness-state",
+    multiple=True,
+    type=click.Choice([r.value for r in ReadinessState], case_sensitive=False),
+    default=None,
+)
+@click.argument("through", default="all")
+@click.option("--force", is_flag=True)
+@click.option("--fake", is_flag=True)
+@click.option("--include-system", is_flag=True)
+@click.option(
+    "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
+)
+def revert(
+    group: Optional[str],
+    readiness_state: Optional[Sequence[str]],
+    through: str,
+    force: bool,
+    fake: bool,
+    include_system: bool,
+    log_level: Optional[str] = None,
+) -> None:
+    """
+    If group is specified, reverse all the migrations for a group.
+    If no group is specified, reverses all migrations for all groups.
+        * by default SYSTEM migrations are NOT reversed
+        * use --include-system to also reverse SYSTEM migrations
+
+    --force is required
+    """
+
+    readiness_states = (
+        [ReadinessState(state) for state in readiness_state]
+        if readiness_state
+        else None
+    )
+
+    setup_logging(log_level)
+    clusters_to_check = (
+        get_clusters_for_readiness_states(readiness_states, CLUSTERS)
+        if readiness_states
+        else CLUSTERS
+    )
+    check_clickhouse_connections(clusters_to_check)
+    runner = Runner()
+
+    try:
+        if group:
+            migration_group = MigrationGroup(group)
+        else:
+            if through != "all":
+                raise click.ClickException("Need migration group")
+            migration_group = None
+        runner.reverse_all(
+            through=through,
+            force=force,
+            fake=fake,
+            include_system=include_system,
+            group=migration_group,
+            readiness_states=readiness_states,
+        )
+    except MigrationError as e:
+        raise click.ClickException(str(e))
+
+    click.echo("Finished reversing migrations")
+
+
+@migrations.command()
 @click.option("--group", required=True, help="Migration group")
 @click.option("--migration-id", required=True, help="Migration ID")
 @click.option("--force", is_flag=True)

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -384,6 +384,67 @@ class Runner:
         else:
             self._reverse_migration_impl(migration_key)
 
+    def reverse_all(
+        self,
+        *,
+        through: str = "all",
+        fake: bool = False,
+        force: bool = False,
+        include_system: bool = False,
+        group: Optional[MigrationGroup] = None,
+        readiness_states: Optional[Sequence[ReadinessState]] = None,
+    ) -> None:
+
+        groups = (
+            [group]
+            if group
+            else (
+                get_active_migration_groups()
+                if include_system
+                else [
+                    g
+                    for g in get_active_migration_groups()
+                    if g != MigrationGroup.SYSTEM
+                ]
+            )
+        )
+        completed_migrations = self._get_completed_migrations(groups)
+
+        if readiness_states:
+            completed_migrations = [
+                m
+                for m in completed_migrations
+                if get_group_readiness_state(m.group) in readiness_states
+            ]
+
+        use_through = False if through == "all" else True
+
+        def exact_migration_exists(through: str) -> bool:
+            migration_ids = [
+                key.migration_id
+                for key in completed_migrations
+                if key.migration_id.startswith(through)
+            ]
+            if len(migration_ids) == 1:
+                return True
+            return False
+
+        if use_through and not exact_migration_exists(through):
+            raise MigrationError(f"No exact match for: {through}")
+
+        if not force:
+            raise MigrationError("Requires force to reverse migrations")
+
+        for migration_key in completed_migrations:
+            if fake:
+                self._update_migration_status(migration_key, Status.NOT_STARTED)
+            else:
+                self._reverse_migration_impl(migration_key)
+
+            if use_through and migration_key.migration_id.startswith(through):
+                logger.info(f"Reverse through: {migration_key.migration_id}")
+                break
+
     def reverse_in_progress(
         self,
         fake: bool = False,
@@ -486,6 +547,34 @@ class Runner:
                 )
                 raise InvalidMigrationState(f"Missing migrations: {missing_migrations}")
 
+        return group_migrations
+
+    def _get_completed_migrations(
+        self, groups: List[MigrationGroup]
+    ) -> List[MigrationKey]:
+        """
+        Get a list of completed migrations for a list of groups
+        """
+        migration_status = self._get_migration_status()
+
+        def get_status(migration_key: MigrationKey) -> Status:
+            return migration_status.get(migration_key, Status.NOT_STARTED)
+
+        group_migrations: List[MigrationKey] = []
+        for group in groups:
+            group_loader = get_group_loader(group)
+            for migration_id in group_loader.get_migrations():
+                migration_key = MigrationKey(group, migration_id)
+                status = get_status(migration_key)
+                if status == Status.IN_PROGRESS:
+                    # can't reverse migrations if one is stuck pending
+                    raise MigrationInProgress(str(migration_key))
+                if status == Status.NOT_STARTED:
+                    continue
+                elif status == Status.COMPLETED:
+                    group_migrations.append(migration_key)
+        # need opposite order
+        group_migrations.reverse()
         return group_migrations
 
     def _update_migration_status(

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -550,7 +550,7 @@ class Runner:
         return group_migrations
 
     def _get_completed_migrations(
-        self, groups: List[MigrationGroup]
+        self, groups: Sequence[MigrationGroup]
     ) -> List[MigrationKey]:
         """
         Get a list of completed migrations for a list of groups

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -346,7 +346,7 @@ def test_reverse_all_for_group() -> None:
     ), "'profile_chunks_local' table should be deleted"
 
 
-@pytest.mark.clickhouse_db
+@pytest.mark.custom_clickhouse_db
 def test_reverse_idempotency_all() -> None:
     """
     This test is to ensure that reversing a migration twice does not cause any

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -316,6 +316,26 @@ def test_run_all_using_readiness() -> None:
 
 
 @pytest.mark.custom_clickhouse_db
+def test_reverse_all_for_group() -> None:
+    runner = Runner()
+    runner.run_all(group=MigrationGroup.PROFILE_CHUNKS, force=True)
+    runner.run_all(group=MigrationGroup.PROFILES, force=True)
+    connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
+        ClickhouseClientSettings.MIGRATE
+    )
+    num_of_tables = len(connection.execute("SHOW TABLES").results)
+
+    runner.reverse_all(
+        group=MigrationGroup.PROFILE_CHUNKS, force=True, include_system=True
+    )
+
+    assert len(connection.execute("SHOW TABLES").results) == num_of_tables - 1
+    assert (
+        connection.execute("SHOW TABLES LIKE 'profile_chunks_local'").results == []
+    ), "'profile_chunks_local' table should be deleted"
+
+
+@pytest.mark.clickhouse_db
 def test_reverse_idempotency_all() -> None:
     """
     This test is to ensure that reversing a migration twice does not cause any


### PR DESCRIPTION
Addresses https://github.com/getsentry/snuba/issues/6964

**New Usage**

Revert all migrations
```
snuba migrations revert --force
```

Revert all migrations, including the `MigrationGroup.SYSTEM` (aka `migrations_local/dist` table(s))
```
snuba migrations revert --include-system --force
```

Revert all migrations for a group
```
snuba migrations revert --group profile_chunks --force
```

Fake reverting all migrations for a group
```
snuba migrations revert --group profile_chunks --fake --force
```

**Notes**
* The `--include-system` is only relevant for when one wants to revert all migrations, it doesn't do anything when you revert with a specific group
* These new commands shouldn't be added to snuba admin as they are not something we really want to do in production, but more to add flexibility when setting up clusters/regions for the first time