### PR TITLE
 feat(storage-routing): strategy selector takes overrides

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategy_selector.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategy_selector.py
@@ -87,7 +87,11 @@ class RoutingStrategySelector:
             str(get_config(_STORAGE_ROUTING_CONFIG_OVERRIDE_KEY, "{}"))
         )
         if str(organization_id) in overrides.keys():
-            return StorageRoutingConfig.from_json(overrides[str(organization_id)])
+            override_config = StorageRoutingConfig.from_json(
+                overrides[str(organization_id)]
+            )
+            if override_config.version == _DEFAULT_STORAGE_ROUTING_CONFIG.version:
+                return override_config
 
         config = str(get_config(_DEFAULT_STORAGE_ROUTING_CONFIG_KEY, "{}"))
         return StorageRoutingConfig.from_json(json.loads(config))

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategy_selector.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategy_selector.py
@@ -92,11 +92,7 @@ class RoutingStrategySelector:
                 str(get_config(_STORAGE_ROUTING_CONFIG_OVERRIDE_KEY, "{}"))
             )
             if organization_id in overrides.keys():
-                override_config = StorageRoutingConfig.from_json(
-                    overrides[organization_id]
-                )
-                if override_config.version == _DEFAULT_STORAGE_ROUTING_CONFIG.version:
-                    return override_config
+                return StorageRoutingConfig.from_json(overrides[organization_id])
 
             config = str(get_config(_DEFAULT_STORAGE_ROUTING_CONFIG_KEY, "{}"))
             return StorageRoutingConfig.from_json(json.loads(config))

--- a/tests/web/rpc/v1/routing_strategies/test_strategy_selector.py
+++ b/tests/web/rpc/v1/routing_strategies/test_strategy_selector.py
@@ -20,7 +20,6 @@ from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategy_sel
     _DEFAULT_STORAGE_ROUTING_CONFIG_KEY,
     _STORAGE_ROUTING_CONFIG_OVERRIDE_KEY,
     RoutingStrategySelector,
-    StorageRoutingConfig,
 )
 
 
@@ -207,50 +206,10 @@ def test_selects_override_if_it_exists() -> None:
 
     assert RoutingStrategySelector().get_storage_routing_config(
         routing_context.in_msg
-    ) == StorageRoutingConfig(
-        version=1,
-        _routing_strategy_and_percentage_routed={
-            "ToyRoutingStrategy1": 0.95,
-            "ToyRoutingStrategy2": 0.05,
-        },
-    )
-
-
-@pytest.mark.redis_db
-def test_does_not_override_if_version_is_different() -> None:
-    state.set_config(
-        _DEFAULT_STORAGE_ROUTING_CONFIG_KEY,
-        '{"version": 1, "config": {"LinearBytesScannedRoutingStrategy": 0.25, "ToyRoutingStrategy1": 0.25, "ToyRoutingStrategy2": 0.25, "ToyRoutingStrategy3": 0.25}}',
-    )
-
-    state.set_config(
-        _STORAGE_ROUTING_CONFIG_OVERRIDE_KEY,
-        '{"10": {"version": 2, "config": {"ToyRoutingStrategy1": 0.95, "ToyRoutingStrategy2": 0.05}}}',
-    )
-
-    routing_context = RoutingContext(
-        in_msg=TimeSeriesRequest(
-            meta=RequestMeta(
-                organization_id=10,
-                project_ids=[11, 12],
-            ),
-        ),
-        timer=Timer(name="doesntmatter"),
-        build_query=build_query,  # type: ignore
-        query_settings=HTTPQuerySettings(),
-    )
-
-    assert RoutingStrategySelector().get_storage_routing_config(
-        routing_context.in_msg
-    ) == StorageRoutingConfig(
-        version=1,
-        _routing_strategy_and_percentage_routed={
-            "LinearBytesScannedRoutingStrategy": 0.25,
-            "ToyRoutingStrategy1": 0.25,
-            "ToyRoutingStrategy2": 0.25,
-            "ToyRoutingStrategy3": 0.25,
-        },
-    )
+    ).get_routing_strategy_and_percentage_routed() == [
+        ("ToyRoutingStrategy1", 0.95),
+        ("ToyRoutingStrategy2", 0.05),
+    ]
 
 
 @pytest.mark.redis_db
