### PR TITLE
chore(eap): Bump _MAX_BUCKETS_IN_REQUEST to 2688

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -36,8 +36,8 @@ _VALID_GRANULARITY_SECS = set(
     ]
 )
 
-# MAX 5 minute granularity over 7 days
-_MAX_BUCKETS_IN_REQUEST = 2016
+# MAX 15 minute granularity over 28 days
+_MAX_BUCKETS_IN_REQUEST = 2688
 
 
 def _enforce_no_duplicate_labels(request: TimeSeriesRequest) -> None:


### PR DESCRIPTION
This is to enable anomaly detection on span alerts. Seer requires 28 days of historical data at the interval requested (smallest allowed interval is 15 minutes). We'll need `28 * 24 * 4 = 2688` buckets.