### PR TITLE
fix(tests):  dataset/drop endpoint for EAP works as expected

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
@@ -56,7 +56,15 @@ storages:
             to_col_table: null
             to_col_name: _hash_map_float
             num_attribute_buckets: 40
-
+  # listing all the materialized views so they get dropped with the entity
+  - storage: eap_items_downsample_8
+    is_writable: false
+  - storage: eap_items_downsample_64
+    is_writable: false
+  - storage: eap_items_downsample_512
+    is_writable: false
+  - storage: eap_item_co_occurring_attrs
+    is_writable: false
 
 storage_selector:
   selector: EAPItemsStorageSelector


### PR DESCRIPTION
the `/tests/{dataset}/drop` endpoint drops all the storages for an entity. due to the fact that the eap_items entity does not define the downsampled storages or attribute storages as entities, it does not drop those tables, causing the data to stick around between test runs