### PR TITLE
chore(eap): Double write subscriptions under both eap_items and eap_items_span entities

### DIFF
--- a/snuba/web/rpc/v1/create_subscription.py
+++ b/snuba/web/rpc/v1/create_subscription.py
@@ -40,7 +40,7 @@ class CreateSubscriptionRequest(
         )
 
         dataset = PluggableDataset(name="eap", all_entities=[])
-        entity_key = EntityKey("eap_items_span")
+        entity_key = EntityKey("eap_items")
 
         subscription = RPCSubscriptionData.from_proto(in_msg, entity_key=entity_key)
         identifier = SubscriptionCreator(dataset, entity_key).create(

--- a/snuba/web/rpc/v1/create_subscription.py
+++ b/snuba/web/rpc/v1/create_subscription.py
@@ -41,7 +41,7 @@ class CreateSubscriptionRequest(
         )
 
         dataset = PluggableDataset(name="eap", all_entities=[])
-        entity_key = EntityKey(self._entity_name())
+        entity_key = EntityKey(get_subscription_entity_name())
 
         subscription = RPCSubscriptionData.from_proto(in_msg, entity_key=entity_key)
         identifier = SubscriptionCreator(dataset, entity_key).create(
@@ -50,12 +50,13 @@ class CreateSubscriptionRequest(
 
         return CreateSubscriptionResponse(subscription_id=str(identifier))
 
-    def _entity_name(self) -> str:
-        default = "eap_items_span"
-        return (
-            state.get_str_config(
-                "CreateSubscriptionRequest.entity_name",
-                default,
-            )
-            or default
+
+def get_subscription_entity_name() -> str:
+    default = "eap_items_span"
+    return (
+        state.get_str_config(
+            "CreateSubscriptionRequest.entity_name",
+            default,
         )
+        or default
+    )

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -163,14 +163,14 @@ def test_scheduler_consumer(tmpdir: LocalPath) -> None:
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
 def test_scheduler_consumer_rpc_subscriptions(tmpdir: LocalPath) -> None:
-    settings.TOPIC_PARTITION_COUNTS = {"snuba-spans": 2}
+    settings.TOPIC_PARTITION_COUNTS = {"snuba-items": 2}
     importlib.reload(scheduler_consumer)
 
     admin_client = AdminClient(get_default_kafka_configuration())
     create_topics(admin_client, [SnubaTopic.EAP_SPANS_COMMIT_LOG])
 
     metrics_backend = TestingMetricsBackend()
-    entity_name = "eap_items_span"
+    entity_name = "eap_items"
     entity = get_entity(EntityKey(entity_name))
     storage = entity.get_writable_storage()
     assert storage is not None
@@ -213,7 +213,7 @@ def test_scheduler_consumer_rpc_subscriptions(tmpdir: LocalPath) -> None:
     builder = scheduler_consumer.SchedulerBuilder(
         entity_name,
         str(uuid.uuid1().hex),
-        "eap_items_span",
+        "eap_items",
         [],
         mock_scheduler_producer,
         "latest",
@@ -247,7 +247,7 @@ def test_scheduler_consumer_rpc_subscriptions(tmpdir: LocalPath) -> None:
             commit_log_topic,
             payload=commit_codec.encode(
                 Commit(
-                    "eap_items_span",
+                    "eap_items",
                     Partition(commit_log_topic, partition),
                     offset,
                     ts,

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -36,7 +36,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
-from snuba import settings, state
+from snuba import settings
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.subscriptions import scheduler_consumer
@@ -49,10 +49,7 @@ from snuba.utils.streams.configuration_builder import (
     get_default_kafka_configuration,
 )
 from snuba.utils.streams.topics import Topic as SnubaTopic
-from snuba.web.rpc.v1.create_subscription import (
-    CreateSubscriptionRequest,
-    get_subscription_entity_name,
-)
+from snuba.web.rpc.v1.create_subscription import CreateSubscriptionRequest
 from tests.assertions import assert_changes
 from tests.backends.metrics import TestingMetricsBackend
 
@@ -166,16 +163,14 @@ def test_scheduler_consumer(tmpdir: LocalPath) -> None:
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
 def test_scheduler_consumer_rpc_subscriptions(tmpdir: LocalPath) -> None:
-    settings.TOPIC_PARTITION_COUNTS = {"snuba-items": 2}
+    settings.TOPIC_PARTITION_COUNTS = {"snuba-spans": 2}
     importlib.reload(scheduler_consumer)
 
     admin_client = AdminClient(get_default_kafka_configuration())
     create_topics(admin_client, [SnubaTopic.EAP_SPANS_COMMIT_LOG])
 
-    state.set_config("CreateSubscriptionRequest.entity_name", "eap_items")
-
     metrics_backend = TestingMetricsBackend()
-    entity_name = get_subscription_entity_name()
+    entity_name = "eap_items_span"
     entity = get_entity(EntityKey(entity_name))
     storage = entity.get_writable_storage()
     assert storage is not None

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -229,7 +229,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
         rpc_subscription_data = list(
             RedisSubscriptionDataStore(
                 get_redis_client(RedisClientKey.SUBSCRIPTION_STORE),
-                EntityKey("eap_items_span"),
+                EntityKey("eap_items"),
                 PartitionId(partition),
             ).all()
         )[0][1]

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -235,7 +235,8 @@ class TestCreateSubscriptionApi(BaseApiTest):
                 EntityKey(
                     state.get_str_config(
                         "CreateSubscriptionRequest.entity_name",
-                    ),
+                    )
+                    or "eap_items",
                 ),
                 PartitionId(partition),
             ).all()

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -236,14 +236,14 @@ class TestCreateSubscriptionApi(BaseApiTest):
             )[0][1]
             assert isinstance(rpc_subscription_data, RPCSubscriptionData)
 
-        request_class = TimeSeriesRequest()
-        request_class.ParseFromString(
-            base64.b64decode(rpc_subscription_data.time_series_request)
-        )
-        assert rpc_subscription_data.time_window_sec == 300
-        assert rpc_subscription_data.resolution_sec == 60
-        assert rpc_subscription_data.request_name == "TimeSeriesRequest"
-        assert rpc_subscription_data.request_version == "v1"
+            request_class = TimeSeriesRequest()
+            request_class.ParseFromString(
+                base64.b64decode(rpc_subscription_data.time_series_request)
+            )
+            assert rpc_subscription_data.time_window_sec == 300
+            assert rpc_subscription_data.resolution_sec == 60
+            assert rpc_subscription_data.request_name == "TimeSeriesRequest"
+            assert rpc_subscription_data.request_version == "v1"
 
     @pytest.mark.parametrize(
         "create_subscription, error_message",

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -23,6 +23,7 @@ from snuba.datasets.entities.entity_key import EntityKey
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.subscriptions.data import PartitionId, RPCSubscriptionData
 from snuba.subscriptions.store import RedisSubscriptionDataStore
+from snuba.web.rpc.v1.create_subscription import get_subscription_entity_name
 from tests.base import BaseApiTest
 from tests.web.rpc.v1.test_endpoint_time_series.test_endpoint_time_series import (
     DummyMetric,
@@ -232,12 +233,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
         rpc_subscription_data = list(
             RedisSubscriptionDataStore(
                 get_redis_client(RedisClientKey.SUBSCRIPTION_STORE),
-                EntityKey(
-                    state.get_str_config(
-                        "CreateSubscriptionRequest.entity_name",
-                    )
-                    or "eap_items",
-                ),
+                EntityKey(get_subscription_entity_name()),
                 PartitionId(partition),
             ).all()
         )[0][1]


### PR DESCRIPTION
As part of the items pipeline rollout, we have to switch subscription schedulers to follow the `snuba-items` topic.

New consumers have been deployed and configured for `snuba-items` and we'll have to move subscriptions over from `eap_items_span` entity to `eap_items` to be able to remove the storage fully.

Once this is merged, we'll be able to regenerate the subscription caches and get rid of `eap_items_span` storage.