### PR TITLE
fix(trace-items): Should return keys in filter

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -243,7 +243,7 @@ def get_co_occurring_attributes(
     attr_filter = not_cond(
         in_cond(
             column("attr.2"),
-            f.array(*attribute_keys_to_search, *UNSEARCHABLE_ATTRIBUTE_KEYS),
+            f.array(*UNSEARCHABLE_ATTRIBUTE_KEYS),
         )
     )
     if request.value_substring_match:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
@@ -293,6 +293,4 @@ class TestTraceItemAttributeNames(BaseApiTest):
                 name="c_tag_000", type=AttributeKey.Type.TYPE_STRING
             ),
         ]
-        for attr in res.attributes:
-            print(attr)
         assert res.attributes == expected


### PR DESCRIPTION
When suggesting keys, we should still return the keys that are already in the filter. This is because as a user, we'd still expect that key to show up in the autocompletions. One case where this is best observed is if the filter is on a wild card and they want to narrow the search. Removing the key from the suggestions seems premature and can lead to confusion.