@@ -279,12 +238,9 @@ def test_does_not_override_if_organization_id_is_different() -> None:
 
     assert RoutingStrategySelector().get_storage_routing_config(
         routing_context.in_msg
-    ) == StorageRoutingConfig(
-        version=1,
-        _routing_strategy_and_percentage_routed={
-            "LinearBytesScannedRoutingStrategy": 0.25,
-            "ToyRoutingStrategy1": 0.25,
-            "ToyRoutingStrategy2": 0.25,
-            "ToyRoutingStrategy3": 0.25,
-        },
-    )
+    ).get_routing_strategy_and_percentage_routed() == [
+        ("LinearBytesScannedRoutingStrategy", 0.25),
+        ("ToyRoutingStrategy1", 0.25),
+        ("ToyRoutingStrategy2", 0.25),
+        ("ToyRoutingStrategy3", 0.25),
+    ]

--- a/tests/web/rpc/v1/routing_strategies/test_strategy_selector.py
+++ b/tests/web/rpc/v1/routing_strategies/test_strategy_selector.py
@@ -38,7 +38,9 @@ class ToyRoutingStrategy3(BaseRoutingStrategy):
 
 @pytest.mark.redis_db
 def test_strategy_selector_selects_default_if_no_config() -> None:
-    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(1)
+    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(
+        TimeSeriesRequest(meta=RequestMeta(organization_id=1))
+    )
     assert storage_routing_config == _DEFAULT_STORAGE_ROUTING_CONFIG
 
 
@@ -48,7 +50,9 @@ def test_strategy_selector_selects_default_if_strategy_does_not_exist() -> None:
         _DEFAULT_STORAGE_ROUTING_CONFIG_KEY,
         '{"version": 1, "config": {"NonExistentStrategy": 1}}',
     )
-    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(1)
+    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(
+        TimeSeriesRequest(meta=RequestMeta(organization_id=1))
+    )
     assert storage_routing_config == _DEFAULT_STORAGE_ROUTING_CONFIG
 
 
@@ -58,7 +62,9 @@ def test_strategy_selector_selects_default_if_percentages_do_not_add_up() -> Non
         _DEFAULT_STORAGE_ROUTING_CONFIG_KEY,
         '{"version": 1, "config": {"LinearBytesScannedRoutingStrategy": 0.1, "ToyRoutingStrategy1": 0.2, "ToyRoutingStrategy2": 0.10}}',
     )
-    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(1)
+    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(
+        TimeSeriesRequest(meta=RequestMeta(organization_id=1))
+    )
     assert storage_routing_config == _DEFAULT_STORAGE_ROUTING_CONFIG
 
 
@@ -68,7 +74,9 @@ def test_valid_config_is_parsed_correctly() -> None:
         _DEFAULT_STORAGE_ROUTING_CONFIG_KEY,
         '{"version": 1, "config": {"LinearBytesScannedRoutingStrategy": 0.1, "ToyRoutingStrategy1": 0.2, "ToyRoutingStrategy2": 0.70}}',
     )
-    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(1)
+    storage_routing_config = RoutingStrategySelector().get_storage_routing_config(
+        TimeSeriesRequest(meta=RequestMeta(organization_id=1))
+    )
     assert storage_routing_config.version == 1
     assert storage_routing_config.get_routing_strategy_and_percentage_routed() == [
         ("LinearBytesScannedRoutingStrategy", 0.1),
@@ -198,7 +206,7 @@ def test_selects_override_if_it_exists() -> None:
     )
 
     assert RoutingStrategySelector().get_storage_routing_config(
-        routing_context.in_msg.meta.organization_id
+        routing_context.in_msg
     ) == StorageRoutingConfig(
         version=1,
         _routing_strategy_and_percentage_routed={
@@ -233,7 +241,7 @@ def test_does_not_override_if_version_is_different() -> None:
     )
 
     assert RoutingStrategySelector().get_storage_routing_config(
-        routing_context.in_msg.meta.organization_id
+        routing_context.in_msg
     ) == StorageRoutingConfig(
         version=1,
         _routing_strategy_and_percentage_routed={
@@ -270,7 +278,7 @@ def test_does_not_override_if_organization_id_is_different() -> None:
     )
 
     assert RoutingStrategySelector().get_storage_routing_config(
-        routing_context.in_msg.meta.organization_id
+        routing_context.in_msg
     ) == StorageRoutingConfig(
         version=1,
         _routing_strategy_and_percentage_routed={


### PR DESCRIPTION
Allow overrides at organization level

For example
`{
    "8392": {
        "version": 1, 
        "config": {
            "LinearBytesScannedRoutingStrategy": 0.25, 
            "ToyRoutingStrategy1": 0.25, 
            "ToyRoutingStrategy2": 0.25, 
            "ToyRoutingStrategy3": 0.25
        }
    },
    "12": {
        "version": 1, 
        "config": {
            "LinearBytesScannedRoutingStrategy": 0.75, 
            "ToyRoutingStrategy3": 0.25
        }
    }
}`

This adds overrides for orgs 8392 and 12