### PR TITLE
feat(eap): add a sample count threshold for percentile reliability

### DIFF
--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -34,6 +34,7 @@ Z_VALUE_P95 = 1.96  # Z value for 95% confidence interval is 1.96 which comes fr
 Z_VALUE_P975 = 2.24  # Z value for 97.5% confidence interval used for the avg() CI
 
 PERCENTILE_PRECISION = 100000
+PERCENTILE_SAMPLE_COUNT_THRESHOLD = 50
 CONFIDENCE_INTERVAL_THRESHOLD = 0.5
 
 CUSTOM_COLUMN_PREFIX = "__snuba_custom_column__"
@@ -190,6 +191,9 @@ class PercentileExtrapolationContext(ExtrapolationContext):
         relative_confidence = (
             abs(max_err / self.value) if self.value != 0 else float("inf")
         )
+
+        if self.sample_count <= PERCENTILE_SAMPLE_COUNT_THRESHOLD:
+            return Reliability.RELIABILITY_LOW
 
         if relative_confidence <= CONFIDENCE_INTERVAL_THRESHOLD:
             return Reliability.RELIABILITY_HIGH

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
@@ -686,7 +686,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
         measurement_reliabilities = [v for v in response.column_values[4].reliabilities]
         assert len(measurement_p90s) == 1
         assert measurement_p90s[0] == 4
-        assert measurement_reliabilities == [Reliability.RELIABILITY_HIGH]
+        assert measurement_reliabilities == [Reliability.RELIABILITY_LOW]
 
     def test_count_reliability_with_group_by(self) -> None:
         spans_storage = get_storage(StorageKey("eap_spans"))
@@ -805,7 +805,7 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
         measurement_reliabilities = [v for v in response.column_values[4].reliabilities]
         assert len(measurement_p90s) == 1
         assert measurement_p90s[0] == 4
-        assert measurement_reliabilities == [Reliability.RELIABILITY_HIGH]
+        assert measurement_reliabilities == [Reliability.RELIABILITY_LOW]
 
     def test_formula(self) -> None:
         """


### PR DESCRIPTION
Adding back the sample count threshold only for percentile reliability.