### PR TITLE
bug(sampling-in-storage): record cached query duration for cached que…

### DIFF
--- a/snuba/pipeline/stages/query_execution.py
+++ b/snuba/pipeline/stages/query_execution.py
@@ -74,6 +74,7 @@ class ExecutionStage(
     def _process_data(
         self, pipe_input: QueryPipelineData[ClickhouseQuery | CompositeQuery[Table]]
     ) -> QueryResult:
+        print("_process_dataaaaa")
         cluster = self.get_cluster(pipe_input.data, pipe_input.query_settings)
         if pipe_input.query_settings.get_dry_run():
             return _dry_run_query_runner(
@@ -127,6 +128,7 @@ def _run_and_apply_column_names(
     reader: Reader,
     cluster_name: str,
 ) -> QueryResult:
+    print("_run_and_apply_column_namessss")
     """
     Executes the query and, after that, replaces the column names in
     QueryResult with the names the user expects and that are stored in
@@ -181,6 +183,7 @@ def _format_storage_query_and_run(
     concurrent_queries_gauge: Optional[Gauge] = None,
     cluster_name: str = "",
 ) -> QueryResult:
+    print("_format_storage_query_and_runnnn")
     """
     Formats the Storage Query and pass it to the DB specific code for execution.
     """

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -71,11 +71,12 @@ class RedisCache(Cache[TValue]):
         if cached_value is not None:
             record_cache_hit_type(RESULT_VALUE)
             decoded_cache_value = self.__codec.decode(cached_value)
-            timer.set_duration_between_marks(
-                "right_before_execute",
-                "execute",
-                decoded_cache_value["profile"]["elapsed"],
-            )
+            if timer:
+                timer.set_duration_between_marks(
+                    "right_before_execute",
+                    "execute",
+                    decoded_cache_value["profile"]["elapsed"],
+                )
             return decoded_cache_value
         else:
             try:

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -70,7 +70,13 @@ class RedisCache(Cache[TValue]):
 
         if cached_value is not None:
             record_cache_hit_type(RESULT_VALUE)
-            return self.__codec.decode(cached_value)
+            decoded_cache_value = self.__codec.decode(cached_value)
+            timer.set_duration_between_marks(
+                "right_before_execute",
+                "execute",
+                decoded_cache_value["profile"]["elapsed"],
+            )
+            return decoded_cache_value
         else:
             try:
                 value = function()

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -71,6 +71,7 @@ class RedisCache(Cache[TValue]):
         if cached_value is not None:
             record_cache_hit_type(RESULT_VALUE)
             decoded_cache_value = self.__codec.decode(cached_value)
+            print("cachehit", decoded_cache_value)
             if timer:
                 timer.set_duration_between_marks(
                     "right_before_execute",
@@ -86,6 +87,7 @@ class RedisCache(Cache[TValue]):
                     self.__codec.encode(value),
                     ex=get_config("cache_expiry_sec", 1),
                 )
+                print("cachemiss", self.__codec.encode(value))
                 record_cache_hit_type(RESULT_EXECUTE)
                 if timer is not None:
                     timer.mark("cache_set")

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -71,13 +71,13 @@ class RedisCache(Cache[TValue]):
         if cached_value is not None:
             record_cache_hit_type(RESULT_VALUE)
             decoded_cache_value = self.__codec.decode(cached_value)
-            print("cachehit", decoded_cache_value)
             if timer:
                 timer.set_duration_between_marks(
                     "right_before_execute",
                     "execute",
-                    decoded_cache_value["profile"]["elapsed"],
+                    decoded_cache_value["profile"]["elapsed"],  # type: ignore
                 )
+            print("cachehit", key, timer._Timer__marks)
             return decoded_cache_value
         else:
             try:
@@ -87,7 +87,7 @@ class RedisCache(Cache[TValue]):
                     self.__codec.encode(value),
                     ex=get_config("cache_expiry_sec", 1),
                 )
-                print("cachemiss", self.__codec.encode(value))
+                print("cachemiss", key, timer._Timer__marks)
                 record_cache_hit_type(RESULT_EXECUTE)
                 if timer is not None:
                     timer.mark("cache_set")

--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -55,6 +55,13 @@ class Timer:
 
         return duration_group
 
+    def set_duration_between_marks(
+        self, start_mark: str, end_mark: str, duration: float
+    ) -> None:
+        self.__data = None
+        self.__marks.append((start_mark, self.__clock.time()))
+        self.__marks.append((end_mark, self.__clock.time() + duration))
+
     def get_duration_between_marks(self, start_mark: str, end_mark: str) -> float:
         start_mark_duration = -1
         end_mark_duration = -1

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -171,6 +171,7 @@ def execute_query(
     clickhouse_query_settings: MutableMapping[str, Any],
     robust: bool,
 ) -> Result:
+    print("execute_queryyyy")
     """
     Execute a query and return a result.
     """
@@ -242,6 +243,8 @@ def execute_query_with_query_id(
     else:
         query_id = get_query_cache_key(formatted_query)
 
+    print("execute_query_with_query_idddd")
+
     try:
         return execute_query_with_readthrough_caching(
             clickhouse_query,
@@ -296,6 +299,7 @@ def execute_query_with_readthrough_caching(
     query_id: str,
     referrer: str,
 ) -> Result:
+    print("execute_query_with_readthrough_cachingggg")
     span = sentry_sdk.get_current_span()
 
     if referrer in settings.BYPASS_CACHE_REFERRERS and state.get_config(
@@ -417,6 +421,7 @@ def _raw_query(
     trace_id: Optional[str] = None,
     robust: bool = False,
 ) -> QueryResult:
+    print("_raw_queryyyy")
     """
     this function is responsible for running the clickhouse query and if there is any error, constructing the
     QueryException that  the rest of the stack depends on. See the `db_query` docstring for more details
@@ -619,6 +624,7 @@ def db_query(
     trace_id: str,
     robust: bool = False,
 ) -> QueryResult:
+    print("db_queryyyyy")
     """This function is responsible for:
 
     * Checking and updating the allocation policy (which exists on the query)

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -41,6 +41,7 @@ def _run_query_pipeline(
     concurrent_queries_gauge: Optional[Gauge] = None,
     force_dry_run: bool = False,
 ) -> QueryResult:
+    print("run_query_pipelineeeeeee")
     clickhouse_query = EntityProcessingStage().execute(
         QueryPipelineResult(
             data=request,
@@ -77,6 +78,8 @@ def run_query(
     Processes, runs a Snuba Query, then records the metadata about the query that was run.
     """
     query_metadata = SnubaQueryMetadata(request, get_dataset_name(dataset), timer)
+
+    print("run_queryyyyy")
 
     try:
         result = _run_query_pipeline(

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -53,6 +53,7 @@ def _get_target_tier(
     timer: Timer, metrics_backend: MetricsBackend, referrer: str
 ) -> Tuple[Tier, float]:
     most_downsampled_query_duration_ms = _get_query_duration(timer)
+    print("durationnn", most_downsampled_query_duration_ms)
 
     target_tier = _get_most_downsampled_tier()
     estimated_target_tier_query_duration = most_downsampled_query_duration_ms * cast(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3550,10 +3550,10 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             ],
         )
 
-        print("----")
+        print("11111111111111111111111111111111111")
         EndpointTraceItemTable().execute(in_msg)
-        print("----")
+        print("222222222222222222222222222222222222")
         EndpointTraceItemTable().execute(in_msg)
-        print("----")
+        print("33333333333333333333333333333333333")
         EndpointTraceItemTable().execute(in_msg)
         assert False

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3550,6 +3550,10 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             ],
         )
 
+        print("----")
         EndpointTraceItemTable().execute(in_msg)
+        print("----")
         EndpointTraceItemTable().execute(in_msg)
+        print("----")
         EndpointTraceItemTable().execute(in_msg)
+        assert False

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3527,3 +3527,29 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
                 ],
             ),
         ]
+
+    def test_will(self) -> None:
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
+        in_msg = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_BEST_EFFORT
+                ),
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="endtoend"))
+            ],
+        )
+
+        EndpointTraceItemTable().execute(in_msg)
+        EndpointTraceItemTable().execute(in_msg)
+        EndpointTraceItemTable().execute(in_msg)


### PR DESCRIPTION
https://github.com/getsentry/eap-planning/issues/237

Reason for this bug: if the query gets cached and the cached result is fetched, then the timer never got the "right_before_execute" and "execute" marks. 

Fix: if we hit the cache, set "right_before_execute" and "execute" marks to be `elapsed` apart: https://github.com/mymarilyn/clickhouse-driver/blob/8a4e7c5b99b532df2b015651d893a6f36288a22c/clickhouse_driver/result.py#L143