### PR TITLE
fix(profiles): Set profile chunk storage as complete

### DIFF
--- a/snuba/datasets/configuration/profiles/storages/chunks.yaml
+++ b/snuba/datasets/configuration/profiles/storages/chunks.yaml
@@ -4,7 +4,7 @@ name: profile_chunks
 storage:
   key: profile_chunks
   set_key: profile_chunks
-readiness_state: partial
+readiness_state: complete
 schema:
   columns:
     [

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -182,7 +182,7 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.PROFILE_CHUNKS: _MigrationGroup(
         loader=ProfileChunksLoader(),
         storage_sets_keys={StorageSetKey.PROFILE_CHUNKS},
-        readiness_state=ReadinessState.PARTIAL,
+        readiness_state=ReadinessState.COMPLETE,
     ),
 }
 


### PR DESCRIPTION
This feature was released to `self-hosted` without the storage marked as complete.