### PR TITLE
fix(eap): Improve performance by using a DISTINCT instead of a LIMIT BY

### DIFF
--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -510,7 +510,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
         )
         trace_ids: list[str] = []
         for row in results.result.get("data", []):
-            trace_ids.append(row["trace_id"])
+            trace_ids.append(list(row.values())[0])
         return trace_ids
 
     def _get_metadata_for_traces(

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -22,7 +22,7 @@ from snuba.attribution.attribution_info import AttributionInfo
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
-from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import (
@@ -497,7 +497,6 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                     expression=column("timestamp"),
                 ),
             ],
-            limitby=LimitBy(limit=1, columns=[column("trace_id")]),
             limit=request.limit if request.limit > 0 else _DEFAULT_ROW_LIMIT,
             offset=request.page_token.offset,
         )


### PR DESCRIPTION
Using `LIMIT BY` was creating performance issues, using `DISTINCT` doesn't.

We need to remove the optimization with the `timestamp` values but since we have a `trace_id` bloom filter index, it shouldn't have too much impact as long as this query uses the index.