### PR TITLE
feat(storage-routing): introduce HIGHEST_ACCURACY queries to outcomes based strategy 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-rapidjson==1.8
 redis==4.5.4
 sentry-arroyo==2.22.0
 sentry-kafka-schemas==1.2.0
-sentry-protos==0.1.72
+sentry-protos==0.1.74
 sentry-redis-tools==0.3.0
 sentry-relay==0.9.5
 sentry-sdk==2.18.0

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/outcomes_based.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/outcomes_based.py
@@ -2,7 +2,6 @@ import uuid
 from typing import cast
 
 from google.protobuf.json_format import MessageToDict
-from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 
 from snuba import state
@@ -62,14 +61,6 @@ def project_id_and_org_conditions(meta: RequestMeta) -> Expression:
 
 
 class OutcomesBasedRoutingStrategy(BaseRoutingStrategy):
-    def _is_highest_accuracy_mode(self, routing_context: RoutingContext) -> bool:
-        if not routing_context.in_msg.meta.HasField("downsampled_storage_config"):
-            return False
-        return (
-            routing_context.in_msg.meta.downsampled_storage_config.mode
-            == DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
-        )
-
     def get_ingested_items_for_timerange(self, routing_context: RoutingContext) -> int:
         entity = Entity(
             key=EntityKey("outcomes"),

--- a/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
+++ b/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
@@ -47,6 +47,25 @@ def _get_request_meta(
     )
 
 
+def _get_highest_accuracy_request_meta(
+    start: datetime | None = None, end: datetime | None = None
+) -> RequestMeta:
+    start = start or BASE_TIME - timedelta(hours=24)
+    end = end or BASE_TIME
+    return RequestMeta(
+        project_ids=[_PROJECT_ID],
+        organization_id=_ORG_ID,
+        cogs_category="something",
+        referrer="something",
+        start_timestamp=Timestamp(seconds=int(start.timestamp())),
+        end_timestamp=Timestamp(seconds=int(end.timestamp())),
+        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        downsampled_storage_config=DownsampledStorageConfig(
+            mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
+        ),
+    )
+
+
 def gen_span_ingest_outcome(time: datetime, num: int) -> Dict[str, int | str | None]:
     return {
         "org_id": _PROJECT_ID,
@@ -124,3 +143,24 @@ def test_outcomes_based_routing_downsample(store_outcomes_data: Any) -> None:
     )
     tier, settings = strategy._decide_tier_and_query_settings(routing_context)
     assert tier == Tier.TIER_512
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_outcomes_based_routing_highest_accuracy_mode(store_outcomes_data: Any) -> None:
+    strategy = OutcomesBasedRoutingStrategy()
+
+    request = TraceItemTableRequest(meta=_get_highest_accuracy_request_meta())
+    request.meta.downsampled_storage_config.mode = (
+        DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+    )
+    routing_context = RoutingContext(
+        in_msg=request,
+        timer=Timer("test"),
+        build_query=build_query,  # type: ignore
+        query_settings=HTTPQuerySettings(),
+    )
+
+    tier, settings = strategy._decide_tier_and_query_settings(routing_context)
+    assert tier == Tier.TIER_1
+    assert settings == {}

--- a/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
+++ b/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
@@ -32,7 +32,9 @@ _ORG_ID = 1
 
 
 def _get_request_meta(
-    start: datetime | None = None, end: datetime | None = None
+    start: datetime | None = None,
+    end: datetime | None = None,
+    downsampled_storage_config: DownsampledStorageConfig | None = None,
 ) -> RequestMeta:
     start = start or BASE_TIME - timedelta(hours=24)
     end = end or BASE_TIME
@@ -44,25 +46,7 @@ def _get_request_meta(
         start_timestamp=Timestamp(seconds=int(start.timestamp())),
         end_timestamp=Timestamp(seconds=int(end.timestamp())),
         trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-    )
-
-
-def _get_highest_accuracy_request_meta(
-    start: datetime | None = None, end: datetime | None = None
-) -> RequestMeta:
-    start = start or BASE_TIME - timedelta(hours=24)
-    end = end or BASE_TIME
-    return RequestMeta(
-        project_ids=[_PROJECT_ID],
-        organization_id=_ORG_ID,
-        cogs_category="something",
-        referrer="something",
-        start_timestamp=Timestamp(seconds=int(start.timestamp())),
-        end_timestamp=Timestamp(seconds=int(end.timestamp())),
-        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-        downsampled_storage_config=DownsampledStorageConfig(
-            mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
-        ),
+        downsampled_storage_config=downsampled_storage_config,
     )
 
 
@@ -150,7 +134,7 @@ def test_outcomes_based_routing_downsample(store_outcomes_data: Any) -> None:
 def test_outcomes_based_routing_highest_accuracy_mode(store_outcomes_data: Any) -> None:
     strategy = OutcomesBasedRoutingStrategy()
 
-    request = TraceItemTableRequest(meta=_get_highest_accuracy_request_meta())
+    request = TraceItemTableRequest(meta=_get_request_meta())
     request.meta.downsampled_storage_config.mode = (
         DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
     )

--- a/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
+++ b/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
@@ -47,6 +47,25 @@ def _get_request_meta(
     )
 
 
+def _get_highest_accuracy_request_meta(
+    start: datetime | None = None, end: datetime | None = None
+) -> RequestMeta:
+    start = start or BASE_TIME - timedelta(hours=24)
+    end = end or BASE_TIME
+    return RequestMeta(
+        project_ids=[_PROJECT_ID],
+        organization_id=_ORG_ID,
+        cogs_category="something",
+        referrer="something",
+        start_timestamp=Timestamp(seconds=int(start.timestamp())),
+        end_timestamp=Timestamp(seconds=int(end.timestamp())),
+        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        downsampled_storage_config=DownsampledStorageConfig(
+            mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
+        ),
+    )
+
+
 def gen_span_ingest_outcome(time: datetime, num: int) -> Dict[str, int | str | None]:
     return {
         "org_id": _PROJECT_ID,
@@ -70,6 +89,27 @@ def store_outcomes_data() -> None:
         messages.append(gen_span_ingest_outcome(time, 1_000_000))
 
     write_raw_unprocessed_events(outcomes_storage, messages)  # type: ignore
+
+
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_outcomes_based_routing_highest_accuracy_mode(store_outcomes_data: Any) -> None:
+    strategy = OutcomesBasedRoutingStrategy()
+
+    request = TraceItemTableRequest(meta=_get_highest_accuracy_request_meta())
+    request.meta.downsampled_storage_config.mode = (
+        DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+    )
+    routing_context = RoutingContext(
+        in_msg=request,
+        timer=Timer("test"),
+        build_query=build_query,  # type: ignore
+        query_settings=HTTPQuerySettings(),
+    )
+
+    tier, settings = strategy._decide_tier_and_query_settings(routing_context)
+    assert tier == Tier.TIER_1
+    assert settings == {}
 
 
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
Right now all queries being served by the outcomes based strategy would participate in the routing logic, but if `HIGHEST_ACCURACY` queries should bypass this logic and go straight to tier 1
