### PR TITLE
feat(storage_routing): Use tiers lower than TIER_8 after 10 billion ingested items

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/outcomes_based.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/outcomes_based.py
@@ -160,6 +160,17 @@ class OutcomesBasedRoutingStrategy(BaseRoutingStrategy):
         routing_context.extra_info[
             "max_items_before_downsampling"
         ] = max_items_before_downsampling
-        if ingested_items > max_items_before_downsampling:
+        if (
+            ingested_items > max_items_before_downsampling
+            and ingested_items <= max_items_before_downsampling * 10
+        ):
             return Tier.TIER_8, {}
+        elif (
+            ingested_items > max_items_before_downsampling * 10
+            and ingested_items <= max_items_before_downsampling * 100
+        ):
+            return Tier.TIER_64, {}
+        elif ingested_items > max_items_before_downsampling * 100:
+            return Tier.TIER_512, {}
+
         return Tier.TIER_1, {}

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/storage_routing.py
@@ -307,7 +307,10 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
                     metrics_backend_func=self.metrics.increment,
                     name="routing_mistake",
                     value=1,
-                    tags={"reason": "time_budget_exceeded"},
+                    tags={
+                        "reason": "time_budget_exceeded",
+                        "tier": routing_context.query_settings.get_sampling_tier().name,
+                    },
                 )
             elif (
                 routing_context.query_settings.get_sampling_tier() != Tier.TIER_1
@@ -318,7 +321,10 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
                     metrics_backend_func=self.metrics.increment,
                     name="routing_mistake",
                     value=1,
-                    tags={"reason": "sampled_too_low"},
+                    tags={
+                        "reason": "sampled_too_low",
+                        "tier": routing_context.query_settings.get_sampling_tier().name,
+                    },
                 )
             else:
                 self._record_value_in_span_and_DD(
@@ -326,7 +332,9 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
                     metrics_backend_func=self.metrics.increment,
                     name="routing_success",
                     value=1,
-                    tags={},
+                    tags={
+                        "tier": routing_context.query_settings.get_sampling_tier().name
+                    },
                 )
 
     @final

--- a/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
+++ b/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
@@ -113,3 +113,14 @@ def test_outcomes_based_routing_downsample(store_outcomes_data: Any) -> None:
     tier, settings = strategy._decide_tier_and_query_settings(routing_context)
     assert tier == Tier.TIER_8
     assert settings == {}
+    state.set_config(
+        "OutcomesBasedRoutingStrategy.max_items_before_downsampling", 500_000
+    )
+    tier, settings = strategy._decide_tier_and_query_settings(routing_context)
+    assert tier == Tier.TIER_64
+
+    state.set_config(
+        "OutcomesBasedRoutingStrategy.max_items_before_downsampling", 50_000
+    )
+    tier, settings = strategy._decide_tier_and_query_settings(routing_context)
+    assert tier == Tier.TIER_512

--- a/tests/web/rpc/v1/test_storage_routing.py
+++ b/tests/web/rpc/v1/test_storage_routing.py
@@ -219,7 +219,7 @@ def test_metrics_output() -> None:
                 "sampling_in_storage_routing_success": {
                     "type": "increment",
                     "value": 1,
-                    "tags": {},
+                    "tags": {"tier": "TIER_8"},
                 },
                 "time_budget": 8000,
             },
@@ -278,7 +278,7 @@ def test_strategy_exceeeds_time_budget() -> None:
     assert routing_context.extra_info["sampling_in_storage_routing_mistake"] == {
         "type": "increment",
         "value": 1,
-        "tags": {"reason": "time_budget_exceeded"},
+        "tags": {"reason": "time_budget_exceeded", "tier": "TIER_8"},
     }
 
 
@@ -295,5 +295,5 @@ def test_outcomes_based_routing_metrics_sampled_too_low() -> None:
     assert routing_context.extra_info["sampling_in_storage_routing_mistake"] == {
         "type": "increment",
         "value": 1,
-        "tags": {"reason": "sampled_too_low"},
+        "tags": {"reason": "sampled_too_low", "tier": "TIER_8"},
     }


### PR DESCRIPTION
After turning on the outcomes based strategy for all customers, we're seeing an exceeding of the time limit more than we would like 

https://app.datadoghq.com/s/FH6-Y3/889-thi-r3u

spot checking a few, it seems like the ingested items were in the tens of billions for those queries. 

Add the ability to downsample further. This can be tuned by changing the `OutcomesBasedRoutingStrategy.max_items_before_downsampling` configuration in the runtime config 