### PR TITLE
ref(eap): tests with orderby label only

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_table.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_table.py
@@ -74,8 +74,8 @@ def _validate_select_and_groupby(in_msg: TraceItemTableRequest) -> None:
 
 
 def _validate_order_by(in_msg: TraceItemTableRequest) -> None:
-    order_by_cols = set([ob.column.label for ob in in_msg.order_by])
-    selected_columns = set([c.label for c in in_msg.columns])
+    order_by_cols = {ob.column.label for ob in in_msg.order_by if ob.column.label}
+    selected_columns = {c.label for c in in_msg.columns}
     if not order_by_cols.issubset(selected_columns):
         raise BadSnubaRPCRequestException(
             f"Ordered by columns {order_by_cols} not selected: {selected_columns}"


### PR DESCRIPTION


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
