### PR TITLE
feat: throw error if duplicate labels are provided in RPC endpoints

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -27,7 +27,6 @@ from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal
 from snuba.query.expressions import Expression
 from snuba.query.logical import Query
-from snuba.query.parser import validate_aliases
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -49,6 +48,7 @@ from snuba.web.rpc.v1.resolvers.common.aggregation import (
     get_confidence_interval_column,
     get_count_column,
 )
+from snuba.web.rpc.v1.resolvers.common.common import validate_aliases
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.sampling_in_storage_util import (
     run_query_to_correct_tier,
 )

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -27,6 +27,7 @@ from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal
 from snuba.query.expressions import Expression
 from snuba.query.logical import Query
+from snuba.query.parser import validate_aliases
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -376,6 +377,7 @@ def build_query(request: TimeSeriesRequest) -> Query:
         ],
     )
     treeify_or_and_conditions(res)
+    validate_aliases(res)
     return res
 
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -255,17 +255,19 @@ def _column_to_expression(column: Column, request_meta: RequestMeta) -> Expressi
             use_sampling_factor(request_meta),
         )
         # aggregation label may not be set and the column label takes priority anyways.
-        if column.label != "":
-            function_expr = replace(function_expr, alias=column.label)
-        else:
+        if column.label == "":
             function_expr = replace(function_expr, alias=None)
+        else:
+            function_expr = replace(function_expr, alias=column.label)
+
         return function_expr
     elif column.HasField("formula"):
         formula_expr = _formula_to_expression(column.formula, request_meta)
-        if column.label != "":
-            formula_expr = replace(formula_expr, alias=column.label)
-        else:
+
+        if column.label == "":
             formula_expr = replace(formula_expr, alias=None)
+        else:
+            formula_expr = replace(formula_expr, alias=column.label)
         return formula_expr
     elif column.HasField("literal"):
         return literal(column.literal.val_double)

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -22,7 +22,6 @@ from snuba.query.dsl import column as snuba_column
 from snuba.query.dsl import literal, or_cond
 from snuba.query.expressions import Expression
 from snuba.query.logical import Query
-from snuba.query.parser import validate_aliases
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -44,6 +43,7 @@ from snuba.web.rpc.v1.resolvers.common.aggregation import (
     get_confidence_interval_column,
     get_count_column,
 )
+from snuba.web.rpc.v1.resolvers.common.common import validate_aliases
 from snuba.web.rpc.v1.resolvers.common.trace_item_table import convert_results
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.sampling_in_storage_util import (
     run_query_to_correct_tier,

--- a/snuba/web/rpc/v1/resolvers/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/common/common.py
@@ -1,12 +1,13 @@
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import LogicalDataSource
 from snuba.query.logical import Query
+from snuba.query.parser import validate_aliases as validate_aliases_parser
 from snuba.query.parser.exceptions import AliasShadowingException
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 
 
 def validate_aliases(query: CompositeQuery[LogicalDataSource] | Query) -> None:
     try:
-        validate_aliases(query)
+        validate_aliases_parser(query)
     except AliasShadowingException as e:
         raise BadSnubaRPCRequestException("duplicate labels detected") from e

--- a/snuba/web/rpc/v1/resolvers/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/common/common.py
@@ -1,0 +1,12 @@
+from snuba.query.composite import CompositeQuery
+from snuba.query.data_source.simple import LogicalDataSource
+from snuba.query.logical import Query
+from snuba.query.parser.exceptions import AliasShadowingException
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+
+
+def validate_aliases(query: CompositeQuery[LogicalDataSource] | Query) -> None:
+    try:
+        validate_aliases(query)
+    except AliasShadowingException as e:
+        raise BadSnubaRPCRequestException("duplicate labels detected") from e

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -40,7 +40,6 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.query.parser.exceptions import AliasShadowingException
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -1789,5 +1788,7 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
         }
         msg = TimeSeriesRequest()
         ParseDict(myreq, msg)
-        with pytest.raises(AliasShadowingException):
+        with pytest.raises(
+            BadSnubaRPCRequestException, match="duplicate labels detected"
+        ):
             EndpointTimeSeries().execute(msg)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from clickhouse_driver.errors import ServerException
+from google.protobuf.json_format import ParseDict
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
     AttributeConditionalAggregation,
@@ -39,6 +40,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query.parser.exceptions import AliasShadowingException
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -1638,3 +1640,154 @@ class TestTimeSeriesApiEAPItems(TestTimeSeriesApi):
             response.meta.downsampled_storage_meta.tier
             != DownsampledStorageMeta.SELECTED_TIER_UNSPECIFIED
         )
