### PR TITLE
fix(querylog): Catch KafkaError specifically as they are not derived from Exception

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -354,8 +354,8 @@ def record_query(query_metadata: snuba_queries_v1.Querylog) -> None:
             data.encode("utf-8"),
             on_delivery=_record_query_delivery_callback,
         )
-    except KafkaError:
-        logger.error("Could not record query due to a KafkaError")
+    except KafkaError as ex:
+        logger.error(f"Could not record query: {ex}")
     except Exception as ex:
         logger.exception("Could not record query due to error: %r", ex)
 

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -354,7 +354,7 @@ def record_query(query_metadata: snuba_queries_v1.Querylog) -> None:
             data.encode("utf-8"),
             on_delivery=_record_query_delivery_callback,
         )
-    except Exception as ex:
+    except (Exception, KafkaError) as ex:
         logger.exception("Could not record query due to error: %r", ex)
 
 

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -354,7 +354,9 @@ def record_query(query_metadata: snuba_queries_v1.Querylog) -> None:
             data.encode("utf-8"),
             on_delivery=_record_query_delivery_callback,
         )
-    except (Exception, KafkaError) as ex:
+    except KafkaError:
+        logger.error("Could not record query due to a KafkaError")
+    except Exception as ex:
         logger.exception("Could not record query due to error: %r", ex)
 
 


### PR DESCRIPTION
`KafkaError` class is not based on `Exception` so it doesn't get handled.

Also, `KafkaError` won't be rendered as a traceback so I'm just logging an error.

```python
import logging

from confluent_kafka import KafkaError, KafkaException

try:
    raise KafkaError(10)
    raise KafkaException("")
except (Exception, KafkaError):
    logging.error("exception")
```