### PR TITLE
feat(sampling-in-storage): remove dependency on Timer

### DIFF
--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -55,26 +55,6 @@ class Timer:
 
         return duration_group
 
-    def get_duration_between_marks(self, start_mark: str, end_mark: str) -> float:
-        start_mark_duration = -1
-        end_mark_duration = -1
-        for mark, timestamp in self.__marks:
-            if mark == start_mark:
-                start_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
-            if mark == end_mark:
-                end_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
-
-        missing_marks = []
-        if start_mark_duration == -1:
-            missing_marks.append(start_mark)
-        if end_mark_duration == -1:
-            missing_marks.append(end_mark)
-
-        if missing_marks:
-            raise MissingTimerMarksException(missing_marks)
-
-        return end_mark_duration - start_mark_duration
-
     def finish(self) -> TimerData:
         if self.__data is None:
             start = self.__marks[0][1]

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -42,7 +42,7 @@ def _get_time_budget() -> float:
 
 
 def _get_query_duration_ms(res: QueryResult) -> float:
-    return cast(float, res.result.get("profile", {}).get("elapsed", 0) * 1000)
+    return cast(float, res.result.get("profile", {}).get("elapsed", 0) * 1000)  # type: ignore
 
 
 def _get_most_downsampled_tier() -> Tier:

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -41,8 +41,8 @@ def _get_time_budget() -> float:
     return sentry_timeout_ms - error_budget_ms
 
 
-def _get_query_duration(timer: Timer) -> float:
-    return timer.get_duration_between_marks("right_before_execute", "execute")
+def _get_query_duration_ms(res: QueryResult) -> float:
+    return cast(float, res.result.get("profile", {}).get("elapsed", 0) * 1000)
 
 
 def _get_most_downsampled_tier() -> Tier:
@@ -50,9 +50,9 @@ def _get_most_downsampled_tier() -> Tier:
 
 
 def _get_target_tier(
-    timer: Timer, metrics_backend: MetricsBackend, referrer: str
+    most_downsampled_res: QueryResult, metrics_backend: MetricsBackend, referrer: str
 ) -> Tuple[Tier, float]:
-    most_downsampled_query_duration_ms = _get_query_duration(timer)
+    most_downsampled_query_duration_ms = _get_query_duration_ms(most_downsampled_res)
 
     target_tier = _get_most_downsampled_tier()
     estimated_target_tier_query_duration = most_downsampled_query_duration_ms * cast(
@@ -92,11 +92,11 @@ def _is_best_effort_mode(in_msg: T) -> bool:
 
 
 def _record_actual_query_duration(
-    metrics_backend: MetricsBackend, timer: Timer, tags: Dict[str, str]
+    metrics_backend: MetricsBackend, res: QueryResult, tags: Dict[str, str]
 ) -> None:
     metrics_backend.timing(
         "sampling_in_storage_actual_query_duration",
-        _get_query_duration(timer),
+        _get_query_duration_ms(res),
         tags=tags,
     )
 
@@ -136,7 +136,7 @@ def _run_query_on_most_downsampled_tier(
     )
     metrics_backend.timing(
         "sampling_in_storage_query_duration_from_most_downsampled_tier",
-        _get_query_duration(timer),
+        _get_query_duration_ms(res),
         tags={"referrer": referrer},
     )
     return res
@@ -178,13 +178,13 @@ def run_query_to_correct_tier(
         )
         query_settings.push_clickhouse_setting("timeout_overflow_mode", "break")
         target_tier, estimated_target_tier_query_duration = _get_target_tier(
-            timer, metrics_backend, referrer
+            res, metrics_backend, referrer
         )
 
         if target_tier == _get_most_downsampled_tier():
             _record_actual_query_duration(
                 metrics_backend,
-                timer,
+                res,
                 tags={"referrer": referrer, "tier": str(target_tier)},
             )
             return res
@@ -202,12 +202,12 @@ def run_query_to_correct_tier(
         )
         _record_actual_query_duration(
             metrics_backend,
-            timer,
+            res,
             tags={"referrer": referrer, "tier": str(target_tier)},
         )
         metrics_backend.timing(
             "sampling_in_storage_estimation_error",
-            estimated_target_tier_query_duration - _get_query_duration(timer),
+            estimated_target_tier_query_duration - _get_query_duration_ms(res),
             tags={"referrer": referrer, "tier": str(target_tier)},
         )
 

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -39,7 +39,6 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -1461,10 +1460,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             )
         )
 
