### PR TITLE
feat(capman): Don't rate limit customers for workflow alert referrers

### DIFF
--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -33,6 +33,9 @@ _PASS_THROUGH_REFERRERS = set(
         "tsdb-modelid:4.batch_alert_event_frequency",
         "tsdb-modelid:4.batch_alert_event_uniq_user_frequency",
         "tsdb-modelid:4.batch_alert_event_frequency_percent",
+        "tsdb-modelid:4.wf_batch_alert_event_frequency",
+        "tsdb-modelid:4.wf_batch_alert_event_uniq_user_frequency",
+        "tsdb-modelid:4.wf_batch_alert_event_frequency_percent",
     ]
 )
 from snuba.query.allocation_policies import MAX_THRESHOLD, NO_SUGGESTION


### PR DESCRIPTION
The new workflow-based alerting implementation referrers should get the same treatment as the referrers in the code they're replacing.
