### PR TITLE
ref(gocd): Cutting over to check_cloudbuild.py

### DIFF
--- a/gocd/templates/bash/check-cloud-build.sh
+++ b/gocd/templates/bash/check-cloud-build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
-  ${GO_REVISION_SNUBA_REPO} \
+/devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
   sentryio \
-  "us-central1-docker.pkg.dev/sentryio/snuba/image"
+  snuba \
+  build-on-branch-push \
+  ${GO_REVISION_SNUBA_REPO} \
+  master


### PR DESCRIPTION
Cutting over to the new check_cloudbuild script that doesn't rely on images anymore and instead relies on repo_name, trigger_name, sha, and branch_name.
https://linear.app/getsentry/issue/DI-629/update-snuba-to-use-new-script