-    @patch.object(Timer, "get_duration_between_marks")
-    def test_best_effort_route_to_tier_64(
-        self, mock_get_duration_between_marks: MagicMock
-    ) -> None:
+    def test_best_effort_route_to_tier_64(self) -> None:
         # store a a test metric with a value of 1, every second of one hour
         granularity_secs = 3600
         query_duration = granularity_secs * 1
@@ -1519,34 +1515,37 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             granularity_secs=granularity_secs,
         )
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
-        mock_get_duration_between_marks.return_value = 2777.0
-        best_effort_response = EndpointTimeSeries().execute(
-            best_effort_downsample_message
-        )
-        non_downsampled_tier_response = EndpointTimeSeries().execute(
-            message_to_non_downsampled_tier
-        )
-
-        best_effort_metric_sum = (
-            best_effort_response.result_timeseries[0].data_points[0].data
-        )
-
-        # tier 1 sum should be 3600, so tier 64 sum should be around 3600 / 64 (give or take due to random sampling)
-        non_downsampled_best_effort_metric_sum = (
-            non_downsampled_tier_response.result_timeseries[0].data_points[0].data
-        )
-        assert (
-            non_downsampled_best_effort_metric_sum / 90
-            <= best_effort_metric_sum
-            <= non_downsampled_best_effort_metric_sum / 40
-        )
-
-        assert (
-            best_effort_response.meta.downsampled_storage_meta
-            == DownsampledStorageMeta(
-                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
+        with patch(
+            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_duration_ms",
+            return_value=2777.0,
+        ):
+            best_effort_response = EndpointTimeSeries().execute(
+                best_effort_downsample_message
             )
-        )
+            non_downsampled_tier_response = EndpointTimeSeries().execute(
+                message_to_non_downsampled_tier
+            )
+
+            best_effort_metric_sum = (
+                best_effort_response.result_timeseries[0].data_points[0].data
+            )
+
+            # tier 1 sum should be 3600, so tier 64 sum should be around 3600 / 64 (give or take due to random sampling)
+            non_downsampled_best_effort_metric_sum = (
+                non_downsampled_tier_response.result_timeseries[0].data_points[0].data
+            )
+            assert (
+                non_downsampled_best_effort_metric_sum / 90
+                <= best_effort_metric_sum
+                <= non_downsampled_best_effort_metric_sum / 40
+            )
+
+            assert (
+                best_effort_response.meta.downsampled_storage_meta
+                == DownsampledStorageMeta(
+                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
+                )
+            )
 
     def test_best_effort_end_to_end(self) -> None:
         granularity_secs = 3600

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3531,6 +3531,18 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
         ]
 
     def test_cached_query_results_is_used_in_routing(self) -> None:
+        items_storage = get_storage(StorageKey("eap_items"))
+        msg_timestamp = BASE_TIME - timedelta(minutes=1)
+        messages = [
+            gen_message(
+                msg_timestamp,
+                tags={"cached": "cached"},
+                randomize_span_id=True,
+            )
+            for _ in range(10)
+        ]
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
+
         ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
         hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
         in_msg = TraceItemTableRequest(
@@ -3548,7 +3560,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
                 ),
             ),
             columns=[
-                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="endtoend"))
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="cached"))
             ],
         )
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3467,6 +3467,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
 
         # ensures we don't get DB::Exception: Illegal type UInt128 of argument of function right
         EndpointTraceItemTable().execute(best_effort_message)
+        assert False
 
     @pytest.mark.redis_db
     def test_non_existant_attribute_filter(self) -> None:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -54,13 +54,15 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.state import set_config
