### PR TITLE
ref(gocd): filter sentry errors by US env

### DIFF
--- a/gocd/templates/bash/saas-sentry-error-check.sh
+++ b/gocd/templates/bash/saas-sentry-error-check.sh
@@ -4,6 +4,7 @@
   --project-id=300688 \
   --project-slug=snuba \
   --release="${GO_REVISION_SNUBA_REPO}" \
+  --sentry-environment="${SENTRY_ENVIRONMENT}" \
   --duration=5 \
   --error-events-limit=500 \
   --skip-warnings=true \

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -80,6 +80,7 @@ local saas_health_check(region) =
                 DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
                 DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
                 LABEL_SELECTOR: 'service=snuba',
+                SENTRY_ENVIRONMENT: 'us',
               },
               elastic_profile_id: 'snuba',
               tasks: [


### PR DESCRIPTION
Errors from `de` prevent `us` from moving forward
https://github.com/getsentry/getsentry/blob/f1730f5fe687c97e3c9347175eb2aaf142583ff7/gocd/templates/bash/backend/check-sentry-errors.sh#L6

Though it seems `de` doesn't have a health check at all so maybe that's why, but perhaps we should add the health check to `de`