### PR TITLE
chore(redis): update sentry-redis-tools to 0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ redis==4.5.4
 sentry-arroyo==2.22.0
 sentry-kafka-schemas==1.3.7
 sentry-protos==0.2.0
-sentry-redis-tools==0.3.0
+sentry-redis-tools==0.5.0
 sentry-relay==0.9.5
 sentry-sdk==2.18.0
 simplejson==3.17.6


### PR DESCRIPTION
looks like we aren't on the latest version, so update to the latest version