### PR TITLE
feat(devservices): Add containerized modes for profiles, uptime, metrics dev

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -113,11 +113,6 @@ services:
     restart: unless-stopped
   profiles-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=profiles,
@@ -148,11 +143,6 @@ services:
     restart: unless-stopped
   profile-chunks-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=profile_chunks,
@@ -183,11 +173,6 @@ services:
     restart: unless-stopped
   functions-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=functions_raw,
@@ -218,11 +203,6 @@ services:
     restart: unless-stopped
   uptime-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=uptime_monitor_checks,
@@ -253,11 +233,6 @@ services:
     restart: unless-stopped
   metrics-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=metrics_raw,
@@ -288,11 +263,6 @@ services:
     restart: unless-stopped
   generic-metrics-distributions-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=generic_metrics_distributions_raw,
@@ -323,11 +293,6 @@ services:
     restart: unless-stopped
   generic-metrics-sets-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=generic_metrics_sets_raw,
@@ -358,11 +323,6 @@ services:
     restart: unless-stopped
   generic-metrics-counters-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
           rust-consumer,
           --storage=generic_metrics_counters_raw,
@@ -393,13 +353,7 @@ services:
     restart: unless-stopped
   generic-metrics-gauges-consumer:
     image: ghcr.io/getsentry/snuba:latest
-    healthcheck:
-      test: curl -f http://localhost:1218/health_envoy
-      interval: 5s
-      timeout: 5s
-      retries: 3
     command: [
-          snuba,
           rust-consumer,
           --storage=generic_metrics_gauges_raw,
           --consumer-group=snuba-gen-metrics-gauges-consumers,


### PR DESCRIPTION
This adds more containerized modes that start up groups of consumers to support profiles, uptime, and metrics dev. The goal of this is to allow toggling of features in sentry without the injection of env variables

Context: 
We're trying to ease development within Sentry if devs want to enable features such as profiling, uptime, and metrics. Instead of changing django settings in their sentry config and using env variable injection manually to start various groups of consumers to support these features, we'd like to make it easier.

This allows us to support something like devservices up --mode profiling in sentry where users would have all the ingest consumers for profiling brought up, vroom, and snuba consumers within one command. Devservices is able to import the definitions to understand the groups of snuba consumers that need to be brought up to support certain features.