### PR TITLE
ci: workaround for rdkafka build error

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -79,3 +79,7 @@ harness = false
 name = "python-processor-infinite"
 path = "bin/python_processor_infinite.rs"
 required-features = ["pyo3/auto-initialize"]
+
+[env]
+# Workaround for https://github.com/confluentinc/librdkafka/pull/5012
+CMAKE_POLICY_VERSION_MINIMUM = "3.10"


### PR DESCRIPTION
Trying the fix from https://github.com/getsentry/relay/pull/4632