### PR TITLE
feat(sampling-in-storage): best effort mode

### DIFF
--- a/snuba/downsampled_storage_tiers.py
+++ b/snuba/downsampled_storage_tiers.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import IntEnum
 
 
-class Tier(Enum):
+class Tier(IntEnum):
     TIER_NO_TIER = -1
     TIER_1 = 1
     TIER_8 = 8

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -147,12 +147,6 @@ class HTTPQuerySettings(QuerySettings):
     def get_sampling_tier(self) -> Tier:
         return self.__tier
 
-    def set_record_query_duration(self, to_time_query_duration: bool) -> None:
-        self.__record_query_duration = to_time_query_duration
-
-    def get_record_query_duration(self) -> bool:
-        return self.__record_query_duration
-
 
 class SubscriptionQuerySettings(QuerySettings):
     """

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -88,6 +88,7 @@ class HTTPQuerySettings(QuerySettings):
     ) -> None:
         super().__init__()
         self.__tier = Tier.TIER_NO_TIER
+        self.__record_query_duration = False
         self.__turbo = turbo
         self.__consistent = consistent
         self.__debug = debug
@@ -145,6 +146,12 @@ class HTTPQuerySettings(QuerySettings):
 
     def get_sampling_tier(self) -> Tier:
         return self.__tier
+
+    def set_record_query_duration(self, to_time_query_duration: bool) -> None:
+        self.__record_query_duration = to_time_query_duration
+
+    def get_record_query_duration(self) -> bool:
+        return self.__record_query_duration
 
 
 class SubscriptionQuerySettings(QuerySettings):

--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -49,6 +49,21 @@ class Timer:
 
         return duration_group
 
+    def get_duration_between_marks(self, start_mark: str, end_mark: str) -> float:
+        start_mark_duration = -1
+        end_mark_duration = -1
+        for name, timestamp in self.__marks:
+            if name == start_mark:
+                start_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
+            if name == end_mark:
+                end_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
+
+        assert (
+            start_mark_duration != -1 and end_mark_duration != -1
+        ), "Please pass in mark names that exist"
+
+        return end_mark_duration - start_mark_duration
+
     def finish(self) -> TimerData:
         if self.__data is None:
             start = self.__marks[0][1]

--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -52,10 +52,10 @@ class Timer:
     def get_duration_between_marks(self, start_mark: str, end_mark: str) -> float:
         start_mark_duration = -1
         end_mark_duration = -1
-        for name, timestamp in self.__marks:
-            if name == start_mark:
+        for mark, timestamp in self.__marks:
+            if mark == start_mark:
                 start_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
-            if name == end_mark:
+            if mark == end_mark:
                 end_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
 
         assert (

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -177,6 +177,12 @@ def execute_query(
     # Apply clickhouse query setting overrides
     clickhouse_query_settings.update(query_settings.get_clickhouse_settings())
 
+    if (
+        isinstance(query_settings, HTTPQuerySettings)
+        and query_settings.get_record_query_duration()
+    ):
+        timer.mark("right_before_execute")
+
     result = reader.execute(
         formatted_query,
         clickhouse_query_settings,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -177,11 +177,7 @@ def execute_query(
     # Apply clickhouse query setting overrides
     clickhouse_query_settings.update(query_settings.get_clickhouse_settings())
 
-    if (
-        isinstance(query_settings, HTTPQuerySettings)
-        and query_settings.get_record_query_duration()
-    ):
-        timer.mark("right_before_execute")
+    timer.mark("right_before_execute")
 
     result = reader.execute(
         formatted_query,

--- a/snuba/web/rpc/common/debug_info.py
+++ b/snuba/web/rpc/common/debug_info.py
@@ -43,7 +43,6 @@ def extract_response_meta(
     debug: bool,
     query_results: List[QueryResult],
     timers: List[Timer],
-    extract_sampling_tier: bool = False,
 ) -> ResponseMeta:
     query_info: List[QueryInfo] = []
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -1,12 +1,24 @@
-from typing import cast
+import uuid
+from typing import Callable, TypeVar, cast
 
+from google.protobuf.json_format import MessageToDict
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableRequest
 
+from snuba.attribution import AppID
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.downsampled_storage_tiers import Tier
-from snuba.query.query_settings import HTTPQuerySettings
-from snuba.web.rpc.common.debug_info import setup_trace_query_settings
+from snuba.query.logical import Query
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
+from snuba.request import Request as SnubaRequest
+from snuba.utils.metrics.timer import Timer
+from snuba.web import QueryResult
+from snuba.web.query import run_query
+
+T = TypeVar("T", TimeSeriesRequest, TraceItemTableRequest)
+
 
 SENTRY_TIMEOUT = 30000  # 30s = 30000ms
 ERROR_BUDGET = 5000  # 5s
@@ -19,23 +31,11 @@ TIER_MULTIPLIERS = {
 }
 
 
-def construct_query_settings(
-    in_msg: TimeSeriesRequest | TraceItemTableRequest,
-) -> HTTPQuerySettings:
-    query_settings = (
-        setup_trace_query_settings() if in_msg.meta.debug else HTTPQuerySettings()
+def _get_target_tier(timer: Timer) -> Tier:
+    most_downsampled_query_duration_ms = timer.get_duration_between_marks(
+        "right_before_execute", "execute"
     )
-    if in_msg.meta.HasField("downsampled_storage_config"):
-        if (
-            in_msg.meta.downsampled_storage_config.mode
-            == DownsampledStorageConfig.MODE_PREFLIGHT
-        ):
-            query_settings.set_sampling_tier(Tier.TIER_512)
 
-    return query_settings
-
-
-def get_target_tier(most_downsampled_query_duration_ms: float) -> Tier:
     target_tier = Tier.TIER_NO_TIER
     for tier in sorted(Tier, reverse=True)[:-1]:
         estimated_query_duration_to_this_tier = (
@@ -43,5 +43,81 @@ def get_target_tier(most_downsampled_query_duration_ms: float) -> Tier:
         )
         if estimated_query_duration_to_this_tier <= SENTRY_TIMEOUT - ERROR_BUDGET:
             target_tier = tier
-        print(tier, estimated_query_duration_to_this_tier)
     return target_tier
+
+
+def is_best_effort_mode(in_msg: T) -> bool:
+    return (
+        in_msg.meta.HasField("downsampled_storage_config")
+        and in_msg.meta.downsampled_storage_config.mode
+        == DownsampledStorageConfig.MODE_BEST_EFFORT
+    )
+
+
+def build_snuba_request(
+    request: T, query_settings: QuerySettings, build_query: Callable[[T], Query]
+) -> SnubaRequest:
+    return SnubaRequest(
+        id=uuid.UUID(request.meta.request_id),
+        original_body=MessageToDict(request),
+        query=build_query(request),
+        query_settings=query_settings,
+        attribution_info=AttributionInfo(
+            referrer=request.meta.referrer,
+            team="eap",
+            feature="eap",
+            tenant_ids={
+                "organization_id": request.meta.organization_id,
+                "referrer": request.meta.referrer,
+            },
+            app_id=AppID("eap"),
+            parent_api="eap_span_samples",
+        ),
+    )
+
+
+def run_query_to_correct_tier(
+    in_msg: T,
+    query_settings: HTTPQuerySettings,
+    timer: Timer,
+    build_query: Callable[[T], Query],
+) -> QueryResult:
+    if not in_msg.meta.HasField("downsampled_storage_config"):
+        return run_query(
+            dataset=PluggableDataset(name="eap", all_entities=[]),
+            request=build_snuba_request(in_msg, query_settings, build_query),
+            timer=timer,
+        )
+
+    query_settings.set_sampling_tier(Tier.TIER_512)
+
+    request_to_most_downsampled_tier = build_snuba_request(
+        in_msg, query_settings, build_query
+    )
+
+    if is_best_effort_mode(in_msg):
+        query_settings.set_record_query_duration(True)
+
+    res = run_query(
+        dataset=PluggableDataset(name="eap", all_entities=[]),
+        request=request_to_most_downsampled_tier,
+        timer=timer,
+    )
+
+    if is_best_effort_mode(in_msg):
+        query_settings.set_sampling_tier(_get_target_tier(timer))
+        query_settings.set_record_query_duration(
+            False
+        )  # doesn't make a functional diff
+
+        request_to_target_tier = build_snuba_request(
+            in_msg, query_settings, build_query
+        )
+
+        res = run_query(
+            dataset=PluggableDataset(name="eap", all_entities=[]),
+            request=request_to_target_tier,
+            timer=timer,
+        )
+
+    return res

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -96,9 +96,6 @@ def run_query_to_correct_tier(
         in_msg, query_settings, build_query
     )
 
-    if is_best_effort_mode(in_msg):
-        query_settings.set_record_query_duration(True)
-
     res = run_query(
         dataset=PluggableDataset(name="eap", all_entities=[]),
         request=request_to_most_downsampled_tier,
@@ -111,9 +108,6 @@ def run_query_to_correct_tier(
         )
         query_settings.push_clickhouse_setting("timeout_overflow_mode", "break")
         query_settings.set_sampling_tier(_get_target_tier(timer))
-        query_settings.set_record_query_duration(
-            False
-        )  # doesn't make a functional diff
 
         request_to_target_tier = build_snuba_request(
             in_msg, query_settings, build_query

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableRequest
@@ -5,6 +7,16 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableR
 from snuba.downsampled_storage_tiers import Tier
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.web.rpc.common.debug_info import setup_trace_query_settings
+
+SENTRY_TIMEOUT = 30000  # 30s = 30000ms
+ERROR_BUDGET = 5000  # 5s
+
+TIER_MULTIPLIERS = {
+    Tier.TIER_512: 1,
+    Tier.TIER_64: 8,
+    Tier.TIER_8: 64,
+    Tier.TIER_1: 512,
+}
 
 
 def construct_query_settings(
@@ -21,3 +33,15 @@ def construct_query_settings(
             query_settings.set_sampling_tier(Tier.TIER_512)
 
     return query_settings
+
+
+def get_target_tier(most_downsampled_query_duration_ms: float) -> Tier:
+    target_tier = Tier.TIER_NO_TIER
+    for tier in sorted(Tier, reverse=True)[:-1]:
+        estimated_query_duration_to_this_tier = (
+            most_downsampled_query_duration_ms * cast(int, TIER_MULTIPLIERS.get(tier))
+        )
+        if estimated_query_duration_to_this_tier <= SENTRY_TIMEOUT - ERROR_BUDGET:
+            target_tier = tier
+        print(tier, estimated_query_duration_to_this_tier)
+    return target_tier

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_time_series.py
@@ -368,7 +368,7 @@ class ResolverTimeSeriesEAPSpans(ResolverTimeSeries):
         )
 
         res = run_query_to_correct_tier(
-            in_msg, query_settings, self._timer, build_query
+            in_msg, query_settings, self._timer, build_query, self._metrics_backend
         )
 
         response_meta = extract_response_meta(

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -339,7 +339,7 @@ class ResolverTraceItemTableEAPSpans(ResolverTraceItemTable):
         )
 
         res = run_query_to_correct_tier(
-            in_msg, query_settings, self._timer, build_query
+            in_msg, query_settings, self._timer, build_query, self._metrics_backend
         )
         column_values = convert_results(in_msg, res.result.get("data", []))
         response_meta = extract_response_meta(

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -375,7 +375,6 @@ class ResolverTraceItemTableEAPSpans(ResolverTraceItemTable):
             in_msg.meta.debug,
             [res],
             [self._timer],
-            extract_sampling_tier=in_msg.meta.HasField("downsampled_storage_config"),
         )
         return TraceItemTableResponse(
             column_values=column_values,

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_trace_item_table.py
@@ -1,8 +1,6 @@
-import uuid
 from dataclasses import replace
 from typing import Sequence
 
-from google.protobuf.json_format import MessageToDict
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     AggregationComparisonFilter,
     AggregationFilter,
@@ -18,27 +16,25 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
 
-from snuba.attribution.appid import AppID
-from snuba.attribution.attribution_info import AttributionInfo
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import and_cond, or_cond
 from snuba.query.expressions import Expression
 from snuba.query.logical import Query
-from snuba.query.query_settings import QuerySettings
-from snuba.request import Request as SnubaRequest
-from snuba.web.query import run_query
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.web.rpc.common.common import (
     add_existence_check_to_subscriptable_references,
     base_conditions_and,
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
 )
-from snuba.web.rpc.common.debug_info import extract_response_meta
+from snuba.web.rpc.common.debug_info import (
+    extract_response_meta,
+    setup_trace_query_settings,
+)
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.resolvers import ResolverTraceItemTable
 from snuba.web.rpc.v1.resolvers.common.aggregation import (
@@ -56,7 +52,7 @@ from snuba.web.rpc.v1.resolvers.R_eap_spans.common.common import (
     use_eap_items_table,
 )
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
-    construct_query_settings,
+    run_query_to_correct_tier,
 )
 
 _DEFAULT_ROW_LIMIT = 10_000
@@ -256,7 +252,7 @@ def _column_to_expression(column: Column, request_meta: RequestMeta) -> Expressi
         )
 
 
-def _build_query(request: TraceItemTableRequest) -> Query:
+def build_query(request: TraceItemTableRequest) -> Query:
     if use_eap_items_table(request.meta):
         entity = Entity(
             key=EntityKey("eap_items"),
@@ -323,29 +319,6 @@ def _build_query(request: TraceItemTableRequest) -> Query:
     return res
 
 
-def _build_snuba_request(
-    request: TraceItemTableRequest, query_settings: QuerySettings
-) -> SnubaRequest:
-
-    return SnubaRequest(
-        id=uuid.UUID(request.meta.request_id),
-        original_body=MessageToDict(request),
-        query=_build_query(request),
-        query_settings=query_settings,
-        attribution_info=AttributionInfo(
-            referrer=request.meta.referrer,
-            team="eap",
-            feature="eap",
-            tenant_ids={
-                "organization_id": request.meta.organization_id,
-                "referrer": request.meta.referrer,
-            },
-            app_id=AppID("eap"),
-            parent_api="eap_span_samples",
-        ),
-    )
-
-
 def _get_page_token(
     request: TraceItemTableRequest, response: list[TraceItemColumnValues]
 ) -> PageToken:
@@ -361,13 +334,12 @@ class ResolverTraceItemTableEAPSpans(ResolverTraceItemTable):
         return TraceItemType.TRACE_ITEM_TYPE_SPAN
 
     def resolve(self, in_msg: TraceItemTableRequest) -> TraceItemTableResponse:
-        query_settings = construct_query_settings(in_msg)
+        query_settings = (
+            setup_trace_query_settings() if in_msg.meta.debug else HTTPQuerySettings()
+        )
 
-        snuba_request = _build_snuba_request(in_msg, query_settings)
-        res = run_query(
-            dataset=PluggableDataset(name="eap", all_entities=[]),
-            request=snuba_request,
-            timer=self._timer,
+        res = run_query_to_correct_tier(
+            in_msg, query_settings, self._timer, build_query
         )
         column_values = convert_results(in_msg, res.result.get("data", []))
         response_meta = extract_response_meta(

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1366,7 +1366,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
 
     @patch.object(Timer, "get_duration_between_marks")
     def test_best_effort_route_to_tier_64(
-        self, mock_get_duration_between_marks
+        self, mock_get_duration_between_marks: MagicMock
     ) -> None:
         # store a a test metric with a value of 1, every second of one hour
         granularity_secs = 3600

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1410,7 +1410,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             granularity_secs=granularity_secs,
         )
 
-        mock_get_duration_between_marks.return_value = 3000.0
+        mock_get_duration_between_marks.return_value = 2778.0
 
         with mock.patch(
             "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._enough_time_budget_to_at_least_run_next_tier",
@@ -1491,7 +1491,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             granularity_secs=granularity_secs,
         )
 
-        mock_get_duration_between_marks.return_value = 3124.0
+        mock_get_duration_between_marks.return_value = 2777.0
 
         best_effort_response = EndpointTimeSeries().execute(
             best_effort_downsample_message

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1512,9 +1512,9 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             non_downsampled_tier_response.result_timeseries[0].data_points[0].data
         )
         assert (
-            non_downsampled_best_effort_metric_sum / 50
+            non_downsampled_best_effort_metric_sum / 80
             <= best_effort_metric_sum
-            <= non_downsampled_best_effort_metric_sum / 80
+            <= non_downsampled_best_effort_metric_sum / 50
         )
 
         assert (

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1421,7 +1421,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             aggregations=aggregations,
             granularity_secs=granularity_secs,
         )
-        # this forces the query to route to tier 64
+        # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         mock_get_duration_between_marks.return_value = 2777.0
         best_effort_response = EndpointTimeSeries().execute(
             best_effort_downsample_message

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1499,13 +1499,9 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             message_to_non_downsampled_tier
         )
 
-        # sums over the best effort metric
-        if best_effort_response.result_timeseries == []:
-            best_effort_metric_sum = 0.0
-        else:
-            best_effort_metric_sum = (
-                best_effort_response.result_timeseries[0].data_points[0].data
-            )
+        best_effort_metric_sum = (
+            best_effort_response.result_timeseries[0].data_points[0].data
+        )
 
         # tier 1 sum should be 3600, so tier 64 sum should be around 3600 / 64 (give or take due to random sampling)
         non_downsampled_best_effort_metric_sum = (
@@ -1517,9 +1513,13 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             <= non_downsampled_best_effort_metric_sum / 50
         )
 
+        breakpoint()
+
         assert (
             best_effort_response.meta.downsampled_storage_meta
             == DownsampledStorageMeta(
                 tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
             )
         )
+
+        assert False

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1439,9 +1439,9 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             non_downsampled_tier_response.result_timeseries[0].data_points[0].data
         )
         assert (
-            non_downsampled_best_effort_metric_sum / 80
+            non_downsampled_best_effort_metric_sum / 90
             <= best_effort_metric_sum
-            <= non_downsampled_best_effort_metric_sum / 50
+            <= non_downsampled_best_effort_metric_sum / 40
         )
 
         assert (

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -38,6 +38,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -1360,5 +1361,91 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             preflight_response.meta.downsampled_storage_meta
             == DownsampledStorageMeta(
                 tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_512
+            )
+        )
+
+    @patch.object(Timer, "get_duration_between_marks")
+    def test_best_effort_route_to_tier_64(
+        self, mock_get_duration_between_marks
+    ) -> None:
+        # store a a test metric with a value of 1, every second of one hour
+        granularity_secs = 3600
+        query_duration = granularity_secs * 1
+        store_spans_timeseries(
+            BASE_TIME,
+            1,
+            query_duration,
+            metrics=[DummyMetric("test_best_effort", get_value=lambda x: 1)],
+        )
+
+        aggregations = [
+            AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM,
+                key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="test_best_effort"),
+                label="sum",
+                extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+            ),
+        ]
+
+        best_effort_downsample_message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_BEST_EFFORT
+                ),
+            ),
+            aggregations=aggregations,
+            granularity_secs=granularity_secs,
+        )
+
+        message_to_non_downsampled_tier = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            aggregations=aggregations,
+            granularity_secs=granularity_secs,
+        )
+
+        mock_get_duration_between_marks.return_value = 3124.0
+
+        best_effort_response = EndpointTimeSeries().execute(
+            best_effort_downsample_message
+        )
+        non_downsampled_tier_response = EndpointTimeSeries().execute(
+            message_to_non_downsampled_tier
+        )
+
+        if best_effort_response.result_timeseries == []:
+            best_effort_metric_sum = 0.0
+        else:
+            best_effort_metric_sum = (
+                best_effort_response.result_timeseries[0].data_points[0].data
+            )
+
+        assert (
+            best_effort_metric_sum
+            < non_downsampled_tier_response.result_timeseries[0].data_points[0].data
+            / 36
+        )
+        assert (
+            best_effort_response.meta.downsampled_storage_meta
+            == DownsampledStorageMeta(
+                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
             )
         )

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -2,6 +2,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, Callable, MutableMapping
+from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -45,6 +46,9 @@ from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.endpoint_time_series import (
     EndpointTimeSeries,
     _validate_time_buckets,
+)
+from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
+    _enough_time_budget_to_at_least_run_next_tier,
 )
 from tests.base import BaseApiTest
 from tests.conftest import SnubaSetConfig
@@ -1363,6 +1367,71 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
                 tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_512
             )
         )
+
+    @patch.object(Timer, "get_duration_between_marks")
+    def test_best_effort_returns_most_downsampled_query_if_not_enough_time_budget_left(
+        self, mock_get_duration_between_marks: MagicMock
+    ) -> None:
+        # store a a test metric with a value of 1, every second of one hour
+        granularity_secs = 3600
+        query_duration = granularity_secs * 1
+        store_spans_timeseries(
+            BASE_TIME,
+            1,
+            query_duration,
+            metrics=[DummyMetric("test_most_downsampled", get_value=lambda x: 1)],
+        )
+
+        best_effort_downsample_message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_BEST_EFFORT
+                ),
+            ),
+            aggregations=[
+                AttributeAggregation(
+                    aggregate=Function.FUNCTION_SUM,
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_FLOAT, name="test_most_downsampled"
+                    ),
+                    label="sum",
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+            ],
+            granularity_secs=granularity_secs,
+        )
+
+        mock_get_duration_between_marks.return_value = 3000.0
+
+        with mock.patch(
+            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._enough_time_budget_to_at_least_run_next_tier",
+            wraps=_enough_time_budget_to_at_least_run_next_tier,
+        ) as mock_enough_time_budget:
+
+            best_effort_response = EndpointTimeSeries().execute(
+                best_effort_downsample_message
+            )
+
+            assert (
+                best_effort_response.meta.downsampled_storage_meta
+                == DownsampledStorageMeta(
+                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_512
+                )
+            )
+
+            assert (
+                mock_enough_time_budget(mock_enough_time_budget.call_args_list[0][0][0])
+                is False
+            )
 
     @patch.object(Timer, "get_duration_between_marks")
     def test_best_effort_route_to_tier_64(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3240,9 +3240,9 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
 
         # tier 1's results should be 3600, so tier 64's results should be around 3600 / 64 (give or take due to random sampling)
         assert (
-            len(non_downsampled_tier_response.column_values) / 50
+            len(non_downsampled_tier_response.column_values) / 80
             <= len(best_effort_response.column_values)
-            <= len(non_downsampled_tier_response.column_values) / 80
+            <= len(non_downsampled_tier_response.column_values) / 50
         )
         assert (
             best_effort_response.meta.downsampled_storage_meta

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -427,11 +427,6 @@ class TestTraceItemTable(BaseApiTest):
                         type=AttributeKey.TYPE_BOOLEAN, name="sentry.is_segment"
                     )
                 ),
-                Column(
-                    key=AttributeKey(
-                        type=AttributeKey.TYPE_STRING, name="sentry.span_id"
-                    )
-                ),
             ],
             order_by=[
                 TraceItemTableRequest.OrderBy(
@@ -450,12 +445,6 @@ class TestTraceItemTable(BaseApiTest):
                 TraceItemColumnValues(
                     attribute_name="sentry.is_segment",
                     results=[AttributeValue(val_bool=True) for _ in range(60)],
-                ),
-                TraceItemColumnValues(
-                    attribute_name="sentry.span_id",
-                    results=[
-                        AttributeValue(val_str="123456781234567d") for _ in range(60)
-                    ],
                 ),
             ],
             page_token=PageToken(offset=60),
@@ -3231,14 +3220,12 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
                 )
             ],
         )
-        # this forces the query to route to tier 64
+        # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         mock_get_duration_between_marks.return_value = 2777.0
         best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
         non_downsampled_tier_response = EndpointTraceItemTable().execute(
             message_to_non_downsampled_tier
         )
-
-        breakpoint()
 
         # tier 1's results should be 3600, so tier 64's results should be around 3600 / 64 (give or take due to random sampling)
         assert (

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3243,9 +3243,9 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
 
         # tier 1's results should be 3600, so tier 64's results should be around 3600 / 64 (give or take due to random sampling)
         assert (
-            len(non_downsampled_tier_response.column_values[0].results) / 80
+            len(non_downsampled_tier_response.column_values[0].results) / 90
             <= len(best_effort_response.column_values[0].results)
-            <= len(non_downsampled_tier_response.column_values[0].results) / 50
+            <= len(non_downsampled_tier_response.column_values[0].results) / 40
         )
         assert (
             best_effort_response.meta.downsampled_storage_meta

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -52,6 +52,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -3171,5 +3172,78 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             preflight_response.meta.downsampled_storage_meta
             == DownsampledStorageMeta(
                 tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_512
+            )
+        )
+
+    @patch.object(Timer, "get_duration_between_marks")
+    def test_best_effort_route_to_tier_64(
+        self, mock_get_duration_between_marks: MagicMock
+    ) -> None:
+        items_storage = get_storage(StorageKey("eap_items"))
+        msg_timestamp = BASE_TIME - timedelta(minutes=1)
+        messages = [
+            gen_message(
+                msg_timestamp,
+                tags={"preflighttag": "preflight"},
+            )
+            for _ in range(30)
+        ]
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
+
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
+
+        columns = [
+            Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="tier64tag"))
+        ]
+        best_effort_message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_BEST_EFFORT
+                ),
+            ),
+            columns=columns,
+        )
+
+        message_to_non_downsampled_tier = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            columns=[
+                Column(
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="tier64tag")
+                )
+            ],
+        )
+
+        mock_get_duration_between_marks.return_value = 3124.0
+
+        best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
+        non_downsampled_tier_response = EndpointTraceItemTable().execute(
+            message_to_non_downsampled_tier
+        )
+        assert (
+            len(best_effort_response.column_values)
+            < len(non_downsampled_tier_response.column_values) / 36
+        )
+        assert (
+            best_effort_response.meta.downsampled_storage_meta
+            == DownsampledStorageMeta(
+                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
             )
         )

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -125,7 +125,7 @@ def gen_message(
             "transaction.op": "http.server",
             "user": "ip:127.0.0.1",
         },
-        "span_id": "123456781234567D",
+        "span_id": uuid.uuid4().hex,
         "tags": {
             "relay_endpoint_version": "3",
             "relay_id": "88888888-4444-4444-8444-cccccccccccc",
@@ -3186,7 +3186,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
                 msg_timestamp,
                 tags={"tier64tag": "tier64tag"},
             )
-            for _ in range(30)
+            for _ in range(3600)
         ]
         write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
@@ -3238,11 +3238,13 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             message_to_non_downsampled_tier
         )
 
+        breakpoint()
+
         # tier 1's results should be 3600, so tier 64's results should be around 3600 / 64 (give or take due to random sampling)
         assert (
-            len(non_downsampled_tier_response.column_values) / 80
-            <= len(best_effort_response.column_values)
-            <= len(non_downsampled_tier_response.column_values) / 50
+            len(non_downsampled_tier_response.column_values[0].results) / 80
+            <= len(best_effort_response.column_values[0].results)
+            <= len(non_downsampled_tier_response.column_values[0].results) / 50
         )
         assert (
             best_effort_response.meta.downsampled_storage_meta

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3117,7 +3117,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
                 tags={"preflighttag": "preflight"},
                 randomize_span_id=True,
             )
-            for _ in range(30)
+            for _ in range(3600)
         ]
         write_raw_unprocessed_events(items_storage, messages)  # type: ignore
 
@@ -3167,8 +3167,8 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             message_to_non_downsampled_tier
         )
         assert (
-            len(preflight_response.column_values)
-            < len(non_downsampled_tier_response.column_values) / 100
+            len(preflight_response.column_values[0].results)
+            < len(non_downsampled_tier_response.column_values[0].results) / 100
         )
         assert (
             preflight_response.meta.downsampled_storage_meta

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3231,7 +3231,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             ],
         )
 
-        mock_get_duration_between_marks.return_value = 3124.0
+        mock_get_duration_between_marks.return_value = 2777.0
 
         best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
         non_downsampled_tier_response = EndpointTraceItemTable().execute(


### PR DESCRIPTION
giving my best effort to the best effort mode

Implements best effort mode according to https://github.com/getsentry/eap-planning/issues/212. Also:
1. added functionality to Timer to get the duration between 2 marks before "finishing"
2. refactored build_snuba_request (because it's the same between the time series and trace item table endpoints) to take in build_request (which is different between the endpoints)

https://github.com/getsentry/eap-planning/issues/218
