### PR TITLE
ref(consumer) only log when there are rows to write

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -46,13 +46,19 @@ impl TaskRunner<BytesInsertBatch<HttpBatch>, BytesInsertBatch<()>, anyhow::Error
 
             let write_start = SystemTime::now();
 
-            tracing::info!("performing write of {} rows {} bytes", num_rows, num_bytes);
+            if num_rows > 0 {
+                tracing::info!("performing write of {} rows {} bytes", num_rows, num_bytes)
+            }
+
             http_batch.finish().await.map_err(RunTaskError::Other)?;
-            tracing::info!(
-                "finished performing write of {} rows {} bytes",
-                num_rows,
-                num_bytes
-            );
+
+            if num_rows > 0 {
+                tracing::info!(
+                    "finished performing write of {} rows {} bytes",
+                    num_rows,
+                    num_bytes
+                );
+            }
 
             let write_finish = SystemTime::now();
 


### PR DESCRIPTION
In local development often times we aren't writing so this will help keep the logs less polluted