### PR TITLE
feat(replay): Add OTA Updates Context

### DIFF
--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -145,6 +145,9 @@ pub fn deserialize_message(
                 offset,
                 os_name: event.contexts.os.name.unwrap_or_default(),
                 os_version: event.contexts.os.version.unwrap_or_default(),
+                ota_updates_channel: event.contexts.ota_updates.channel.unwrap_or_default(),
+                ota_updates_runtime_version: event.contexts.ota_updates.runtime_version.unwrap_or_default(),
+                ota_updates_update_id: event.contexts.ota_updates.update_id.unwrap_or_default(),
                 partition,
                 platform: event.platform.unwrap_or("".to_string()),
                 project_id: replay_message.project_id,
@@ -339,6 +342,8 @@ struct Contexts {
     os: Version,
     #[serde(default)]
     replay: ReplayContext,
+    #[serde(default)]
+    ota_updates: OTAUpdates,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -359,6 +364,16 @@ struct ReplayContext {
     error_sample_rate: Option<f64>,
     #[serde(default)]
     session_sample_rate: Option<f64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct OTAUpdates {
+    #[serde(default)]
+    channel: Option<String>,
+    #[serde(default)]
+    runtime_version: Option<String>,
+    #[serde(default)]
+    update_id: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -445,6 +460,9 @@ pub struct ReplayRow {
     offset: u64,
     os_name: String,
     os_version: String,
+    ota_updates_channel: String,
+    ota_updates_runtime_version: String,
+    ota_updates_update_id: String,
     partition: u16,
     platform: String,
     project_id: u64,
@@ -569,6 +587,11 @@ mod tests {
                     "name": "os",
                     "version": "v1"
                 },
+                "ota_updates": {
+                    "channel": "channel",
+                    "runtime_version": "runtime_version",
+                    "update_id": "update_id"
+                },
                 "replay": {
                     "error_sample_rate": 1,
                     "session_sample_rate": 0.5
@@ -687,6 +710,9 @@ mod tests {
         assert_eq!(replay_row.info_id, Uuid::nil());
         assert_eq!(replay_row.viewed_by_id, 0);
         assert_eq!(replay_row.warning_id, Uuid::nil());
+        assert_eq!(replay_row.ota_updates_channel, "channel");
+        assert_eq!(replay_row.ota_updates_runtime_version, "runtime_version");
+        assert_eq!(replay_row.ota_updates_update_id, "update_id");
     }
 
     #[test]
@@ -818,6 +844,9 @@ mod tests {
         assert_eq!(replay_row.info_id, Uuid::nil());
         assert_eq!(replay_row.viewed_by_id, 0);
         assert_eq!(replay_row.warning_id, Uuid::nil());
+        assert_eq!(replay_row.ota_updates_channel, "");
+        assert_eq!(replay_row.ota_updates_runtime_version, "");
+        assert_eq!(replay_row.ota_updates_update_id, "");
     }
 
     #[test]

--- a/snuba/datasets/configuration/replays/entities/replays.yaml
+++ b/snuba/datasets/configuration/replays/entities/replays.yaml
@@ -102,6 +102,21 @@ schema:
       type: String,
       args: { schema_modifiers: [nullable] },
     },
+    {
+      name: ota_updates_channel,
+      type: String,
+      args: { schema_modifiers: [nullable] },
+    },
+    {
+      name: ota_updates_runtime_version,
+      type: String,
+      args: { schema_modifiers: [nullable] },
+    },
+    {
+      name: ota_updates_update_id,
+      type: String,
+      args: { schema_modifiers: [nullable] },
+    },
     { name: sdk_name, type: String, args: { schema_modifiers: [nullable] } },
     { name: sdk_version, type: String, args: { schema_modifiers: [nullable] } },
     {

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -119,7 +119,20 @@ schema:
         type: String,
         args: { schema_modifiers: [nullable] },
       },
-      { name: sdk_name, type: String, args: { schema_modifiers: [nullable] } },
+      {
+        name: ota_updates_channel,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: ota_updates_runtime_version,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: ota_updates_update_id,
+        type: String,
+        args: { schema_modifiers: [nullable] },
       {
         name: sdk_version,
         type: String,

--- a/snuba/snuba_migrations/replays/0022_add_context_ota_updates.py
+++ b/snuba/snuba_migrations/replays/0022_add_context_ota_updates.py
@@ -1,0 +1,58 @@
+from typing import Iterator, Sequence, Tuple
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+new_columns: Sequence[Tuple[Column[Modifiers], str]] = [
+    (Column("ota_updates_channel", String(Modifiers(nullable=True))), "browser_version"),
+    (Column("ota_updates_runtime_version", String(Modifiers(nullable=True))), "ota_updates_channel"),
+    (Column("ota_updates_update_id", String(Modifiers(nullable=True))), "ota_updates_runtime_version"),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(forward_columns_iter())
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(backward_columns_iter())
+
+
+def forward_columns_iter() -> Iterator[operations.SqlOperation]:
+    for column, after in new_columns:
+        yield operations.AddColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_local",
+            column=column,
+            after=after,
+            target=operations.OperationTarget.LOCAL,
+        )
+
+        yield operations.AddColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_dist",
+            column=column,
+            after=after,
+            target=operations.OperationTarget.DISTRIBUTED,
+        )
+
+
+def backward_columns_iter() -> Iterator[operations.SqlOperation]:
+    for column, _ in new_columns:
+        yield operations.DropColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_dist",
+            target=operations.OperationTarget.DISTRIBUTED,
+            column_name=column.name,
+        )
+
+        yield operations.DropColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_local",
+            target=operations.OperationTarget.LOCAL,
+            column_name=column.name,
+        )


### PR DESCRIPTION
Closed in favor of:
- https://github.com/getsentry/snuba/pull/7164
- https://github.com/getsentry/snuba/pull/7165
- https://github.com/getsentry/snuba/pull/7166


This is part of Sentry Expo integration.

We want replays filterable using the OTA Updates properties.

Making Replays filterable is in-progress:
- (this) https://github.com/getsentry/snuba/pull/7163
- https://github.com/getsentry/relay/pull/4711
- Sentry Backend make the fields searchable (PR TBA)
- Sentry Frontend make the fields discoverable (PR TBA)

For Errors and Transactions this context was added in:
- https://github.com/getsentry/relay/pull/4690
- https://github.com/getsentry/sentry/pull/90148
- https://github.com/getsentry/sentry/pull/90162
- https://github.com/getsentry/sentry/pull/90475