### PR TITLE
fix(eap): Cast timestamp as a float to and then make it a datetime

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from operator import attrgetter
 from typing import Any, Dict, Iterable
 
@@ -329,10 +329,12 @@ def _convert_results(
 
     for row in data:
         id = row.pop("id")
-        dt = datetime.fromtimestamp(row.pop("timestamp"), timezone.utc)
+        ts = row.pop("timestamp")
 
         timestamp = Timestamp()
-        timestamp.FromDatetime(dt)
+        # truncate to microseconds since we store microsecond precision only
+        # then transform to nanoseconds
+        timestamp.FromNanoseconds(int(ts * 1e6) * 1000)
 
         attributes: list[GetTraceResponse.Item.Attribute] = []
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from operator import attrgetter
 from typing import Any, Dict, Iterable
 
@@ -106,19 +106,18 @@ def _build_query(request: GetTraceRequest) -> Query:
         ),
         SelectedExpression(
             name="timestamp",
-            expression=f.CAST(
+            expression=f.cast(
                 attribute_key_to_expression_eap_items(
                     AttributeKey(
                         name="sentry.start_timestamp_precise",
                         type=AttributeKey.Type.TYPE_DOUBLE,
                     )
+                )
+                if use_eap_items_table(request.meta)
+                else column(
+                    "start_timestamp",
                 ),
-                "DateTime64(6)",
-                alias="timestamp",
-            )
-            if use_eap_items_table(request.meta)
-            else column(
-                "start_timestamp",
+                "Float64",
                 alias="timestamp",
             ),
         ),
@@ -330,7 +329,7 @@ def _convert_results(
 
     for row in data:
         id = row.pop("id")
-        dt = row.pop("timestamp")
+        dt = datetime.fromtimestamp(row.pop("timestamp"), timezone.utc)
 
         timestamp = Timestamp()
         timestamp.FromDatetime(dt)

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -249,6 +249,8 @@ class TestGetTrace(BaseApiTest):
         timestamps: list[Timestamp] = []
         for span in _SPANS:
             timestamp = Timestamp()
+            # truncate to microseconds since we store microsecond precision only
+            # then transform to nanoseconds
             timestamp.FromNanoseconds(int(span["start_timestamp_precise"] * 1e6) * 1000)
             timestamps.append(timestamp)
 


### PR DESCRIPTION
We were seeing errors with `dt` sometime being a string or a `datetime`. This will always for it to be a `Float64`.