### PR TITLE
fix(eap): Use trace_id field in TraceItemDetails

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -216,6 +216,22 @@ class EndpointTraceItemDetails(
             raise BadSnubaRPCRequestException(
                 "This endpoint requires meta.trace_item_type to be set (are you requesting spans? logs?)"
             )
+        if in_msg.item_id == "":
+            raise BadSnubaRPCRequestException(
+                "This endpoint requires item_id to be set."
+            )
+        if in_msg.trace_id == "":
+            raise BadSnubaRPCRequestException(
+                "This endpoint requires trace_id to be set."
+            )
+        else:
+            try:
+                _ = uuid.UUID(in_msg.trace_id)
+            except ValueError:
+                raise BadSnubaRPCRequestException(
+                    "This endpoint requires trace_id to be a valid UUID."
+                )
+
         snuba_request = _build_snuba_request(in_msg)
         res = run_query(
             dataset=PluggableDataset(name="eap", all_entities=[]),

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -67,7 +67,10 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
                 "timestamp", f.toUnixTimestamp(column("timestamp"), alias="timestamp")
             ),
             SelectedExpression("hex_item_id", column("item_id", alias="hex_item_id")),
-            SelectedExpression("trace_id", column("trace_id", alias="trace_id")),
+            SelectedExpression(
+                "trace_id",
+                column("trace_id", alias="selected_trace_id"),
+            ),
             SelectedExpression(
                 "organization_id", column("organization_id", alias="organization_id")
             ),

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -101,6 +101,10 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
                 column("item_id"),
                 literal(request.item_id),
             ),
+            f.equals(
+                column("trace_id"),
+                literal(request.trace_id),
+            ),
             trace_item_filters_to_expression(
                 request.filter, attribute_key_to_expression
             ),

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -149,6 +149,7 @@ class TestTraceItemDetails(BaseApiTest):
                 trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
             ),
             item_id="00000",
+            trace_id=uuid.uuid4().hex,
         )
         response = self.app.post(
             "/rpc/EndpointTraceItemDetails/v1", data=message.SerializeToString()
@@ -181,13 +182,19 @@ class TestTraceItemDetails(BaseApiTest):
                             key=AttributeKey(
                                 type=AttributeKey.TYPE_STRING, name="sentry.item_id"
                             )
-                        )
+                        ),
+                        Column(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING, name="sentry.trace_id"
+                            )
+                        ),
                     ],
                 )
             )
             .column_values
         )
         log_id = logs[0].results[0].val_str
+        trace_id = logs[1].results[0].val_str
 
         res = EndpointTraceItemDetails().execute(
             TraceItemDetailsRequest(
@@ -202,6 +209,7 @@ class TestTraceItemDetails(BaseApiTest):
                     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
                 ),
                 item_id=log_id,
+                trace_id=trace_id,
             )
         )
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -159,6 +159,79 @@ class TestTraceItemDetails(BaseApiTest):
             error_proto.ParseFromString(response.data)
         assert response.status_code == 404, error_proto
 
+    def test_missing_item_id(self, setup_logs_in_db: Any) -> None:
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        message = TraceItemDetailsRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=0),
+                end_timestamp=ts,
+                request_id=_REQUEST_ID,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+            trace_id=uuid.uuid4().hex,
+        )
+        response = self.app.post(
+            "/rpc/EndpointTraceItemDetails/v1", data=message.SerializeToString()
+        )
+        error_proto = ErrorProto()
+        if response.status_code != 200:
+            error_proto.ParseFromString(response.data)
+        assert response.status_code == 400, error_proto
+
+    def test_missing_trace_id(self, setup_logs_in_db: Any) -> None:
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        message = TraceItemDetailsRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=0),
+                end_timestamp=ts,
+                request_id=_REQUEST_ID,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+            item_id="00000",
+        )
+        response = self.app.post(
+            "/rpc/EndpointTraceItemDetails/v1", data=message.SerializeToString()
+        )
+        error_proto = ErrorProto()
+        if response.status_code != 200:
+            error_proto.ParseFromString(response.data)
+        assert response.status_code == 400, error_proto
+
+    def test_invalid_trace_id(self, setup_logs_in_db: Any) -> None:
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        message = TraceItemDetailsRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=0),
+                end_timestamp=ts,
+                request_id=_REQUEST_ID,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+            item_id="00000",
+            trace_id="baduuid",
+        )
+        response = self.app.post(
+            "/rpc/EndpointTraceItemDetails/v1", data=message.SerializeToString()
+        )
+        error_proto = ErrorProto()
+        if response.status_code != 200:
+            error_proto.ParseFromString(response.data)
+        assert response.status_code == 400, error_proto
+
     def test_endpoint_on_logs(self, setup_logs_in_db: Any) -> None:
         ts = Timestamp()
         ts.GetCurrentTime()

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -246,13 +246,19 @@ class TestTraceItemDetails(BaseApiTest):
                             key=AttributeKey(
                                 type=AttributeKey.TYPE_STRING, name="sentry.item_id"
                             )
-                        )
+                        ),
+                        Column(
+                            key=AttributeKey(
+                                type=AttributeKey.TYPE_STRING, name="sentry.trace_id"
+                            )
+                        ),
                     ],
                 )
             )
             .column_values
         )
         span_id = spans[0].results[0].val_str
+        trace_id = spans[1].results[0].val_str
 
         res = EndpointTraceItemDetails().execute(
             TraceItemDetailsRequest(
@@ -267,6 +273,7 @@ class TestTraceItemDetails(BaseApiTest):
                     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
                 item_id=span_id,
+                trace_id=trace_id,
             )
         )
 


### PR DESCRIPTION
Use the now required `trace_id` field in this request so the `trace_id` is correctly promoted to the `PREWHERE` clause.
```
SELECT (toUnixTimestamp(timestamp) AS timestamp), (leftPad(lower(hex(item_id)), 32, '0') AS hex_item_id), (replaceAll(toString(trace_id), '-', '') AS trace_id), organization_id, project_id, item_type, (mapConcat(attributes_string_0, ...) AS attributes_string), (mapConcat(attributes_float_0, ...) AS attributes_float), attributes_int, attributes_bool FROM eap_items_1_local PREWHERE equals(trace_id, 'f16dd70d-80d4-47f5-ae7d-6e2048f9ea4d') WHERE in(project_id, [1]) AND equals(organization_id, 1) AND less(timestamp, toDateTime(1744054948)) AND greaterOrEquals(timestamp, toDateTime(1744041600)) AND equals(item_type, 1) AND equals(item_id, '276171113345555592925493239168611803141') AND true LIMIT 1 OFFSET 0
```