### PR TITLE
chore(eap): Add a eap_items_span entity for backwards compatibility

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/dataset.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/dataset.yaml
@@ -8,4 +8,5 @@ entities:
   - spans_str_attrs
   - uptime_checks
   - eap_items
+  - eap_items_span
   - eap_items_log

--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_items_span.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_items_span.yaml
@@ -1,0 +1,89 @@
+version: v1
+kind: entity
+name: eap_items_span
+
+schema:
+  [
+    { name: organization_id, type: UInt, args: { size: 64 } },
+    { name: project_id, type: UInt, args: { size: 64 } },
+    { name: item_type, type: UInt, args: { size: 8 } },
+    { name: timestamp, type: DateTime },
+    { name: trace_id, type: UUID },
+    { name: item_id, type: UInt, args: { size: 128 } },
+    { name: sampling_weight, type: UInt, args: { size: 64 } },
+    { name: sampling_factor, type: Float, args: { size: 64 } },
+    { name: retention_days, type: UInt, args: { size: 16 } },
+
+    { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+    { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+    { name: attributes_string, type: Map, args: { key: { type: String }, value: { type: String } } },
+    { name: attributes_float, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+    { name: _hash_map_float, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
+    { name: _hash_map_string, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
+  ]
+
+storages:
+  - storage: eap_items_span
+    is_writable: true
+    translation_mappers:
+      subscriptables:
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_string
+            to_col_table: null
+            to_col_name: attributes_string
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_float
+            to_col_table: null
+            to_col_name: attributes_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_string
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_float
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+  # listing all the materialized views so they get dropped with the entity
+  - storage: eap_items_downsample_8
+    is_writable: false
+  - storage: eap_items_downsample_64
+    is_writable: false
+  - storage: eap_items_downsample_512
+    is_writable: false
+  - storage: eap_item_co_occurring_attrs
+    is_writable: false
+
+storage_selector:
+  selector: EAPItemsStorageSelector
+
+query_processors:
+  - processor: HashBucketFunctionTransformer
+    args:
+      hash_bucket_names:
+        - attributes_string
+        - attributes_float
+      num_attribute_buckets: 40
+  - processor: HashMapHasFunctionTransformer
+    args:
+      hash_bucket_names:
+        - _hash_map_float
+        - _hash_map_string
+      num_attribute_buckets: 40
+
+validators: []
+
+validate_data_model: do_nothing
+required_time_column: timestamp

--- a/tests/datasets/test_entity_factory.py
+++ b/tests/datasets/test_entity_factory.py
@@ -54,6 +54,7 @@ ENTITY_KEYS = [
     EntityKey.UPTIME_CHECKS,
     EntityKey.EAP_ITEMS,
     EntityKey.EAP_ITEMS_LOG,
+    EntityKey.EAP_ITEMS_SPAN,
 ]
 
 


### PR DESCRIPTION
We need to redirect the Sentry tests to write to the `eap-items-span` processor, not the future `eap-items` processor.

https://github.com/getsentry/sentry/pull/90808
https://github.com/getsentry/snuba/pull/7122