### PR TITLE
fix(ourlogs): Fix doubles not being handled for logs

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_ourlogs/common/attribute_key_to_expression.py
+++ b/snuba/web/rpc/v1/resolvers/R_ourlogs/common/attribute_key_to_expression.py
@@ -46,7 +46,10 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
             )
         if attr_key.type == AttributeKey.Type.TYPE_INT:
             return f.CAST(column(attr_key.name[len("sentry.") :]), "Int64", alias=alias)
-        if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
+        if (
+            attr_key.type == AttributeKey.Type.TYPE_FLOAT
+            or attr_key.type == AttributeKey.Type.TYPE_DOUBLE
+        ):
             return f.CAST(
                 column(attr_key.name[len("sentry.") :]), "Float64", alias=alias
             )
@@ -66,7 +69,10 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
         return f.arrayElement(
             column("attributes_string"), literal(attr_key.name), alias=alias
         )
-    if attr_key.type == AttributeKey.Type.TYPE_FLOAT:
+    if (
+        attr_key.type == AttributeKey.Type.TYPE_FLOAT
+        or attr_key.type == AttributeKey.Type.TYPE_DOUBLE
+    ):
         return f.arrayElement(
             column("attributes_float"), literal(attr_key.name), alias=alias
         )


### PR DESCRIPTION
### Summary
We're deprecating floats in lieu of doubles, but logs is not handling the case for doubles since doubles were deprecated (instead of floats) when this was added a few months ago. 

Currently causing 500's if a user tries to filter on a non-int number on the log table page (see [SNUBA-82G](https://sentry.sentry.io/issues/6467815361/events/df8c28fcbf98437a915c6aabe2a9fe16/)).

#### Screenshot example
![Screenshot 2025-04-02 at 5 50 21 PM](https://github.com/user-attachments/assets/56faeb8e-d7a3-4c1e-bf9a-c2e986546cc5)


