### PR TITLE
feat(attributes): add sampling to autocomplete

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,6 +66,9 @@
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": ["tests"],
   "python.analysis.autoImportCompletions": true,
-  "mypy-type-checker.args": ["--strict"]
+  "mypy-type-checker.args": [
+    "--strict"
+  ],
+  "makefile.configureOnOpen": false
 
 }

--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -135,7 +135,7 @@ def _build_snuba_request(
         id=uuid.uuid4(),
         original_body=MessageToDict(request),
         query=_build_query(request),
-        query_settings=HTTPQuerySettings(),
+        query_settings=settings,
         attribution_info=AttributionInfo(
             referrer=request.meta.referrer,
             team="eap",

--- a/tests/web/rpc/v1/test_endpoint_trace_item_stats.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_stats.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from typing import Any
 
 import pytest
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
     AttributeDistribution,
     AttributeDistributionsRequest,
@@ -89,6 +90,9 @@ class TestTraceItemAttributesStats(BaseApiTest):
                 start_timestamp=START_TIMESTAMP,
                 end_timestamp=END_TIMESTAMP,
                 trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
+                ),
             ),
             stats_types=[
                 StatsType(
@@ -144,6 +148,9 @@ class TestTraceItemAttributesStats(BaseApiTest):
                 start_timestamp=START_TIMESTAMP,
                 end_timestamp=END_TIMESTAMP,
                 trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
+                ),
             ),
             filter=TraceItemFilter(
                 comparison_filter=ComparisonFilter(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_stats_logs.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_stats_logs.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
     AttributeDistribution,
     AttributeDistributionsRequest,
@@ -63,6 +64,9 @@ class TestTraceItemStatsForLogs(BaseApiTest):
                 end_timestamp=end_timestamp,
                 request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
                 trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY,
+                ),
             ),
             stats_types=[
                 StatsType(


### PR DESCRIPTION
1. We have a lot of timeouts on the autocomplete endpoint which uses the main tables to suggest attribute values. We can definitely sample these queries
2. The TraceItemStats endpoint often times out (especially for large projects), so put in a special case to downgrade the storage tier for them automatically