### PR TITLE
test redis cache set connection error

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -74,6 +74,7 @@ class RedisCache(Cache[TValue]):
         else:
             try:
                 value = function()
+                raise ConnectionError("test")
                 self.__client.set(
                     result_key,
                     self.__codec.encode(value),


### PR DESCRIPTION
NOT TO BE MERGED

this forces a redis connection error on cache set. if you run test_api.py you can see it causes most of the tests to fail.