### PR TITLE
chore(eap-timeseries): Bump max allowed bucktes by 1 (DAIN-667)

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -37,8 +37,8 @@ _VALID_GRANULARITY_SECS = set(
     ]
 )
 
-# MAX 15 minute granularity over 28 days
-_MAX_BUCKETS_IN_REQUEST = 2688
+# MAX 15 minute granularity over 28 days (2688 buckets) + 1 bucket to allow for partial time buckets on
+_MAX_BUCKETS_IN_REQUEST = 2689
 
 
 def _enforce_no_duplicate_labels(request: TimeSeriesRequest) -> None:


### PR DESCRIPTION
Adding an additional bucket since we have updated the product
to make queries with stable time bucket quantization and that means
we could have partial buckets at the ends of the timeseries. So we
need one extra bucket to support 15 min intervals over 28 days.