### PR TITLE
feat(sampling-in-storage): most downsampled tier is now tier 64

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/sampling_in_storage_util.py
@@ -99,7 +99,14 @@ def _get_query_duration_ms(res: QueryResult) -> float:
 
 
 def _get_most_downsampled_tier() -> Tier:
-    return sorted(Tier, reverse=True)[0]
+    return sorted(Tier, reverse=True)[1]
+
+
+def _get_multiplier(tier: Tier) -> int:
+    return int(
+        DOWNSAMPLING_TIER_MULTIPLIERS[tier]
+        / DOWNSAMPLING_TIER_MULTIPLIERS[_get_most_downsampled_tier()]
+    )
 
 
 def _record_value_in_span_and_DD(
@@ -132,16 +139,14 @@ def _get_target_tier(
 
         target_tier = _get_most_downsampled_tier()
         estimated_target_tier_bytes_scanned = (
-            most_downsampled_query_bytes_scanned
-            * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(target_tier))
+            most_downsampled_query_bytes_scanned * _get_multiplier(target_tier)
         )
         for tier in sorted(Tier, reverse=True)[:-1]:
             with sentry_sdk.start_span(
                 op=f"_get_target_tier.Tier_{tier}"
             ) as tier_specific_span:
                 estimated_query_bytes_scanned_to_this_tier = (
-                    most_downsampled_query_bytes_scanned
-                    * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(tier))
+                    most_downsampled_query_bytes_scanned * _get_multiplier(tier)
                 )
 
                 _record_value_in_span_and_DD(

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1418,7 +1418,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
         assert (
             sum_of_preflight_metric
             < non_downsampled_tier_response.result_timeseries[0].data_points[0].data
-            / 100
+            / 10
         )
         assert (
             preflight_response.meta.downsampled_storage_meta

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1423,7 +1423,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
         assert (
             preflight_response.meta.downsampled_storage_meta
             == DownsampledStorageMeta(
-                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_512
+                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
             )
         )
 
@@ -1484,11 +1484,12 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         with patch(
             "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_bytes_scanned",
-            return_value=2516582401,
+            return_value=20132659201,
         ):
             best_effort_response = EndpointTimeSeries().execute(
                 best_effort_downsample_message
             )
+            print(best_effort_response)
             non_downsampled_tier_response = EndpointTimeSeries().execute(
                 message_to_non_downsampled_tier
             )

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3360,7 +3360,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
         )
         assert (
             len(preflight_response.column_values[0].results)
-            < len(non_downsampled_tier_response.column_values[0].results) / 100
+            < len(non_downsampled_tier_response.column_values[0].results) / 10
         )
         assert (
             preflight_response.meta.downsampled_storage_meta

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3365,7 +3365,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
         assert (
             preflight_response.meta.downsampled_storage_meta
             == DownsampledStorageMeta(
-                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_512
+                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64
             )
         )
 
@@ -3422,7 +3422,7 @@ class TestTraceItemTableEAPItems(TestTraceItemTable):
         # this forces the query to route to tier 64. take a look at _get_target_tier to find out why
         with patch(
             "snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util._get_query_bytes_scanned",
-            return_value=2516582401,
+            return_value=20132659201,
         ):
             best_effort_response = EndpointTraceItemTable().execute(best_effort_message)
             non_downsampled_tier_response = EndpointTraceItemTable().execute(

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -46,7 +46,6 @@ def test_get_target_tier(
         target_tier, estimated_target_tier_query_bytes_scanned = _get_target_tier(
             res, metrics_mock, DOESNT_MATTER_STR, timer
         )
-        print(estimated_target_tier_query_bytes_scanned)
         assert target_tier == expected_tier
         assert (
             estimated_target_tier_query_bytes_scanned

--- a/tests/web/rpc/v1/test_sampling_in_storage_util.py
+++ b/tests/web/rpc/v1/test_sampling_in_storage_util.py
@@ -1,4 +1,3 @@
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,7 +7,6 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 from snuba.web.rpc.v1.resolvers.R_eap_spans.common.sampling_in_storage_util import (
-    DOWNSAMPLING_TIER_MULTIPLIERS,
     _get_target_tier,
 )
 
@@ -20,18 +18,19 @@ SAMPLING_IN_STORAGE_UTIL_PREFIX = (
 
 
 @pytest.mark.parametrize(
-    "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier",
+    "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier, expected_estimated_bytes_scanned",
     [
-        (100, 200, Tier.TIER_512),
-        (100, 900, Tier.TIER_64),
-        (100, 6500, Tier.TIER_8),
-        (100, 51300, Tier.TIER_1),
+        (100, 200, Tier.TIER_64, 100),
+        (100, 900, Tier.TIER_8, 800),
+        (100, 6500, Tier.TIER_1, 6400),
+        (100, 51300, Tier.TIER_1, 6400),
     ],
 )
 def test_get_target_tier(
     most_downsampled_query_bytes_scanned: int,
     bytes_scanned_limit: int,
     expected_tier: Tier,
+    expected_estimated_bytes_scanned: int,
 ) -> None:
     res = MagicMock(QueryResult)
     metrics_mock = MagicMock(spec=MetricsBackend)
@@ -47,9 +46,9 @@ def test_get_target_tier(
         target_tier, estimated_target_tier_query_bytes_scanned = _get_target_tier(
             res, metrics_mock, DOESNT_MATTER_STR, timer
         )
+        print(estimated_target_tier_query_bytes_scanned)
         assert target_tier == expected_tier
         assert (
             estimated_target_tier_query_bytes_scanned
-            == most_downsampled_query_bytes_scanned
-            * cast(int, DOWNSAMPLING_TIER_MULTIPLIERS.get(target_tier))
+            == expected_estimated_bytes_scanned
         )


### PR DESCRIPTION
Based on manual QA, we see tier512 being a small amount of data for small orgs which doesn't provide a good way to extrapolate (hence why we also bump the threshold).

On top of that, we noticed the data we show until we display the result of the higher tier query is meaningfully different.

Based on this, bumping the minimal tier would make us query more data in hopes of better accuracy when estimating what higher tier to hit and also present less of a difference in the shape of the data.

https://github.com/getsentry/snuba/pull/7066#issuecomment-2798106164