### PR TITLE
Fix: Add correct clickhouse connection http scheme in rust consumer

### DIFF
--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -53,6 +53,7 @@ fn create_factory(
         clickhouse_cluster: ClickhouseConfig {
             host: "test".into(),
             port: 1234,
+            secure: false,
             http_port: 1234,
             user: "test".into(),
             password: "test".into(),

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -84,6 +84,7 @@ pub struct StorageConfig {
 pub struct ClickhouseConfig {
     pub host: String,
     pub port: u16,
+    pub secure: bool,
     pub http_port: u16,
     pub user: String,
     pub password: String,

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -116,6 +116,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.clickhouse_concurrency,
             &self.storage_config.clickhouse_cluster.user,
             &self.storage_config.clickhouse_cluster.password,
+            &self.storage_config.clickhouse_cluster.secure,
             self.async_inserts,
             self.batch_write_timeout,
             self.custom_envoy_request_timeout,

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -116,7 +116,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             &self.clickhouse_concurrency,
             &self.storage_config.clickhouse_cluster.user,
             &self.storage_config.clickhouse_cluster.password,
-            &self.storage_config.clickhouse_cluster.secure,
+            self.storage_config.clickhouse_cluster.secure,
             self.async_inserts,
             self.batch_write_timeout,
             self.custom_envoy_request_timeout,

--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -41,6 +41,7 @@ impl BatchFactory {
         concurrency: &ConcurrencyConfig,
         clickhouse_user: &str,
         clickhouse_password: &str,
+        clickhouse_secure: bool,
         async_inserts: bool,
         batch_write_timeout: Option<Duration>,
         custom_envoy_request_timeout: Option<u64>,
@@ -77,7 +78,9 @@ impl BatchFactory {
             }
         }
 
-        let url = format!("http://{hostname}:{http_port}?{query_params}");
+        let scheme = if clickhouse_secure { "https" } else { "http" };
+
+        let url = format!("{scheme}://{hostname}:{http_port}?{query_params}");
         let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
 
         let client = if let Some(timeout_duration) = batch_write_timeout {
@@ -274,6 +277,7 @@ mod tests {
             "default",
             "",
             false,
+            false,
             None,
             None,
         );
@@ -309,6 +313,7 @@ mod tests {
             &concurrency,
             "default",
             "",
+            false,
             true,
             None,
             None,
@@ -345,6 +350,7 @@ mod tests {
             "default",
             "",
             false,
+            false,
             None,
             None,
         );
@@ -377,6 +383,7 @@ mod tests {
             &concurrency,
             "default",
             "",
+            false,
             false,
             None,
             None,
@@ -412,6 +419,7 @@ mod tests {
             &concurrency,
             "default",
             "",
+            false,
             true,
             // pass in an unreasonably short timeout
             // which prevents the client request from reaching Clickhouse
@@ -448,6 +456,7 @@ mod tests {
             &concurrency,
             "default",
             "",
+            false,
             true,
             // pass in a reasonable timeout
             Some(Duration::from_millis(1000)),

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -441,6 +441,9 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
     def get_http_port(self) -> int:
         return self.__http_port
 
+    def get_secure(self) -> bool:
+        return self.__secure
+
 
 CLUSTERS = [
     ClickhouseCluster(

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -19,6 +19,7 @@ class ClickhouseClusterConfig:
     user: str
     password: str
     database: str
+    secure: bool
 
 
 @dataclass(frozen=True)
@@ -275,6 +276,7 @@ def resolve_storage_config(
         http_port=cluster.get_http_port(),
         user=user,
         password=password,
+        secure=cluster.get_secure(),
         database=cluster.get_database(),
     )
 


### PR DESCRIPTION
I encountered the need to use Snuba with a secure connection to ClickHouse, but it turned out that the URL for the query hardcodes the http scheme. So I added a parameter for a secure connection in the connection configuration to the Rust consumer and implemented logic to determine the required scheme (http/https) based on it.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
