### PR TITLE
feat(sampling_in_storage): Log routing decisions to querylog

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -287,6 +287,12 @@ PRETTY_FORMAT_EXPRESSIONS = os.environ.get("PRETTY_FORMAT_EXPRESSIONS", "1") == 
 # situation eventually)
 RAISE_ON_ALLOCATION_POLICY_FAILURES = False
 
+# By default, routing strategies won't block requests from going through in a production
+# environment to not cause incidents unnecessarily. If something goes wrong with routing strategy
+# code, the request will still be able to go through (but it will create a dangerous
+# situation eventually)
+RAISE_ON_ROUTING_STRATEGY_FAILURES = False
+
 # By default, the readthrough cache won't block requests from going through in a production
 # environment to not cause incidents unnecessarily. If something goes wrong with redis or the readthrough cache
 # the request will still be able to go through as if the cache did not exist

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -31,6 +31,7 @@ PRETTY_FORMAT_EXPRESSIONS = os.environ.get("PRETTY_FORMAT_EXPRESSIONS", "1") == 
 # environment to not cause incidents unnecessarily. But if you're testing the policy, it
 # should fail on bad code
 RAISE_ON_ALLOCATION_POLICY_FAILURES = True
+RAISE_ON_ROUTING_STRATEGY_FAILURES = True
 RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES = True
 
 # override replacer threshold to write to redis every time a replacement message is consumed

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/routing_strategies/linear_bytes_scanned_storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/routing_strategies/linear_bytes_scanned_storage_routing.py
@@ -132,6 +132,7 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
                         * self._get_multiplier(tier)
                     )
                     self._record_value_in_span_and_DD(
+                        routing_context,
                         self.metrics.distribution,
                         "estimated_query_bytes_scanned_to_this_tier",
                         estimated_query_bytes_scanned_to_this_tier,
@@ -185,6 +186,7 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
             )
 
             self._record_value_in_span_and_DD(
+                routing_context,
                 self.metrics.timing,
                 "query_bytes_scanned_from_most_downsampled_tier",
                 self._get_query_bytes_scanned(res, span),
@@ -249,12 +251,14 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
         error_pct = abs(error) / actual
 
         self._record_value_in_span_and_DD(
+            routing_context,
             self.metrics.distribution,
             "estimation_error_percentage",
             error_pct,
             tags,
         )
         self._record_value_in_span_and_DD(
+            routing_context,
             self.metrics.distribution,
             "over_estimation_error" if error > 0 else "under_estimation_error",
             abs(error),
@@ -269,12 +273,14 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
                 routing_context, {"tier": str(target_tier)}
             )
             self._record_value_in_span_and_DD(
+                routing_context,
                 self.metrics.distribution,
                 f"actual_bytes_scanned_in_target_tier_{target_tier}",
                 self._get_query_bytes_scanned(routing_context.query_result),
                 tags={"tier": str(target_tier)},
             )
             self._record_value_in_span_and_DD(
+                routing_context,
                 self.metrics.timing,
                 f"time_to_run_query_in_target_tier_{target_tier}",
                 self._get_query_duration_ms(routing_context.query_result),

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/routing_strategies/storage_routing.py
@@ -1,14 +1,15 @@
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, TypeAlias, Union
+from typing import Any, Callable, Dict, Optional, TypeAlias, Union, cast, final
 
 import sentry_sdk
 from google.protobuf.json_format import MessageToDict
+from sentry_kafka_schemas.schema_types import snuba_queries_v1
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableRequest
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
-from snuba import environment
+from snuba import environment, settings
 from snuba.attribution import AppID
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.datasets.pluggable_dataset import PluggableDataset
@@ -16,6 +17,7 @@ from snuba.downsampled_storage_tiers import Tier
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
+from snuba.state import record_query
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.util import with_span
 from snuba.utils.metrics.wrapper import MetricsWrapper
@@ -42,6 +44,69 @@ class RoutingContext:
     query_settings: HTTPQuerySettings
     query_result: Optional[QueryResult] = field(default=None)
     extra_info: dict[str, Any] = field(default_factory=dict)
+
+    def to_log_dict(self) -> dict[str, Any]:
+        query_result: dict[str, Any] = {}
+        if self.query_result:
+            query_result["meta"] = self.query_result.result.get("meta", {})
+            query_result["profile"] = self.query_result.result.get("profile", {})
+
+        return {
+            "extra_info": self.extra_info,
+            "clickhouse_settings_settings": self.query_settings.get_clickhouse_settings(),
+            "result_info": query_result,
+            "routed_tier": self.query_settings.get_sampling_tier(),
+        }
+
+
+def _construct_hacky_querylog_payload(
+    strategy: "BaseRoutingStrategy", routing_context: RoutingContext
+) -> snuba_queries_v1.Querylog:
+    cur_span = sentry_sdk.get_current_span()
+    return {
+        "request": {
+            "id": str(uuid.uuid4()),
+            "app_id": "storage_routing",
+            "body": MessageToDict(routing_context.in_msg),
+            "referrer": strategy.__class__.__name__,
+        },
+        "dataset": "storage_routing",
+        "entity": "eap",
+        "start_timestamp": routing_context.in_msg.meta.start_timestamp.seconds,
+        "end_timestamp": routing_context.in_msg.meta.end_timestamp.seconds,
+        "status": routing_context.query_settings.get_sampling_tier().name,
+        "request_status": "NA",
+        "slo": "N/A",
+        "projects": list(routing_context.in_msg.meta.project_ids),
+        "timing": routing_context.timer.for_json(),
+        "snql_anonymized": "",
+        "query_list": [
+            {
+                "sql": "",
+                "sql_anonymized": "",
+                "start_timestamp": routing_context.in_msg.meta.start_timestamp.seconds,
+                "end_timestamp": routing_context.in_msg.meta.end_timestamp.seconds,
+                "stats": cast(
+                    snuba_queries_v1._QueryMetadataStats, routing_context.to_log_dict()
+                ),
+                "status": "0",
+                "trace_id": cur_span.trace_id if cur_span else "no_current_span",
+                "profile": {
+                    "time_range": None,
+                    "table": "eap_items",
+                    "all_columns": [],
+                    "multi_level_condition": False,
+                    "where_profile": {"columns": [], "mapping_cols": []},
+                    "array_join_cols": [],
+                    "groupby_cols": [],
+                },
+                "result_profile": {"bytes": 0, "progress_bytes": 0, "elapsed": 0},
+                "request_status": "na",
+                "slo": "na",
+            }
+        ],
+        "organization": routing_context.in_msg.meta.organization_id,
+    }
 
 
 class BaseRoutingStrategy(metaclass=RegisteredClass):
@@ -119,6 +184,7 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
 
     def _record_value_in_span_and_DD(
         self,
+        routing_context: RoutingContext,
         metrics_backend_func: MetricsBackendType,
         name: str,
         value: float | int,
@@ -135,9 +201,16 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
     ) -> tuple[Tier, ClickhouseQuerySettings]:
         raise NotImplementedError
 
+    @final
+    def __output_metrics(self, routing_context: RoutingContext) -> None:
+        self._output_metrics(routing_context)
+        # send the routing context extra info to the querylog
+        record_query(_construct_hacky_querylog_payload(self, routing_context))
+
     def _output_metrics(self, routing_context: RoutingContext) -> None:
         pass
 
+    @final
     @with_span(op="function")
     def run_query_to_correct_tier(self, routing_context: RoutingContext) -> QueryResult:
         with sentry_sdk.start_span(op="decide_tier"):
@@ -148,6 +221,7 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
                 )
                 routing_context.timer.mark(_END_ESTIMATION_MARK)
                 self._record_value_in_span_and_DD(
+                    routing_context,
                     self.metrics.timing,
                     "estimation_time_overhead",
                     routing_context.timer.get_duration_between_marks(
@@ -160,6 +234,8 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
                 self.metrics.increment("estimation_failure")
                 sentry_sdk.capture_exception(e)
                 target_tier = Tier.TIER_1
+                if settings.RAISE_ON_ROUTING_STRATEGY_FAILURES:
+                    raise e
 
             routing_context.query_settings.set_sampling_tier(target_tier)
 
@@ -168,10 +244,11 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
             routing_context.query_result = output
         with sentry_sdk.start_span(op="output_metrics"):
             try:
-                self._output_metrics(routing_context)
+                self.__output_metrics(routing_context)
             except Exception as e:
                 # log some error metrics
                 self.metrics.increment("metrics_failure")
                 sentry_sdk.capture_exception(e)
-                pass
+                if settings.RAISE_ON_ROUTING_STRATEGY_FAILURES:
+                    raise e
         return routing_context.query_result

--- a/tests/web/rpc/v1/test_storage_routing.py
+++ b/tests/web/rpc/v1/test_storage_routing.py
@@ -1,7 +1,11 @@
 from copy import deepcopy
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 
 from snuba.downsampled_storage_tiers import Tier
 from snuba.query.query_settings import HTTPQuerySettings
@@ -10,9 +14,34 @@ from snuba.web import QueryException, QueryResult
 from snuba.web.rpc.v1.resolvers.R_eap_items.routing_strategies.storage_routing import (
     BaseRoutingStrategy,
     ClickhouseQuerySettings,
-    RoutedRequestType,
     RoutingContext,
 )
+
+
+def _get_in_msg() -> TimeSeriesRequest:
+    ts = Timestamp()
+    ts.GetCurrentTime()
+    tstart = Timestamp(seconds=ts.seconds - 3600)
+
+    return TimeSeriesRequest(
+        meta=RequestMeta(
+            project_ids=[1, 2, 3],
+            organization_id=1,
+            cogs_category="something",
+            referrer="something",
+            start_timestamp=tstart,
+            end_timestamp=ts,
+            trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        ),
+        granularity_secs=60,
+    )
+
+
+def get_query_result() -> QueryResult:
+    return QueryResult(
+        result={"profile": {"bytes": 420}, "data": [{"row": ["a", "b", "c"]}]},
+        extra={"stats": {}, "sql": "", "experiments": {}},
+    )
 
 
 class RoutingStrategyFailsToSelectTier(BaseRoutingStrategy):
@@ -22,7 +51,7 @@ class RoutingStrategyFailsToSelectTier(BaseRoutingStrategy):
         raise Exception
 
     def _run_query(self, routing_context: RoutingContext) -> QueryResult:
-        return QueryResult(result=MagicMock(), extra=MagicMock())
+        return get_query_result()
 
     def _output_metrics(self, routing_context: RoutingContext) -> None:
         pass
@@ -35,7 +64,7 @@ class RoutingStrategySelectsTier8(BaseRoutingStrategy):
         return Tier.TIER_8, {}
 
     def _run_query(self, routing_context: RoutingContext) -> QueryResult:
-        return QueryResult(result=MagicMock(), extra=MagicMock())
+        return get_query_result()
 
     def _output_metrics(self, routing_context: RoutingContext) -> None:
         pass
@@ -48,7 +77,7 @@ class RoutingStrategyUpdatesQuerySettings(BaseRoutingStrategy):
         return Tier.TIER_8, {"some_setting": "some_value"}
 
     def _run_query(self, routing_context: RoutingContext) -> QueryResult:
-        return QueryResult(result=MagicMock(), extra=MagicMock())
+        return get_query_result()
 
     def _output_metrics(self, routing_context: RoutingContext) -> None:
         pass
@@ -61,7 +90,7 @@ class RoutingStrategyBadMetrics(BaseRoutingStrategy):
         return Tier.TIER_8, {"some_setting": "some_value"}
 
     def _run_query(self, routing_context: RoutingContext) -> QueryResult:
-        return QueryResult(result=MagicMock(), extra=MagicMock())
+        return get_query_result()
 
     def _output_metrics(self, routing_context: RoutingContext) -> None:
         if 1 / 0 > 10:
@@ -69,6 +98,11 @@ class RoutingStrategyBadMetrics(BaseRoutingStrategy):
 
 
 class RoutingStrategyQueryFails(BaseRoutingStrategy):
+    def _decide_tier_and_query_settings(
+        self, routing_context: RoutingContext
+    ) -> tuple[Tier, ClickhouseQuerySettings]:
+        return Tier.TIER_8, {"some_setting": "some_value"}
+
     def _run_query(self, routing_context: RoutingContext) -> QueryResult:
         raise QueryException("this query failed")
 
@@ -77,8 +111,8 @@ class RoutingStrategyQueryFails(BaseRoutingStrategy):
 
 
 ROUTING_CONTEXT = RoutingContext(
-    in_msg=MagicMock(spec=RoutedRequestType),
-    timer=MagicMock(spec=Timer),
+    in_msg=_get_in_msg(),
+    timer=Timer("stuff"),
     build_query=MagicMock(),
     query_settings=HTTPQuerySettings(),
     query_result=MagicMock(spec=QueryResult),
@@ -87,9 +121,10 @@ ROUTING_CONTEXT = RoutingContext(
 
 
 def test_target_tier_is_tier_1_if_routing_strategy_fails_to_decide_tier() -> None:
-    routing_context = deepcopy(ROUTING_CONTEXT)
-    RoutingStrategyFailsToSelectTier().run_query_to_correct_tier(routing_context)
-    assert routing_context.query_settings.get_sampling_tier() == Tier.TIER_1
+    with mock.patch("snuba.settings.RAISE_ON_ROUTING_STRATEGY_FAILURES", False):
+        routing_context = deepcopy(ROUTING_CONTEXT)
+        RoutingStrategyFailsToSelectTier().run_query_to_correct_tier(routing_context)
+        assert routing_context.query_settings.get_sampling_tier() == Tier.TIER_1
 
 
 def test_target_tier_is_set_in_routing_context() -> None:
@@ -108,11 +143,32 @@ def test_merge_query_settings() -> None:
 
 
 def test_outputting_metrics_fails_open() -> None:
-    routing_context = deepcopy(ROUTING_CONTEXT)
-    RoutingStrategyBadMetrics().run_query_to_correct_tier(routing_context)
+    with mock.patch("snuba.settings.RAISE_ON_ROUTING_STRATEGY_FAILURES", False):
+        routing_context = deepcopy(ROUTING_CONTEXT)
+        RoutingStrategyBadMetrics().run_query_to_correct_tier(routing_context)
 
 
 def test_failed_query() -> None:
     routing_context = deepcopy(ROUTING_CONTEXT)
     with pytest.raises(QueryException):
         RoutingStrategyQueryFails().run_query_to_correct_tier(routing_context)
+
+
+def test_metrics_output() -> None:
+    metric = 0
+
+    class MetricsStrategy(RoutingStrategySelectsTier8):
+        def _output_metrics(self, routing_context: RoutingContext) -> None:
+            nonlocal metric
+            res = super()._output_metrics(routing_context)
+            metric += 1
+            return res
+
+    routing_context = deepcopy(ROUTING_CONTEXT)
+    with mock.patch(
+        "snuba.web.rpc.v1.resolvers.R_eap_items.routing_strategies.storage_routing.record_query"
+    ) as record_query:
+        # with mock.patch("snuba.state.record_query") as record_query:
+        MetricsStrategy().run_query_to_correct_tier(routing_context)
+        record_query.assert_called_once()
+        assert metric == 1


### PR DESCRIPTION
Right now we don't have a good way to drill down and understand our routing decisions. spans do an okay job but are subject to sampling. This PR:

* creates a hacky entry in the querylog for every routing decision we make, it abuses the `clickhouse_queries.stats` field which accepts arbitrary JSON and the `dataset=storage_routing` field to make the requests separate
* All metrics outputted by the routing strategy are added to the payload
* Adds tests for this functionality