### PR TITLE
ci: acquire docker image from ghcr for release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,15 +6,17 @@ statusProvider:
   name: github
   config:
     contexts:
-      - 'build-on-branch-push (sentryio)'
+      - 'build-amd64'
+      - 'build-arm64'
+      - 'assemble'
 targets:
   - id: release
     name: docker
-    source: us-central1-docker.pkg.dev/sentryio/snuba/image
+    source: ghcr.io/getsentry/snuba
     target: getsentry/snuba
   - id: latest
     name: docker
-    source: us-central1-docker.pkg.dev/sentryio/snuba/image
+    source: ghcr.io/getsentry/snuba
     target: getsentry/snuba
     targetFormat: '{{{target}}}:latest'
   - name: github

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,6 +13,7 @@ jobs:
           - os: ubuntu-24.04-arm
             platform: arm64
     runs-on: ${{ matrix.os }}
+    name: build-${{ matrix.platform }}
     permissions:
       contents: read
       packages: write
@@ -111,14 +112,7 @@ jobs:
     name: Publish Snuba to DockerHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # v3.1.0
-      - name: Pull the test image
-        id: image_pull
-        env:
-          IMAGE_URL: ghcr.io/getsentry/snuba:${{ github.sha }}
-        shell: bash
-        run: |
-          docker pull "$IMAGE_URL"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get short SHA for docker tag
         id: short_sha
         shell: bash


### PR DESCRIPTION
**This PR is due for 25.7.0 release (before 15 July 2025).**

Craft was trying to copy the Docker image from Google Artifact Registry (which only has arm64 image) instead of GitHub Container Registry (which has both arm64 and amd64 editions). This was the debug message (acquired from [this log file](https://github.com/getsentry/publish/issues/5717#issuecomment-2977646400)):

```
[debug] [[target/docker]] Copying image from us-central1-docker.pkg.dev/sentryio/snuba/image:0a1f1b510058691b10fe9ddfec72a03778bd644d to getsentry/snuba:25.6.0...
```

Therefore, we moved Craft `statusProvider.context` to the one on GitHub Actions, and change the source to GHCR.

Also, this workflow never succeed: https://github.com/getsentry/snuba/actions/workflows/release-ghcr-version-tag.yml -- this is fixed by adding `releases/*` on the `branches` list.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
