### PR TITLE
Stop writing querylog to redis for no reason

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -345,7 +345,6 @@ def _record_query_delivery_callback(
 
 
 def record_query(query_metadata: snuba_queries_v1.Querylog) -> None:
-    max_redis_queries = 200
     try:
         producer = _kafka_producer()
         data = safe_dumps(query_metadata)

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -41,7 +41,6 @@ config_description_hash = "snuba-config-description"
 config_history_hash = "snuba-config-history"
 config_changes_list = "snuba-config-changes"
 config_changes_list_limit = 25
-queries_list = "snuba-queries"
 rate_limit_config_key = "snuba-ratelimit-config:"
 
 # Rate Limiting and Deduplication

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -350,9 +350,6 @@ def record_query(query_metadata: snuba_queries_v1.Querylog) -> None:
     try:
         producer = _kafka_producer()
         data = safe_dumps(query_metadata)
-        rds.pipeline(transaction=False).lpush(queries_list, data).ltrim(
-            queries_list, 0, max_redis_queries - 1
-        ).execute()
         producer.poll(0)  # trigger queued delivery callbacks
         producer.produce(
             settings.KAFKA_TOPIC_MAP.get(Topic.QUERYLOG.value, Topic.QUERYLOG.value),


### PR DESCRIPTION
Randomly found this from early days of snuba. 7 years ago, we didn't have the kafka querylog and it looks like https://github.com/getsentry/snuba/blob/2dec3b082cbc07bc75fd1eff34dc99577b50fe9f/snuba/state.py#L149-L160. When the kafka change went in, the redis operation was never cleaned up.