### PR TITLE
ref(clickhouse-settings): ignore_clickhouse_settings_override runtime config

### DIFF
--- a/snuba/query/processors/physical/clickhouse_settings_override.py
+++ b/snuba/query/processors/physical/clickhouse_settings_override.py
@@ -41,8 +41,8 @@ class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
             new_settings.update(self.__settings)
             new_settings.update(query_settings.get_clickhouse_settings())
 
-        if get_str_config("ignore_clickhouse_settings_override", default=""):
-            ignored_settings = get_str_config("ignore_clickhouse_settings_override")
+        ignored_settings = get_str_config("ignore_clickhouse_settings_override")
+        if ignored_settings:
             new_settings = {
                 setting: value
                 for setting, value in new_settings.items()

--- a/snuba/query/processors/physical/clickhouse_settings_override.py
+++ b/snuba/query/processors/physical/clickhouse_settings_override.py
@@ -3,6 +3,7 @@ from typing import Any, MutableMapping
 from snuba.clickhouse.query import Query
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
+from snuba.state import get_str_config
 
 
 class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
@@ -39,4 +40,13 @@ class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
         else:
             new_settings.update(self.__settings)
             new_settings.update(query_settings.get_clickhouse_settings())
+
+        if get_str_config("ignore_clickhouse_settings_override", default=""):
+            ignored_settings = get_str_config("ignore_clickhouse_settings_override")
+            new_settings = {
+                setting: value
+                for setting, value in new_settings.items()
+                if setting not in ignored_settings
+            }
+
         query_settings.set_clickhouse_settings(new_settings)

--- a/tests/query/processors/test_clickhouse_settings_override.py
+++ b/tests/query/processors/test_clickhouse_settings_override.py
@@ -2,6 +2,7 @@ from typing import Any, MutableMapping
 
 import pytest
 
+from snuba import state
 from snuba.clickhouse.columns import ColumnSet, DateTime
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String
@@ -29,7 +30,7 @@ tests = [
 @pytest.mark.parametrize("clickhouse_settings", tests)
 @pytest.mark.redis_db
 def test_apply_clickhouse_settings(
-    clickhouse_settings: MutableMapping[str, Any]
+    clickhouse_settings: MutableMapping[str, Any],
 ) -> None:
     query = Query(
         Table(
@@ -83,6 +84,60 @@ def test_per_query_settings() -> None:
 
     initial_settings = {"initial_setting": "true", "overridden_setting": "1"}
     overrides = {"overridden_setting": "2", "max_rows_to_group_by": 1000000}
+
+    # create initial settings for the query
+    settings = HTTPQuerySettings()
+    settings.set_clickhouse_settings(initial_settings)
+
+    # apply the overrides (for the entire dataset)
+    ClickhouseSettingsOverride(overrides).process_query(query, settings)
+
+    expected = {
+        "initial_setting": "true",
+        "overridden_setting": "2",
+        "max_rows_to_group_by": 1000000,
+    }
+    assert settings.get_clickhouse_settings() == expected
+
+
+@pytest.mark.redis_db
+def test_ignore_clickhouse_settings_overrides() -> None:
+    state.set_config(
+        "ignore_clickhouse_settings_override",
+        "max_execution_time,timeout_overflow_mode",
+    )
+    query = Query(
+        Table(
+            "discover",
+            ColumnSet(
+                [
+                    ("timestamp", DateTime()),
+                    ("mismatched1", String(Modifiers(nullable=True))),
+                    ("mismatched2", String(Modifiers(nullable=True))),
+                ]
+            ),
+            storage_key=StorageKey("dontmatter"),
+        ),
+        selected_columns=[
+            SelectedExpression(
+                name="_snuba_count_unique_sdk_version",
+                expression=FunctionCall(
+                    None, "uniq", (Column(None, None, "mismatched1"),)
+                ),
+            )
+        ],
+    )
+
+    initial_settings = {
+        "initial_setting": "true",
+        "overridden_setting": "1",
+        "max_execution_time": 30,
+    }
+    overrides = {
+        "overridden_setting": "2",
+        "max_rows_to_group_by": 1000000,
+        "timeout_overflow_mode": "break",
+    }
 
     # create initial settings for the query
     settings = HTTPQuerySettings()


### PR DESCRIPTION
Allow us to ignore clickhouse override settings - going to use this to test out some clickhouse query settings in S4S for EAP cluster. This is a temporary change, but I didn't want to change the yaml config for EAP since that would affect all regions