### PR TITLE
fix(eap): allow hashmaps to be used in the entity

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
@@ -44,7 +44,7 @@ storages:
         - mapper: SubscriptableHashBucketMapper
           args:
             from_column_table: null
-            from_column_name: _hash_map_float
+            from_column_name: _hash_map_string
             to_col_table: null
             to_col_name: _hash_map_float
             num_attribute_buckets: 40

--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
@@ -18,86 +18,8 @@ schema:
 
     { name: attributes_string, type: Map, args: { key: { type: String }, value: { type: String } } },
     { name: attributes_float, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
-    { name: _hash_map_string_0, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_1, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_2, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_3, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_4, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_5, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_6, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_7, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_8, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_9, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_10, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_11, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_12, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_13, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_14, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_15, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_16, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_17, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_18, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_19, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_20, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_21, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_22, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_23, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_24, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_25, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_26, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_27, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_28, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_29, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_30, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_31, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_32, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_33, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_34, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_35, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_36, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_37, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_38, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_string_39, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_0, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_1, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_2, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_3, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_4, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_5, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_6, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_7, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_8, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_9, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_10, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_11, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_12, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_13, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_14, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_15, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_16, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_17, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_18, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_19, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_20, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_21, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_22, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_23, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_24, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_25, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_26, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_27, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_28, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_29, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_30, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_31, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_32, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_33, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_34, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_35, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_36, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_37, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_38, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
-    { name: _hash_map_float_39, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
+    { name: _hash_map_float, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
+    { name: _hash_map_string, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
   ]
 
 storages:
@@ -119,6 +41,21 @@ storages:
             to_col_table: null
             to_col_name: attributes_float
             num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_float
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_float
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+
 
 storage_selector:
   selector: DefaultQueryStorageSelector


### PR DESCRIPTION
Use the hash bucket mapper to allow us to use the hashmap optimization when we need to explicitly. Since we're controlling all the queries ourselves I didn't see a need to create a generic optimizer