### PR TITLE
fix(sampling-in-storage): make tests not flakey

### DIFF
--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1535,9 +1535,9 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
                 non_downsampled_tier_response.result_timeseries[0].data_points[0].data
             )
             assert (
-                non_downsampled_best_effort_metric_sum / 90
+                non_downsampled_best_effort_metric_sum / 200
                 <= best_effort_metric_sum
-                <= non_downsampled_best_effort_metric_sum / 40
+                <= non_downsampled_best_effort_metric_sum / 16
             )
 
             assert (

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3373,9 +3373,9 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
 
             # tier 1's results should be 3600, so tier 64's results should be around 3600 / 64 (give or take due to random sampling)
             assert (
-                len(non_downsampled_tier_response.column_values[0].results) / 90
+                len(non_downsampled_tier_response.column_values[0].results) / 200
                 <= len(best_effort_response.column_values[0].results)
-                <= len(non_downsampled_tier_response.column_values[0].results) / 40
+                <= len(non_downsampled_tier_response.column_values[0].results) / 16
             )
             assert (
                 best_effort_response.meta.downsampled_storage_meta


### PR DESCRIPTION
Bounds are too tight, let's loosen them. As long as the count is reasonably away from 3600/512 (Tier 512) and 3600/8 (Tier 8) we're good