### PR TITLE
fix(storage-routing): fix metric name

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
@@ -131,7 +131,7 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
                     self._record_value_in_span_and_DD(
                         routing_context,
                         self.metrics.distribution,
-                        "estimated_query_bytes_scanned_to_this_tier",
+                        f"estimated_query_bytes_scanned_to_tier_{tier}",
                         estimated_query_bytes_scanned_to_this_tier,
                         {"tier": str(tier)},
                     )

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/normal_mode_linear_bytes_scanned.py
@@ -109,7 +109,7 @@ class NormalModeLinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
                     self._record_value_in_span_and_DD(
                         routing_context,
                         self.metrics.distribution,
-                        "estimated_query_bytes_scanned_to_this_tier",
+                        f"estimated_query_bytes_scanned_to_tier_{tier}",
                         estimated_query_bytes_scanned_to_this_tier,
                         {"tier": str(tier)},
                     )


### PR DESCRIPTION
This was just getting overwritten in Querylog because it had the same name