### PR TITLE
feat(subscriptions): subscription scheduler followed consumer group override

### DIFF
--- a/scripts/send_spans.py
+++ b/scripts/send_spans.py
@@ -27,7 +27,7 @@ Frontend makes 1-3 backend calls, which make 1-3 API calls
 """
 
 PROJECTS = [1, 2, 3]
-ORGANIZATION_ID = 1123
+ORGANIZATION_ID = 1
 RECEIVED = datetime.datetime.now().timestamp()
 CUSTOM_TAGS: list[tuple[str, Callable[[], Any]]] = [
     ("tag1", partial(random.randint, 0, 10)),

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -241,3 +241,9 @@ mandatory_condition_checkers:
 stream_loader:
   processor: EAPItemsProcessor
   default_topic: snuba-spans
+  commit_log_topic: snuba-eap-spans-commit-log
+  subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
+  subscription_scheduled_topic: scheduled-subscriptions-eap-spans
+  subscription_result_topic: eap-spans-subscription-results
+  subscription_delay_seconds: 60

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -116,7 +116,10 @@ class CommitLogTickConsumer(Consumer[Tick]):
         )
 
         if override_group is not None:
-            logger.info("override_group tripped")
+            self.__metrics.increment(
+                "followed_group_override",
+                tags={"original_group": self.__followed_consumer_group},
+            )
             return override_group
         return self.__followed_consumer_group
 
@@ -155,6 +158,10 @@ class CommitLogTickConsumer(Consumer[Tick]):
             return None
 
         if commit.group != self.followed_group_dynamic():
+            self.__metrics.increment(
+                "followed_group_mismatch",
+                tags={"group": commit.group},
+            )
             return None
 
         previous_message = self.__previous_messages.get(commit.partition)


### PR DESCRIPTION
This is a proof-of-concept, validated locally, that we can switch between followed consumer groups in a subscription scheduler without restarting.

We want this in order to run eap_spans subscriptions from the eap_items commit log without having to switch subscription scheduler and executor topics or run a parallel processing pipeline. These are fed from the same topic (`snuba-spans`) and so the commit offsets/timestamps should be comparable.

Some subscriptions results will likely be lost in the cutover, meaning maybe a few seconds without subscriptions executing on eap_spans. This should not be noticeable/important for a pre-GA product

Testing "script":
- created a subscription on eap_spans
- ran `snuba rust-consumer --storage eap_items --consumer-group snuba-items-consumers`
- ran `snuba subscriptions-scheduler --entity eap_spans --followed-consumer-group snuba-spans-consumers` (mimicking current production config)
- inserted some data with scripts/send_spans.py
- **verified that no offsets were committed by the scheduler, and no subscriptions were scheduled** (as desired, the override isn't set yet)
- shut down the `snuba-items-consumers` group consumer
- ran `snuba rust-consumer --storage eap_spans --consumer-group snuba-spans-consumers`
- inserted some data with scripts/send_spans.py
- **verified that the subscription was scheduled**
- set the run-time config to override following snuba-spans-consumers: 
  -   `snuba config set subscriptions_override_consumer_group_snuba-spans-consumers snuba-items-consumers`
- inserted some data with scripts/send_spans.py
- **verified that no subscriptions were scheduled** (once the run-time config is enabled, it should be ignoring commits from the snuba-spans-consumer group in favor of the override snuba-items-consumer. at this point the snuba-items-consumer is not running)
- **verified that we were hitting the override code path via logs**
- shut down the `snuba-spans-consumers` group consumer
- brought up the `snuba-items-consumers` group consumer
- inserted some data with scripts/send_spans.py
- **verified that the subscription was scheduled**