### PR TITLE
fix(eap): Remove max execution time from attribute names endpoint

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -277,7 +277,6 @@ def get_co_occurring_attributes(
 
     treeify_or_and_conditions(query)
     settings = HTTPQuerySettings()
-    settings.push_clickhouse_setting("max_execution_time", 1)
     snuba_request = SnubaRequest(
         id=uuid.UUID(request.meta.request_id),
         original_body=MessageToDict(request),


### PR DESCRIPTION
Since we removed the timeout_overflow_mode=break, this is causing timeouts on large queries