### PR TITLE
[wip] job(eap): rewrite eap_spans subscriptions to be based on eap_items

### DIFF
--- a/snuba/manual_jobs/rewrite_subscription_entity.py
+++ b/snuba/manual_jobs/rewrite_subscription_entity.py
@@ -1,0 +1,47 @@
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.manual_jobs import Job, JobLogger, JobSpec
+from snuba.redis import RedisClientKey, get_redis_client
+from snuba.subscriptions.data import PartitionId
+from snuba.subscriptions.store import RedisSubscriptionDataStore
+from snuba.utils.metrics.wrapper import MetricsWrapper
+
+redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
+
+
+class RewriteSubscriptionEntity(Job):
+    """
+    A manual job to rewrite the entity field in subscriptions table.
+    """
+
+    def __init__(self, job_spec: JobSpec) -> None:
+        super().__init__(job_spec)
+        self.__metrics = MetricsWrapper(None)
+
+    def execute(self, logger: JobLogger) -> None:
+        """
+        Executes the job to rewrite subscription entities.
+        """
+        partitions = redis_client.keys("subscriptions:{entity.value}:*")
+        for partition_hash_key in partitions:
+            partition_id = int(partition_hash_key.split(":")[-1])
+
+            logger.info(f"rewriting partition {partition_id}")
+            span_store = RedisSubscriptionDataStore(
+                redis_client,
+                EntityKey.EAP_SPANS,
+                PartitionId(partition_id),
+            )
+            item_store = RedisSubscriptionDataStore(
+                redis_client,
+                EntityKey.EAP_ITEMS,
+                PartitionId(partition_id),
+            )
+            rewritten_count = 0
+            for key, data in span_store.all():
+                data.entity = EntityKey.EAP_ITEMS
+                item_store.create(key, data)
+                span_store.delete(key)
+                rewritten_count += 1
+            logger.info(
+                f"sucessfully rewrote {rewritten_count} subscriptions for partition {partition_id}"
+            )

--- a/snuba/manual_jobs/rewrite_subscription_entity.py
+++ b/snuba/manual_jobs/rewrite_subscription_entity.py
@@ -19,7 +19,9 @@ class RewriteSubscriptionEntity(Job):
 
     def execute(self, logger: JobLogger) -> None:
         """
-        Executes the job to rewrite subscription entities.
+        Executes the job to migrate subscription entities, without
+        changing the underlying subscription data (as much as possible). This
+        does require the subscription data to be RPC-encoded (as in EAP).
         """
         partitions = redis_client.keys(f"subscriptions:{self.__source_entity.value}:*")
         for partition_hash_key in partitions:

--- a/snuba/manual_jobs/rewrite_subscription_entity.py
+++ b/snuba/manual_jobs/rewrite_subscription_entity.py
@@ -1,9 +1,8 @@
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.manual_jobs import Job, JobLogger, JobSpec
 from snuba.redis import RedisClientKey, get_redis_client
-from snuba.subscriptions.data import PartitionId
+from snuba.subscriptions.data import PartitionId, RPCSubscriptionData
 from snuba.subscriptions.store import RedisSubscriptionDataStore
-from snuba.utils.metrics.wrapper import MetricsWrapper
 
 redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
 
@@ -15,33 +14,48 @@ class RewriteSubscriptionEntity(Job):
 
     def __init__(self, job_spec: JobSpec) -> None:
         super().__init__(job_spec)
-        self.__metrics = MetricsWrapper(None)
+        self.__source_entity = EntityKey(job_spec.params["source_entity"])
+        self.__target_entity = EntityKey(job_spec.params["target_entity"])
 
     def execute(self, logger: JobLogger) -> None:
         """
         Executes the job to rewrite subscription entities.
         """
-        partitions = redis_client.keys("subscriptions:{entity.value}:*")
+        partitions = redis_client.keys(f"subscriptions:{self.__source_entity.value}:*")
         for partition_hash_key in partitions:
-            partition_id = int(partition_hash_key.split(":")[-1])
+            partition_id = int(partition_hash_key.decode("utf-8").split(":")[-1])
 
-            logger.info(f"rewriting partition {partition_id}")
+            logger.info(
+                f"rewriting partition {partition_id} from {self.__source_entity} to {self.__target_entity}"
+            )
             span_store = RedisSubscriptionDataStore(
                 redis_client,
-                EntityKey.EAP_SPANS,
+                self.__source_entity,
                 PartitionId(partition_id),
             )
             item_store = RedisSubscriptionDataStore(
                 redis_client,
-                EntityKey.EAP_ITEMS,
+                self.__target_entity,
                 PartitionId(partition_id),
             )
+
             rewritten_count = 0
             for key, data in span_store.all():
-                data.entity = EntityKey.EAP_ITEMS
-                item_store.create(key, data)
+                assert isinstance(data, RPCSubscriptionData)
+                copied_subscription_entity = RPCSubscriptionData(
+                    project_id=data.project_id,
+                    resolution_sec=data.resolution_sec,
+                    time_window_sec=data.time_window_sec,
+                    entity=self.__target_entity,
+                    metadata=data.metadata,
+                    time_series_request=data.time_series_request,
+                    request_name=data.request_name,
+                    request_version=data.request_version,
+                )
+                item_store.create(key, copied_subscription_entity)
                 span_store.delete(key)
                 rewritten_count += 1
+
             logger.info(
                 f"sucessfully rewrote {rewritten_count} subscriptions for partition {partition_id}"
             )

--- a/tests/manual_jobs/test_rewrite_subscription_entity.py
+++ b/tests/manual_jobs/test_rewrite_subscription_entity.py
@@ -14,6 +14,8 @@ redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
 
 @pytest.mark.redis_db
 def test_rewrite_subscription_entity():
