### PR TITLE
feat(consumers): Create V2 consumer copy

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -8,7 +8,6 @@ use sentry_arroyo::backends::kafka::producer::KafkaProducer;
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
 use sentry_arroyo::metrics;
 use sentry_arroyo::processing::dlq::{DlqLimit, DlqPolicy, KafkaDlqProducer};
-use sentry_arroyo::processing::strategies::ProcessingStrategyFactory;
 
 use sentry_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use sentry_arroyo::processing::StreamProcessor;

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -8,6 +8,7 @@ use sentry_arroyo::backends::kafka::producer::KafkaProducer;
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
 use sentry_arroyo::metrics;
 use sentry_arroyo::processing::dlq::{DlqLimit, DlqPolicy, KafkaDlqProducer};
+use sentry_arroyo::processing::strategies::ProcessingStrategyFactory;
 
 use sentry_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use sentry_arroyo::processing::StreamProcessor;
@@ -18,6 +19,7 @@ use pyo3::types::PyBytes;
 
 use crate::config;
 use crate::factory::ConsumerStrategyFactory;
+use crate::factory_v2::ConsumerStrategyFactoryV2;
 use crate::logging::{setup_logging, setup_sentry};
 use crate::metrics::global_tags::set_global_tag;
 use crate::metrics::statsd::StatsDBackend;
