### PR TITLE
feat(consumers): set default join timeout on rust consumers

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -185,7 +185,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
 @click.option(
     "--join-timeout-ms",
     type=int,
-    default=0,
+    default=1000,
     help="number of milliseconds to wait for the current batch to be flushed by the consumer in case of rebalance",
 )
 @click.option(


### PR DESCRIPTION
This has demonstrated to be useful in mitigating consumer lag during rebalancing, make it the default for consumers across the board