### PR TITLE
feat(storage-routing): NORMAL mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-rapidjson==1.8
 redis==4.5.4
 sentry-arroyo==2.22.0
 sentry-kafka-schemas==1.2.0
-sentry-protos==0.1.70
+sentry-protos==0.1.72
 sentry-redis-tools==0.3.0
 sentry-relay==0.9.5
 sentry-sdk==2.18.0

--- a/snuba/web/rpc/common/debug_info.py
+++ b/snuba/web/rpc/common/debug_info.py
@@ -32,6 +32,7 @@ def _construct_meta_if_downsampled(
                 DownsampledStorageMeta.SelectedTier,
                 "SELECTED_" + highest_sampling_tier.name,
             ),
+            can_go_to_higher_accuracy_tier=highest_sampling_tier != Tier.TIER_1,
         )
         if highest_sampling_tier != Tier.TIER_NO_TIER
         else None

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
@@ -275,31 +275,37 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
         assert routing_context.query_result
         target_tier = routing_context.query_settings.get_sampling_tier()
         query_duration_ms = self._get_query_duration_ms(routing_context.query_result)
-        if (
-            query_duration_ms
-            >= self._get_time_budget_ms() - 0.02 * self._get_time_budget_ms()
-        ):
+        if query_duration_ms >= 0.98 * self._get_time_budget_ms():
             self.metrics.increment(
                 "timeout_overflow_mode_was_hit",
                 1,
                 {"tier": str(target_tier)},
             )
 
