### PR TITLE
feat(ci): tag GHCR image with release version

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,6 +25,7 @@ jobs:
         if [ ${{ github.event_name }} = 'push' ]; then
           args+=(
             --tag ghcr.io/getsentry/snuba:latest
+            --tag ghcr.io/getsentry/snuba:nightly
             --tag ghcr.io/getsentry/snuba:amd64-latest
             --cache-to type=registry,ref=ghcr.io/getsentry/snuba:buildcache,mode=max
             --push

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -1,0 +1,22 @@
+name: Release GHCR Versioned Image
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  release-ghcr-version-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag release version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/snuba:${{ github.ref_name }} \
+           ghcr.io/getsentry/snuba:${{ github.sha }}


### PR DESCRIPTION
Similar work with these PRs:
- https://github.com/getsentry/relay/pull/4532
- https://github.com/getsentry/symbolicator/pull/1635

While also trying to provide a solution (or at least an alternative) for this issue: https://github.com/getsentry/self-hosted/issues/3593


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
