### PR TITLE
Set timeout_before_checking_execution speed to 0

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -237,6 +237,7 @@ query_processors:
         group_by_overflow_mode: any
         max_parallel_replicas: 3
         max_execution_time: 30
+        timeout_before_checking_execution_speed: 0
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer


### PR DESCRIPTION
Time out in reality, don't rely on the clickhouse estimator

fixes:

https://sentry.sentry.io/issues/6512417860/?project=300688&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20transaction%3A%5BEndpointTraceItemAttributeNames__v1%2CEndpointTimeSeries__v1%2CEndpointTraceItemTable__v1%2CEndpointGetTrace__v1%5D&referrer=issue-stream&sort=date&stream_index=2