-        if self._is_normal_mode(routing_context):
-            self._emit_estimation_error_info(
-                routing_context, {"tier": str(target_tier)}
-            )
-            self._record_value_in_span_and_DD(
-                routing_context,
-                self.metrics.distribution,
-                f"actual_bytes_scanned_in_target_tier_{target_tier}",
-                self._get_query_bytes_scanned(routing_context.query_result),
-                tags={"tier": str(target_tier)},
-            )
-            self._record_value_in_span_and_DD(
-                routing_context,
-                self.metrics.timing,
-                f"time_to_run_query_in_target_tier_{target_tier}",
-                self._get_query_duration_ms(routing_context.query_result),
-                tags={"tier": str(target_tier)},
+        self._emit_estimation_error_info(routing_context, {"tier": str(target_tier)})
+        self._record_value_in_span_and_DD(
+            routing_context,
+            self.metrics.distribution,
+            f"actual_bytes_scanned_in_target_tier_{target_tier}",
+            self._get_query_bytes_scanned(routing_context.query_result),
+            tags={"tier": str(target_tier)},
+        )
+        self._record_value_in_span_and_DD(
+            routing_context,
+            self.metrics.timing,
+            f"time_to_run_query_in_target_tier_{target_tier}",
+            query_duration_ms,
+            tags={"tier": str(target_tier)},
+        )
+
+        if (
+            target_tier != Tier.TIER_1
+            and (self._get_time_budget_ms() - query_duration_ms)
+            / self._get_time_budget_ms()
+            >= 0.2
+        ):
+            self.metrics.increment(
+                "query_should_run_on_higher_accuracy_tier",
+                1,
+                {"tier": str(target_tier)},
             )

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
@@ -33,15 +33,11 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
     def _get_time_budget_ms(self) -> float:
         sentry_timeout_ms = cast(
             int,
-            state.get_int_config(
-                _SAMPLING_IN_STORAGE_PREFIX + "sentry_timeout", default=30000
-            ),
+            state.get_int_config(self.config_key() + "_sentry_timeout", default=30000),
         )  # 30s = 30000ms
         error_budget_ms = cast(
             int,
-            state.get_int_config(
-                _SAMPLING_IN_STORAGE_PREFIX + "error_budget", default=5000
-            ),
+            state.get_int_config(self.config_key() + "_error_budget", default=5000),
         )  # 5s = 5000ms
         return sentry_timeout_ms - error_budget_ms
 
@@ -97,7 +93,7 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
         return cast(
             int,
             state.get_int_config(
-                _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+                self.config_key() + "_bytes_scanned_per_query_limit",
                 default=161061273600,
             ),
         )

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
@@ -258,14 +258,14 @@ class NormalModeLinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
             self._record_value_in_span_and_DD(
                 routing_context,
                 self.metrics.distribution,
-                f"actual_bytes_scanned_in_target_tier_{target_tier}",
+                "actual_bytes_scanned_in_target_tier",
                 self._get_query_bytes_scanned(routing_context.query_result),
                 tags={"tier": str(target_tier)},
             )
             self._record_value_in_span_and_DD(
                 routing_context,
                 self.metrics.timing,
-                f"time_to_run_query_in_target_tier_{target_tier}",
+                "time_to_run_query_in_target_tier",
                 query_duration_ms,
                 tags={"tier": str(target_tier)},
             )

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
@@ -32,8 +32,8 @@ class NormalModeLinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
     def _get_time_budget_ms(self) -> float:
         sentry_timeout_ms = cast(
             int,
-            state.get_int_config(self.config_key() + "_sentry_timeout", default=5000),
-        )  # 5s
+            state.get_int_config(self.config_key() + "_sentry_timeout", default=8000),
+        )  # 8s
         error_budget_ms = cast(
             int,
             state.get_int_config(self.config_key() + "_error_budget", default=500),

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
@@ -1,0 +1,310 @@
+from dataclasses import asdict
+from typing import Any, Callable, Dict, Optional, TypeAlias, Union, cast
+
+import sentry_sdk
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+from sentry_sdk.tracing import Span
+
+from snuba import state
+from snuba.datasets.pluggable_dataset import PluggableDataset
+from snuba.downsampled_storage_tiers import Tier
+from snuba.utils.metrics.util import with_span
+from snuba.web import QueryResult
+from snuba.web.query import run_query
+from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.storage_routing import (
+    BaseRoutingStrategy,
+    ClickhouseQuerySettings,
+    RoutingContext,
+)
+
+_SAMPLING_IN_STORAGE_PREFIX = "sampling_in_storage_"
+_DOWNSAMPLING_TIER_MULTIPLIERS: Dict[Tier, int] = {
+    Tier.TIER_512: 1,
+    Tier.TIER_64: 8,
+    Tier.TIER_8: 64,
+    Tier.TIER_1: 512,
+}
+MetricsBackendType: TypeAlias = Callable[
+    [str, Union[int, float], Optional[Dict[str, str]], Optional[str]], None
+]
+
+
+class NormalModeLinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
+    def _get_time_budget_ms(self) -> float:
+        sentry_timeout_ms = cast(
+            int,
+            state.get_int_config(
+                _SAMPLING_IN_STORAGE_PREFIX + "sentry_timeout", default=5000
+            ),
+        )  # 5s
+        error_budget_ms = cast(
+            int,
+            state.get_int_config(
+                _SAMPLING_IN_STORAGE_PREFIX + "error_budget", default=500
+            ),
+        )  # 0.5s
+        return sentry_timeout_ms - error_budget_ms
+
+    def _get_most_downsampled_tier(self) -> Tier:
+        return Tier.TIER_64
+
+    def _get_multiplier(self, tier: Tier) -> int:
+        return int(
+            _DOWNSAMPLING_TIER_MULTIPLIERS[tier]
+            / _DOWNSAMPLING_TIER_MULTIPLIERS[self._get_most_downsampled_tier()]
+        )
+
+    def _is_normal_mode(self, routing_context: RoutingContext) -> bool:
+        if not routing_context.in_msg.meta.HasField("downsampled_storage_config"):
+            return False
+        mode = routing_context.in_msg.meta.downsampled_storage_config.mode
+        return (
+            mode == DownsampledStorageConfig.MODE_NORMAL
+            or mode == DownsampledStorageConfig.MODE_PREFLIGHT
+            or mode == DownsampledStorageConfig.MODE_BEST_EFFORT
+        )
+
+    def _exclude_user_data_from_res(self, res: QueryResult) -> Dict[str, Any]:
+        result_dict = asdict(res)
+        result_dict["result"] = {
+            k: v for k, v in result_dict["result"].items() if k != "data"
+        }
+        return result_dict
+
+    def _get_query_bytes_scanned(
+        self, res: QueryResult, span: Span | None = None
+    ) -> int:
+        profile_dict = res.result.get("profile") or {}
+        progress_bytes = profile_dict.get("progress_bytes")
+
+        if progress_bytes is not None:
+            return cast(int, progress_bytes)
+
+        error_type = (
+            "QueryResult_contains_no_profile"
+            if profile_dict is None
+            else "QueryResult_contains_no_progress_bytes"
+        )
+        res_without_user_data = self._exclude_user_data_from_res(res)
+        sentry_sdk.capture_message(
+            f"{error_type}: {res_without_user_data}", level="error"
+        )
+        if span:
+            span.set_data(error_type, res_without_user_data)
+        return 0
+
+    def _get_query_duration_ms(self, res: QueryResult) -> float:
+        return cast(float, res.result.get("profile", {}).get("elapsed", 0) * 1000)  # type: ignore
+
+    def _get_bytes_scanned_limit(self) -> int:
+        return cast(
+            int,
+            state.get_int_config(
+                _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+                default=161061273600,
+            ),
+        )
+
+    def _get_target_tier(
+        self,
+        most_downsampled_tier_query_result: QueryResult,
+        routing_context: RoutingContext,
+    ) -> Tier:
+        estimated_query_bytes_scanned_to_this_tier = -1
+        with sentry_sdk.start_span(op="_get_target_tier") as span:
+            most_downsampled_tier_query_bytes_scanned = self._get_query_bytes_scanned(
+                most_downsampled_tier_query_result, span
+            )
+
+            span.set_data(
+                _SAMPLING_IN_STORAGE_PREFIX + "most_downsampled_query_bytes_scanned",
+                most_downsampled_tier_query_bytes_scanned,
+            )
+
+            target_tier = self._get_most_downsampled_tier()
+            estimated_target_tier_bytes_scanned = (
+                most_downsampled_tier_query_bytes_scanned
+                * self._get_multiplier(target_tier)
+            )
+            for tier in sorted(Tier, reverse=True)[:-1]:
+                with sentry_sdk.start_span(
+                    op=f"_get_target_tier.Tier_{tier}"
+                ) as tier_specific_span:
+                    estimated_query_bytes_scanned_to_this_tier = (
+                        most_downsampled_tier_query_bytes_scanned
+                        * self._get_multiplier(tier)
+                    )
+                    self._record_value_in_span_and_DD(
+                        routing_context,
+                        self.metrics.distribution,
+                        "estimated_query_bytes_scanned_to_this_tier",
+                        estimated_query_bytes_scanned_to_this_tier,
+                        {"tier": str(tier)},
+                    )
+                    bytes_scanned_limit = self._get_bytes_scanned_limit()
+                    if (
+                        estimated_query_bytes_scanned_to_this_tier
+                        <= bytes_scanned_limit
+                    ):
+                        target_tier = tier
+                        estimated_target_tier_bytes_scanned = (
+                            estimated_query_bytes_scanned_to_this_tier
+                        )
+                    tier_specific_span.set_data(
+                        _SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier
+                    )
+                    tier_specific_span.set_data(
+                        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_limit",
+                        bytes_scanned_limit,
+                    )
+            self.metrics.increment(
+                _SAMPLING_IN_STORAGE_PREFIX + "target_tier",
+                1,
+                {"tier": str(target_tier)},
+            )
+            span.set_data(_SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier)
+            span.set_data(
+                _SAMPLING_IN_STORAGE_PREFIX + "estimated_target_tier_bytes_scanned",
+                estimated_target_tier_bytes_scanned,
+            )
+            routing_context.extra_info[
+                "estimated_target_tier_bytes_scanned"
+            ] = estimated_target_tier_bytes_scanned
+            return target_tier
+
+    def _run_query_on_most_downsampled_tier(
+        self, routing_context: RoutingContext
+    ) -> QueryResult:
+        with sentry_sdk.start_span(op="_run_query_on_most_downsampled_tier") as span:
+            routing_context.query_settings.set_sampling_tier(
+                self._get_most_downsampled_tier()
+            )
+            request_to_most_downsampled_tier = self._build_snuba_request(
+                routing_context
+            )
+            res = run_query(
+                dataset=PluggableDataset(name="eap", all_entities=[]),
+                request=request_to_most_downsampled_tier,
+                timer=routing_context.timer,
+            )
+
+            most_downsampled_query_bytes_scanned = self._get_query_bytes_scanned(res)
+            if most_downsampled_query_bytes_scanned == 0:
+                self.metrics.increment(
+                    "scanned_zero_bytes_in_most_downsampled_tier",
+                    1,
+                    {"tier": str(self._get_most_downsampled_tier())},
+                )
+
+            self._record_value_in_span_and_DD(
+                routing_context,
+                self.metrics.timing,
+                "query_bytes_scanned_from_most_downsampled_tier",
+                self._get_query_bytes_scanned(res, span),
+            )
+            return res
+
+    @with_span(op="function")
+    def _decide_tier_and_query_settings(
+        self, routing_context: RoutingContext
+    ) -> tuple[Tier, ClickhouseQuerySettings]:
+        if (
+            not routing_context.in_msg.meta.HasField("downsampled_storage_config")
+            or routing_context.in_msg.meta.downsampled_storage_config.mode
+            == DownsampledStorageConfig.MODE_UNSPECIFIED
+        ):
+            return Tier.TIER_1, {}
+
+        routing_context.query_result = self._run_query_on_most_downsampled_tier(
+            routing_context
+        )
+
+        query_settings = {
+            "max_execution_time": self._get_time_budget_ms() / 1000,
+            "timeout_overflow_mode": "break",
+        }
+
+        return (
+            self._get_target_tier(routing_context.query_result, routing_context),
+            query_settings,
+        )
+
+    def _emit_routing_mistake(self, mistake_reason: str, tags: Dict[str, str]) -> None:
+        self.metrics.increment(mistake_reason, 1, tags)
+
+    def _emit_estimation_error_info(
+        self,
+        routing_context: RoutingContext,
+        tags: Dict[str, str],
+    ) -> None:
+        assert routing_context.query_result
+        actual = self._get_query_bytes_scanned(routing_context.query_result)
+        if actual == 0:
+            self.metrics.increment(
+                "scanned_zero_bytes_in_target_tier",
+                1,
+                tags,
+            )
+            return
+
+        estimated = routing_context.extra_info.get(
+            "estimated_target_tier_bytes_scanned"
+        )
+        if estimated is None:
+            return
+
+        error = estimated - actual
+        error_pct = abs(error) / actual
+
+        self._record_value_in_span_and_DD(
+            routing_context,
+            self.metrics.distribution,
+            "estimation_error_percentage",
+            error_pct,
+            tags,
+        )
+        self._record_value_in_span_and_DD(
+            routing_context,
+            self.metrics.distribution,
+            "over_estimation_error" if error > 0 else "under_estimation_error",
+            abs(error),
+            tags,
+        )
+
+    def _output_metrics(self, routing_context: RoutingContext) -> None:
+        assert routing_context.query_result
+        target_tier = routing_context.query_settings.get_sampling_tier()
+        query_duration_ms = self._get_query_duration_ms(routing_context.query_result)
+        tags = {"tier": str(target_tier)}
+
+        if query_duration_ms >= 0.98 * self._get_time_budget_ms():
+            self._emit_routing_mistake("timeout_overflow_mode_was_hit", tags)
+
+        if self._is_normal_mode(routing_context):
+            self._emit_estimation_error_info(
+                routing_context, {"tier": str(target_tier)}
+            )
+            self._record_value_in_span_and_DD(
+                routing_context,
+                self.metrics.distribution,
+                f"actual_bytes_scanned_in_target_tier_{target_tier}",
+                self._get_query_bytes_scanned(routing_context.query_result),
+                tags={"tier": str(target_tier)},
+            )
+            self._record_value_in_span_and_DD(
+                routing_context,
+                self.metrics.timing,
+                f"time_to_run_query_in_target_tier_{target_tier}",
+                query_duration_ms,
+                tags={"tier": str(target_tier)},
+            )
+
+            if (
+                target_tier != Tier.TIER_1
+                and (self._get_time_budget_ms() - query_duration_ms)
+                / self._get_time_budget_ms()
+                >= 0.2
+            ):
+                self._emit_routing_mistake(
+                    "query_should_run_on_higher_accuracy_tier", tags
+                )

--- a/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
@@ -7,7 +7,6 @@ from snuba.downsampled_storage_tiers import Tier
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.linear_bytes_scanned_storage_routing import (
-    _SAMPLING_IN_STORAGE_PREFIX,
     LinearBytesScannedRoutingStrategy,
 )
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.storage_routing import (
@@ -36,7 +35,7 @@ def test_get_target_tier(
     context = RoutingContext(MagicMock(), timer, MagicMock(), MagicMock())
 
     state.set_config(
-        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+        "LinearBytesScannedRoutingStrategy_bytes_scanned_per_query_limit",
         bytes_scanned_limit,
     )
     target_tier = strategy._get_target_tier(
@@ -57,7 +56,7 @@ def test_target_tier_is_1_if_most_downsampled_query_bytes_scanned_is_0() -> None
     context = RoutingContext(MagicMock(), timer, MagicMock(), MagicMock())
 
     state.set_config(
-        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+        "LinearBytesScannedRoutingStrategy_bytes_scanned_per_query_limit",
         10000,
     )
     target_tier = strategy._get_target_tier(

--- a/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
@@ -8,7 +8,6 @@ from snuba.downsampled_storage_tiers import Tier
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.normal_mode_linear_bytes_scanned import (
-    _SAMPLING_IN_STORAGE_PREFIX,
     NormalModeLinearBytesScannedRoutingStrategy,
 )
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.storage_routing import (
@@ -37,7 +36,7 @@ def test_get_target_tier(
     context = RoutingContext(MagicMock(), timer, MagicMock(), MagicMock())
 
     state.set_config(
-        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+        "NormalModeLinearBytesScannedRoutingStrategy_bytes_scanned_per_query_limit",
         bytes_scanned_limit,
     )
     target_tier = strategy._get_target_tier(
@@ -58,7 +57,7 @@ def test_target_tier_is_1_if_most_downsampled_query_bytes_scanned_is_0() -> None
     context = RoutingContext(MagicMock(), timer, MagicMock(), MagicMock())
 
     state.set_config(
-        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+        "NormalModeLinearBytesScannedRoutingStrategy_bytes_scanned_per_query_limit",
         10000,
     )
     target_tier = strategy._get_target_tier(

--- a/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+
+from snuba import state
+from snuba.downsampled_storage_tiers import Tier
+from snuba.utils.metrics.timer import Timer
+from snuba.web import QueryResult
+from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.normal_mode_linear_bytes_scanned import (
+    _SAMPLING_IN_STORAGE_PREFIX,
+    NormalModeLinearBytesScannedRoutingStrategy,
+)
+from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.storage_routing import (
+    RoutingContext,
+)
+
+
+@pytest.mark.redis_db
+@pytest.mark.parametrize(
+    "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier, expected_estimated_bytes_scanned",
+    [
+        (100, 200, Tier.TIER_64, 100),
+        (100, 900, Tier.TIER_8, 800),
+        (100, 6500, Tier.TIER_1, 6400),
+        (100, 51300, Tier.TIER_1, 6400),
+    ],
+)
+def test_get_target_tier(
+    most_downsampled_query_bytes_scanned: int,
+    bytes_scanned_limit: int,
+    expected_tier: Tier,
+    expected_estimated_bytes_scanned: int,
+) -> None:
+    timer = MagicMock(spec=Timer)
+    strategy = NormalModeLinearBytesScannedRoutingStrategy()
+    context = RoutingContext(MagicMock(), timer, MagicMock(), MagicMock())
+
+    state.set_config(
+        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+        bytes_scanned_limit,
+    )
+    target_tier = strategy._get_target_tier(
+        most_downsampled_tier_query_result=QueryResult(result={"profile": {"progress_bytes": most_downsampled_query_bytes_scanned}}, extra={}),  # type: ignore
+        routing_context=context,
+    )
+    assert target_tier == expected_tier
+    assert (
+        context.extra_info["estimated_target_tier_bytes_scanned"]
+        == expected_estimated_bytes_scanned
+    )
+
+
+@pytest.mark.redis_db
+def test_target_tier_is_1_if_most_downsampled_query_bytes_scanned_is_0() -> None:
+    timer = MagicMock(spec=Timer)
+    strategy = NormalModeLinearBytesScannedRoutingStrategy()
+    context = RoutingContext(MagicMock(), timer, MagicMock(), MagicMock())
+
+    state.set_config(
+        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_per_query_limit",
+        10000,
+    )
+    target_tier = strategy._get_target_tier(
+        most_downsampled_tier_query_result=QueryResult(result={"profile": {"progress_bytes": 0}}, extra={}),  # type: ignore
+        routing_context=context,
+    )
+    assert target_tier == Tier.TIER_1
+
+
+def test_preflight_and_best_effort_mode_are_normal_mode() -> None:
+    timer = MagicMock(spec=Timer)
+    strategy = NormalModeLinearBytesScannedRoutingStrategy()
+    context = RoutingContext(MagicMock(), timer, MagicMock(), MagicMock())
+
+    context.in_msg.meta.downsampled_storage_config.mode = (
+        DownsampledStorageConfig.MODE_PREFLIGHT
+    )
+    assert strategy._is_normal_mode(context)
+
+    context.in_msg.meta.downsampled_storage_config.mode = (
+        DownsampledStorageConfig.MODE_BEST_EFFORT
+    )
+    assert strategy._is_normal_mode(context)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1312,7 +1312,89 @@ class TestTimeSeriesApi(BaseApiTest):
             expected_formula_timeseries,
         ]
 
-    def test_normal_mode_route_to_tier_64(self) -> None:
+    def test_preflight(self) -> None:
+        # store a a test metric with a value of 1, every second of one hour
+        granularity_secs = 3600
+        query_duration = granularity_secs * 1
+        store_spans_timeseries(
+            BASE_TIME,
+            1,
+            query_duration,
+            metrics=[DummyMetric("test_preflight_metric", get_value=lambda x: 1)],
+        )
+
+        aggregations = [
+            AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM,
+                key=AttributeKey(
+                    type=AttributeKey.TYPE_FLOAT, name="test_preflight_metric"
+                ),
+                label="sum",
+                extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+            ),
+        ]
+
+        preflight_message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_PREFLIGHT
+                ),
+            ),
+            aggregations=aggregations,
+            granularity_secs=granularity_secs,
+        )
+
+        message_to_non_downsampled_tier = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            aggregations=aggregations,
+            granularity_secs=granularity_secs,
+        )
+
+        preflight_response = EndpointTimeSeries().execute(preflight_message)
+        non_downsampled_tier_response = EndpointTimeSeries().execute(
+            message_to_non_downsampled_tier
+        )
+
+        if preflight_response.result_timeseries == []:
+            sum_of_preflight_metric = 0.0
+        else:
+            sum_of_preflight_metric = (
+                preflight_response.result_timeseries[0].data_points[0].data
+            )
+
+        assert (
+            sum_of_preflight_metric
+            < non_downsampled_tier_response.result_timeseries[0].data_points[0].data
+            / 10
+        )
+        assert (
+            preflight_response.meta.downsampled_storage_meta
+            == DownsampledStorageMeta(
+                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64,
+                can_go_to_higher_accuracy_tier=True,
+            )
+        )
+
+    def test_best_effort_route_to_tier_64(self) -> None:
         # store a a test metric with a value of 1, every second of one hour
         granularity_secs = 3600
         query_duration = granularity_secs * 1

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3166,7 +3166,77 @@ class TestTraceItemTable(BaseApiTest):
             AttributeValue(val_str="a") for _ in range(10)
         ] + [AttributeValue(val_str="default") for _ in range(5)]
 
-    def test_normal_mode_route_to_tier_64(self) -> None:
+    def test_preflight(self) -> None:
+        items_storage = get_storage(StorageKey("eap_items"))
+        msg_timestamp = BASE_TIME - timedelta(minutes=1)
+        messages = [
+            gen_message(
+                msg_timestamp,
+                tags={"preflighttag": "preflight"},
+                randomize_span_id=True,
+            )
+            for _ in range(3600)
+        ]
+        write_raw_unprocessed_events(items_storage, messages)  # type: ignore
+
+        ts = Timestamp(seconds=int(BASE_TIME.timestamp()))
+        hour_ago = int((BASE_TIME - timedelta(hours=1)).timestamp())
+
+        columns = [
+            Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="preflighttag"))
+        ]
+        preflight_message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_PREFLIGHT
+                ),
+            ),
+            columns=columns,
+        )
+
+        message_to_non_downsampled_tier = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=hour_ago),
+                end_timestamp=ts,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            columns=[
+                Column(
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="preflighttag")
+                )
+            ],
+        )
+
+        preflight_response = EndpointTraceItemTable().execute(preflight_message)
+        non_downsampled_tier_response = EndpointTraceItemTable().execute(
+            message_to_non_downsampled_tier
+        )
+        assert (
+            len(preflight_response.column_values[0].results)
+            < len(non_downsampled_tier_response.column_values[0].results) / 10
+        )
+        assert (
+            preflight_response.meta.downsampled_storage_meta
+            == DownsampledStorageMeta(
+                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64,
+                can_go_to_higher_accuracy_tier=True,
+            )
+        )
+
+    def test_best_effort_route_to_tier_64(self) -> None:
         items_storage = get_storage(StorageKey("eap_items"))
         msg_timestamp = BASE_TIME - timedelta(minutes=1)
         messages = [


### PR DESCRIPTION
The NORMAL query mode is 5 seconds
- EAP will route to whatever tier it needs to in order to facilitate this
- The return payload from EAP will need to inform the client if there exists a higher tier to scan, WITHOUT considering the potential of timeout if the query runs on a higher tier
- Queries on this mode should not time out

We previously had preflight mode and best_effort mode. These are now treated the same as normal mode

More details: https://www.notion.so/sentry/Storage-Routing-Alignment-1d88b10e4b5d8056b921ffd50cb31f59?pvs=4