### PR TITLE
feat(error-sampling): Add `sample_weight` column to errors

### DIFF
--- a/snuba/snuba_migrations/events/0029_add_sample_weight_column_to_errors.py
+++ b/snuba/snuba_migrations/events/0029_add_sample_weight_column_to_errors.py
@@ -1,0 +1,72 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.operations import (
+    AddColumn,
+    DropColumn,
+    OperationTarget,
+    SqlOperation,
+)
+from snuba.utils.schemas import Column, Float
+
+
+class Migration(ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            AddColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name="errors_local",
+                column=Column(
+                    "sample_weight",
+                    Float(64, modifiers=MigrationModifiers(nullable=True)),
+                ),
+                after="timestamp_ms",
+                target=OperationTarget.LOCAL,
+            ),
+            AddColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name="errors_dist",
+                column=Column(
+                    "sample_weight",
+                    Float(64, modifiers=MigrationModifiers(nullable=True)),
+                ),
+                after="timestamp_ms",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            AddColumn(
+                storage_set=StorageSetKey.EVENTS_RO,
+                table_name="errors_dist_ro",
+                column=Column(
+                    "sample_weight",
+                    Float(64, modifiers=MigrationModifiers(nullable=True)),
+                ),
+                after="timestamp_ms",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            DropColumn(
+                storage_set=StorageSetKey.EVENTS_RO,
+                table_name="errors_dist_ro",
+                column_name="sample_weight",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            DropColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name="errors_dist",
+                column_name="sample_weight",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            DropColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name="errors_local",
+                column_name="sample_weight",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
This field will contain the result of 1/sample_rate on error events which are sampled, and will then be summed up to reach the extrapolated count of events.

context: https://www.notion.so/sentry/Tech-Spec-Error-Up-Sampling-1e58b10e4b5d80af855cf3b992f75894?pvs=4