### PR TITLE
ref(deps): Bump arroyo to 2.27.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pytest-watch==4.2.0
 python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.5.4
-sentry-arroyo==2.22.0
+sentry-arroyo==2.27.0
 sentry-kafka-schemas==1.3.7
 sentry-protos==0.3.0
 sentry-redis-tools==0.5.0

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3558,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "sentry_arroyo"
-version = "2.25.0"
+version = "2.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c26499a688f5faf0d434aee9d2de16d52a7c90e0ee4a7f65dbb20acf85dfdf"
+checksum = "e9556aa8820b4e81f28ca6490a9e31d87699f945eee380202d9c88a896205078"
 dependencies = [
  "chrono",
  "coarsetime",
@@ -3568,7 +3568,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rdkafka 0.37.0",
- "sentry",
+ "sentry-core",
  "serde",
  "serde_json",
  "thiserror",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -41,7 +41,7 @@ reqwest = { version = "0.11.11", features = ["stream"] }
 schemars = { version = "0.8.16", features = ["uuid1"] }
 sentry = { version = "0.32.0", features = ["anyhow", "tracing"] }
 sentry-kafka-schemas = "1.3.7"
-sentry_arroyo = { version = "2.22.0", features = ["ssl"] }
+sentry_arroyo = { version = "2.27.0", features = ["ssl"] }
 sentry_protos = "0.3.0"
 sentry_usage_accountant = { version = "0.1.0", features = ["kafka"] }
 seq-macro = "0.3"

--- a/snuba/utils/streams/configuration_builder.py
+++ b/snuba/utils/streams/configuration_builder.py
@@ -4,6 +4,9 @@ from arroyo.backends.kafka import build_kafka_configuration
 from arroyo.backends.kafka import (
     build_kafka_consumer_configuration as _build_kafka_consumer_configuration,
 )
+from arroyo.backends.kafka import (
+    build_kafka_producer_configuration as _build_kafka_producer_configuration,
+)
 
 from snuba import settings
 from snuba.utils.streams.topics import Topic
@@ -69,11 +72,12 @@ def build_kafka_producer_configuration(
     bootstrap_servers: Optional[Sequence[str]] = None,
     override_params: Optional[Mapping[str, Any]] = None,
 ) -> KafkaBrokerConfig:
-    broker_config = get_default_kafka_configuration(
-        topic=topic,
-        slice_id=slice_id,
-        bootstrap_servers=bootstrap_servers,
-        override_params=override_params,
+    default_topic_config = _get_default_topic_configuration(topic, slice_id)
+
+    broker_config = _build_kafka_producer_configuration(
+        default_topic_config,
+        bootstrap_servers,
+        override_params,
     )
 
     # at time of writing (2022-05-09) lz4 was chosen because it


### PR DESCRIPTION
This introduces some configuration changes as well, so
https://github.com/getsentry/arroyo/pull/423 can take effect.

arroyo was bumped to 2.25 before in an unrelated PR, and so we already
saw produce metrics from Rust, but with this PR we'll get them from
python producers as well.
