### PR TITLE
feat(capman): Fix model ID for workflow querying referrer

### DIFF
--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -34,7 +34,7 @@ _PASS_THROUGH_REFERRERS = set(
         "tsdb-modelid:4.batch_alert_event_uniq_user_frequency",
         "tsdb-modelid:4.batch_alert_event_frequency_percent",
         "tsdb-modelid:4.wf_batch_alert_event_frequency",
-        "tsdb-modelid:4.wf_batch_alert_event_uniq_user_frequency",
+        "tsdb-modelid:300.wf_batch_alert_event_uniq_user_frequency",
         "tsdb-modelid:4.wf_batch_alert_event_frequency_percent",
     ]
 )


### PR DESCRIPTION
One of our referrers queries `users_affected_by_group`, and our passthrough config needs to reflect that.
