### PR TITLE
feat(logs): Add support for creating logs subscriptions

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -217,6 +217,31 @@ def devserver(*, bootstrap: bool, workers: bool, log_level: str) -> None:
                     f"--log-level={log_level}",
                 ],
             ),
+            (
+                "subscriptions-scheduler-eap-items",
+                [
+                    "snuba",
+                    "subscriptions-scheduler",
+                    "--entity=eap_items",
+                    "--consumer-group=snuba-eap_items-subscriptions-scheduler",
+                    "--followed-consumer-group=eap_items_group",
+                    "--auto-offset-reset=latest",
+                    f"--log-level={log_level}",
+                    "--schedule-ttl=10",
+                ],
+            ),
+            (
+                "subscriptions-executor-eap-items",
+                [
+                    "snuba",
+                    "subscriptions-executor",
+                    "--dataset=events_analytics_platform",
+                    "--entity=eap_items_span",
+                    "--consumer-group=snuba-eap_items-subscription-executor",
+                    "--auto-offset-reset=latest",
+                    f"--log-level={log_level}",
+                ],
+            ),
         ]
 
     else:
@@ -262,6 +287,22 @@ def devserver(*, bootstrap: bool, workers: bool, log_level: str) -> None:
                     "--entity=eap_items_span",
                     "--consumer-group=snuba-eap_spans-subscription-executor",
                     "--followed-consumer-group=eap_items_span_group",
+                    "--auto-offset-reset=latest",
+                    "--no-strict-offset-reset",
+                    f"--log-level={log_level}",
+                    "--schedule-ttl=10",
+                    "--stale-threshold-seconds=900",
+                ],
+            ),
+            (
+                "subscriptions-scheduler-executor-eap-items",
+                [
+                    "snuba",
+                    "subscriptions-scheduler-executor",
+                    "--dataset=events_analytics_platform",
+                    "--entity=eap_items",
+                    "--consumer-group=snuba-eap_items-subscriptions-scheduler",
+                    "--followed-consumer-group=eap_items_group",
                     "--auto-offset-reset=latest",
                     "--no-strict-offset-reset",
                     f"--log-level={log_level}",

--- a/snuba/web/rpc/v1/create_subscription.py
+++ b/snuba/web/rpc/v1/create_subscription.py
@@ -46,7 +46,7 @@ class CreateSubscriptionRequest(
 
         if (
             in_msg.time_series_request.meta.trace_item_type
-            == TraceItemType.TRACE_ITEM_TYPE_LOG
+            != TraceItemType.TRACE_ITEM_TYPE_SPAN
         ):
             entity_key = EntityKey("eap_items")
 

--- a/snuba/web/rpc/v1/create_subscription.py
+++ b/snuba/web/rpc/v1/create_subscription.py
@@ -6,6 +6,7 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
 from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
     CreateSubscriptionResponse,
 )
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
 from snuba import state
 from snuba.datasets.entities.entity_key import EntityKey
@@ -42,6 +43,13 @@ class CreateSubscriptionRequest(
 
         dataset = PluggableDataset(name="eap", all_entities=[])
         entity_key = EntityKey(subscription_entity_name())
+
+        if (
+            in_msg.time_series_request.meta.trace_item_type
+            == TraceItemType.TRACE_ITEM_TYPE_LOG
+        ):
+            entity_key = EntityKey("eap_items")
+
         subscription = RPCSubscriptionData.from_proto(in_msg, entity_key=entity_key)
         identifier = SubscriptionCreator(dataset, entity_key).create(
             subscription, self._timer

--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -37,8 +37,8 @@ _VALID_GRANULARITY_SECS = set(
     ]
 )
 
-# MAX 15 minute granularity over 28 days
-_MAX_BUCKETS_IN_REQUEST = 2688
+# MAX 15 minute granularity over 28 days (2688 buckets) + 1 bucket to allow for partial time buckets on
+_MAX_BUCKETS_IN_REQUEST = 2689
 
 
 def _enforce_no_duplicate_labels(request: TimeSeriesRequest) -> None:

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -274,3 +274,64 @@ class TestCreateSubscriptionApi(BaseApiTest):
         error = Error()
         error.ParseFromString(response.data)
         assert error_message in error.message
+
+    def test_create_valid_logs_subscription(self) -> None:
+        message = CreateSubscriptionRequest(
+            time_series_request=TimeSeriesRequest(
+                meta=RequestMeta(
+                    project_ids=[1],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                ),
+                aggregations=[
+                    AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_FLOAT, name="test_metric"
+                        ),
+                        label="sum",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+                    ),
+                ],
+                granularity_secs=300,
+            ),
+            time_window_secs=300,
+            resolution_secs=60,
+        )
+        response = self.app.post(
+            "/rpc/CreateSubscriptionRequest/v1", data=message.SerializeToString()
+        )
+
+        assert response.status_code == 200
+
+        response_class = CreateSubscriptionResponse()
+        response_class.ParseFromString(response.data)
+
+        assert response_class.subscription_id
+
+        partition = int(response_class.subscription_id.split("/", 1)[0])
+        rpc_subscription_data = list(
+            RedisSubscriptionDataStore(
+                get_redis_client(RedisClientKey.SUBSCRIPTION_STORE),
+                EntityKey(
+                    "eap_items"
+                ),  # Logs subscriptions always get created in eap_items
+                PartitionId(partition),
+            ).all()
+        )[0][1]
+
+        assert isinstance(rpc_subscription_data, RPCSubscriptionData)
+
+        request_class = TimeSeriesRequest()
+        request_class.ParseFromString(
+            base64.b64decode(rpc_subscription_data.time_series_request)
+        )
+
+        assert request_class.meta.trace_item_type == TraceItemType.TRACE_ITEM_TYPE_LOG
+
+        assert rpc_subscription_data.time_window_sec == 300
+        assert rpc_subscription_data.resolution_sec == 60
+        assert rpc_subscription_data.request_name == "TimeSeriesRequest"
+        assert rpc_subscription_data.request_version == "v1"


### PR DESCRIPTION
We'd like to test log alerts in production (with flag enabled just for sentry). 
This allows us to do do so without being blocked on spans moving to the items pipeline. 

Current behaviour is `CreateSubscription` uses a single entity key agnostic of trace item type,
and currently goes to `eap_items_span`. This updates the behaviour to check if trace item type
is logs, and if so, use `eap_items`.

Subscriptions consumers and topics for eap_items [exist in prod alread](https://github.com/getsentry/ops/blob/master/k8s/services/snuba/region_overrides/us/default.yaml#L331-L334)y, so this change
should let us test log alerts in prod. 

I also tested it locally end-to-end with sentry to make sure both span and log alerts work as expected
and span subscriptions are stored in `subscriptions:eap_items_span:<partition_number>` in the cache
and log subscriptions are stored in `subscriptions:eap_items:<partition_number>`