### PR TITLE
chore: remove feature flag enable_clear_labels_eap

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -9,7 +9,6 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
-from snuba.state import get_int_config
 from snuba.web.rpc import RPCEndpoint, TraceItemDataResolver
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.proto_visitor import (
@@ -133,7 +132,6 @@ class EndpointTimeSeries(RPCEndpoint[TimeSeriesRequest, TimeSeriesResponse]):
         )
         in_msg_wrapper = TimeSeriesRequestWrapper(in_msg)
         in_msg_wrapper.accept(aggregation_to_conditional_aggregation_visitor)
-        if bool(get_int_config("enable_clear_labels_eap", 0)):
-            preprocess_expression_labels(in_msg)
+        preprocess_expression_labels(in_msg)
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         return resolver.resolve(in_msg)

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -39,7 +39,6 @@ from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.state import set_config
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -1484,7 +1483,6 @@ class TestTimeSeriesApi(BaseApiTest):
         This test ensures that duplicate labels in top level expressions
         raises exception
         """
-        set_config("enable_clear_labels_eap", 1)
         granularity_secs = 3600
         query_duration = granularity_secs * 1
         message = TimeSeriesRequest(
@@ -1527,7 +1525,6 @@ class TestTimeSeriesApi(BaseApiTest):
         This test ensures that duplicate labels across different expressions
         doesnt cause incorrect behavior
         """
-        set_config("enable_clear_labels_eap", 1)
         granularity_secs = 30
         query_duration = granularity_secs * 4
         metric1_value = 3
@@ -1648,7 +1645,6 @@ class TestTimeSeriesApi(BaseApiTest):
         ensure that when the label of the aggregate differs from the label of the expression,
         it still works
         """
-        set_config("enable_clear_labels_eap", 1)
         # store a a test metric with a value of 1, every second of one hour
         granularity_secs = 300
         query_duration = 60 * 30


### PR DESCRIPTION
the feature flag `enable_clear_labels_eap` was added in this PR https://github.com/getsentry/snuba/pull/7139
it has been enabled and running in prod for a few weeks with no issue, so im removing the feature flag.