### PR TITLE
feat(eap): store span kind in EAP Items

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -246,6 +246,10 @@ impl From<FromSpanMessage> for EAPItem {
             res.attributes
                 .insert_bool("sentry.is_segment".to_string(), from.is_segment);
 
+            if let Some(kind) = from.kind {
+                res.attributes.insert_str("kind".to_string(), kind);
+            }
+
             if let Some(parent_span_id) = from.parent_span_id {
                 res.attributes
                     .insert_str("sentry.parent_span_id".to_string(), parent_span_id);
@@ -289,6 +293,7 @@ mod tests {
     "event_id": "d826225de75d42d6b2f01b957d51f18f",
     "exclusive_time_ms": 0.228,
     "is_segment": true,
+    "kind": "server",
     "data": {
         "sentry.environment": "development",
         "sentry.release": "backend@24.7.0.dev0+c45b49caed1e5fcbf70097ab3f434b487c359b6b",

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_items__tests__serialization.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__eap_items__tests__serialization.snap
@@ -74,6 +74,7 @@ expression: item
     "sentry.status_code": "200"
   },
   "attributes_string_19": {
+    "kind": "server",
     "sentry.op": "http.server"
   },
   "attributes_string_20": {

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -43,6 +43,7 @@ pub(crate) struct FromSpanMessage {
     pub(crate) event_id: Option<Uuid>,
     pub(crate) exclusive_time_ms: f64,
     pub(crate) is_segment: bool,
+    pub(crate) kind: Option<String>,
     pub(crate) measurements: Option<BTreeMap<String, FromMeasurementValue>>,
     pub(crate) data: Option<BTreeMap<String, Value>>,
     pub(crate) parent_span_id: Option<String>,


### PR DESCRIPTION
Spans have a `kind` field that is [sent over Kafka](https://github.com/getsentry/relay/blob/888d9f54854d1bf49ce7b82d6658e8baf614d9ba/relay-server/src/services/store.rs#L1427) but not yet stored in the EAP Items table. Write it to the `kind` key, to follow the intended search key for this field.

Fixes OPE-1.