### PR TITLE
fix(ourlogs): Do not store span_id

### DIFF
--- a/rust_snuba/src/processors/ourlogs.rs
+++ b/rust_snuba/src/processors/ourlogs.rs
@@ -26,7 +26,6 @@ pub(crate) struct FromLogMessage {
 
     //optional attributes
     trace_id: Option<Uuid>,
-    span_id: Option<String>, //hex encoded
     attributes: Option<BTreeMap<String, FromAttribute>>,
     severity_text: Option<String>,
     severity_number: Option<u8>,
@@ -153,10 +152,6 @@ impl From<FromLogMessage> for EAPItem {
         );
         res.attributes
             .insert_str("sentry.body".to_string(), from.body);
-        if let Some(span_id) = from.span_id {
-            res.attributes
-                .insert_str("sentry.span_id".to_string(), span_id)
-        }
 
         if let Some(attributes) = from.attributes {
             for (k, v) in attributes {

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-ourlogs-OurlogsMessageProcessor-snuba-ourlogs__1__maximal_log.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@snuba-ourlogs-OurlogsMessageProcessor-snuba-ourlogs__1__maximal_log.json.snap
@@ -31,9 +31,6 @@ expression: snapshot_payload
     "attributes_string_0": {
       "sentry.body": "hello world!"
     },
-    "attributes_string_12": {
-      "sentry.span_id": "11002233AABBCCDD"
-    },
     "attributes_string_28": {
       "some.user.tag": "hello"
     },

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -288,7 +288,6 @@ class TestTraceItemDetails(BaseApiTest):
 
         assert set(x.name for x in res.attributes) == {
             "sentry.body",
-            "sentry.span_id",
             "sentry.severity_text",
             "sentry.severity_number",
             "sentry.organization_id",

--- a/tests/web/rpc/v1/test_endpoint_trace_item_stats_logs.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_stats_logs.py
@@ -77,21 +77,13 @@ class TestTraceItemStatsForLogs(BaseApiTest):
         assert response.results[0].HasField("attribute_distributions")
         actual = response.results[0].attribute_distributions.attributes
         assert len(actual) == 3
-        assert actual[0:2] == [
-            AttributeDistribution(
-                attribute_name="sentry.severity_text",
-                buckets=[AttributeDistribution.Bucket(label="INFO", value=60)],
-            ),
-            AttributeDistribution(
-                attribute_name="sentry.span_id",
-                buckets=[
-                    AttributeDistribution.Bucket(label="123456781234567D", value=60)
-                ],
-            ),
-        ]
-        assert actual[2].attribute_name == "sentry.body"
+        assert actual[0] == AttributeDistribution(
+            attribute_name="sentry.severity_text",
+            buckets=[AttributeDistribution.Bucket(label="INFO", value=60)],
+        )
+        assert actual[1].attribute_name == "sentry.body"
         assert sorted(
-            actual[2].buckets, key=lambda x: int(x.label[len("hello world ") :])
+            actual[1].buckets, key=lambda x: int(x.label[len("hello world ") :])
         ) == [
             AttributeDistribution.Bucket(label=f"hello world {i}", value=1)
             for i in range(1, 61)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_stats_logs.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_stats_logs.py
@@ -76,7 +76,7 @@ class TestTraceItemStatsForLogs(BaseApiTest):
         response = EndpointTraceItemStats().execute(message)
         assert response.results[0].HasField("attribute_distributions")
         actual = response.results[0].attribute_distributions.attributes
-        assert len(actual) == 3
+        assert len(actual) == 2
         assert actual[0] == AttributeDistribution(
             attribute_name="sentry.severity_text",
             buckets=[AttributeDistribution.Bucket(label="INFO", value=60)],


### PR DESCRIPTION
In the trace items table, this is called 'parent_span_id', and it comes from the SDKs setting an attribute instead of the kafka topic.