### PR TITLE
feat(api): Support multipart/form-data to receive binary data

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -589,7 +589,6 @@ if application.debug or application.testing:
     def _write_to_entity(
         *,
         entity: EntityType,
-        decode_base64: bool = False,
     ) -> RespTuple:
         from snuba.processor import InsertBatch
 
@@ -637,7 +636,6 @@ if application.debug or application.testing:
     def write_bytes_to_entity(*, entity: EntityType) -> RespTuple:
         return _write_to_entity(
             entity=entity,
-            decode_base64=True,
         )
 
     @application.route("/tests/<entity:entity>/eventstream", methods=["POST"])

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import atexit
-import base64
 import functools
 import logging
 import random
@@ -599,14 +598,14 @@ if application.debug or application.testing:
         writable_storage = entity.get_writable_storage()
         assert writable_storage is not None
         table_writer = writable_storage.get_table_writer()
-        messages = json.loads(http_request.data)
+
+        if http_request.files:
+            messages = [file.read() for _, file in http_request.files.items()]
+        else:
+            messages = json.loads(http_request.data)
 
         for index, message in enumerate(messages):
             offset = offset_base + index
-
-            if decode_base64:
-                message = base64.b64decode(message)
-
             processed_message = (
                 table_writer.get_stream_loader()
                 .get_processor()

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import base64
 import functools
 import logging
 import random
@@ -234,7 +235,6 @@ def health_envoy() -> Response:
 
 @application.route("/health")
 def health() -> Response:
-
     thorough = http_request.args.get("thorough", False)
     health_info = get_health_info(thorough)
 
@@ -598,6 +598,9 @@ if application.debug or application.testing:
 
         for index, message in enumerate(json.loads(http_request.data)):
             offset = offset_base + index
+
+            if http_request.content_type == "application/x-protobuf":
+                message = base64.b64decode(message)
 
             processed_message = (
                 table_writer.get_stream_loader()


### PR DESCRIPTION
For the items pipeline, we use Protobuf. Tests in Sentry have been sending JSON to insert into ClickHouse and whatever was received was just pushed to the processor.

Now, we need to be able to receive bytes and this PR will read data sent over as `multipart/form-data` to then insert into the processor.