### PR TITLE
fix(sampling-in-storage): fix division by zero in estimation metric

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -302,13 +302,14 @@ def run_query_to_correct_tier(
                     estimated_target_tier_query_bytes_scanned
                     - _get_query_bytes_scanned(res)
                 )
-                _record_value_in_span_and_DD(
-                    span,
-                    metrics_backend.distribution,
-                    "estimation_error_percentage",
-                    abs(estimation_error) / _get_query_bytes_scanned(res),
-                    {"referrer": referrer, "tier": str(target_tier)},
-                )
+                if _get_query_bytes_scanned(res) != 0:
+                    _record_value_in_span_and_DD(
+                        span,
+                        metrics_backend.distribution,
+                        "estimation_error_percentage",
+                        abs(estimation_error) / _get_query_bytes_scanned(res),
+                        {"referrer": referrer, "tier": str(target_tier)},
+                    )
 
                 estimation_error_metric_name = (
                     "over_estimation_error"


### PR DESCRIPTION
I'm seeing queries to EAP fail with a `division by zero` error (see [issue in Sentry](https://sentry.sentry.io/issues/6532558122/)) introduced in #7051.

`_get_query_bytes_scanned` can return 0:
https://github.com/getsentry/snuba/blob/04609965f16b12e83b411ad0828a44bdcf7ec33a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py#L70-L71
This throws when used as a divisor in the `estimation_error_percentage` metric. This change makes emitting the metric conditional on bytes scanned being > 0, avoiding the division otherwise.

Note that I don't know if 0 is ever an expected value here - there might be an underlying issue as well.