### PR TITLE
ref(INC-1119): add metrics and tokio timeout

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/batch.rs
+++ b/rust_snuba/src/strategies/clickhouse/batch.rs
@@ -6,6 +6,7 @@ use std::mem;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::task::JoinHandle;
+use tokio::time::timeout;
 use tokio::time::{sleep, Duration};
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -125,11 +126,14 @@ impl BatchFactory {
         let client = self.client.clone();
 
         let result_handle = self.handle.spawn(async move {
+            let sleep_time = 0;
             while receiver.is_empty() && !receiver.is_closed() {
                 // continously check on the receiver stream, only when it's
                 // not empty do we write to clickhouse
+                sleep_time += 800;
                 sleep(Duration::from_millis(800)).await;
             }
+            gauge!("rust_consumer.receiver_sleep_time_ms", sleep_time as u64);
 
             if !receiver.is_empty() {
                 // only make the request to clickhouse if there is data
@@ -233,7 +237,10 @@ impl HttpBatch {
         // finish stream
         drop(self.sender.take());
         if let Some(handle) = self.result_handle.take() {
-            handle.await??;
+            // timeout on writing a batch to clickhouse after 2 minutes
+            if let Err(_) = timeout(Duration::from_millis(120000), handle).await {
+                anyhow::bail!("Timedout writing to clickhouse");
+            }
             Ok(true)
         } else {
             Ok(false)

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -46,8 +46,9 @@ impl TaskRunner<BytesInsertBatch<HttpBatch>, BytesInsertBatch<()>, anyhow::Error
 
             let write_start = SystemTime::now();
 
-            tracing::debug!("performing write");
+            tracing::info!("performing write");
             http_batch.finish().await.map_err(RunTaskError::Other)?;
+            tracing::info!("finished performing write");
 
             let write_finish = SystemTime::now();
 

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -46,9 +46,13 @@ impl TaskRunner<BytesInsertBatch<HttpBatch>, BytesInsertBatch<()>, anyhow::Error
 
             let write_start = SystemTime::now();
 
-            tracing::info!("performing write");
+            tracing::info!("performing write of {} rows {} bytes", num_rows, num_bytes);
             http_batch.finish().await.map_err(RunTaskError::Other)?;
-            tracing::info!("finished performing write");
+            tracing::info!(
+                "finished performing write of {} rows {} bytes",
+                num_rows,
+                num_bytes
+            );
 
             let write_finish = SystemTime::now();
 


### PR DESCRIPTION
* add more metrics to see if it's possible that we are getting stuck waiting while the channel is empty but open
* attempt to add a timeout to joinhandle for writing to clickhouse using [tokio](https://docs.rs/tokio/1.4.0/tokio/index.html)::[time](https://docs.rs/tokio/1.4.0/tokio/time/index.html)::[timeout](https://docs.rs/tokio/1.4.0/tokio/time/fn.timeout.html)