### PR TITLE
fix(eap): make sure trace id bloom filter is hit

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -185,7 +185,11 @@ def _build_query(request: GetTraceRequest) -> Query:
         selected_columns.extend(
             map(
                 lambda col_name: SelectedExpression(
-                    name=col_name, expression=column(col_name, alias=col_name)
+                    name=col_name,
+                    expression=column(
+                        col_name,
+                        alias=f"selected_{col_name}",
+                    ),
                 ),
                 NORMALIZED_COLUMNS_TO_INCLUDE_EAP_ITEMS
                 if use_eap_items_table(request.meta)

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -233,11 +233,7 @@ def _build_query(request: GetTraceRequest) -> Query:
                 request.meta.end_timestamp.seconds,
             ),
             equals(
-                f.cast(
-                    column("trace_id"),
-                    "String",
-                    alias="trace_id",
-                ),
+                column("trace_id"),
                 literal(request.trace_id),
             ),
         ),


### PR DESCRIPTION
We weren't hitting the bloom filter before because we weren't comparing directly against `trace_id`. This ensures that the uuid processor correctly transforms the condition.