@@ -47,29 +49,289 @@ pub fn consumer(
     max_dlq_buffer_length: Option<usize>,
     custom_envoy_request_timeout: Option<u64>,
     join_timeout_ms: Option<u64>,
+    consumer_version: Option<&str>,
 ) -> usize {
-    py.allow_threads(|| {
-        consumer_impl(
-            consumer_group,
-            auto_offset_reset,
-            no_strict_offset_reset,
-            consumer_config_raw,
-            concurrency,
-            clickhouse_concurrency,
-            use_rust_processor,
-            enforce_schema,
-            max_poll_interval_ms,
-            async_inserts,
-            python_max_queue_depth,
-            health_check_file,
-            stop_at_timestamp,
-            batch_write_timeout_ms,
+    if consumer_version == Some("v2") {
+        return py.allow_threads(|| {
+            return consumer_v2_impl(
+                consumer_group,
+                auto_offset_reset,
+                no_strict_offset_reset,
+                consumer_config_raw,
+                concurrency,
+                clickhouse_concurrency,
+                use_rust_processor,
+                enforce_schema,
+                max_poll_interval_ms,
+                async_inserts,
+                python_max_queue_depth,
+                health_check_file,
+                stop_at_timestamp,
+                batch_write_timeout_ms,
+                max_dlq_buffer_length,
+                custom_envoy_request_timeout,
+                join_timeout_ms,
+                health_check,
+            );
+        });
+    } else {
+        return py.allow_threads(|| {
+            return consumer_impl(
+                consumer_group,
+                auto_offset_reset,
+                no_strict_offset_reset,
+                consumer_config_raw,
+                concurrency,
+                clickhouse_concurrency,
+                use_rust_processor,
+                enforce_schema,
+                max_poll_interval_ms,
+                async_inserts,
+                python_max_queue_depth,
+                health_check_file,
+                stop_at_timestamp,
+                batch_write_timeout_ms,
+                max_dlq_buffer_length,
+                custom_envoy_request_timeout,
+                join_timeout_ms,
+                health_check,
+            );
+        });
+    }
+}
+
+pub fn consumer_v2_impl(
+    consumer_group: &str,
+    auto_offset_reset: &str,
+    no_strict_offset_reset: bool,
+    consumer_config_raw: &str,
+    concurrency: usize,
+    clickhouse_concurrency: usize,
+    use_rust_processor: bool,
+    enforce_schema: bool,
+    max_poll_interval_ms: usize,
+    async_inserts: bool,
+    python_max_queue_depth: Option<usize>,
+    health_check_file: Option<&str>,
+    stop_at_timestamp: Option<i64>,
+    batch_write_timeout_ms: Option<u64>,
+    max_dlq_buffer_length: Option<usize>,
+    custom_envoy_request_timeout: Option<u64>,
+    join_timeout_ms: Option<u64>,
+    health_check: &str,
+) -> usize {
+    setup_logging();
+
+    let consumer_config = config::ConsumerConfig::load_from_str(consumer_config_raw).unwrap();
+    let max_batch_size = consumer_config.max_batch_size;
+    let max_batch_time = Duration::from_millis(consumer_config.max_batch_time_ms);
+
+    let batch_write_timeout = match batch_write_timeout_ms {
+        Some(timeout_ms) => {
+            if timeout_ms >= consumer_config.max_batch_time_ms {
+                Some(Duration::from_millis(timeout_ms))
+            } else {
+                None
+            }
+        }
+        None => None,
+    };
+
+    for storage in &consumer_config.storages {
+        tracing::info!(
+            "Storage: {}, ClickHouse Table Name: {}, Message Processor: {:?}, ClickHouse host: {}, ClickHouse port: {}, ClickHouse HTTP port: {}, ClickHouse database: {}",
+            storage.name,
+            storage.clickhouse_table_name,
+            &storage.message_processor,
+            storage.clickhouse_cluster.host,
+            storage.clickhouse_cluster.port,
+            storage.clickhouse_cluster.http_port,
+            storage.clickhouse_cluster.database,
+        );
+    }
+
+    // TODO: Support multiple storages
+    assert_eq!(consumer_config.storages.len(), 1);
+
+    let mut _sentry_guard = None;
+
+    let env_config = consumer_config.env.clone();
+
+    // setup sentry
+    if let Some(dsn) = consumer_config.env.sentry_dsn {
+        tracing::debug!(sentry_dsn = dsn);
+        // this forces anyhow to record stack traces when capturing an error:
+        std::env::set_var("RUST_BACKTRACE", "1");
+        _sentry_guard = Some(setup_sentry(&dsn));
+    }
+
+    // setup arroyo metrics
+    if let (Some(host), Some(port)) = (
+        consumer_config.env.dogstatsd_host,
+        consumer_config.env.dogstatsd_port,
+    ) {
+        let storage_name = consumer_config
+            .storages
+            .iter()
+            .map(|s| s.name.clone())
+            .collect::<Vec<_>>()
+            .join(",");
+        set_global_tag("storage".to_owned(), storage_name);
+        set_global_tag("consumer_group".to_owned(), consumer_group.to_owned());
+
+        metrics::init(StatsDBackend::new(
+            &host,
+            port,
+            "snuba.consumer",
+            env_config.ddm_metrics_sample_rate,
+        ))
+        .unwrap();
+    }
+
+    if !use_rust_processor {
+        procspawn::init();
+    }
+
+    let first_storage = consumer_config.storages[0].clone();
+
+    tracing::info!(
+        storage = first_storage.name,
+        "Starting consumer for {:?}",
+        first_storage.name,
+    );
+
+    let config = KafkaConfig::new_consumer_config(
+        vec![],
+        consumer_group.to_owned(),
+        auto_offset_reset.parse().expect(
+            "Invalid value for `auto_offset_reset`. Valid values: `error`, `earliest`, `latest`",
+        ),
+        !no_strict_offset_reset,
+        max_poll_interval_ms,
+        Some(consumer_config.raw_topic.broker_config),
+    );
+
+    let logical_topic_name = consumer_config.raw_topic.logical_topic_name;
+
+    // XXX: this variable must live for the lifetime of the entire consumer. we should do something
+    // to ensure this statically, such as use actual Rust lifetimes or ensuring the runtime stays
+    // alive by storing it inside of the DlqPolicy
+    let dlq_concurrency_config = ConcurrencyConfig::new(10);
+
+    // DLQ policy applies only if we are not skipping writes, otherwise we don't want to be
+    // writing to the DLQ topics in prod.
+    let dlq_policy = consumer_config.dlq_topic.map(|dlq_topic_config| {
+        let producer_config =
+            KafkaConfig::new_producer_config(vec![], Some(dlq_topic_config.broker_config));
+        let producer = KafkaProducer::new(producer_config);
+
+        let kafka_dlq_producer = Box::new(KafkaDlqProducer::new(
+            producer,
+            Topic::new(&dlq_topic_config.physical_topic_name),
+        ));
+
+        let handle = dlq_concurrency_config.handle();
+        DlqPolicy::new(
+            handle,
+            kafka_dlq_producer,
+            DlqLimit {
+                max_invalid_ratio: None,
+                max_consecutive_count: None,
+            },
             max_dlq_buffer_length,
-            custom_envoy_request_timeout,
-            join_timeout_ms,
-            health_check,
         )
-    })
+    });
+
+    let commit_log_producer = if let Some(topic_config) = consumer_config.commit_log_topic {
+        let producer_config =
+            KafkaConfig::new_producer_config(vec![], Some(topic_config.broker_config));
+        let producer = KafkaProducer::new(producer_config);
+        Some((
+            Arc::new(producer),
+            Topic::new(&topic_config.physical_topic_name),
+        ))
+    } else {
+        None
+    };
+
+    let replacements_config = if let Some(topic_config) = consumer_config.replacements_topic {
+        let producer_config =
+            KafkaConfig::new_producer_config(vec![], Some(topic_config.broker_config));
+        Some((
+            producer_config,
+            Topic::new(&topic_config.physical_topic_name),
+        ))
+    } else {
+        None
+    };
+
+    let topic = Topic::new(&consumer_config.raw_topic.physical_topic_name);
+
+    let mut rebalance_delay_secs = consumer_config
+        .raw_topic
+        .quantized_rebalance_consumer_group_delay_secs;
+    let config_rebalance_delay_secs = rebalancing::get_rebalance_delay_secs(consumer_group);
+    if let Some(secs) = config_rebalance_delay_secs {
+        rebalance_delay_secs = Some(secs);
+    }
+    if let Some(secs) = rebalance_delay_secs {
+        rebalancing::delay_kafka_rebalance(secs)
+    }
+
+    let factory = ConsumerStrategyFactoryV2 {
+        storage_config: first_storage,
+        env_config,
+        logical_topic_name,
+        max_batch_size,
+        max_batch_time,
+        processing_concurrency: ConcurrencyConfig::new(concurrency),
+        clickhouse_concurrency: ConcurrencyConfig::new(clickhouse_concurrency),
+        commitlog_concurrency: ConcurrencyConfig::new(2),
+        replacements_concurrency: ConcurrencyConfig::new(4),
+        async_inserts,
+        python_max_queue_depth,
+        use_rust_processor,
+        health_check_file: health_check_file.map(ToOwned::to_owned),
+        enforce_schema,
+        commit_log_producer,
+        replacements_config,
+        physical_consumer_group: consumer_group.to_owned(),
+        physical_topic_name: Topic::new(&consumer_config.raw_topic.physical_topic_name),
+        accountant_topic_config: consumer_config.accountant_topic,
+        stop_at_timestamp,
+        batch_write_timeout,
+        custom_envoy_request_timeout,
+        join_timeout_ms,
+        health_check: health_check.to_string(),
+    };
+
+    let processor = StreamProcessor::with_kafka(config, factory, topic, dlq_policy);
+
+    let mut handle = processor.get_handle();
+
+    match rebalance_delay_secs {
+        Some(secs) => {
+            ctrlc::set_handler(move || {
+                rebalancing::delay_kafka_rebalance(secs);
+                handle.signal_shutdown();
+            })
+            .expect("Error setting Ctrl-C handler");
+        }
+        None => {
+            ctrlc::set_handler(move || {
+                handle.signal_shutdown();
+            })
+            .expect("Error setting Ctrl-C handler");
+        }
+    }
+
+    if let Err(error) = processor.run() {
+        let error: &dyn std::error::Error = &error;
+        tracing::error!("{:?}", error);
+        1
+    } else {
+        0
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -51,8 +51,8 @@ pub fn consumer(
     consumer_version: Option<&str>,
 ) -> usize {
     if consumer_version == Some("v2") {
-        return py.allow_threads(|| {
-            return consumer_v2_impl(
+        py.allow_threads(|| {
+            consumer_v2_impl(
                 consumer_group,
                 auto_offset_reset,
                 no_strict_offset_reset,
@@ -71,11 +71,11 @@ pub fn consumer(
                 custom_envoy_request_timeout,
                 join_timeout_ms,
                 health_check,
-            );
-        });
+            )
+        })
     } else {
-        return py.allow_threads(|| {
-            return consumer_impl(
+        py.allow_threads(|| {
+            consumer_impl(
                 consumer_group,
                 auto_offset_reset,
                 no_strict_offset_reset,
@@ -94,11 +94,12 @@ pub fn consumer(
                 custom_envoy_request_timeout,
                 join_timeout_ms,
                 health_check,
-            );
-        });
+            )
+        })
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn consumer_v2_impl(
     consumer_group: &str,
     auto_offset_reset: &str,

--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -1,0 +1,283 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use sentry::{Hub, SentryFutureExt};
+use sentry_arroyo::backends::kafka::config::KafkaConfig;
+use sentry_arroyo::backends::kafka::producer::KafkaProducer;
+use sentry_arroyo::backends::kafka::types::KafkaPayload;
+use sentry_arroyo::processing::strategies::commit_offsets::CommitOffsets;
+use sentry_arroyo::processing::strategies::healthcheck::HealthCheck;
+use sentry_arroyo::processing::strategies::reduce::Reduce;
+use sentry_arroyo::processing::strategies::run_task_in_threads::{
+    ConcurrencyConfig, RunTaskInThreads,
+};
+use sentry_arroyo::processing::strategies::run_task_in_threads::{
+    RunTaskError, RunTaskFunc, TaskRunner,
+};
+use sentry_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
+use sentry_arroyo::types::Message;
+use sentry_arroyo::types::{Partition, Topic};
+use sentry_kafka_schemas::Schema;
+
+use crate::config;
+use crate::metrics::global_tags::set_global_tag;
+use crate::processors::{self, get_cogs_label};
+use crate::strategies::accountant::RecordCogs;
+use crate::strategies::clickhouse::batch::{BatchFactory, HttpBatch};
+use crate::strategies::clickhouse::ClickhouseWriterStep;
+use crate::strategies::commit_log::ProduceCommitLog;
+use crate::strategies::healthcheck::HealthCheck as SnubaHealthCheck;
+use crate::strategies::join_timeout::SetJoinTimeout;
+use crate::strategies::processor::{
+    get_schema, make_rust_processor, make_rust_processor_with_replacements, validate_schema,
+};
+use crate::strategies::python::PythonTransformStep;
+use crate::strategies::replacements::ProduceReplacements;
+use crate::types::{BytesInsertBatch, CogsData, RowData};
+
+pub struct ConsumerStrategyFactoryV2 {
+    pub storage_config: config::StorageConfig,
+    pub env_config: config::EnvConfig,
+    pub logical_topic_name: String,
+    pub max_batch_size: usize,
+    pub max_batch_time: Duration,
+    pub processing_concurrency: ConcurrencyConfig,
+    pub clickhouse_concurrency: ConcurrencyConfig,
+    pub commitlog_concurrency: ConcurrencyConfig,
+    pub replacements_concurrency: ConcurrencyConfig,
+    pub async_inserts: bool,
+    pub python_max_queue_depth: Option<usize>,
+    pub use_rust_processor: bool,
+    pub health_check_file: Option<String>,
+    pub enforce_schema: bool,
+    pub commit_log_producer: Option<(Arc<KafkaProducer>, Topic)>,
+    pub replacements_config: Option<(KafkaConfig, Topic)>,
+    pub physical_consumer_group: String,
+    pub physical_topic_name: Topic,
+    pub accountant_topic_config: config::TopicConfig,
+    pub stop_at_timestamp: Option<i64>,
+    pub batch_write_timeout: Option<Duration>,
+    pub custom_envoy_request_timeout: Option<u64>,
+    pub join_timeout_ms: Option<u64>,
+    pub health_check: String,
+}
+
+impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
+    fn update_partitions(&self, partitions: &HashMap<Partition, u64>) {
+        match partitions.keys().map(|partition| partition.index).min() {
+            Some(min) => set_global_tag("min_partition".to_owned(), min.to_string()),
+            None => set_global_tag("min_partition".to_owned(), "none".to_owned()),
+        }
+    }
+
+    fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
+        // Commit offsets
+        let next_step = CommitOffsets::new(Duration::from_secs(1));
+
+        // Produce commit log if there is one
+        let next_step: Box<dyn ProcessingStrategy<BytesInsertBatch<()>>> =
+            if let Some((ref producer, destination)) = self.commit_log_producer {
+                Box::new(ProduceCommitLog::new(
+                    next_step,
+                    producer.clone(),
+                    destination,
+                    self.physical_topic_name,
+                    self.physical_consumer_group.clone(),
+                    &self.commitlog_concurrency,
+                    false,
+                ))
+            } else {
+                Box::new(next_step)
+            };
+
+        let cogs_label = get_cogs_label(&self.storage_config.message_processor.python_class_name);
+
+        // Produce cogs if generic metrics AND we are not skipping writes AND record_cogs is true
+        let next_step: Box<dyn ProcessingStrategy<BytesInsertBatch<()>>> =
+            match (self.env_config.record_cogs, cogs_label) {
+                (true, Some(resource_id)) => Box::new(RecordCogs::new(
+                    next_step,
+                    resource_id,
+                    self.accountant_topic_config.broker_config.clone(),
+                    &self.accountant_topic_config.physical_topic_name,
+                )),
+                _ => next_step,
+            };
+
+        // Write to clickhouse
+        let next_step = ClickhouseWriterStep::new(next_step, &self.clickhouse_concurrency);
+
+        let next_step = SetJoinTimeout::new(
+            next_step,
+            Some(Duration::from_millis(self.join_timeout_ms.unwrap_or(0))),
+        );
+
+        // Batch insert rows
+        let batch_factory = BatchFactory::new(
+            &self.storage_config.clickhouse_cluster.host,
+            self.storage_config.clickhouse_cluster.http_port,
+            &self.storage_config.clickhouse_table_name,
+            &self.storage_config.clickhouse_cluster.database,
+            &self.clickhouse_concurrency,
+            &self.storage_config.clickhouse_cluster.user,
+            &self.storage_config.clickhouse_cluster.password,
+            self.storage_config.clickhouse_cluster.secure,
+            self.async_inserts,
+            self.batch_write_timeout,
+            self.custom_envoy_request_timeout,
+        );
+
+        let accumulator = Arc::new(
+            |batch: BytesInsertBatch<HttpBatch>,
+             small_batch: Message<BytesInsertBatch<RowData>>| {
+                Ok(batch.merge(small_batch.into_payload()))
+            },
+        );
+
+        let next_step = Reduce::new(
+            next_step,
+            accumulator,
+            Arc::new(move || {
+                BytesInsertBatch::new(
+                    batch_factory.new_batch(),
+                    None,
+                    None,
+                    None,
+                    Default::default(),
+                    CogsData::default(),
+                )
+            }),
+            self.max_batch_size,
+            self.max_batch_time,
+            BytesInsertBatch::len,
+            // we need to enable this to deal with storages where we skip 100% of values, such as
+            // gen-metrics-gauges in s4s. we still need to commit there
+        )
+        .flush_empty_batches(true);
+
+        // Transform messages
+        let next_step = match (
+            self.use_rust_processor,
+            processors::get_processing_function(
+                &self.storage_config.message_processor.python_class_name,
+            ),
+        ) {
+            (
+                true,
+                Some(processors::ProcessingFunctionType::ProcessingFunctionWithReplacements(func)),
+            ) => {
+                let (replacements_config, replacements_destination) =
+                    self.replacements_config.clone().unwrap();
+
+                let producer = KafkaProducer::new(replacements_config);
+                let replacements_step = ProduceReplacements::new(
+                    next_step,
+                    producer,
+                    replacements_destination,
+                    &self.replacements_concurrency,
+                    false,
+                );
+
+                make_rust_processor_with_replacements(
+                    replacements_step,
+                    func,
+                    &self.logical_topic_name,
+                    self.enforce_schema,
+                    &self.processing_concurrency,
+                    config::ProcessorConfig {
+                        env_config: self.env_config.clone(),
+                    },
+                    self.stop_at_timestamp,
+                )
+            }
+            (true, Some(processors::ProcessingFunctionType::ProcessingFunction(func))) => {
+                make_rust_processor(
+                    next_step,
+                    func,
+                    &self.logical_topic_name,
+                    self.enforce_schema,
+                    &self.processing_concurrency,
+                    config::ProcessorConfig {
+                        env_config: self.env_config.clone(),
+                    },
+                    self.stop_at_timestamp,
+                )
+            }
+            (
+                false,
+                Some(processors::ProcessingFunctionType::ProcessingFunctionWithReplacements(_)),
+            ) => {
+                panic!("Consumer with replacements cannot be run in hybrid-mode");
+            }
+            _ => {
+                let schema = get_schema(&self.logical_topic_name, self.enforce_schema);
+
+                Box::new(RunTaskInThreads::new(
+                    PythonTransformStep::new(
+                        next_step,
+                        self.storage_config.message_processor.clone(),
+                        self.processing_concurrency.concurrency,
+                        self.python_max_queue_depth,
+                    )
+                    .unwrap(),
+                    SchemaValidator {
+                        schema,
+                        enforce_schema: self.enforce_schema,
+                    },
+                    &self.processing_concurrency,
+                    Some("validate_schema"),
+                ))
+            }
+        };
+
+        // force message processor to drop all in-flight messages, as it is not worth the time
+        // spent in rebalancing to wait for them and it is idempotent anyway. later, we overwrite
+        // the timeout again for the clickhouse writer step
+        let next_step = SetJoinTimeout::new(
+            next_step,
+            Some(Duration::from_millis(self.join_timeout_ms.unwrap_or(0))),
+        );
+        if let Some(path) = &self.health_check_file {
+            {
+                if self.health_check == "snuba" {
+                    tracing::info!(
+                        "Using Snuba HealthCheck for consumer group: {}",
+                        self.physical_consumer_group
+                    );
+                    Box::new(SnubaHealthCheck::new(next_step, path))
+                } else {
+                    Box::new(HealthCheck::new(next_step, path))
+                }
+            }
+        } else {
+            Box::new(next_step)
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SchemaValidator {
+    schema: Option<Arc<Schema>>,
+    enforce_schema: bool,
+}
+
+impl SchemaValidator {
+    async fn process_message(
+        self,
+        message: Message<KafkaPayload>,
+    ) -> Result<Message<KafkaPayload>, RunTaskError<anyhow::Error>> {
+        validate_schema(&message, &self.schema, self.enforce_schema)?;
+        Ok(message)
+    }
+}
+
+impl TaskRunner<KafkaPayload, KafkaPayload, anyhow::Error> for SchemaValidator {
+    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<KafkaPayload, anyhow::Error> {
+        Box::pin(
+            self.clone()
+                .process_message(message)
+                .bind_hub(Hub::new_from_top(Hub::current())),
+        )
+    }
+}

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -1,6 +1,7 @@
 mod config;
 mod consumer;
 mod factory;
+mod factory_v2;
 mod logging;
 mod metrics;
 mod processors;
@@ -27,6 +28,7 @@ pub use config::{
     StorageConfig, TopicConfig,
 };
 pub use factory::ConsumerStrategyFactory;
+pub use factory_v2::ConsumerStrategyFactoryV2;
 pub use metrics::statsd::StatsDBackend;
 pub use processors::{ProcessingFunction, ProcessingFunctionType, PROCESSORS};
 pub use strategies::noop::Noop;

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -194,6 +194,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     type=click.Choice(["snuba", "arroyo"]),
     help="Specify which health check to use for the consumer. If not specified, the default Arroyo health check is used.",
 )
+@click.option(
+    "--consumer-version",
+    default="v1",
+    type=click.Choice(["v1", "v2"]),
+    help="Specify which consumer version to use, v1 is stable, v2 is experimental",
+)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -227,7 +233,8 @@ def rust_consumer(
     max_dlq_buffer_length: Optional[int],
     quantized_rebalance_consumer_group_delay_secs: Optional[int],
     custom_envoy_request_timeout: Optional[int],
-    join_timeout_ms: Optional[int]
+    join_timeout_ms: Optional[int],
+    consumer_version: Optional[str],
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -284,6 +291,7 @@ def rust_consumer(
         max_dlq_buffer_length,
         custom_envoy_request_timeout,
         join_timeout_ms,
+        consumer_version,
     )
 
     sys.exit(exitcode)


### PR DESCRIPTION
Create a copy of the snuba consumer which is selectable via command line argument. This is what will be used to experiment with new consumer implementations in production. As of now, the V2 and V1 consumers are exactly the same. 

Resolves https://linear.app/getsentry/issue/EAP-124/create-forked-snuba-consumer-implmentation
