### PR TITLE
feat: implement support for expressions in subscriptions pipeline

### DIFF
--- a/snuba/web/rpc/v1/create_subscription.py
+++ b/snuba/web/rpc/v1/create_subscription.py
@@ -10,6 +10,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.web.rpc import RPCEndpoint
+from snuba.web.rpc.v1.endpoint_time_series import _convert_aggregations_to_expressions
 
 
 class CreateSubscriptionRequest(
@@ -32,6 +33,11 @@ class CreateSubscriptionRequest(
     ) -> CreateSubscriptionResponse:
         from snuba.subscriptions.data import RPCSubscriptionData
         from snuba.subscriptions.subscription import SubscriptionCreator
+
+        # convert aggregations to expressions
+        in_msg.time_series_request.CopyFrom(
+            _convert_aggregations_to_expressions(in_msg.time_series_request)
+        )
 
         dataset = PluggableDataset(name="eap", all_entities=[])
         entity_key = EntityKey("eap_spans")

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -91,16 +91,17 @@ def build_rpc_subscription_data(
     entity_key: EntityKey, metadata: Mapping[str, Any]
 ) -> SubscriptionData:
 
-    return RPCSubscriptionData(
+    tmp = RPCSubscriptionData(
         project_id=1,
         time_window_sec=300,
         resolution_sec=60,
         entity=get_entity(entity_key),
         metadata=metadata,
-        time_series_request="Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIaGggBEg8IAxILdGVzdF9tZXRyaWMaA3N1bSAB",
+        time_series_request="Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIyIQoaCAESDwgDEgt0ZXN0X21ldHJpYxoDc3VtIAEaA3N1bQ==",
         request_name="TimeSeriesRequest",
         request_version="v1",
     )
+    return tmp
 
 
 RPC_CASES = [
@@ -484,7 +485,7 @@ def test_subscription_task_encoder_rpc() -> None:
         b'"timestamp":"1970-01-01T00:00:00",'
         b'"entity":"eap_spans",'
         b'"task":{'
-        b'"data":{"project_id":1,"time_window":300,"resolution":60,"time_series_request":"Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIaGggBEg8IAxILdGVzdF9tZXRyaWMaA3N1bSAB","request_version":"v1","request_name":"TimeSeriesRequest","subscription_type":"rpc"}},'
+        b'"data":{"project_id":1,"time_window":300,"resolution":60,"time_series_request":"Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIyIQoaCAESDwgDEgt0ZXN0X21ldHJpYxoDc3VtIAEaA3N1bQ==","request_version":"v1","request_name":"TimeSeriesRequest","subscription_type":"rpc"}},'
         b'"tick_upper_offset":5'
         b"}"
     )

--- a/tests/web/rpc/test_get_expression_aggregations_visitor.py
+++ b/tests/web/rpc/test_get_expression_aggregations_visitor.py
@@ -1,0 +1,88 @@
+from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
+    AttributeConditionalAggregation,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import Expression
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    Function,
+)
+
+from snuba.web.rpc.proto_visitor import (
+    GetExpressionAggregationsVisitor,
+    TimeSeriesExpressionWrapper,
+)
+
+
+def test_formula() -> None:
+    expression = Expression(
+        formula=Expression.BinaryFormula(
+            op=Expression.BinaryFormula.OP_DIVIDE,
+            left=Expression(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric1"),
+                    label="sum",
+                )
+            ),
+            right=Expression(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric2"),
+                    label="sum",
+                )
+            ),
+        )
+    )
+    vis = GetExpressionAggregationsVisitor()
+    TimeSeriesExpressionWrapper(expression).accept(vis)
+    assert vis.aggregations == [
+        AttributeAggregation(
+            aggregate=Function.FUNCTION_SUM,
+            key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric1"),
+            label="sum",
+        ),
+        AttributeAggregation(
+            aggregate=Function.FUNCTION_SUM,
+            key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric2"),
+            label="sum",
+        ),
+    ]
+
+
+def test_basic() -> None:
+    expression = Expression(
+        aggregation=AttributeAggregation(
+            aggregate=Function.FUNCTION_SUM,
+            key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric1"),
+            label="sum",
+        )
+    )
+    vis = GetExpressionAggregationsVisitor()
+    TimeSeriesExpressionWrapper(expression).accept(vis)
+    assert vis.aggregations == [
+        AttributeAggregation(
+            aggregate=Function.FUNCTION_SUM,
+            key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric1"),
+            label="sum",
+        )
+    ]
+
+
+def test_conditional_aggregation() -> None:
+    expression = Expression(
+        conditional_aggregation=AttributeConditionalAggregation(
+            aggregate=Function.FUNCTION_SUM,
+            key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric1"),
+            label="sum",
+        )
+    )
+    vis = GetExpressionAggregationsVisitor()
+    TimeSeriesExpressionWrapper(expression).accept(vis)
+    assert vis.aggregations == [
+        AttributeConditionalAggregation(
+            aggregate=Function.FUNCTION_SUM,
+            key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_metric1"),
+            label="sum",
+        )
+    ]

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -119,7 +119,7 @@ TESTS_INVALID_RPC_SUBSCRIPTIONS = [
             time_window_secs=300,
             resolution_secs=60,
         ),
-        "Exactly one aggregation required",
+        "Exactly one expression required",
         id="Invalid subscription: multiple aggregations",
     ),
     pytest.param(


### PR DESCRIPTION
recently sentry switched to sending expressions in their subscriptions request
https://github.com/getsentry/sentry/pull/87031

this caused subscriptions to break bc the pipeline didnt have support for expressions yet
https://sentry.sentry.io/issues/6431285714/?project=300688&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=6

this pr implements support for expressions in the subscriptions pipeline.

## major changes
* convert all use of aggregation to expression
* implement support for expression