### PR TITLE
fix(storage-routing): most downsampled query can exceed limit

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
@@ -119,41 +119,38 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
                 most_downsampled_tier_query_bytes_scanned
                 * self._get_multiplier(target_tier)
             )
-            if (
-                most_downsampled_tier_query_bytes_scanned
-                < self._get_bytes_scanned_limit()
-            ):
-                for tier in sorted(Tier, reverse=True)[:-1]:
-                    with sentry_sdk.start_span(
-                        op=f"_get_target_tier.Tier_{tier}"
-                    ) as tier_specific_span:
-                        estimated_query_bytes_scanned_to_this_tier = (
-                            most_downsampled_tier_query_bytes_scanned
-                            * self._get_multiplier(tier)
-                        )
-                        self._record_value_in_span_and_DD(
-                            routing_context,
-                            self.metrics.distribution,
-                            "estimated_query_bytes_scanned_to_this_tier",
-                            estimated_query_bytes_scanned_to_this_tier,
-                            {"tier": str(tier)},
-                        )
-                        bytes_scanned_limit = self._get_bytes_scanned_limit()
-                        if (
+
+            for tier in sorted(Tier, reverse=True)[:-1]:
+                with sentry_sdk.start_span(
+                    op=f"_get_target_tier.Tier_{tier}"
+                ) as tier_specific_span:
+                    estimated_query_bytes_scanned_to_this_tier = (
+                        most_downsampled_tier_query_bytes_scanned
+                        * self._get_multiplier(tier)
+                    )
+                    self._record_value_in_span_and_DD(
+                        routing_context,
+                        self.metrics.distribution,
+                        "estimated_query_bytes_scanned_to_this_tier",
+                        estimated_query_bytes_scanned_to_this_tier,
+                        {"tier": str(tier)},
+                    )
+                    bytes_scanned_limit = self._get_bytes_scanned_limit()
+                    if (
+                        estimated_query_bytes_scanned_to_this_tier
+                        <= bytes_scanned_limit
+                    ):
+                        target_tier = tier
+                        estimated_target_tier_bytes_scanned = (
                             estimated_query_bytes_scanned_to_this_tier
-                            <= bytes_scanned_limit
-                        ):
-                            target_tier = tier
-                            estimated_target_tier_bytes_scanned = (
-                                estimated_query_bytes_scanned_to_this_tier
-                            )
-                        tier_specific_span.set_data(
-                            _SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier
                         )
-                        tier_specific_span.set_data(
-                            _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_limit",
-                            bytes_scanned_limit,
-                        )
+                    tier_specific_span.set_data(
+                        _SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier
+                    )
+                    tier_specific_span.set_data(
+                        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_limit",
+                        bytes_scanned_limit,
+                    )
             self.metrics.increment(
                 _SAMPLING_IN_STORAGE_PREFIX + "target_tier",
                 1,
@@ -218,6 +215,18 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
         routing_context.query_result = self._run_query_on_most_downsampled_tier(
             routing_context
         )
+
+        if (
+            self._get_query_bytes_scanned(routing_context.query_result)
+            >= self._get_bytes_scanned_limit()
+        ):
+            self._record_value_in_span_and_DD(
+                routing_context,
+                self.metrics.increment,
+                "most_downsampled_tier_query_bytes_scanned_exceeds_limit",
+                1,
+            )
+            return self._get_most_downsampled_tier(), {}
 
         query_settings = {
             "max_execution_time": self._get_time_budget_ms() / 1000,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
@@ -119,37 +119,41 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
                 most_downsampled_tier_query_bytes_scanned
                 * self._get_multiplier(target_tier)
             )
-            for tier in sorted(Tier, reverse=True)[:-1]:
-                with sentry_sdk.start_span(
-                    op=f"_get_target_tier.Tier_{tier}"
-                ) as tier_specific_span:
-                    estimated_query_bytes_scanned_to_this_tier = (
-                        most_downsampled_tier_query_bytes_scanned
-                        * self._get_multiplier(tier)
-                    )
-                    self._record_value_in_span_and_DD(
-                        routing_context,
-                        self.metrics.distribution,
-                        "estimated_query_bytes_scanned_to_this_tier",
-                        estimated_query_bytes_scanned_to_this_tier,
-                        {"tier": str(tier)},
-                    )
-                    bytes_scanned_limit = self._get_bytes_scanned_limit()
-                    if (
-                        estimated_query_bytes_scanned_to_this_tier
-                        <= bytes_scanned_limit
-                    ):
-                        target_tier = tier
-                        estimated_target_tier_bytes_scanned = (
-                            estimated_query_bytes_scanned_to_this_tier
+            if (
+                most_downsampled_tier_query_bytes_scanned
+                < self._get_bytes_scanned_limit()
+            ):
+                for tier in sorted(Tier, reverse=True)[:-1]:
+                    with sentry_sdk.start_span(
+                        op=f"_get_target_tier.Tier_{tier}"
+                    ) as tier_specific_span:
+                        estimated_query_bytes_scanned_to_this_tier = (
+                            most_downsampled_tier_query_bytes_scanned
+                            * self._get_multiplier(tier)
                         )
-                    tier_specific_span.set_data(
-                        _SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier
-                    )
-                    tier_specific_span.set_data(
-                        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_limit",
-                        bytes_scanned_limit,
-                    )
+                        self._record_value_in_span_and_DD(
+                            routing_context,
+                            self.metrics.distribution,
+                            "estimated_query_bytes_scanned_to_this_tier",
+                            estimated_query_bytes_scanned_to_this_tier,
+                            {"tier": str(tier)},
+                        )
+                        bytes_scanned_limit = self._get_bytes_scanned_limit()
+                        if (
+                            estimated_query_bytes_scanned_to_this_tier
+                            <= bytes_scanned_limit
+                        ):
+                            target_tier = tier
+                            estimated_target_tier_bytes_scanned = (
+                                estimated_query_bytes_scanned_to_this_tier
+                            )
+                        tier_specific_span.set_data(
+                            _SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier
+                        )
+                        tier_specific_span.set_data(
+                            _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_limit",
+                            bytes_scanned_limit,
+                        )
             self.metrics.increment(
                 _SAMPLING_IN_STORAGE_PREFIX + "target_tier",
                 1,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
@@ -97,41 +97,38 @@ class NormalModeLinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
                 most_downsampled_tier_query_bytes_scanned
                 * self._get_multiplier(target_tier)
             )
-            if (
-                most_downsampled_tier_query_bytes_scanned
-                < self._get_bytes_scanned_limit()
-            ):
-                for tier in sorted(Tier, reverse=True)[:-1]:
-                    with sentry_sdk.start_span(
-                        op=f"_get_target_tier.Tier_{tier}"
-                    ) as tier_specific_span:
-                        estimated_query_bytes_scanned_to_this_tier = (
-                            most_downsampled_tier_query_bytes_scanned
-                            * self._get_multiplier(tier)
-                        )
-                        self._record_value_in_span_and_DD(
-                            routing_context,
-                            self.metrics.distribution,
-                            "estimated_query_bytes_scanned_to_this_tier",
-                            estimated_query_bytes_scanned_to_this_tier,
-                            {"tier": str(tier)},
-                        )
-                        bytes_scanned_limit = self._get_bytes_scanned_limit()
-                        if (
+
+            for tier in sorted(Tier, reverse=True)[:-1]:
+                with sentry_sdk.start_span(
+                    op=f"_get_target_tier.Tier_{tier}"
+                ) as tier_specific_span:
+                    estimated_query_bytes_scanned_to_this_tier = (
+                        most_downsampled_tier_query_bytes_scanned
+                        * self._get_multiplier(tier)
+                    )
+                    self._record_value_in_span_and_DD(
+                        routing_context,
+                        self.metrics.distribution,
+                        "estimated_query_bytes_scanned_to_this_tier",
+                        estimated_query_bytes_scanned_to_this_tier,
+                        {"tier": str(tier)},
+                    )
+                    bytes_scanned_limit = self._get_bytes_scanned_limit()
+                    if (
+                        estimated_query_bytes_scanned_to_this_tier
+                        <= bytes_scanned_limit
+                    ):
+                        target_tier = tier
+                        estimated_target_tier_bytes_scanned = (
                             estimated_query_bytes_scanned_to_this_tier
-                            <= bytes_scanned_limit
-                        ):
-                            target_tier = tier
-                            estimated_target_tier_bytes_scanned = (
-                                estimated_query_bytes_scanned_to_this_tier
-                            )
-                        tier_specific_span.set_data(
-                            _SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier
                         )
-                        tier_specific_span.set_data(
-                            _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_limit",
-                            bytes_scanned_limit,
-                        )
+                    tier_specific_span.set_data(
+                        _SAMPLING_IN_STORAGE_PREFIX + "target_tier", target_tier
+                    )
+                    tier_specific_span.set_data(
+                        _SAMPLING_IN_STORAGE_PREFIX + "bytes_scanned_limit",
+                        bytes_scanned_limit,
+                    )
             self.metrics.increment(
                 _SAMPLING_IN_STORAGE_PREFIX + "target_tier",
                 1,
@@ -193,6 +190,18 @@ class NormalModeLinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
         routing_context.query_result = self._run_query_on_most_downsampled_tier(
             routing_context
         )
+
+        if (
+            self._get_query_bytes_scanned(routing_context.query_result)
+            >= self._get_bytes_scanned_limit()
+        ):
+            self._record_value_in_span_and_DD(
+                routing_context,
+                self.metrics.increment,
+                "most_downsampled_tier_query_bytes_scanned_exceeds_limit",
+                1,
+            )
+            return self._get_most_downsampled_tier(), {}
 
         return (
             self._get_target_tier(routing_context.query_result, routing_context),

--- a/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
@@ -18,6 +18,7 @@ from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.s
 @pytest.mark.parametrize(
     "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier, expected_estimated_bytes_scanned",
     [
+        (100, 99, Tier.TIER_64, 100),
         (100, 200, Tier.TIER_64, 100),
         (100, 900, Tier.TIER_8, 800),
         (100, 6500, Tier.TIER_1, 6400),

--- a/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
@@ -1,11 +1,16 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 
 from snuba import state
 from snuba.downsampled_storage_tiers import Tier
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
+from snuba.web.rpc.v1.resolvers.R_eap_items.resolver_time_series import build_query
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.linear_bytes_scanned_storage_routing import (
     LinearBytesScannedRoutingStrategy,
 )
@@ -18,7 +23,6 @@ from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.s
 @pytest.mark.parametrize(
     "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier, expected_estimated_bytes_scanned",
     [
-        (100, 99, Tier.TIER_64, 100),
         (100, 200, Tier.TIER_64, 100),
         (100, 900, Tier.TIER_8, 800),
         (100, 6500, Tier.TIER_1, 6400),
@@ -48,6 +52,42 @@ def test_get_target_tier(
         context.extra_info["estimated_target_tier_bytes_scanned"]
         == expected_estimated_bytes_scanned
     )
+
+
+@pytest.mark.redis_db
+def test_most_downsampled_tier_query_bytes_scanned_exceeds_limit() -> None:
+    routing_context = RoutingContext(
+        in_msg=TimeSeriesRequest(
+            meta=RequestMeta(
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_BEST_EFFORT
+                )
+            )
+        ),
+        timer=Timer(name="doesntmatter"),
+        build_query=build_query,  # type: ignore
+        query_settings=HTTPQuerySettings(),
+    )
+
+    high_bytes_query_result = QueryResult(
+        result={
+            "profile": {
+                "progress_bytes": 200000000000,
+            }
+        },
+        extra={"stats": {}, "sql": "", "experiments": {}},
+    )
+
+    strategy = LinearBytesScannedRoutingStrategy()
+
+    with patch.object(
+        strategy,
+        "_run_query_on_most_downsampled_tier",
+        return_value=high_bytes_query_result,
+    ):
+        tier, _ = strategy._decide_tier_and_query_settings(routing_context)
+
+        assert tier == Tier.TIER_64
 
 
 @pytest.mark.redis_db

--- a/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_linear_bytes_scanned.py
@@ -68,11 +68,15 @@ def test_most_downsampled_tier_query_bytes_scanned_exceeds_limit() -> None:
         build_query=build_query,  # type: ignore
         query_settings=HTTPQuerySettings(),
     )
+    state.set_config(
+        "LinearBytesScannedRoutingStrategy_bytes_scanned_per_query_limit",
+        99,
+    )
 
     high_bytes_query_result = QueryResult(
         result={
             "profile": {
-                "progress_bytes": 200000000000,
+                "progress_bytes": 100,
             }
         },
         extra={"stats": {}, "sql": "", "experiments": {}},

--- a/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
@@ -1,12 +1,16 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 
 from snuba import state
 from snuba.downsampled_storage_tiers import Tier
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
+from snuba.web.rpc.v1.resolvers.R_eap_items.resolver_time_series import build_query
 from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.normal_mode_linear_bytes_scanned import (
     NormalModeLinearBytesScannedRoutingStrategy,
 )
@@ -19,7 +23,6 @@ from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.s
 @pytest.mark.parametrize(
     "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier, expected_estimated_bytes_scanned",
     [
-        (100, 99, Tier.TIER_64, 100),
         (100, 200, Tier.TIER_64, 100),
         (100, 900, Tier.TIER_8, 800),
         (100, 6500, Tier.TIER_1, 6400),
@@ -49,6 +52,42 @@ def test_get_target_tier(
         context.extra_info["estimated_target_tier_bytes_scanned"]
         == expected_estimated_bytes_scanned
     )
+
+
+@pytest.mark.redis_db
+def test_most_downsampled_tier_query_bytes_scanned_exceeds_limit() -> None:
+    routing_context = RoutingContext(
+        in_msg=TimeSeriesRequest(
+            meta=RequestMeta(
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_BEST_EFFORT
+                )
+            )
+        ),
+        timer=Timer(name="doesntmatter"),
+        build_query=build_query,  # type: ignore
+        query_settings=HTTPQuerySettings(),
+    )
+
+    high_bytes_query_result = QueryResult(
+        result={
+            "profile": {
+                "progress_bytes": 200000000000,
+            }
+        },
+        extra={"stats": {}, "sql": "", "experiments": {}},
+    )
+
+    strategy = NormalModeLinearBytesScannedRoutingStrategy()
+
+    with patch.object(
+        strategy,
+        "_run_query_on_most_downsampled_tier",
+        return_value=high_bytes_query_result,
+    ):
+        tier, _ = strategy._decide_tier_and_query_settings(routing_context)
+
+        assert tier == Tier.TIER_64
 
 
 @pytest.mark.redis_db

--- a/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
@@ -19,6 +19,7 @@ from snuba.web.rpc.v1.resolvers.R_eap_items.storage_routing.routing_strategies.s
 @pytest.mark.parametrize(
     "most_downsampled_query_bytes_scanned, bytes_scanned_limit, expected_tier, expected_estimated_bytes_scanned",
     [
+        (100, 99, Tier.TIER_64, 100),
         (100, 200, Tier.TIER_64, 100),
         (100, 900, Tier.TIER_8, 800),
         (100, 6500, Tier.TIER_1, 6400),

--- a/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
+++ b/tests/web/rpc/v1/routing_strategies/test_normal_mode_linear_bytes_scanned.py
@@ -69,10 +69,15 @@ def test_most_downsampled_tier_query_bytes_scanned_exceeds_limit() -> None:
         query_settings=HTTPQuerySettings(),
     )
 
+    state.set_config(
+        "NormalModeLinearBytesScannedRoutingStrategy_bytes_scanned_per_query_limit",
+        99,
+    )
+
     high_bytes_query_result = QueryResult(
         result={
             "profile": {
-                "progress_bytes": 200000000000,
+                "progress_bytes": 100,
             }
         },
         extra={"stats": {}, "sql": "", "experiments": {}},


### PR DESCRIPTION
If a query to the most downsampled tier already exceeds the bytes scanned limit, then don't re-route it