### PR TITLE
feat(storage-routing): dont emit tier

### DIFF
--- a/snuba/web/rpc/common/debug_info.py
+++ b/snuba/web/rpc/common/debug_info.py
@@ -28,10 +28,6 @@ def _construct_meta_if_downsampled(
 
     return (
         DownsampledStorageMeta(
-            tier=getattr(
-                DownsampledStorageMeta.SelectedTier,
-                "SELECTED_" + highest_sampling_tier.name,
-            ),
             can_go_to_higher_accuracy_tier=highest_sampling_tier != Tier.TIER_1,
         )
         if highest_sampling_tier != Tier.TIER_NO_TIER

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1389,7 +1389,6 @@ class TestTimeSeriesApi(BaseApiTest):
         assert (
             preflight_response.meta.downsampled_storage_meta
             == DownsampledStorageMeta(
-                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64,
                 can_go_to_higher_accuracy_tier=True,
             )
         )
@@ -1478,7 +1477,6 @@ class TestTimeSeriesApi(BaseApiTest):
             assert (
                 best_effort_response.meta.downsampled_storage_meta
                 == DownsampledStorageMeta(
-                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64,
                     can_go_to_higher_accuracy_tier=True,
                 )
             )
@@ -1518,11 +1516,7 @@ class TestTimeSeriesApi(BaseApiTest):
             ],
             granularity_secs=granularity_secs,
         )
-        response = EndpointTimeSeries().execute(best_effort_downsample_message)
-        assert (
-            response.meta.downsampled_storage_meta.tier
-            != DownsampledStorageMeta.SELECTED_TIER_UNSPECIFIED
-        )
+        EndpointTimeSeries().execute(best_effort_downsample_message)
 
 
 class TestUtils:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -428,7 +428,7 @@ class TestTraceItemTable(BaseApiTest):
             meta=ResponseMeta(
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
                 downsampled_storage_meta=DownsampledStorageMeta(
-                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_1
+                    can_go_to_higher_accuracy_tier=False,
                 ),
             ),
         )
@@ -517,7 +517,7 @@ class TestTraceItemTable(BaseApiTest):
             meta=ResponseMeta(
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
                 downsampled_storage_meta=DownsampledStorageMeta(
-                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_1
+                    can_go_to_higher_accuracy_tier=False,
                 ),
             ),
         )
@@ -604,7 +604,7 @@ class TestTraceItemTable(BaseApiTest):
             meta=ResponseMeta(
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
                 downsampled_storage_meta=DownsampledStorageMeta(
-                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_1
+                    can_go_to_higher_accuracy_tier=False,
                 ),
             ),
         )
@@ -697,7 +697,7 @@ class TestTraceItemTable(BaseApiTest):
             meta=ResponseMeta(
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
                 downsampled_storage_meta=DownsampledStorageMeta(
-                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_1
+                    can_go_to_higher_accuracy_tier=False,
                 ),
             ),
         )
@@ -3231,7 +3231,6 @@ class TestTraceItemTable(BaseApiTest):
         assert (
             preflight_response.meta.downsampled_storage_meta
             == DownsampledStorageMeta(
-                tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64,
                 can_go_to_higher_accuracy_tier=True,
             )
         )
@@ -3305,7 +3304,6 @@ class TestTraceItemTable(BaseApiTest):
             assert (
                 best_effort_response.meta.downsampled_storage_meta
                 == DownsampledStorageMeta(
-                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_64,
                     can_go_to_higher_accuracy_tier=True,
                 )
             )
@@ -3344,11 +3342,7 @@ class TestTraceItemTable(BaseApiTest):
                 Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="endtoend"))
             ],
         )
-        response = EndpointTraceItemTable().execute(best_effort_message)
-        assert (
-            response.meta.downsampled_storage_meta.tier
-            != DownsampledStorageMeta.SELECTED_TIER_UNSPECIFIED
-        )
+        EndpointTraceItemTable().execute(best_effort_message)
 
     def test_downsampling_uses_hexintcolumnprocessor(self) -> None:
         items_storage = get_storage(StorageKey("eap_items"))

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
@@ -152,7 +152,7 @@ class TestTraceItemTableForLogs(BaseApiTest):
             meta=ResponseMeta(
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
                 downsampled_storage_meta=DownsampledStorageMeta(
-                    tier=DownsampledStorageMeta.SelectedTier.SELECTED_TIER_1
+                    can_go_to_higher_accuracy_tier=False,
                 ),
             ),
         )


### PR DESCRIPTION
We no longer emit which tier the query went to. Clients should use `can_go_to_higher_accuracy_tier`