### PR TITLE
fix(eap): Pad to 16 or 32 depending on the size of item_id

### DIFF
--- a/snuba/query/processors/physical/hexint_column_processor.py
+++ b/snuba/query/processors/physical/hexint_column_processor.py
@@ -37,20 +37,23 @@ class HexIntColumnProcessor(BaseTypeConverter):
     def _process_expressions(self, exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in self.columns:
             hex = f.hex(column(exp.column_name))
-            return f.lower(
-                f.leftPad(
-                    hex,
-                    if_cond(
-                        f.greater(
-                            f.length(hex),
+            return FunctionCall(
+                exp.alias,
+                "lower",
+                (
+                    f.leftPad(
+                        hex,
+                        if_cond(
+                            f.greater(
+                                f.length(hex),
+                                literal(16),
+                            ),
+                            literal(32),
                             literal(16),
                         ),
-                        literal(32),
-                        literal(16),
+                        literal("0"),
                     ),
-                    literal("0"),
                 ),
-                alias=exp.alias,
             )
         return exp
 

--- a/snuba/query/processors/physical/hexint_column_processor.py
+++ b/snuba/query/processors/physical/hexint_column_processor.py
@@ -36,13 +36,21 @@ class HexIntColumnProcessor(BaseTypeConverter):
         if isinstance(exp, Column) and exp.column_name in self.columns:
             return FunctionCall(
                 exp.alias,
-                "lower",
+                "replaceRegexpOne",
                 (
                     FunctionCall(
                         None,
-                        "hex",
-                        (Column(None, None, exp.column_name),),
+                        "lower",
+                        (
+                            FunctionCall(
+                                None,
+                                "hex",
+                                (Column(None, None, exp.column_name),),
+                            ),
+                        ),
                     ),
+                    Literal(None, "^[0]+"),
+                    Literal(None, ""),
                 ),
             )
         return exp

--- a/snuba/query/processors/physical/hexint_column_processor.py
+++ b/snuba/query/processors/physical/hexint_column_processor.py
@@ -36,21 +36,13 @@ class HexIntColumnProcessor(BaseTypeConverter):
         if isinstance(exp, Column) and exp.column_name in self.columns:
             return FunctionCall(
                 exp.alias,
-                "leftPad",
+                "lower",
                 (
                     FunctionCall(
                         None,
-                        "lower",
-                        (
-                            FunctionCall(
-                                None,
-                                "hex",
-                                (Column(None, None, exp.column_name),),
-                            ),
-                        ),
+                        "hex",
+                        (Column(None, None, exp.column_name),),
                     ),
-                    Literal(None, self._size),
-                    Literal(None, "0"),
                 ),
             )
         return exp

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -52,7 +52,6 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
         schema=get_entity(EntityKey("eap_items")).get_data_model(),
         sample=None,
     )
-
     res = Query(
         from_clause=entity,
         selected_columns=[

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -131,7 +131,7 @@ def attribute_key_to_expression_eap_items(attr_key: AttributeKey) -> Expression:
         # However, a 128 bit integer cannot be represented as a 16 character hex string (16 characters can at most represent a 64 bit integer). Hence,
         # by default we represent item_id as a 32 character hex string. Since the user expects 16 characters and we know that a span_id will currently never use the full 128 bits,
         # it's safe to get rid of the first 16 characters since we know those will just be padding.
-        if attr_key.name == "sentry.span_id":
+        if attr_key.name in {"sentry.span_id", "sentry.item_id"}:
             return f.right(
                 column(converted_attr_name[len(COLUMN_PREFIX) :]), 16, alias=alias
             )

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/common/common.py
@@ -125,15 +125,10 @@ def attribute_key_to_expression_eap_items(attr_key: AttributeKey) -> Expression:
                 f"Attribute {attr_key.name} must be one of [{formatted_attribute_types}], got {AttributeKey.Type.Name(attr_key.type)}"
             )
 
-        # To maintain backwards compatibility with the old span_id column, we only need the last 16 characters of the item_id
-        # In eap_items, they're just integers, there's no issue fitting a 64 bit integer in a 128 bit integer.
-        # The problem is that this is just our internal representation, but when a user interacts with span_id through EAP, it's treated as a hex string with 16 characters.
-        # However, a 128 bit integer cannot be represented as a 16 character hex string (16 characters can at most represent a 64 bit integer). Hence,
-        # by default we represent item_id as a 32 character hex string. Since the user expects 16 characters and we know that a span_id will currently never use the full 128 bits,
-        # it's safe to get rid of the first 16 characters since we know those will just be padding.
         if attr_key.name in {"sentry.span_id", "sentry.item_id"}:
-            return f.right(
-                column(converted_attr_name[len(COLUMN_PREFIX) :]), 16, alias=alias
+            return column(
+                converted_attr_name[len(COLUMN_PREFIX) :],
+                alias=alias,
             )
         elif attr_key.name == "sentry.sampling_factor":
             return f.divide(

--- a/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_spans/resolver_get_trace.py
@@ -56,7 +56,7 @@ def _build_query(request: GetTraceRequest) -> Query:
             expression=(
                 attribute_key_to_expression_eap_items(
                     AttributeKey(
-                        name="sentry.span_id", type=AttributeKey.Type.TYPE_STRING
+                        name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING
                     )
                 )
             ),

--- a/tests/query/processors/test_hexint_column_processor.py
+++ b/tests/query/processors/test_hexint_column_processor.py
@@ -51,7 +51,7 @@ tests = [
             Column(None, None, "column1"),
             FunctionCall(None, "toString", (Literal(None, "a" * 16),)),
         ),
-        "equals(lower(hex(column1)), toString('aaaaaaaaaaaaaaaa'))",
+        "equals(replaceRegexpOne(lower(hex(column1)), '^[0]+', ''), toString('aaaaaaaaaaaaaaaa'))",
         id="non_optimizable_condition_pattern",
     ),
     pytest.param(
@@ -60,7 +60,7 @@ tests = [
             Column(None, None, "column1"),
             FunctionCall(None, "toString", (Literal(None, f"00{'a' * 14}"),)),
         ),
-        "equals(lower(hex(column1)), toString('00aaaaaaaaaaaaaa'))",
+        "equals(replaceRegexpOne(lower(hex(column1)), '^[0]+', ''), toString('00aaaaaaaaaaaaaa'))",
         id="non_optimizable_condition_pattern_with_leading_zeroes",
     ),
 ]
@@ -82,13 +82,21 @@ def test_hexint_column_processor(unprocessed: Expression, formatted_value: str) 
             "column1",
             FunctionCall(
                 None,
-                "lower",
+                "replaceRegexpOne",
                 (
                     FunctionCall(
                         None,
-                        "hex",
-                        (Column(None, None, "column1"),),
+                        "lower",
+                        (
+                            FunctionCall(
+                                None,
+                                "hex",
+                                (Column(None, None, "column1"),),
+                            ),
+                        ),
                     ),
+                    Literal(None, "^[0]+"),
+                    Literal(None, ""),
                 ),
             ),
         )

--- a/tests/query/processors/test_hexint_column_processor.py
+++ b/tests/query/processors/test_hexint_column_processor.py
@@ -7,6 +7,8 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query import SelectedExpression
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.data_source.simple import Table
+from snuba.query.dsl import Functions as f
+from snuba.query.dsl import column, if_cond, literal
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.physical.hexint_column_processor import (
     HexIntColumnProcessor,
@@ -51,7 +53,7 @@ tests = [
             Column(None, None, "column1"),
             FunctionCall(None, "toString", (Literal(None, "a" * 16),)),
         ),
-        "equals(replaceRegexpOne(lower(hex(column1)), '^[0]+', ''), toString('aaaaaaaaaaaaaaaa'))",
+        "equals(lower(leftPad(hex(column1), if(greater(length(hex(column1)), 16), 32, 16), '0')), toString('aaaaaaaaaaaaaaaa'))",
         id="non_optimizable_condition_pattern",
     ),
     pytest.param(
@@ -60,7 +62,7 @@ tests = [
             Column(None, None, "column1"),
             FunctionCall(None, "toString", (Literal(None, f"00{'a' * 14}"),)),
         ),
-        "equals(replaceRegexpOne(lower(hex(column1)), '^[0]+', ''), toString('00aaaaaaaaaaaaaa'))",
+        "equals(lower(leftPad(hex(column1), if(greater(length(hex(column1)), 16), 32, 16), '0')), toString('00aaaaaaaaaaaaaa'))",
         id="non_optimizable_condition_pattern_with_leading_zeroes",
     ),
 ]
@@ -73,6 +75,7 @@ def test_hexint_column_processor(unprocessed: Expression, formatted_value: str) 
         selected_columns=[SelectedExpression("column1", Column(None, None, "column1"))],
         condition=unprocessed,
     )
+    hex = f.hex(column("column1"))
 
     HexIntColumnProcessor(set(["column1"])).process_query(
         unprocessed_query, HTTPQuerySettings()
@@ -80,23 +83,18 @@ def test_hexint_column_processor(unprocessed: Expression, formatted_value: str) 
     assert unprocessed_query.get_selected_columns() == [
         SelectedExpression(
             "column1",
-            FunctionCall(
-                None,
-                "replaceRegexpOne",
-                (
-                    FunctionCall(
-                        None,
-                        "lower",
-                        (
-                            FunctionCall(
-                                None,
-                                "hex",
-                                (Column(None, None, "column1"),),
-                            ),
+            f.lower(
+                f.leftPad(
+                    hex,
+                    if_cond(
+                        f.greater(
+                            f.length(hex),
+                            literal(16),
                         ),
+                        literal(32),
+                        literal(16),
                     ),
-                    Literal(None, "^[0]+"),
-                    Literal(None, ""),
+                    literal("0"),
                 ),
             ),
         )

--- a/tests/query/processors/test_hexint_column_processor.py
+++ b/tests/query/processors/test_hexint_column_processor.py
@@ -51,7 +51,7 @@ tests = [
             Column(None, None, "column1"),
             FunctionCall(None, "toString", (Literal(None, "a" * 16),)),
         ),
-        "equals(leftPad(lower(hex(column1)), 16, '0'), toString('aaaaaaaaaaaaaaaa'))",
+        "equals(lower(hex(column1)), toString('aaaaaaaaaaaaaaaa'))",
         id="non_optimizable_condition_pattern",
     ),
     pytest.param(
@@ -60,7 +60,7 @@ tests = [
             Column(None, None, "column1"),
             FunctionCall(None, "toString", (Literal(None, f"00{'a' * 14}"),)),
         ),
-        "equals(leftPad(lower(hex(column1)), 16, '0'), toString('00aaaaaaaaaaaaaa'))",
+        "equals(lower(hex(column1)), toString('00aaaaaaaaaaaaaa'))",
         id="non_optimizable_condition_pattern_with_leading_zeroes",
     ),
 ]
@@ -82,21 +82,13 @@ def test_hexint_column_processor(unprocessed: Expression, formatted_value: str) 
             "column1",
             FunctionCall(
                 None,
-                "leftPad",
+                "lower",
                 (
                     FunctionCall(
                         None,
-                        "lower",
-                        (
-                            FunctionCall(
-                                None,
-                                "hex",
-                                (Column(None, None, "column1"),),
-                            ),
-                        ),
+                        "hex",
+                        (Column(None, None, "column1"),),
                     ),
-                    Literal(None, 16),
-                    Literal(None, "0"),
                 ),
             ),
         )

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -277,10 +277,6 @@ def generate_spans_and_timestamps() -> tuple[list[TraceItem], list[Timestamp]]:
 
 def get_span_id(span: TraceItem) -> str:
     # cut the 0x prefix
-    return hex(
-        int.from_bytes(
-            span.item_id,
-            byteorder="little",
-            signed=False,
-        )
-    )[2:]
+    return hex(int.from_bytes(span.item_id, byteorder="little", signed=False,))[
+        2:
+    ].rjust(16, "0")

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -41,7 +41,11 @@ _SPANS = [
     gen_item_message(
         start_timestamp=_BASE_TIME + timedelta(minutes=i),
         trace_id=_TRACE_ID,
-        item_id=int(uuid.uuid4().hex[:16], 16).to_bytes(16, "little"),
+        item_id=int(uuid.uuid4().hex[:16], 16).to_bytes(
+            16,
+            byteorder="little",
+            signed=False,
+        ),
         attributes={
             "sentry.op": AnyValue(string_value="http.server" if i == 0 else "db"),
             "sentry.raw_description": AnyValue(
@@ -273,6 +277,10 @@ def generate_spans_and_timestamps() -> tuple[list[TraceItem], list[Timestamp]]:
 
 def get_span_id(span: TraceItem) -> str:
     # cut the 0x prefix
-    span_id = hex(int.from_bytes(span.item_id, byteorder="little"))[2:]
-    padded = span_id.rjust(16, "0")
-    return padded
+    return hex(
+        int.from_bytes(
+            span.item_id,
+            byteorder="little",
+            signed=False,
+        )
+    )[2:]

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -41,12 +41,13 @@ _SPANS = [
     gen_item_message(
         start_timestamp=_BASE_TIME + timedelta(minutes=i),
         trace_id=_TRACE_ID,
+        item_id=int(uuid.uuid4().hex[:16], 16).to_bytes(16, "little"),
         attributes={
             "sentry.op": AnyValue(string_value="http.server" if i == 0 else "db"),
             "sentry.raw_description": AnyValue(
                 string_value="root" if i == 0 else f"child {i + 1} of {_SPAN_COUNT}",
             ),
-            "is_segment": AnyValue(bool_value=i == 0),
+            "sentry.is_segment": AnyValue(bool_value=i == 0),
         },
     )
     for i in range(_SPAN_COUNT)
@@ -271,5 +272,7 @@ def generate_spans_and_timestamps() -> tuple[list[TraceItem], list[Timestamp]]:
 
 
 def get_span_id(span: TraceItem) -> str:
-    # cut the 0x prefix and the first 8 bytes
-    return hex(int.from_bytes(span.item_id, byteorder="little"))[-16:]
+    # cut the 0x prefix
+    span_id = hex(int.from_bytes(span.item_id, byteorder="little"))[2:]
+    padded = span_id.rjust(16, "0")
+    return padded


### PR DESCRIPTION
In order for the product to directly use `sentry.item_id` and not the alias `sentry.span_id`, we still need to trim the leading zeroes.

I debated making a more generic "trim item_id of the leading 0s" but i don't think i want to handle that now as it might lead to other test failures, so I just want to copy the current behavior for span IDs.