### PR TITLE
perf(sampling-in-storage): add perf metrics

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -31,11 +31,6 @@ DOWNSAMPLING_TIER_MULTIPLIERS = {
 }
 
 
-def _get_referrer(in_msg: T) -> str:
-    # if the referrer isn't set, this would return ""
-    return in_msg.meta.referrer
-
-
 def _get_time_budget() -> float:
     sentry_timeout_ms = cast(
         int, state.get_int_config("sampling_in_storage_sentry_timeout", default=30000)
@@ -161,7 +156,7 @@ def run_query_to_correct_tier(
 
     query_settings.set_sampling_tier(_get_most_downsampled_tier())
 
-    referrer = _get_referrer(in_msg)
+    referrer = in_msg.meta.referrer
 
     request_to_most_downsampled_tier = build_snuba_request(
         in_msg, query_settings, build_query

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -78,7 +78,7 @@ def _get_target_tier(
     metrics_backend.timing(
         "sampling_in_storage_routed_tier",
         target_tier,
-        tags={"referrer": referrer, "tier": str(target_tier)},
+        tags={"referrer": referrer},
     )
     return target_tier, estimated_target_tier_query_duration
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -31,6 +31,11 @@ DOWNSAMPLING_TIER_MULTIPLIERS = {
 }
 
 
+def _get_referrer(in_msg: T) -> str:
+    # if the referrer isn't set, this would return ""
+    return in_msg.meta.referrer
+
+
 def _get_time_budget() -> float:
     sentry_timeout_ms = cast(
         int, state.get_int_config("sampling_in_storage_sentry_timeout", default=30000)
@@ -45,7 +50,9 @@ def _get_query_duration(timer: Timer) -> float:
     return timer.get_duration_between_marks("right_before_execute", "execute")
 
 
-def _get_target_tier(timer: Timer) -> Tier:
+def _get_target_tier(
+    timer: Timer, metrics_backend: MetricsBackend, referrer: str
+) -> Tier:
     most_downsampled_query_duration_ms = _get_query_duration(timer)
 
     target_tier = Tier.TIER_512
@@ -54,12 +61,20 @@ def _get_target_tier(timer: Timer) -> Tier:
             most_downsampled_query_duration_ms
             * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(tier))
         )
+        metrics_backend.timing(
+            f"sampling_in_storage_estimated_query_duration_to_{target_tier}",
+            estimated_query_duration_to_this_tier,
+            tags={"referrer": referrer},
+        )
         if (
             estimated_query_duration_to_this_tier
             <= _get_time_budget() - most_downsampled_query_duration_ms
         ):
             target_tier = tier
 
+    metrics_backend.gauge(
+        "sampling_in_storage_routed_tier", target_tier, tags={"referrer": referrer}
+    )
     return target_tier
 
 
@@ -94,30 +109,22 @@ def build_snuba_request(
 
 
 def _run_query_on_most_downsampled_tier(
-    is_best_effort_mode: bool,
     request_to_most_downsampled_tier: Request,
     timer: Timer,
     metrics_backend: MetricsBackend,
+    referrer: str,
 ) -> QueryResult:
-    start_mark = "sampling_in_storage_start_estimation"
-    end_mark = "sampling_in_storage_finished_estimation"
 
-    if is_best_effort_mode:
-        timer.mark(start_mark)
     res = run_query(
         dataset=PluggableDataset(name="eap", all_entities=[]),
         request=request_to_most_downsampled_tier,
         timer=timer,
     )
-    if is_best_effort_mode:
-        timer.mark(end_mark)
-        metrics_backend.timing(
-            "sampling_in_storage_estimation_duration",
-            timer.get_duration_between_marks(
-                start_mark,
-                end_mark,
-            ),
-        )
+    metrics_backend.timing(
+        "sampling_in_storage_most_downsampled_tier_query_duration",
+        _get_query_duration(timer),
+        tags={"referrer": referrer},
+    )
     return res
 
 
@@ -141,14 +148,13 @@ def run_query_to_correct_tier(
 
     query_settings.set_sampling_tier(Tier.TIER_512)
 
+    referrer = _get_referrer(in_msg)
+
     request_to_most_downsampled_tier = build_snuba_request(
         in_msg, query_settings, build_query
     )
     res = _run_query_on_most_downsampled_tier(
-        _is_best_effort_mode(in_msg),
-        request_to_most_downsampled_tier,
-        timer,
-        metrics_backend,
+        request_to_most_downsampled_tier, timer, metrics_backend, referrer
     )
 
     if _is_best_effort_mode(in_msg):
@@ -157,7 +163,7 @@ def run_query_to_correct_tier(
             _get_time_budget() / 1000,
         )
         query_settings.push_clickhouse_setting("timeout_overflow_mode", "break")
-        target_tier = _get_target_tier(timer)
+        target_tier = _get_target_tier(timer, metrics_backend, referrer)
 
         if target_tier == Tier.TIER_512:
             return res
@@ -172,6 +178,11 @@ def run_query_to_correct_tier(
             dataset=PluggableDataset(name="eap", all_entities=[]),
             request=request_to_target_tier,
             timer=timer,
+        )
+        metrics_backend.timing(
+            "sampling_in_storage_actual_query_duration",
+            _get_query_duration(timer),
+            tags={"referrer": referrer},
         )
 
     return res

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -53,15 +53,15 @@ def test_get_target_tier(
                 int, DOWNSAMPLING_TIER_MULTIPLIERS.get(tier)
             )
             metrics_mock.timing.assert_any_call(
-                f"sampling_in_storage_estimated_query_duration_to_TIER_{tier}",
+                "sampling_in_storage_estimated_query_duration",
                 expected_estimated_duration,
-                tags={"referrer": DOESNT_MATTER_STR},
+                tags={"referrer": DOESNT_MATTER_STR, "tier": str(tier)},
             )
 
-        metrics_mock.gauge.assert_called_once_with(
+        metrics_mock.timing.assert_any_call(
             "sampling_in_storage_routed_tier",
             expected_tier,
-            tags={"referrer": DOESNT_MATTER_STR},
+            tags={"referrer": DOESNT_MATTER_STR, "tier": str(expected_tier)},
         )
 
 

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -46,17 +46,15 @@ def test_get_target_tier(
     ), patch(
         SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_time_budget", return_value=time_budget
     ):
-        assert _get_target_tier(timer, metrics_mock, DOESNT_MATTER_STR) == expected_tier
-
-        for tier in sorted(Tier, reverse=True)[:-1]:
-            expected_estimated_duration = most_downsampled_query_duration_ms * cast(
-                int, DOWNSAMPLING_TIER_MULTIPLIERS.get(tier)
-            )
-            metrics_mock.timing.assert_any_call(
-                "sampling_in_storage_estimated_query_duration",
-                expected_estimated_duration,
-                tags={"referrer": DOESNT_MATTER_STR, "tier": str(tier)},
-            )
+        target_tier, estimated_target_tier_query_duration = _get_target_tier(
+            timer, metrics_mock, DOESNT_MATTER_STR
+        )
+        assert target_tier == expected_tier
+        assert (
+            estimated_target_tier_query_duration
+            == most_downsampled_query_duration_ms
+            * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(target_tier))
+        )
 
         metrics_mock.timing.assert_any_call(
             "sampling_in_storage_routed_tier",

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -1,39 +1,50 @@
+import uuid
 from unittest.mock import MagicMock, patch
 
-from snuba.reader import Result
+from snuba.attribution import AppID
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.query.logical import Query as LogicalQuery
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
-from snuba.web import QueryExtraData, QueryResult
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
     _run_query_on_most_downsampled_tier,
 )
 
+DOESNT_MATTER_STR = "doesntmatter"
+DOESNT_MATTER_INT = 2
 
-def test_sampling_in_storage_estimation_duration_metric_is_sent() -> None:
+
+def test_sampling_in_storage_most_downsampled_tier_query_duration_metric_is_sent() -> None:
+    timer = Timer(DOESNT_MATTER_STR)
     metrics_mock = MagicMock(spec=MetricsBackend)
-    timer = Timer("doesntmatter")
-    doesntmatterresult = QueryResult(
-        result=MagicMock(spec=Result),
-        extra=MagicMock(spec=QueryExtraData),
-    )
 
+    doesnt_matter_request = Request(
+        id=uuid.uuid4(),
+        original_body={},
+        query=LogicalQuery(from_clause=None),
+        query_settings=HTTPQuerySettings(),
+        attribution_info=AttributionInfo(
+            app_id=AppID(key=DOESNT_MATTER_STR),
+            tenant_ids={},
+            referrer=DOESNT_MATTER_STR,
+            team=None,
+            feature=None,
+            parent_api=None,
+        ),
+    )
     with patch(
         "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util.run_query",
-        return_value=doesntmatterresult,
+    ), patch(
+        "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_duration",
+        return_value=DOESNT_MATTER_INT,
     ):
-
         _run_query_on_most_downsampled_tier(
-            request_to_most_downsampled_tier=MagicMock(spec=Request),
-            timer=timer,
-            metrics_backend=metrics_mock,
-            referrer="doesntmatter",
-        )
-
-        duration = timer.get_duration_between_marks(
-            "right_before_execute",
-            "execute",
+            doesnt_matter_request, timer, metrics_mock, DOESNT_MATTER_STR
         )
         metrics_mock.timing.assert_called_once_with(
-            "sampling_in_storage_estimation_duration", duration
+            "sampling_in_storage_most_downsampled_tier_query_duration",
+            DOESNT_MATTER_INT,
+            tags={"referrer": DOESNT_MATTER_STR},
         )

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -24,15 +24,15 @@ def test_sampling_in_storage_estimation_duration_metric_is_sent() -> None:
     ):
 
         _run_query_on_most_downsampled_tier(
-            is_best_effort_mode=True,
             request_to_most_downsampled_tier=MagicMock(spec=Request),
             timer=timer,
             metrics_backend=metrics_mock,
+            referrer="doesntmatter",
         )
 
         duration = timer.get_duration_between_marks(
-            "sampling_in_storage_start_estimation",
-            "sampling_in_storage_finished_estimation",
+            "right_before_execute",
+            "execute",
         )
         metrics_mock.timing.assert_called_once_with(
             "sampling_in_storage_estimation_duration", duration

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -60,7 +60,7 @@ def test_get_target_tier(
         metrics_mock.timing.assert_any_call(
             "sampling_in_storage_routed_tier",
             expected_tier,
-            tags={"referrer": DOESNT_MATTER_STR, "tier": str(expected_tier)},
+            tags={"referrer": DOESNT_MATTER_STR},
         )
 
 

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -3,13 +3,6 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
-from google.protobuf.timestamp_pb2 import Timestamp
-from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
-    Column,
-    TraceItemTableRequest,
-)
-from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.attribution import AppID
 from snuba.attribution.attribution_info import AttributionInfo
@@ -21,7 +14,6 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
     DOWNSAMPLING_TIER_MULTIPLIERS,
-    _get_referrer,
     _get_target_tier,
     _run_query_on_most_downsampled_tier,
 )
@@ -31,44 +23,6 @@ DOESNT_MATTER_INT = 2
 SAMPLING_IN_STORAGE_UTIL_PREFIX = (
     "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util."
 )
-
-
-def test_get_referrer() -> None:
-    expected_extracted_referrer = "important_referrer"
-    in_msg_with_referrer = TraceItemTableRequest(
-        meta=RequestMeta(
-            project_ids=[1],
-            organization_id=1,
-            cogs_category=DOESNT_MATTER_STR,
-            referrer=expected_extracted_referrer,
-            start_timestamp=Timestamp(),
-            end_timestamp=Timestamp(),
-            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-        ),
-        columns=[
-            Column(
-                key=AttributeKey(type=AttributeKey.TYPE_STRING, name=DOESNT_MATTER_STR)
-            )
-        ],
-    )
-    assert _get_referrer(in_msg_with_referrer) == expected_extracted_referrer
-
-    in_msg_without_referrer = TraceItemTableRequest(
-        meta=RequestMeta(
-            project_ids=[1],
-            organization_id=1,
-            cogs_category=DOESNT_MATTER_STR,
-            start_timestamp=Timestamp(),
-            end_timestamp=Timestamp(),
-            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-        ),
-        columns=[
-            Column(
-                key=AttributeKey(type=AttributeKey.TYPE_STRING, name=DOESNT_MATTER_STR)
-            )
-        ],
-    )
-    assert _get_referrer(in_msg_without_referrer) == ""
 
 
 @pytest.mark.parametrize(
@@ -81,7 +35,7 @@ def test_get_referrer() -> None:
     ],
 )
 def test_get_target_tier(
-    most_downsampled_query_duration_ms, time_budget, expected_tier
+    most_downsampled_query_duration_ms: int, time_budget: int, expected_tier: Tier
 ) -> None:
     timer = Timer(DOESNT_MATTER_STR)
     metrics_mock = MagicMock(spec=MetricsBackend)

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -55,6 +55,7 @@ def test_get_target_tier(
             == most_downsampled_query_duration_ms
             * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(target_tier))
         )
+        print({"referrer": DOESNT_MATTER_STR, "tier": str(expected_tier)})
 
         metrics_mock.timing.assert_any_call(
             "sampling_in_storage_routed_tier",

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -1,22 +1,117 @@
 import uuid
+from typing import cast
 from unittest.mock import MagicMock, patch
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.attribution import AppID
 from snuba.attribution.attribution_info import AttributionInfo
+from snuba.downsampled_storage_tiers import Tier
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
+    DOWNSAMPLING_TIER_MULTIPLIERS,
+    _get_referrer,
+    _get_target_tier,
     _run_query_on_most_downsampled_tier,
 )
 
 DOESNT_MATTER_STR = "doesntmatter"
 DOESNT_MATTER_INT = 2
+SAMPLING_IN_STORAGE_UTIL_PREFIX = (
+    "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util."
+)
 
 
-def test_sampling_in_storage_most_downsampled_tier_query_duration_metric_is_sent() -> None:
+def test_get_referrer() -> None:
+    expected_extracted_referrer = "important_referrer"
+    in_msg_with_referrer = TraceItemTableRequest(
+        meta=RequestMeta(
+            project_ids=[1],
+            organization_id=1,
+            cogs_category=DOESNT_MATTER_STR,
+            referrer=expected_extracted_referrer,
+            start_timestamp=Timestamp(),
+            end_timestamp=Timestamp(),
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        ),
+        columns=[
+            Column(
+                key=AttributeKey(type=AttributeKey.TYPE_STRING, name=DOESNT_MATTER_STR)
+            )
+        ],
+    )
+    assert _get_referrer(in_msg_with_referrer) == expected_extracted_referrer
+
+    in_msg_without_referrer = TraceItemTableRequest(
+        meta=RequestMeta(
+            project_ids=[1],
+            organization_id=1,
+            cogs_category=DOESNT_MATTER_STR,
+            start_timestamp=Timestamp(),
+            end_timestamp=Timestamp(),
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        ),
+        columns=[
+            Column(
+                key=AttributeKey(type=AttributeKey.TYPE_STRING, name=DOESNT_MATTER_STR)
+            )
+        ],
+    )
+    assert _get_referrer(in_msg_without_referrer) == ""
+
+
+@pytest.mark.parametrize(
+    "most_downsampled_query_duration_ms, time_budget, expected_tier",
+    [
+        (100, 200, Tier.TIER_512),
+        (100, 900, Tier.TIER_64),
+        (100, 6500, Tier.TIER_8),
+        (100, 51300, Tier.TIER_1),
+    ],
+)
+def test_get_target_tier(
+    most_downsampled_query_duration_ms, time_budget, expected_tier
+) -> None:
+    timer = Timer(DOESNT_MATTER_STR)
+    metrics_mock = MagicMock(spec=MetricsBackend)
+
+    with patch(
+        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_duration",
+        return_value=most_downsampled_query_duration_ms,
+    ), patch(
+        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_time_budget", return_value=time_budget
+    ):
+        assert _get_target_tier(timer, metrics_mock, DOESNT_MATTER_STR) == expected_tier
+
+        for tier in sorted(Tier, reverse=True)[:-1]:
+            expected_estimated_duration = most_downsampled_query_duration_ms * cast(
+                int, DOWNSAMPLING_TIER_MULTIPLIERS.get(tier)
+            )
+            metrics_mock.timing.assert_any_call(
+                f"sampling_in_storage_estimated_query_duration_to_TIER_{tier}",
+                expected_estimated_duration,
+                tags={"referrer": DOESNT_MATTER_STR},
+            )
+
+        metrics_mock.gauge.assert_called_once_with(
+            "sampling_in_storage_routed_tier",
+            expected_tier,
+            tags={"referrer": DOESNT_MATTER_STR},
+        )
+
+
+def test_sampling_in_storage_query_duration_from_most_downsampled_tier_metric_is_sent() -> None:
     timer = Timer(DOESNT_MATTER_STR)
     metrics_mock = MagicMock(spec=MetricsBackend)
 
@@ -34,17 +129,15 @@ def test_sampling_in_storage_most_downsampled_tier_query_duration_metric_is_sent
             parent_api=None,
         ),
     )
-    with patch(
-        "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util.run_query",
-    ), patch(
-        "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_duration",
+    with patch(SAMPLING_IN_STORAGE_UTIL_PREFIX + "run_query",), patch(
+        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_duration",
         return_value=DOESNT_MATTER_INT,
     ):
         _run_query_on_most_downsampled_tier(
             doesnt_matter_request, timer, metrics_mock, DOESNT_MATTER_STR
         )
         metrics_mock.timing.assert_called_once_with(
-            "sampling_in_storage_most_downsampled_tier_query_duration",
+            "sampling_in_storage_query_duration_from_most_downsampled_tier",
             DOESNT_MATTER_INT,
             tags={"referrer": DOESNT_MATTER_STR},
         )


### PR DESCRIPTION
record the following things for each query:
1. The time that it took to run the query on the most downsampled tier
2. difference between estimated time and actual time it took to run the query
3. what tier the query was run on

exceptions:
preflight mode queries will not (2) or (3)recorded