### PR TITLE
fix: fix duplicate labels in RPC causing incorrect behavior

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -17,11 +17,7 @@ from snuba.web.rpc.proto_visitor import (
     TimeSeriesRequestWrapper,
 )
 from snuba.web.rpc.v1.resolvers import ResolverTimeSeries
-from snuba.web.rpc.v1.visitors.visitor_v2 import (
-    AddAggregateLabelsVisitor,
-    RemoveInnerExpressionLabelsVisitor,
-    ValidateAliasVisitor,
-)
+from snuba.web.rpc.v1.visitors.visitor_v2 import preprocess_expression_labels
 
 _VALID_GRANULARITY_SECS = set(
     [
@@ -138,8 +134,6 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
         if bool(get_int_config("enable_clear_labels_eap", 0)):
-            ValidateAliasVisitor().visit(in_msg)
-            RemoveInnerExpressionLabelsVisitor().visit(in_msg)
-            AddAggregateLabelsVisitor().visit(in_msg)
+            preprocess_expression_labels(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -16,6 +16,10 @@ from snuba.web.rpc.proto_visitor import (
     TimeSeriesRequestWrapper,
 )
 from snuba.web.rpc.v1.resolvers import ResolverTimeSeries
+from snuba.web.rpc.v1.visitors.visitor_v2 import (
+    PrefixLabelsVisitor,
+    ValidateAliasVisitor,
+)
 
 _VALID_GRANULARITY_SECS = set(
     [
@@ -131,7 +135,7 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
-        # ValidateAliasVisitor().visit(in_msg)
-        # PrefixLabelsVisitor().visit(in_msg)
+        ValidateAliasVisitor().visit(in_msg)
+        PrefixLabelsVisitor().visit(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -16,10 +16,6 @@ from snuba.web.rpc.proto_visitor import (
     TimeSeriesRequestWrapper,
 )
 from snuba.web.rpc.v1.resolvers import ResolverTimeSeries
-from snuba.web.rpc.v1.visitors.visitor_v2 import (
-    PrefixLabelsVisitor,
-    ValidateAliasVisitor,
-)
 
 _VALID_GRANULARITY_SECS = set(
     [
@@ -135,7 +131,7 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
-        ValidateAliasVisitor().visit(in_msg)
-        PrefixLabelsVisitor().visit(in_msg)
+        # ValidateAliasVisitor().visit(in_msg)
+        # PrefixLabelsVisitor().visit(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -9,6 +9,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
+from snuba.state import get_int_config
 from snuba.web.rpc import RPCEndpoint, TraceItemDataResolver
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.proto_visitor import (
@@ -136,9 +137,9 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
-        # if bool(get_int_config("enable_clear_labels_eap", 0)):
-        ValidateAliasVisitor().visit(in_msg)
-        RemoveInnerExpressionLabelsVisitor().visit(in_msg)
-        AddAggregateLabelsVisitor().visit(in_msg)
+        if bool(get_int_config("enable_clear_labels_eap", 0)):
+            ValidateAliasVisitor().visit(in_msg)
+            RemoveInnerExpressionLabelsVisitor().visit(in_msg)
+            AddAggregateLabelsVisitor().visit(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -16,6 +16,10 @@ from snuba.web.rpc.proto_visitor import (
     TimeSeriesRequestWrapper,
 )
 from snuba.web.rpc.v1.resolvers import ResolverTimeSeries
+from snuba.web.rpc.v1.visitors.visitor_v2 import (
+    PrefixLabelsVisitor,
+    ValidateAliasVisitor,
+)
 
 _VALID_GRANULARITY_SECS = set(
     [
@@ -131,5 +135,7 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
+        ValidateAliasVisitor().visit(in_msg)
+        PrefixLabelsVisitor().visit(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -9,6 +9,7 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
+from snuba.state import get_int_config
 from snuba.web.rpc import RPCEndpoint, TraceItemDataResolver
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.proto_visitor import (
@@ -17,7 +18,8 @@ from snuba.web.rpc.proto_visitor import (
 )
 from snuba.web.rpc.v1.resolvers import ResolverTimeSeries
 from snuba.web.rpc.v1.visitors.visitor_v2 import (
-    PrefixLabelsVisitor,
+    AddAggregateLabelsVisitor,
+    RemoveInnerExpressionLabelsVisitor,
     ValidateAliasVisitor,
 )
 
@@ -135,7 +137,9 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
-        ValidateAliasVisitor().visit(in_msg)
-        PrefixLabelsVisitor().visit(in_msg)
+        if bool(get_int_config("enable_clear_labels_eap", 0)):
+            ValidateAliasVisitor().visit(in_msg)
+            RemoveInnerExpressionLabelsVisitor().visit(in_msg)
+            AddAggregateLabelsVisitor().visit(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -9,7 +9,6 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
-from snuba.state import get_int_config
 from snuba.web.rpc import RPCEndpoint, TraceItemDataResolver
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.proto_visitor import (
@@ -137,9 +136,9 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
-        if bool(get_int_config("enable_clear_labels_eap", 0)):
-            ValidateAliasVisitor().visit(in_msg)
-            RemoveInnerExpressionLabelsVisitor().visit(in_msg)
-            AddAggregateLabelsVisitor().visit(in_msg)
+        # if bool(get_int_config("enable_clear_labels_eap", 0)):
+        ValidateAliasVisitor().visit(in_msg)
+        RemoveInnerExpressionLabelsVisitor().visit(in_msg)
+        AddAggregateLabelsVisitor().visit(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/snuba/web/rpc/v1/visitors/visitor_v2.py
+++ b/snuba/web/rpc/v1/visitors/visitor_v2.py
@@ -1,0 +1,127 @@
+from abc import ABC
+from random import randint
+
+from google.protobuf.message import Message
+from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
+    AttributeConditionalAggregation,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    Expression,
+    TimeSeriesRequest,
+)
+from sentry_protos.snuba.v1.formula_pb2 import Literal
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeAggregation
+
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+
+
+class TimeSeriesRequestVisitor(ABC):
+    def visit(self, node: Message) -> None:
+        method_name = "visit_" + type(node).__name__
+        visitor = getattr(self, method_name, self.generic_visit)
+        visitor(node)
+
+    def generic_visit(self, node: Message) -> None:
+        raise NotImplementedError(f"No visit_{type(node).__name__} method")
+
+
+class ValidateAliasVisitor(TimeSeriesRequestVisitor):
+    """
+    This visitor validates that all top level expression labels are unique.
+    It also adds default labels to top-level expressions that dont have them.
+    """
+
+    def __init__(self) -> None:
+        self.expression_labels: set[str] = set()
+        super().__init__()
+
+    def visit_TimeSeriesRequest(self, node: TimeSeriesRequest) -> None:
+        for expr in node.expressions:
+            if expr.label == "":
+                continue
+            if expr.label in self.expression_labels:
+                raise BadSnubaRPCRequestException(
+                    f"Duplicate expression label: {expr.label}"
+                )
+            self.expression_labels.add(expr.label)
+
+        for expr in node.expressions:
+            if expr.label == "":
+                new_label = f"expr_{randint(0, 1000000)}"
+                while new_label in self.expression_labels:
+                    # theoretically this could loop forever, but the probability is so small
+                    new_label = f"expr_{randint(0, 1000000)}"
+                expr.label = new_label
+                self.expression_labels.add(new_label)
+
+
+class PrefixLabelsVisitor(TimeSeriesRequestVisitor):
+    """
+    This vistor prefixes all labels in an expression with an identifier unique to the expression its in.
+    This is useful because it makes it so that if you have duplicate labels across different expressions,
+    its ok and doesnt cause issues. It requires all top level expressions to have a unique label.
+
+    example:
+    expression {
+        label: "expr_label"
+        formula {
+            column: "column_name"
+        }
+    }
+    will be transformed into:
+    expression {
+        label: "expr_label"
+        formula {
+            column: "expr_0.column_name"
+        }
+    """
+
+    def __init__(self) -> None:
+        self.current_label_prefix = ""
+        super().__init__()
+
+    def visit_TimeSeriesRequest(self, node: TimeSeriesRequest) -> None:
+        # validate that all top level expressions have unique label
+        seen_labels: set[str] = set()
+        for expr in node.expressions:
+            if expr.label == "":
+                raise ValueError("Expression label is required")
+            elif expr.label in seen_labels:
+                raise ValueError(f"Duplicate expression label: {expr.label}")
+            seen_labels.add(expr.label)
+
+        # add prefix to all labels under the same expression
+        for expr in node.expressions:
+            self.current_label_prefix = expr.label
+            # instead of visiting the expression directly, we visit one level down
+            # what is inside of the expression. this is bc we dont want to modify the
+            # top level expressions, but we do want to modify the labels of the inner expressions
+            expr_type = expr.WhichOneof("expression")
+            if expr_type is None:
+                raise ValueError("Unknown expression type: None")
+            self.visit(getattr(expr, expr_type))
+
+    def visit_Expression(self, node: Expression) -> None:
+        if node.label != "":
+            node.label = f"{self.current_label_prefix}.{node.label}"
+        expr_type = node.WhichOneof("expression")
+        if expr_type is None:
+            raise ValueError("Unknown expression type: None")
+        self.visit(getattr(node, expr_type))
+
+    def visit_AttributeAggregation(self, node: AttributeAggregation) -> None:
+        if node.label != "":
+            node.label = f"{self.current_label_prefix}.{node.label}"
+
+    def visit_BinaryFormula(self, node: Expression.BinaryFormula) -> None:
+        self.visit(node.left)
+        self.visit(node.right)
+
+    def visit_AttributeConditionalAggregation(
+        self, node: AttributeConditionalAggregation
+    ) -> None:
+        if node.label != "":
+            node.label = f"{self.current_label_prefix}.{node.label}"
+
+    def visit_Literal(self, node: Literal) -> None:
+        return

--- a/snuba/web/rpc/v1/visitors/visitor_v2.py
+++ b/snuba/web/rpc/v1/visitors/visitor_v2.py
@@ -113,3 +113,9 @@ class AddAggregateLabelsVisitor(TimeSeriesRequestVisitor):
         self, node: AttributeConditionalAggregation
     ) -> None:
         node.label = self.current_label
+
+
+def preprocess_expression_labels(msg: TimeSeriesRequest) -> None:
+    ValidateAliasVisitor().visit(msg)
+    RemoveInnerExpressionLabelsVisitor().visit(msg)
+    AddAggregateLabelsVisitor().visit(msg)

--- a/snuba/web/rpc/v1/visitors/visitor_v2.py
+++ b/snuba/web/rpc/v1/visitors/visitor_v2.py
@@ -118,4 +118,7 @@ class AddAggregateLabelsVisitor(TimeSeriesRequestVisitor):
 def preprocess_expression_labels(msg: TimeSeriesRequest) -> None:
     ValidateAliasVisitor().visit(msg)
     RemoveInnerExpressionLabelsVisitor().visit(msg)
+
+    # We need this visitor because the endpoint only behaves correctly if
+    # all aggregates have the exact same label as the expression they are in
     AddAggregateLabelsVisitor().visit(msg)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1478,6 +1478,7 @@ class TestTimeSeriesApi(BaseApiTest):
         )
         EndpointTimeSeries().execute(best_effort_downsample_message)
 
+    @pytest.mark.xfail
     def test_duplicate_top_level_labels(self) -> None:
         """
         This test ensures that duplicate labels in top level expressions
@@ -1520,6 +1521,7 @@ class TestTimeSeriesApi(BaseApiTest):
         ):
             EndpointTimeSeries().execute(message)
 
+    @pytest.mark.xfail
     def test_duplicate_labels_inner(self) -> None:
         """
         This test ensures that duplicate labels across different expressions

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1484,6 +1484,7 @@ class TestTimeSeriesApi(BaseApiTest):
         This test ensures that duplicate labels in top level expressions
         raises exception
         """
+        set_config("enable_clear_labels_eap", 1)
         granularity_secs = 3600
         query_duration = granularity_secs * 1
         message = TimeSeriesRequest(

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1478,7 +1478,6 @@ class TestTimeSeriesApi(BaseApiTest):
         )
         EndpointTimeSeries().execute(best_effort_downsample_message)
 
-    @pytest.mark.xfail
     def test_duplicate_top_level_labels(self) -> None:
         """
         This test ensures that duplicate labels in top level expressions


### PR DESCRIPTION
The main purpose of this PR was to fix a bug involving duplicate labels provided in a users request. Top level expressions have labels, additionally the nested aggregates and formulas inside the expressions also have labels. EX:
```
expression: {
  label: label1
  aggregate: {
    label: label2
    ...
  }
}
```
When the inner labels are duplicated across expressions it causes incorrect behavior. To see the specific bug that was fixed, see here: https://github.com/getsentry/eap-planning/issues/242

this PR resolves https://github.com/getsentry/eap-planning/issues/244

## Major Changes
I solved this by implemented visitors on the protobuf request do the following:
1. ensure all top-level expressions have labels, if not adds a unique one. this is required for later steps.
2. remove all inner-expression labels. that is all labels inside an expression that isnt the very top level label. This solves the bug of duplicate labels.
3. add a label to all `aggregate` or `conditional aggregate` expressions that is the same as the expression label. I discovered while making this PR that this is necessary for correct functioning of the timeseries endpoint.

4. In order to create all these visitors, I implemented a new base visitor class that I believe offers some benefits over our existing one. The main benefit is that this one each visitor can independently define traversal, whereas with the old one all visitors had to traverse the same.

## Next steps
This PR makes any user provided labels inside an expression obsolete, so those fields should be deprecated in the protobuf.

