### PR TITLE
feat(consumers): add join timeout option to consumer

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -45,6 +45,7 @@ pub fn consumer(
     batch_write_timeout_ms: Option<u64>,
     max_dlq_buffer_length: Option<usize>,
     custom_envoy_request_timeout: Option<u64>,
+    join_timeout_ms: Option<u64>,
 ) -> usize {
     py.allow_threads(|| {
         consumer_impl(
@@ -64,6 +65,7 @@ pub fn consumer(
             batch_write_timeout_ms,
             max_dlq_buffer_length,
             custom_envoy_request_timeout,
+            join_timeout_ms,
         )
     })
 }
@@ -86,6 +88,7 @@ pub fn consumer_impl(
     batch_write_timeout_ms: Option<u64>,
     max_dlq_buffer_length: Option<usize>,
     custom_envoy_request_timeout: Option<u64>,
+    join_timeout_ms: Option<u64>,
 ) -> usize {
     setup_logging();
 
@@ -268,6 +271,7 @@ pub fn consumer_impl(
         stop_at_timestamp,
         batch_write_timeout,
         custom_envoy_request_timeout,
+        join_timeout_ms,
     };
 
     let processor = StreamProcessor::with_kafka(config, factory, topic, dlq_policy);

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -106,8 +106,10 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
         // Write to clickhouse
         let next_step = ClickhouseWriterStep::new(next_step, &self.clickhouse_concurrency);
 
-        let next_step =
-            SetJoinTimeout::new(next_step, Some(Duration::from_millis(self.join_timeout_ms)));
+        let next_step = SetJoinTimeout::new(
+            next_step,
+            Some(Duration::from_millis(self.join_timeout_ms.unwrap_or(0))),
+        );
 
         // Batch insert rows
         let batch_factory = BatchFactory::new(

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -182,6 +182,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     default=None,
     help="Quantized rebalancing means that during deploys, rebalancing is triggered across all pods within a consumer group at the same time. The value is used by the pods to align their group join/leave activity to some multiple of the delay",
 )
+@click.option(
+    "--join-timeout-ms",
+    type=int,
+    default=0,
+    help="number of milliseconds to wait for the current batch to be flushed by the consumer in case of rebalance",
+)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -214,6 +220,7 @@ def rust_consumer(
     max_dlq_buffer_length: Optional[int],
     quantized_rebalance_consumer_group_delay_secs: Optional[int],
     custom_envoy_request_timeout: Optional[int],
+    join_timeout_ms: Optional[int]
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -268,6 +275,7 @@ def rust_consumer(
         batch_write_timeout_ms,
         max_dlq_buffer_length,
         custom_envoy_request_timeout,
+        join_timeout_ms,
     )
 
     sys.exit(exitcode)


### PR DESCRIPTION
There is a hypothesis that during rebalance, the consumers do not flush their batches which causes larger backlogs than it should. Add an option so we can try it out on some consumers 