### PR TITLE
feat: eap traceitemtable, enable default values for formulas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-rapidjson==1.8
 redis==4.5.4
 sentry-arroyo==2.22.0
 sentry-kafka-schemas==1.2.0
-sentry-protos==0.1.69
+sentry-protos==0.1.70
 sentry-redis-tools==0.3.0
 sentry-relay==0.9.5
 sentry-sdk==2.18.0

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -215,10 +215,21 @@ def _get_reliability_context_columns(
 def _formula_to_expression(
     formula: Column.BinaryFormula, request_meta: RequestMeta
 ) -> Expression:
-    return OP_TO_EXPR[formula.op](
+    formula_expr = OP_TO_EXPR[formula.op](
         _column_to_expression(formula.left, request_meta),
         _column_to_expression(formula.right, request_meta),
     )
+    match formula.WhichOneof("default_value"):
+        case None:
+            return formula_expr
+        case "default_value_double":
+            return f.coalesce(formula_expr, formula.default_value_double)
+        case "default_value_int64":
+            return f.coalesce(formula_expr, formula.default_value_int64)
+        case default:
+            raise BadSnubaRPCRequestException(
+                f"Unknown default_value in formula. Expected default_value_double or default_value_int64 but got {default}"
+            )
 
 
 def _column_to_expression(column: Column, request_meta: RequestMeta) -> Expression:


### PR DESCRIPTION
enables users to specify a default value for formulas. the default is applied if the formula ever evaluates to null. resolves this ticket https://github.com/orgs/getsentry/projects/284/views/1?pane=issue&itemId=104071496&issue=getsentry%7Ceap-planning%7C232

still needs to be done for timeseries