### PR TITLE
fix(job): log correct query for truncating EAP spans

### DIFF
--- a/snuba/manual_jobs/truncate_eap_spans.py
+++ b/snuba/manual_jobs/truncate_eap_spans.py
@@ -21,7 +21,7 @@ class TruncateEAPSpans(Job):
             ClickhouseClientSettings.MIGRATE,
             storage_node,
         )
-        logger.info("Run truncate table statement: {STATEMENT}")
+        logger.info(f"Run truncate table statement: {STATEMENT}")
         connection.execute(query=STATEMENT)
 
         logger.info("TRUNCATE completed")


### PR DESCRIPTION
interpolate the value of STATEMENT rather than logging STATEMENT