### PR TITLE
chore(devservices): Bump devservices to 1.0.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 clickhouse-driver==0.2.9
 confluent-kafka==2.7.0
 datadog==0.21.0
-devservices==1.0.17
+devservices==1.0.18
 flake8==7.0.0
 Flask==2.2.5
 google-cloud-storage==2.18.0


### PR DESCRIPTION
This picks up better observability in sentry for CI runs that use devservices and adds additional information on what devservices is doing behind the scenes for `devservices up`

https://github.com/getsentry/devservices/releases/tag/1.0.18