### PR TITLE
feat: Enable Spotlight in dev mode by default

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -76,7 +76,7 @@ def setup_logging(level: Optional[str] = None) -> None:
 
 def setup_sentry() -> None:
     if settings.DEBUG:
-        spotlight = os.getenv("SENTRY_SPOTLIGHT", "")
+        spotlight: bool | str = os.getenv("SENTRY_SPOTLIGHT", "")
         if spotlight.lower() in ("0", "false", "n", "no"):
             spotlight = False
         elif not spotlight.startswith("http"):

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -75,8 +75,18 @@ def setup_logging(level: Optional[str] = None) -> None:
 
 
 def setup_sentry() -> None:
+    if settings.DEBUG:
+        spotlight = os.getenv("SENTRY_SPOTLIGHT", "")
+        if spotlight.lower() in ("0", "false", "n", "no"):
+            spotlight = False
+        elif not spotlight.startswith("http"):
+            spotlight = True
+    else:
+        spotlight = False
+
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
+        spotlight=spotlight,
         integrations=[
             FlaskIntegration(),
             GnuBacktraceIntegration(),

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -75,14 +75,15 @@ def setup_logging(level: Optional[str] = None) -> None:
 
 
 def setup_sentry() -> None:
+    spotlight: bool | str = False
     if settings.DEBUG:
-        spotlight: bool | str = os.getenv("SENTRY_SPOTLIGHT", "")
-        if spotlight.lower() in ("0", "false", "n", "no"):
+        spotlight_env = os.getenv("SENTRY_SPOTLIGHT", "")
+        if spotlight_env.lower() in ("0", "false", "n", "no"):
             spotlight = False
-        elif not spotlight.startswith("http"):
+        elif not spotlight_env.startswith("http"):
+            spotlight = spotlight_env
+        else:
             spotlight = True
-    else:
-        spotlight = False
 
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,


### PR DESCRIPTION
This is a follow up to getsentry/sentry#87295. Can be disabled by setting `SENTRY_SPOTLIGHT=0` env variable
