### PR TITLE
fix(migrations): handle missing nodes

### DIFF
--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -460,6 +460,7 @@ def test_reset_settings() -> None:
 
 
 @mock.patch("snuba.clusters.cluster.ClickhouseCluster.get_local_nodes", return_value=[])
+@pytest.mark.clickhouse_custom_db
 def test_missing_nodes_for_operation(mock_get_local_nodes: Mock) -> None:
     with pytest.raises(OperationMissingNodes):
         TruncateTable(

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -459,8 +459,18 @@ def test_reset_settings() -> None:
 
 
 @mock.patch("snuba.clusters.cluster.ClickhouseCluster.get_local_nodes", return_value=[])
-def test_missing_nodes_for_operation(mock_get_local_nodes: Mock) -> None:
+@mock.patch(
+    "snuba.clusters.cluster.ClickhouseCluster.get_distributed_nodes", return_value=[]
+)
+def test_missing_nodes_for_operation(
+    mock_get_local_nodes: Mock, mock_get_dist_nodes: Mock
+) -> None:
     with pytest.raises(OperationMissingNodes):
         TruncateTable(
             StorageSetKey.EVENTS, "blah_table", target=OperationTarget.LOCAL
         ).execute()
+
+    # in single node mode get_distributed_nodes returning [] is okay
+    TruncateTable(
+        StorageSetKey.EVENTS, "blah_table", target=OperationTarget.DISTRIBUTED
+    ).execute()

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -460,7 +460,7 @@ def test_reset_settings() -> None:
 
 
 @mock.patch("snuba.clusters.cluster.ClickhouseCluster.get_local_nodes", return_value=[])
-@pytest.mark.clickhouse_custom_db
+@pytest.mark.custom_clickhouse_db
 def test_missing_nodes_for_operation(mock_get_local_nodes: Mock) -> None:
     with pytest.raises(OperationMissingNodes):
         TruncateTable(


### PR DESCRIPTION
Addresses https://github.com/getsentry/snuba/issues/6962

A migration should only be successful if it actually runs the sql operations on the nodes for the cluster - if there are no nodes, it probably means the cluster or migration itself wasn't set up right

The exception to this is when migrations are run in single node mode (which is the setup locally) - in that case it is expected to not have any nodes for the distributed target operations
