### PR TITLE
chore(eap): Remove hashed_keys column

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0043_remove_hashed_keys_column.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0043_remove_hashed_keys_column.py
@@ -1,0 +1,30 @@
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    storage_set_key = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+    local_table_name = "eap_items_1_local"
+    dist_table_name = "eap_items_1_dist"
+    column_to_remove = "hashed_keys"
+
+    def forwards_ops(self) -> list[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                column_name=self.column_to_remove,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                column_name=self.column_to_remove,
+                target=OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> list[operations.SqlOperation]:
+        return []


### PR DESCRIPTION
We experimented with this coupled with a bloom filter index to speed up queries and it turned out to not yield the performance we wanted so we're not doing and cleaning up.

It's the first of a long line of PRs removing columns we don't need anymore.