+
+    def test_duplicate_labels(self) -> None:
+        """
+        This test ensures that duplicate labels across different expressions
+        raises an exception
+        """
+        myreq = {
+            "meta": {
+                "organizationId": "1",
+                "referrer": "api.organization-event-stats",
+                "projectIds": ["1"],
+                "startTimestamp": "2025-04-08T10:00:00Z",
+                "endTimestamp": "2025-04-08T10:04:00Z",
+                "traceItemType": "TRACE_ITEM_TYPE_SPAN",
+                "downsampledStorageConfig": {},
+            },
+            "granularitySecs": "60",
+            "expressions": [
+                {
+                    "formula": {
+                        "op": "OP_DIVIDE",
+                        "left": {
+                            "conditionalAggregation": {
+                                "aggregate": "FUNCTION_COUNT",
+                                "key": {
+                                    "type": "TYPE_STRING",
+                                    "name": "sentry.status_code",
+                                },
+                                "label": "error_request_count",
+                                "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED",
+                                "filter": {
+                                    "comparisonFilter": {
+                                        "key": {
+                                            "type": "TYPE_STRING",
+                                            "name": "sentry.status_code",
+                                        },
+                                        "op": "OP_IN",
+                                        "value": {
+                                            "valStrArray": {
+                                                "values": [
+                                                    "400",
+                                                    "401",
+                                                    "402",
+                                                    "403",
+                                                    "404",
+                                                    "405",
+                                                    "406",
+                                                    "407",
+                                                    "408",
+                                                    "409",
+                                                    "410",
+                                                    "411",
+                                                    "412",
+                                                    "413",
+                                                    "414",
+                                                    "415",
+                                                    "416",
+                                                    "417",
+                                                    "418",
+                                                    "421",
+                                                    "422",
+                                                    "423",
+                                                    "424",
+                                                    "425",
+                                                    "426",
+                                                    "428",
+                                                    "429",
+                                                    "431",
+                                                    "451",
+                                                ]
+                                            }
+                                        },
+                                    }
+                                },
+                            }
+                        },
+                        "right": {
+                            "aggregation": {
+                                "aggregate": "FUNCTION_COUNT",
+                                "key": {
+                                    "type": "TYPE_STRING",
+                                    "name": "sentry.status_code",
+                                },
+                                "label": "total_request_count",
+                                "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED",
+                            }
+                        },
+                    },
+                    "label": "http_response_rate(4)",
+                },
+                {
+                    "formula": {
+                        "op": "OP_DIVIDE",
+                        "left": {
+                            "conditionalAggregation": {
+                                "aggregate": "FUNCTION_COUNT",
+                                "key": {
+                                    "type": "TYPE_STRING",
+                                    "name": "sentry.status_code",
+                                },
+                                "label": "error_request_count",
+                                "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED",
+                                "filter": {
+                                    "comparisonFilter": {
+                                        "key": {
+                                            "type": "TYPE_STRING",
+                                            "name": "sentry.status_code",
+                                        },
+                                        "op": "OP_IN",
+                                        "value": {
+                                            "valStrArray": {
+                                                "values": [
+                                                    "500",
+                                                    "501",
+                                                    "502",
+                                                    "503",
+                                                    "504",
+                                                    "505",
+                                                    "506",
+                                                    "507",
+                                                    "508",
+                                                    "509",
+                                                    "510",
+                                                    "511",
+                                                ]
+                                            }
+                                        },
+                                    }
+                                },
+                            }
+                        },
+                        "right": {
+                            "aggregation": {
+                                "aggregate": "FUNCTION_COUNT",
+                                "key": {
+                                    "type": "TYPE_STRING",
+                                    "name": "sentry.status_code",
+                                },
+                                "label": "total_request_count",
+                                "extrapolationMode": "EXTRAPOLATION_MODE_SAMPLE_WEIGHTED",
+                            }
+                        },
+                    },
+                    "label": "http_response_rate(5)",
+                },
+            ],
+        }
+        msg = TimeSeriesRequest()
+        ParseDict(myreq, msg)
+        with pytest.raises(AliasShadowingException):
+            EndpointTimeSeries().execute(msg)


### PR DESCRIPTION
this makes it timeseries and itemtable endpoints throw BadSnubaRPCException if there are duplicate labels in the request. previously there was no error and it was just causing unexpected results for users.

see: https://github.com/getsentry/eap-planning/issues/242

this resolves https://github.com/getsentry/eap-planning/issues/244