### PR TITLE
remove sentry logging

### DIFF
--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -319,7 +319,6 @@ class BaseRoutingStrategy(metaclass=RegisteredClass):
 
     def _emit_routing_mistake(self, routing_decision: RoutingDecision) -> None:
         if routing_decision.routing_context.query_result is None:
-            sentry_sdk.capture_message("storage routing: query_result is None")
             return
         if self._is_highest_accuracy_mode(routing_decision.routing_context):
             return


### PR DESCRIPTION
We have thousands of these info messages in Sentry ([SNUBA-8YR](https://sentry.sentry.io/issues/6678392556/?project=300688&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)) that don't seem to be useful

