### PR TITLE
feat(eap): Transform an order by on timestamp to the full sort key order to improve performance 

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -316,7 +316,9 @@ def build_query(request: TraceItemTableRequest) -> Query:
             ),
             *item_type_conds,
         ),
-        order_by=_convert_order_by(set(groupby), request.order_by, request.meta),
+        order_by=_convert_order_by(
+            set(exp.alias for exp in groupby), request.order_by, request.meta
+        ),
         groupby=groupby,
         # Only support offset page tokens for now
         offset=request.page_token.offset,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -302,12 +302,9 @@ def build_query(request: TraceItemTableRequest) -> Query:
     item_type_conds = [
         f.equals(snuba_column("item_type"), request.meta.trace_item_type)
     ]
-    groupby = (
-        [
-            attribute_key_to_expression_eap_items(attr_key)
-            for attr_key in request.group_by
-        ],
-    )
+    groupby = [
+        attribute_key_to_expression_eap_items(attr_key) for attr_key in request.group_by
+    ]
     res = Query(
         from_clause=entity,
         selected_columns=selected_columns,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -317,7 +317,7 @@ def build_query(request: TraceItemTableRequest) -> Query:
             *item_type_conds,
         ),
         order_by=_convert_order_by(
-            set(exp.alias for exp in groupby), request.order_by, request.meta
+            set(exp.alias for exp in groupby), request.order_by, request.meta  # type: ignore
         ),
         groupby=groupby,
         # Only support offset page tokens for now

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -124,21 +124,34 @@ def _convert_order_by(
 ) -> Sequence[OrderBy]:
     if len(order_by) == 1:
         order = order_by[0]
-        if order.column.key.name == "sentry.timestamp":
+        if (
+            order.column.key.name == "sentry.timestamp"
+            and "organization_id" in groupby
+            and "project_id" in groupby
+            and "item_type" in groupby
+            and "timestamp" in groupby
+        ):
             direction = (
                 OrderByDirection.DESC if order.descending else OrderByDirection.ASC
             )
-            order_by_columns = []
-            for col in ["organization_id", "project_id", "item_type", "timestamp"]:
-                if col in groupby:
-                    order_by_columns.append(
-                        OrderBy(
-                            direction=direction,
-                            expression=snuba_column(col),
-                        )
-                    )
-
-            return order_by_columns
+            return [
+                OrderBy(
+                    direction=direction,
+                    expression=snuba_column("organization_id"),
+                ),
+                OrderBy(
+                    direction=direction,
+                    expression=snuba_column("project_id"),
+                ),
+                OrderBy(
+                    direction=direction,
+                    expression=snuba_column("item_type"),
+                ),
+                OrderBy(
+                    direction=direction,
+                    expression=snuba_column("timestamp"),
+                ),
+            ]
 
     res: list[OrderBy] = []
     for x in order_by:

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -317,7 +317,9 @@ def build_query(request: TraceItemTableRequest) -> Query:
             *item_type_conds,
         ),
         order_by=_convert_order_by(
-            set(exp.alias for exp in groupby), request.order_by, request.meta  # type: ignore
+            set(exp.alias for exp in groupby if exp.alias is not None),
+            request.order_by,
+            request.meta,
         ),
         groupby=groupby,
         # Only support offset page tokens for now

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1135,6 +1135,33 @@ class TestTraceItemTable(BaseApiTest):
         measurements = [v.val_double for v in response.column_values[1].results]
         assert sorted(measurements) == measurements
 
+    def test_order_by_does_not_error_if_groupby_exists(self) -> None:
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            columns=[
+                Column(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING, name="sentry.timestamp"
+                    )
+                ),
+                Column(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_COUNT,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_STRING, name="sentry.timestamp"
+                        ),
+                    )
+                ),
+            ],
+            group_by=[
+                AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.timestamp")
+            ],
+        )
+        EndpointTraceItemTable().execute(message)
+
     def test_aggregation_on_attribute_column_backward_compat(
         self,
         setup_teardown: Any,


### PR DESCRIPTION
redoing https://github.com/getsentry/snuba/pull/7149

only add all the sort key columns to order by if the GROUP BY is empty or else we'd get error DB::Exception: Column blah is not under aggregate function and not in GROUP BY
