### PR TITLE
fix(ci): Tag snuba docker images using PR commit shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,6 @@ jobs:
             --network devservices \
             ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }}
           docker exec snuba-snuba-1 snuba migrations migrate --force
-          docker ps
 
       - name: Run snuba tests
         if: needs.files-changed.outputs.api_changes == 'false'


### PR DESCRIPTION
On PR runs, `github.sha` will not give you the commit sha

More details: https://github.com/orgs/community/discussions/25191