### PR TITLE
fix(discover): Remove PREWHERE clause since 24.3 do not support them anymore

### DIFF
--- a/snuba/datasets/configuration/discover/storages/discover.yaml
+++ b/snuba/datasets/configuration/discover/storages/discover.yaml
@@ -124,14 +124,6 @@ query_processors:
       columns: !!set
         span_id: null
   - processor: EventsBooleanContextsProcessor
-  - processor: PrewhereProcessor
-    args:
-      prewhere_candidates:
-        - event_id
-        - release
-        - transaction_name
-        - environment
-        - project_id
   - processor: NullColumnCaster
     args:
       merge_table_sources:


### PR DESCRIPTION
We get this error since we upgraded the Discover cluster to 24.3
```
DB::Exception: Storage Merge doesn't support PREWHERE.
```

We'll disable the `PREWHERE` optimization for now while we investigate.