### PR TITLE
feat: throw error if duplicate labels are provided in RPC endpoints

### DIFF
--- a/snuba/web/rpc/proto_visitor.py
+++ b/snuba/web/rpc/proto_visitor.py
@@ -5,7 +5,6 @@ from types import MethodType
 from typing import Any, Callable, Generic, TypeVar
 
 from google.protobuf.message import Message as ProtobufMessage
-from proto import Message
 from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
     AttributeConditionalAggregation,
 )
@@ -236,9 +235,9 @@ class GetExpressionAggregationsVisitor(ProtoVisitor):
 class ValidateLabelsVisitor(ProtoVisitor):
     def __init__(self) -> None:
         super().__init__()
-        self.label_to_expr: dict[str, Message] = {}
+        self.label_to_expr: dict[str, ProtobufMessage] = {}
 
-    def _register_label(self, label: str, e: Message) -> None:
+    def _register_label(self, label: str, e: ProtobufMessage) -> None:
         if label == "":
             return
         if label not in self.label_to_expr:

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -14,6 +14,7 @@ from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.proto_visitor import (
     AggregationToConditionalAggregationVisitor,
     TimeSeriesRequestWrapper,
+    ValidateLabelsVisitor,
 )
 from snuba.web.rpc.v1.resolvers import ResolverTimeSeries
 
@@ -131,5 +132,6 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
+        in_msg_wrapper.accept(ValidateLabelsVisitor())
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)


### PR DESCRIPTION
this makes it timeseries and itemtable endpoints throw BadSnubaRPCException if there are duplicate labels in the request. previously there was no error and it was just causing unexpected results for users.

see: https://github.com/getsentry/eap-planning/issues/242

this resolves https://github.com/getsentry/eap-planning/issues/244


## notes
this PR was very annoying to make IMO the current request visitors dont work very well and should be redesigned.