### PR TITLE
feat(eap-spans): push eap-items commits to the commit log

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -245,3 +245,9 @@ mandatory_condition_checkers:
 stream_loader:
   processor: EAPItemsProcessor
   default_topic: snuba-spans
+  commit_log_topic: snuba-eap-spans-commit-log
+  subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
+  subscription_scheduled_topic: scheduled-subscriptions-eap-spans
+  subscription_result_topic: eap-spans-subscription-results
+  subscription_delay_seconds: 60

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -144,6 +144,10 @@ class CommitLogTickConsumer(Consumer[Tick]):
             return None
 
         if commit.group != self.__followed_consumer_group:
+            self.__metrics.increment(
+                "followed_group_mismatch",
+                tags={"group": commit.group},
+            )
             return None
 
         previous_message = self.__previous_messages.get(commit.partition)


### PR DESCRIPTION
We want this in order to run eap_spans subscriptions from the eap_items commit log without having to switch subscription scheduler and executor topics or run a parallel processing pipeline. These are fed from the same topic (snuba-spans) and so the commit offsets/timestamps should be comparable.

This change starts pushing eap_items commits to the spans commit log topic. The scheduler consumer has logic to ignore these messages until an ops configuration change is made. We add a metric here to make sure that path is hit