### PR TITLE
fix(eap): fix stupid attribute values query for item id

### DIFF
--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -115,10 +115,12 @@ def _build_query(
             OrderBy(direction=OrderByDirection.ASC, expression=column("attr_value")),
         ],
         limit=request.limit,
-        offset=request.page_token.offset
-        if request.page_token.HasField("offset")
-        else 0,
+        offset=(
+            request.page_token.offset if request.page_token.HasField("offset") else 0
+        ),
     )
+    breakpoint()
+    print(res)
     return res
 
 
@@ -162,6 +164,13 @@ class AttributeValuesRequest(
     def _execute(
         self, in_msg: TraceItemAttributeValuesRequest
     ) -> TraceItemAttributeValuesResponse:
+        # if for some reason the item_id is the key, we can just return the value
+        # item ids are unique
+        if in_msg.key.name == "sentry.item_id" and in_msg.value_substring_match:
+            return TraceItemAttributeValuesResponse(
+                values=[in_msg.value_substring_match],
+                page_token=None,
+            )
         in_msg.limit = in_msg.limit or 1000
         snuba_request = _build_snuba_request(in_msg)
         res = run_query(

--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -119,8 +119,6 @@ def _build_query(
             request.page_token.offset if request.page_token.HasField("offset") else 0
         ),
     )
-    breakpoint()
-    print(res)
     return res
 
 


### PR DESCRIPTION
For some reason there are queries being done for `item_id` with a substring match:
https://sentry.sentry.io/issues/6622721618/events/latest/?referrer=latest-event

in the case that we get this query, just return the substring match itself, don't bother querying the DB