### PR TITLE
hotfix(inc-1098): Increase use 'break' overflow mode for replays

### DIFF
--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -182,7 +182,7 @@ query_processors:
   - processor: ClickhouseSettingsOverride
     args:
       settings:
-        max_rows_to_group_by: 1000000
+        max_rows_to_group_by: 1500000
         group_by_overflow_mode: any
   - processor: MappingOptimizer
     args:

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -182,8 +182,8 @@ query_processors:
   - processor: ClickhouseSettingsOverride
     args:
       settings:
-        max_rows_to_group_by: 1500000
-        group_by_overflow_mode: any
+        max_rows_to_group_by: 1000000
+        group_by_overflow_mode: break
   - processor: MappingOptimizer
     args:
       column_name: tags


### PR DESCRIPTION
The `group_by_overflow_mode=any` setting is causing the cluster to segfault (oopsie!)

As a bandaid, use `break`