### PR TITLE
feat: open fail for snuba cache write failures

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Callable, Optional
 
+import sentry_sdk
+
 from redis.exceptions import ConnectionError, ReadOnlyError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from snuba import environment, settings
@@ -84,7 +86,7 @@ class RedisCache(Cache[TValue]):
                     timer.mark("cache_set")
             except Exception as e:
                 metrics.increment("execute_error", tags=metric_tags)
-                raise e
+                sentry_sdk.capture_exception(e)
             return value
 
     def get_readthrough(

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional
 
 import sentry_sdk
 
+from redis import RedisError
 from redis.exceptions import ConnectionError, ReadOnlyError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from snuba import environment, settings
@@ -76,17 +77,22 @@ class RedisCache(Cache[TValue]):
         else:
             try:
                 value = function()
-                self.__client.set(
-                    result_key,
-                    self.__codec.encode(value),
-                    ex=get_config("cache_expiry_sec", 1),
-                )
+                try:
+                    self.__client.set(
+                        result_key,
+                        self.__codec.encode(value),
+                        ex=get_config("cache_expiry_sec", 1),
+                    )
+                except RedisError as e:
+                    metrics.increment("redis_cache_set_error", tags=metric_tags)
+                    sentry_sdk.capture_exception(e)
+                    return value
                 record_cache_hit_type(RESULT_EXECUTE)
                 if timer is not None:
                     timer.mark("cache_set")
             except Exception as e:
                 metrics.increment("execute_error", tags=metric_tags)
-                sentry_sdk.capture_exception(e)
+                raise e
             return value
 
     def get_readthrough(


### PR DESCRIPTION
Previously if a cache write failed by raising an exception it would cause the entire query to fail. We want the query to succeed even if the cache write fails. This PR does that.

This is for inc-1215