### PR TITLE
ref(eap): remove timeout_overflow_mode

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -235,7 +235,6 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
-        timeout_overflow_mode: 'break'
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512.yaml
@@ -235,7 +235,6 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
-        timeout_overflow_mode: 'break'
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
@@ -235,7 +235,6 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
-        timeout_overflow_mode: 'break'
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8.yaml
@@ -235,7 +235,6 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
-        timeout_overflow_mode: 'break'
 
 
 mandatory_condition_checkers:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_span.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_span.yaml
@@ -237,7 +237,6 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
-        timeout_overflow_mode: 'break'
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -278,7 +278,6 @@ def get_co_occurring_attributes(
     treeify_or_and_conditions(query)
     settings = HTTPQuerySettings()
     settings.push_clickhouse_setting("max_execution_time", 1)
-    settings.push_clickhouse_setting("timeout_overflow_mode", "break")
     snuba_request = SnubaRequest(
         id=uuid.UUID(request.meta.request_id),
         original_body=MessageToDict(request),

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/storage_routing/routing_strategies/linear_bytes_scanned_storage_routing.py
@@ -228,7 +228,6 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
 
         query_settings = {
             "max_execution_time": self._get_time_budget_ms() / 1000,
-            "timeout_overflow_mode": "break",
         }
 
         return (
@@ -288,16 +287,6 @@ class LinearBytesScannedRoutingStrategy(BaseRoutingStrategy):
     def _output_metrics(self, routing_context: RoutingContext) -> None:
         assert routing_context.query_result
         target_tier = routing_context.query_settings.get_sampling_tier()
-        query_duration_ms = self._get_query_duration_ms(routing_context.query_result)
-        if (
-            query_duration_ms
-            >= self._get_time_budget_ms() - 0.02 * self._get_time_budget_ms()
-        ):
-            self.metrics.increment(
-                "timeout_overflow_mode_was_hit",
-                1,
-                {"tier": str(target_tier)},
-            )
         if not self._is_preflight_mode(routing_context):
 
             self._emit_estimation_error_info(


### PR DESCRIPTION
**context**
The [`timeout_overflow_mode`](https://clickhouse.com/docs/operations/settings/settings#timeout_overflow_mode) setting in ClickHouse is suppose to dictate the behavior of a query if it exceeds `max_execution_time`

options for `timeout_overflow_mode`:
* `throw` which throws a `TimeoutExceeded` error (the default)
* `break` which is supposed to return partial results

Setting `timeout_overflow_mode` to break doesn't actually provide the partial results that it was assumed to return. Additionally, not only does it _not_ provide partial results, but it also is likely related to the series of `TablesStatusResponse` errors we have been seeing when testing out the newer version of ClickHouse that we want to upgrade to. 

In order to prevent possible issues when doing the rest of the ClickHouse upgrades - I'm removing any places where we set this to `break`

**product considerations**
Right now since we aren't getting proper results back, I don't think this should change how we are rendering the results. I think we get an error anyway, it's just not a timeout error (this doesn't happen super ofter but here is an example from snuba admin us)
<img width="1336" alt="Screenshot 2025-04-29 at 12 30 30 PM" src="https://github.com/user-attachments/assets/294bfa4a-a1b2-42f8-ae7a-e39d4d08b608" />



