### PR TITLE
obs(snuba): add query settings to db span

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -186,6 +186,8 @@ class ClickhousePool(object):
                             span.set_data(
                                 sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse"
                             )
+                            span.set_data("query_id", query_id)
+                            span.set_data("settings", settings)
                             return conn.execute(  # type: ignore
                                 query,
                                 params=params,


### PR DESCRIPTION
Settings are crucial to understanding the actual query that ran