### PR TITLE
feat(sampling-in-storage): use bytes scanned instead of time

### DIFF
--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -55,6 +55,26 @@ class Timer:
 
         return duration_group
 
+    def get_duration_between_marks(self, start_mark: str, end_mark: str) -> float:
+        start_mark_duration = -1
+        end_mark_duration = -1
+        for mark, timestamp in self.__marks:
+            if mark == start_mark:
+                start_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
+            if mark == end_mark:
+                end_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
+
+        missing_marks = []
+        if start_mark_duration == -1:
+            missing_marks.append(start_mark)
+        if end_mark_duration == -1:
+            missing_marks.append(end_mark)
+
+        if missing_marks:
+            raise MissingTimerMarksException(missing_marks)
+
+        return end_mark_duration - start_mark_duration
+
     def finish(self) -> TimerData:
         if self.__data is None:
             start = self.__marks[0][1]

--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -55,26 +55,6 @@ class Timer:
 
         return duration_group
 
-    def get_duration_between_marks(self, start_mark: str, end_mark: str) -> float:
-        start_mark_duration = -1
-        end_mark_duration = -1
-        for mark, timestamp in self.__marks:
-            if mark == start_mark:
-                start_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
-            if mark == end_mark:
-                end_mark_duration = self.__diff_ms(self.__marks[0][1], timestamp)
-
-        missing_marks = []
-        if start_mark_duration == -1:
-            missing_marks.append(start_mark)
-        if end_mark_duration == -1:
-            missing_marks.append(end_mark)
-
-        if missing_marks:
-            raise MissingTimerMarksException(missing_marks)
-
-        return end_mark_duration - start_mark_duration
-
     def finish(self) -> TimerData:
         if self.__data is None:
             start = self.__marks[0][1]

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -177,8 +177,6 @@ def execute_query(
     # Apply clickhouse query setting overrides
     clickhouse_query_settings.update(query_settings.get_clickhouse_settings())
 
-    timer.mark("right_before_execute")
-
     result = reader.execute(
         formatted_query,
         clickhouse_query_settings,

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1517,7 +1517,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         with patch(
             "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_bytes_scanned",
-            return_value=314572799,
+            return_value=2516582401,
         ):
             best_effort_response = EndpointTimeSeries().execute(
                 best_effort_downsample_message

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1516,8 +1516,8 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
         )
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         with patch(
-            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_duration_ms",
-            return_value=2777.0,
+            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_bytes_scanned",
+            return_value=314572799,
         ):
             best_effort_response = EndpointTimeSeries().execute(
                 best_effort_downsample_message

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3362,8 +3362,8 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
         )
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         with patch(
-            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_duration_ms",
-            return_value=2777.0,
+            "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_bytes_scanned",
+            return_value=314572799,
         ):
             best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
             non_downsampled_tier_response = EndpointTraceItemTable().execute(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3363,7 +3363,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         with patch(
             "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_bytes_scanned",
-            return_value=314572799,
+            return_value=2516582401,
         ):
             best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
             non_downsampled_tier_response = EndpointTraceItemTable().execute(

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -42,6 +42,7 @@ def test_get_target_tier(
 ) -> None:
     res = MagicMock(QueryResult)
     metrics_mock = MagicMock(spec=MetricsBackend)
+    timer = MagicMock(spec=Timer)
 
     with patch(
         SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_bytes_scanned",
@@ -51,7 +52,7 @@ def test_get_target_tier(
         return_value=bytes_scanned_limit,
     ):
         target_tier, estimated_target_tier_query_bytes_scanned = _get_target_tier(
-            res, metrics_mock, DOESNT_MATTER_STR
+            res, metrics_mock, DOESNT_MATTER_STR, timer
         )
         assert target_tier == expected_tier
         assert (

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -61,12 +61,6 @@ def test_get_target_tier(
             * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(target_tier))
         )
 
-        metrics_mock.timing.assert_any_call(
-            "sampling_in_storage_routed_tier",
-            expected_tier,
-            tags={"referrer": DOESNT_MATTER_STR},
-        )
-
 
 def test_sampling_in_storage_query_bytes_scanned_from_most_downsampled_tier_metric_is_sent() -> None:
     timer = Timer(DOESNT_MATTER_STR)

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -27,7 +27,7 @@ SAMPLING_IN_STORAGE_UTIL_PREFIX = (
 
 
 @pytest.mark.parametrize(
-    "most_downsampled_query_duration_ms, time_budget, expected_tier",
+    "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier",
     [
         (100, 200, Tier.TIER_512),
         (100, 900, Tier.TIER_64),
@@ -36,27 +36,29 @@ SAMPLING_IN_STORAGE_UTIL_PREFIX = (
     ],
 )
 def test_get_target_tier(
-    most_downsampled_query_duration_ms: int, time_budget: int, expected_tier: Tier
+    most_downsampled_query_bytes_scanned: int,
+    bytes_scanned_limit: int,
+    expected_tier: Tier,
 ) -> None:
     res = MagicMock(QueryResult)
     metrics_mock = MagicMock(spec=MetricsBackend)
 
     with patch(
-        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_duration_ms",
-        return_value=most_downsampled_query_duration_ms,
+        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_bytes_scanned",
+        return_value=most_downsampled_query_bytes_scanned,
     ), patch(
-        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_time_budget", return_value=time_budget
+        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_bytes_scanned_limit",
+        return_value=bytes_scanned_limit,
     ):
-        target_tier, estimated_target_tier_query_duration = _get_target_tier(
+        target_tier, estimated_target_tier_query_bytes_scanned = _get_target_tier(
             res, metrics_mock, DOESNT_MATTER_STR
         )
         assert target_tier == expected_tier
         assert (
-            estimated_target_tier_query_duration
-            == most_downsampled_query_duration_ms
+            estimated_target_tier_query_bytes_scanned
+            == most_downsampled_query_bytes_scanned
             * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(target_tier))
         )
-        print({"referrer": DOESNT_MATTER_STR, "tier": str(expected_tier)})
 
         metrics_mock.timing.assert_any_call(
             "sampling_in_storage_routed_tier",
@@ -65,7 +67,7 @@ def test_get_target_tier(
         )
 
 
-def test_sampling_in_storage_query_duration_from_most_downsampled_tier_metric_is_sent() -> None:
+def test_sampling_in_storage_query_bytes_scanned_from_most_downsampled_tier_metric_is_sent() -> None:
     timer = Timer(DOESNT_MATTER_STR)
     metrics_mock = MagicMock(spec=MetricsBackend)
 
@@ -84,14 +86,14 @@ def test_sampling_in_storage_query_duration_from_most_downsampled_tier_metric_is
         ),
     )
     with patch(SAMPLING_IN_STORAGE_UTIL_PREFIX + "run_query",), patch(
-        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_duration_ms",
+        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_bytes_scanned",
         return_value=DOESNT_MATTER_INT,
     ):
         _run_query_on_most_downsampled_tier(
             doesnt_matter_request, timer, metrics_mock, DOESNT_MATTER_STR
         )
         metrics_mock.timing.assert_called_once_with(
-            "sampling_in_storage_query_duration_from_most_downsampled_tier",
+            "sampling_in_storage_query_bytes_scanned_from_most_downsampled_tier",
             DOESNT_MATTER_INT,
             tags={"referrer": DOESNT_MATTER_STR},
         )

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -1,22 +1,15 @@
-import uuid
 from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from snuba.attribution import AppID
-from snuba.attribution.attribution_info import AttributionInfo
 from snuba.downsampled_storage_tiers import Tier
-from snuba.query.logical import Query as LogicalQuery
-from snuba.query.query_settings import HTTPQuerySettings
-from snuba.request import Request
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
     DOWNSAMPLING_TIER_MULTIPLIERS,
     _get_target_tier,
-    _run_query_on_most_downsampled_tier,
 )
 
 DOESNT_MATTER_STR = "doesntmatter"
@@ -59,36 +52,4 @@ def test_get_target_tier(
             estimated_target_tier_query_bytes_scanned
             == most_downsampled_query_bytes_scanned
             * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(target_tier))
-        )
-
-
-def test_sampling_in_storage_query_bytes_scanned_from_most_downsampled_tier_metric_is_sent() -> None:
-    timer = Timer(DOESNT_MATTER_STR)
-    metrics_mock = MagicMock(spec=MetricsBackend)
-
-    doesnt_matter_request = Request(
-        id=uuid.uuid4(),
-        original_body={},
-        query=LogicalQuery(from_clause=None),
-        query_settings=HTTPQuerySettings(),
-        attribution_info=AttributionInfo(
-            app_id=AppID(key=DOESNT_MATTER_STR),
-            tenant_ids={},
-            referrer=DOESNT_MATTER_STR,
-            team=None,
-            feature=None,
-            parent_api=None,
-        ),
-    )
-    with patch(SAMPLING_IN_STORAGE_UTIL_PREFIX + "run_query",), patch(
-        SAMPLING_IN_STORAGE_UTIL_PREFIX + "_get_query_bytes_scanned",
-        return_value=DOESNT_MATTER_INT,
-    ):
-        _run_query_on_most_downsampled_tier(
-            doesnt_matter_request, timer, metrics_mock, DOESNT_MATTER_STR
-        )
-        metrics_mock.timing.assert_called_once_with(
-            "sampling_in_storage_query_bytes_scanned_from_most_downsampled_tier",
-            DOESNT_MATTER_INT,
-            tags={"referrer": DOESNT_MATTER_STR},
         )


### PR DESCRIPTION
using time gave us 10s in estimation error and bc we want cost based model. More details here: https://www.notion.so/sentry/Storage-routing-V2-1ca8b10e4b5d80319620c21d32de4dc5?pvs=4