### PR TITLE
fix(eap): make query settings uniform across downsampled tiers

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512.yaml
@@ -231,12 +231,15 @@ query_processors:
   - processor: TupleUnaliaser
   - processor: ClickhouseSettingsOverride
     args:
+      overwrite_existing: false
       settings:
         max_memory_usage: 5000000000
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
         max_parallel_replicas: 3
-        max_execution_time: 30
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        timeout_overflow_mode: 'break'
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
@@ -231,12 +231,15 @@ query_processors:
   - processor: TupleUnaliaser
   - processor: ClickhouseSettingsOverride
     args:
+      overwrite_existing: false
       settings:
         max_memory_usage: 5000000000
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
         max_parallel_replicas: 3
-        max_execution_time: 30
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        timeout_overflow_mode: 'break'
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8.yaml
@@ -231,12 +231,16 @@ query_processors:
   - processor: TupleUnaliaser
   - processor: ClickhouseSettingsOverride
     args:
+      overwrite_existing: false
       settings:
         max_memory_usage: 5000000000
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
         max_parallel_replicas: 3
-        max_execution_time: 30
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        timeout_overflow_mode: 'break'
+
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer


### PR DESCRIPTION
[This](https://sentry.sentry.io/explore/traces/?project=1&statsPeriod=14d) query was timing out.  Based on [trace](https://sentry.sentry.io/explore/traces/trace/8d27b6fbd8bd4f8a9b0404e1a39d82c7/?fov=0%2C39926&node=txn-46f66b11b5d84e17b3545e62bd8acc78&project=1&query=user.email%3Anar.saynorath%40sentry.io&source=traces&statsPeriod=1h&targetId=8b179c5400eb861a&timestamp=1744742365), it looks like `timeout_before_checking_execution_speed` setting didn't get applied correctly.