### PR TITLE
Fix: Fixed another hardcoded http url schema in clickhouse connection string

### DIFF
--- a/rust_snuba/src/mutations/clickhouse.rs
+++ b/rust_snuba/src/mutations/clickhouse.rs
@@ -27,6 +27,7 @@ impl ClickhouseWriter {
         database: &str,
         clickhouse_user: &str,
         clickhouse_password: &str,
+        clickhouse_secure: bool,
         batch_write_timeout: Option<Duration>,
     ) -> Self {
         let mut headers = HeaderMap::with_capacity(5);
@@ -45,7 +46,9 @@ impl ClickhouseWriter {
             HeaderValue::from_str(database).unwrap(),
         );
 
-        let url = format!("http://{hostname}:{http_port}");
+        let scheme = if clickhouse_secure { "https" } else { "http" };
+
+        let url = format!("{scheme}://{hostname}:{http_port}");
 
         let mut client_builder = ClientBuilder::new().default_headers(headers);
 

--- a/rust_snuba/src/mutations/factory.rs
+++ b/rust_snuba/src/mutations/factory.rs
@@ -53,6 +53,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for MutConsumerStrategyFactory {
                 &self.storage_config.clickhouse_cluster.database,
                 &self.storage_config.clickhouse_cluster.user,
                 &self.storage_config.clickhouse_cluster.password,
+                self.storage_config.clickhouse_cluster.secure,
                 self.batch_write_timeout,
             ),
             &self.clickhouse_concurrency,


### PR DESCRIPTION
Fixed another hardcoded http url schema in clickhouse connection string

P.S.: Honestly, this part should be somewhere in clickhouse utility functions, like `create_connection_url`, but I don't know where to place it

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
