### PR TITLE
feat(errors) - Add `timestamp_ms` to discover and discover-events entites

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -272,6 +272,11 @@ schema:
       type: UInt,
       args: { schema_modifiers: [nullable], size: 64 },
     },
+    {
+        name: timestamp_ms,
+        type: DateTime64,
+        args: { schema_modifiers: [nullable], precision: 3 },
+      },
   ]
 required_time_column: timestamp
 storages:

--- a/snuba/datasets/configuration/discover/entities/discover_events.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_events.yaml
@@ -205,6 +205,11 @@ schema:
       type: UInt,
       args: { schema_modifiers: [nullable], size: 8 },
     },
+    {
+        name: timestamp_ms,
+        type: DateTime64,
+        args: { schema_modifiers: [nullable], precision: 3 },
+      },
   ]
 required_time_column: timestamp
 storages:

--- a/snuba/query/snql/discover_entity_selection.py
+++ b/snuba/query/snql/discover_entity_selection.py
@@ -27,6 +27,7 @@ from snuba.query.matchers import Or, Param
 from snuba.query.matchers import String as StringMatch
 from snuba.query.subscripts import subscript_key_column_name
 from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.utils.schemas import DateTime64
 
 """
 
@@ -92,6 +93,7 @@ EVENTS_COLUMNS = ColumnSet(
         ("trace_sampled", UInt(8, Modifiers(nullable=True))),
         ("num_processing_errors", UInt(64, Modifiers(nullable=True))),
         ("symbolicated_in_app", UInt(8, Modifiers(nullable=True))),
+        ("timestamp_ms", DateTime64(3, modifiers=Modifiers(nullable=True))),
     ]
 )
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1787,6 +1787,34 @@ class TestDiscoverApi(BaseApiTest):
         assert len(data["data"]) == 1
         assert data["data"][0]["symbolicated_in_app"] == True
 
+    def test_timestamp_ms_query(self) -> None:
+        response = self.post(
+            json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "selected_columns": ["timestamp_ms"],
+                    "conditions": [
+                        [
+                            "timestamp_ms",
+                            ">=",
+                            (self.base_time - self.skew).isoformat(),
+                        ],
+                        ["timestamp_ms", "<", (self.base_time + self.skew).isoformat()],
+                    ],
+                    "limit": 1,
+                    "from_date": (self.base_time - self.skew).isoformat(),
+                    "to_date": (self.base_time + self.skew).isoformat(),
+                    "tenant_ids": {"referrer": "r", "organization_id": 1234},
+                }
+            ),
+        )
+        data = json.loads(response.data)
+        assert response.status_code == 200
+        assert len(data["data"]) == 1
+        assert "timestamp_ms" in data["data"][0]
+        assert data["data"][0]["timestamp_ms"] is not None
+
 
 class TestDiscoverAPIEntitySelection(TestDiscoverApi):
     """


### PR DESCRIPTION
after adding new column on errors `timestamp_ms`, this exposes it to be queryable in discover