-from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.endpoint_trace_item_table import (
     EndpointTraceItemTable,
     _apply_labels_to_columns,
+)
+from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
+    _run_query_on_most_downsampled_tier,
 )
 from tests.base import BaseApiTest
 from tests.conftest import SnubaSetConfig
@@ -3312,10 +3314,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             )
         )
 
-    @patch.object(Timer, "get_duration_between_marks")
-    def test_best_effort_route_to_tier_64(
-        self, mock_get_duration_between_marks: MagicMock
-    ) -> None:
+    def test_best_effort_route_to_tier_64(self) -> None:
         items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = [
@@ -3366,24 +3365,27 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
             columns=columns,
         )
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
-        mock_get_duration_between_marks.return_value = 2777.0
-        best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
-        non_downsampled_tier_response = EndpointTraceItemTable().execute(
-            message_to_non_downsampled_tier
-        )
-
-        # tier 1's results should be 3600, so tier 64's results should be around 3600 / 64 (give or take due to random sampling)
-        assert (
-            len(non_downsampled_tier_response.column_values[0].results) / 90
-            <= len(best_effort_response.column_values[0].results)
-            <= len(non_downsampled_tier_response.column_values[0].results) / 40
-        )
-        assert (
-            best_effort_response.meta.downsampled_storage_meta
-            == DownsampledStorageMeta(
-                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
+        with patch(
+            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_duration_ms",
+            return_value=2777.0,
+        ):
+            best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
+            non_downsampled_tier_response = EndpointTraceItemTable().execute(
+                message_to_non_downsampled_tier
             )
-        )
+
+            # tier 1's results should be 3600, so tier 64's results should be around 3600 / 64 (give or take due to random sampling)
+            assert (
+                len(non_downsampled_tier_response.column_values[0].results) / 90
+                <= len(best_effort_response.column_values[0].results)
+                <= len(non_downsampled_tier_response.column_values[0].results) / 40
+            )
+            assert (
+                best_effort_response.meta.downsampled_storage_meta
+                == DownsampledStorageMeta(
+                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
+                )
+            )
 
     def test_best_effort_end_to_end(self) -> None:
         items_storage = get_storage(StorageKey("eap_items"))
@@ -3467,7 +3469,6 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
 
         # ensures we don't get DB::Exception: Illegal type UInt128 of argument of function right
         EndpointTraceItemTable().execute(best_effort_message)
-        assert False
 
     @pytest.mark.redis_db
     def test_non_existant_attribute_filter(self) -> None:
@@ -3528,3 +3529,44 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
                 ],
             ),
         ]
+
+    def test_cached_query_results_is_used_in_routing(self) -> None:
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
+        in_msg = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_BEST_EFFORT
+                ),
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="endtoend"))
+            ],
+        )
+
+        with patch(
+            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._run_query_on_most_downsampled_tier",
+            wraps=_run_query_on_most_downsampled_tier,
+        ) as mock_run_query_on_most_downsampled_tier:
+            EndpointTraceItemTable().execute(in_msg)
+            EndpointTraceItemTable().execute(in_msg)
+            assert mock_run_query_on_most_downsampled_tier.call_count == 2
+            first_call_result = mock_run_query_on_most_downsampled_tier(
+                *mock_run_query_on_most_downsampled_tier.call_args_list[0].args,
+                *mock_run_query_on_most_downsampled_tier.call_args_list[0].kwargs
+            )
+            second_call_result = mock_run_query_on_most_downsampled_tier(
+                *mock_run_query_on_most_downsampled_tier.call_args_list[1].args,
+                *mock_run_query_on_most_downsampled_tier.call_args_list[1].kwargs
+            )
+            assert first_call_result.result.get("profile", {}).get(
+                "elapsed"
+            ) == second_call_result.result.get("profile", {}).get("elapsed")


### PR DESCRIPTION
https://github.com/getsentry/eap-planning/issues/237

Reason for this bug: if the query gets cached and the cached result is fetched, then the timer never got the "right_before_execute" and "execute" marks.

Fix: just use the elapsed field: https://github.com/mymarilyn/clickhouse-driver/blob/8a4e7c5b99b532df2b015651d893a6f36288a22c/clickhouse_driver/result.py#L143