### PR TITLE
feat(consumers): Create an experimental healhcheck using a different strategy

### DIFF
--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -23,10 +23,12 @@ use sentry_kafka_schemas::Schema;
 use crate::config;
 use crate::metrics::global_tags::set_global_tag;
 use crate::processors::{self, get_cogs_label};
+use crate::runtime_config::get_str_config;
 use crate::strategies::accountant::RecordCogs;
 use crate::strategies::clickhouse::batch::{BatchFactory, HttpBatch};
 use crate::strategies::clickhouse::ClickhouseWriterStep;
 use crate::strategies::commit_log::ProduceCommitLog;
+use crate::strategies::healthcheck::HealthCheck as SnubaHealthCheck;
 use crate::strategies::join_timeout::SetJoinTimeout;
 use crate::strategies::processor::{
     get_schema, make_rust_processor, make_rust_processor_with_replacements, validate_schema,
@@ -231,7 +233,28 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
         let next_step = SetJoinTimeout::new(next_step, Some(Duration::from_secs(0)));
 
         if let Some(path) = &self.health_check_file {
-            Box::new(HealthCheck::new(next_step, path))
+            {
+                let snuba_health_check_groups =
+                    get_str_config("snuba_health_check_consumer_groups")
+                        .ok()
+                        .flatten()
+                        .unwrap_or_default();
+
+                let consumer_groups: Vec<&str> = snuba_health_check_groups
+                    .split(',')
+                    .map(|s| s.trim())
+                    .collect();
+
+                if consumer_groups.contains(&self.physical_consumer_group.as_str()) {
+                    tracing::info!(
+                        "Using Snuba HealthCheck for consumer group: {}",
+                        self.physical_consumer_group
+                    );
+                    Box::new(SnubaHealthCheck::new(next_step, path))
+                } else {
+                    Box::new(HealthCheck::new(next_step, path))
+                }
+            }
         } else {
             Box::new(next_step)
         }

--- a/rust_snuba/src/strategies/healthcheck.rs
+++ b/rust_snuba/src/strategies/healthcheck.rs
@@ -1,0 +1,94 @@
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use sentry_arroyo::counter;
+use sentry_arroyo::processing::strategies::{
+    CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
+};
+use sentry_arroyo::types::Message;
+
+use crate::runtime_config::get_str_config;
+
+const TOUCH_INTERVAL: Duration = Duration::from_secs(1);
+
+pub struct HealthCheck<Next> {
+    next_step: Next,
+    path: PathBuf,
+    interval: Duration,
+    deadline: SystemTime,
+    iterations_since_last_submit: u32,
+}
+
+impl<Next> HealthCheck<Next> {
+    pub fn new(next_step: Next, path: impl Into<PathBuf>) -> Self {
+        let interval = TOUCH_INTERVAL;
+        let deadline = SystemTime::now() + interval;
+
+        Self {
+            next_step,
+            path: path.into(),
+            interval,
+            deadline,
+            iterations_since_last_submit: 0,
+        }
+    }
+
+    fn maybe_touch_file(&mut self) {
+        let now = SystemTime::now();
+        if now < self.deadline {
+            return;
+        }
+
+        if let Err(err) = std::fs::File::create(&self.path) {
+            let error: &dyn std::error::Error = &err;
+            tracing::error!(error);
+        }
+
+        counter!("arroyo.processing.strategies.healthcheck.touch");
+        self.deadline = now + self.interval;
+    }
+}
+
+impl<TPayload, Next> ProcessingStrategy<TPayload> for HealthCheck<Next>
+where
+    Next: ProcessingStrategy<TPayload> + 'static,
+{
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
+        let poll_result = self.next_step.poll();
+
+        if get_str_config("experimental_healthcheck")
+            .ok()
+            .flatten()
+            .unwrap_or("0".to_string())
+            == "1".to_string()
+        {
+            // If we are receiving a commit request, it means we are making progress and this can be considered a healthy state
+            if let Ok(Some(_commit_request)) = poll_result.as_ref() {
+                self.maybe_touch_file();
+            }
+
+            // If we aren't submitting, it means we are not processing messages and we consider this a healthy state
+            if self.iterations_since_last_submit > 0 {
+                self.maybe_touch_file();
+            }
+
+            self.iterations_since_last_submit += 1;
+        } else {
+            self.maybe_touch_file();
+        }
+        poll_result
+    }
+
+    fn submit(&mut self, message: Message<TPayload>) -> Result<(), SubmitError<TPayload>> {
+        self.iterations_since_last_submit = 0;
+        self.next_step.submit(message)
+    }
+
+    fn terminate(&mut self) {
+        self.next_step.terminate()
+    }
+
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
+        self.next_step.join(timeout)
+    }
+}

--- a/rust_snuba/src/strategies/mod.rs
+++ b/rust_snuba/src/strategies/mod.rs
@@ -1,6 +1,7 @@
 pub mod accountant;
 pub mod clickhouse;
 pub mod commit_log;
+pub mod healthcheck;
 pub mod join_timeout;
 pub mod noop;
 pub mod processor;


### PR DESCRIPTION
Instead of touching the health file every time we call poll, we only touch it when one of the following two conditions is true:
1. We have a commit request which means we are actively processing messages
2. We are calling poll after not calling submit in the previous iteration - this happens when we don't have messages to process which is a healthy state

Here's an example of how we could enter an unhealthy state:
- If we are not getting back a commit request in poll, it means there's either a strategy error (an unhealthy state) or we haven't committed and thus not making progress (potentially unhealthy if we are still receiving messages). This allows us to kill the consumer using the liveness probe (i.e. if we are in an unhealthy state for a certain amount of time, the consumer will be killed)