+    request_contents = "Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIyIQoaCAESDwgDEgt0ZXN0X21ldHJpYxoDc3VtIAEaA3N1bQ=="
+
     # Create eap_spans subscriptions
     for partition_id in [1, 2]:
         RedisSubscriptionDataStore(
@@ -26,7 +28,7 @@ def test_rewrite_subscription_entity():
                 time_window_sec=300,
                 entity=EntityKey("eap_spans"),
                 metadata={},
-                time_series_request="Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIyIQoaCAESDwgDEgt0ZXN0X21ldHJpYxoDc3VtIAEaA3N1bQ==",
+                time_series_request=request_contents,
                 request_name="TimeSeriesRequest",
                 request_version="v1",
             ),
@@ -56,10 +58,7 @@ def test_rewrite_subscription_entity():
             assert stored_data is not None
             assert isinstance(stored_data, RPCSubscriptionData)
             assert stored_data.entity.entity_key == EntityKey.EAP_ITEMS
-            assert (
-                stored_data.time_series_request
-                == "Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIyIQoaCAESDwgDEgt0ZXN0X21ldHJpYxoDc3VtIAEaA3N1bQ=="
-            )
+            assert stored_data.time_series_request == request_contents
 
             # Verify data was removed from spans
             assert spans_store.all() == []

--- a/tests/manual_jobs/test_rewrite_subscription_entity.py
+++ b/tests/manual_jobs/test_rewrite_subscription_entity.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.manual_jobs import JobSpec
 from snuba.manual_jobs.runner import run_job
 from snuba.redis import RedisClientKey, get_redis_client
@@ -13,7 +14,7 @@ redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
 
 
 @pytest.mark.redis_db
-def test_rewrite_subscription_entity():
+def test_rewrite_subscription_entity() -> None:
     request_contents = "Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIyIQoaCAESDwgDEgt0ZXN0X21ldHJpYxoDc3VtIAEaA3N1bQ=="
 
     # Create eap_spans subscriptions
@@ -26,7 +27,7 @@ def test_rewrite_subscription_entity():
                 project_id=1,
                 resolution_sec=60,
                 time_window_sec=300,
-                entity=EntityKey("eap_spans"),
+                entity=get_entity(EntityKey.EAP_SPANS),
                 metadata={},
                 time_series_request=request_contents,
                 request_name="TimeSeriesRequest",
@@ -37,7 +38,7 @@ def test_rewrite_subscription_entity():
     # Execute job
     run_job(
         JobSpec(
-            1,
+            "jobid",
             "RewriteSubscriptionEntity",
             False,
             {"source_entity": "eap_spans", "target_entity": "eap_items"},
@@ -57,7 +58,7 @@ def test_rewrite_subscription_entity():
         for _, stored_data in items_store.all():
             assert stored_data is not None
             assert isinstance(stored_data, RPCSubscriptionData)
-            assert stored_data.entity.entity_key == EntityKey.EAP_ITEMS
+            assert stored_data.entity == get_entity(EntityKey.EAP_ITEMS)
             assert stored_data.time_series_request == request_contents
 
             # Verify data was removed from spans

--- a/tests/manual_jobs/test_rewrite_subscription_entity.py
+++ b/tests/manual_jobs/test_rewrite_subscription_entity.py
@@ -1,0 +1,60 @@
+import json
+import uuid
+
+import pytest
+
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs.runner import run_job
+from snuba.redis import RedisClientKey, get_redis_client
+from snuba.subscriptions.data import PartitionId, RPCSubscriptionData
+from snuba.subscriptions.store import RedisSubscriptionDataStore
+
+redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
+
+
+@pytest.mark.redis_db
+def test_rewrite_subscription_entity():
+    # Setup test data in Redis
+    test_data = {
+        "subscription1": {"some": "data"},
+        "subscription2": {"other": "data"},
+    }
+
+    # Create test data in Redis for spans
+    for partition_id in [1, 2]:
+        RedisSubscriptionDataStore(
+            redis_client, EntityKey("eap_spans"), PartitionId(partition_id)
+        ).create(
+            uuid.uuid4(),
+            RPCSubscriptionData(
+                project_id=1,
+                resolution_sec=60,
+                time_window_sec=300,
+                entity=EntityKey("eap_spans"),
+                metadata={},
+                time_series_request="Ch0IARIJc29tZXRoaW5nGglzb21ldGhpbmciAwECAxIUIhIKBwgBEgNmb28QBhoFEgNiYXIyIQoaCAESDwgDEgt0ZXN0X21ldHJpYxoDc3VtIAEaA3N1bQ==",
+                request_name="TimeSeriesRequest",
+                request_version="v1",
+            ),
+        )
+
+    # Create and execute job
+    run_job(JobSpec(1, "RewriteSubscriptionEntity"))
+
+    # Verify data was moved correctly
+    for partition_id in [1, 2]:
+        spans_store = RedisSubscriptionDataStore(
+            redis_client, EntityKey("eap_spans"), PartitionId(partition_id)
+        )
+        items_store = RedisSubscriptionDataStore(
+            redis_client, EntityKey("eap_items"), PartitionId(partition_id)
+        )
+
+        # Verify data was moved to items
+        for sub_id, stored_data in items_store.all():
+            assert stored_data is not None
+            assert json.loads(stored_data) == test_data
+
+            # Verify data was removed from spans
+            assert spans_store.get(sub_id) is None


### PR DESCRIPTION
before we can delete the EAP_SPANS entity key, we need subscriptions to be based off EAP_ITEMS. In our largest environment there are only about 50 of these so I think this can run in a few seconds