### PR TITLE
ref(gocd): use console script entry points

### DIFF
--- a/gocd/templates/bash/canary-ddog-health-check.sh
+++ b/gocd/templates/bash/canary-ddog-health-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/datadog/monitor_status.py \
+checks-datadog-monitor-status \
   140973101
 
 

--- a/gocd/templates/bash/check-cloud-build.sh
+++ b/gocd/templates/bash/check-cloud-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
+checks-googlecloud-check-cloudbuild \
   sentryio \
   snuba \
   build-on-branch-push \

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/githubactions/checkruns.py \
+checks-githubactions-checkruns \
   --timeout-mins 60 \
   getsentry/snuba \
   ${GO_REVISION_SNUBA_REPO} \

--- a/gocd/templates/bash/deploy-st.sh
+++ b/gocd/templates/bash/deploy-st.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --container-name="snuba" \
   --container-name="snuba-admin"
 
-/devinfra/scripts/k8s/k8s-deploy.py \
+k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --type="cronjob" \

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 /devinfra/scripts/k8s/k8stunnel \
-&& /devinfra/scripts/k8s/k8s-deploy.py \
+&& k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --container-name="api" \
@@ -52,14 +52,14 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="transactions-subscriptions-scheduler" \
   --container-name="uptime-results-consumer" \
   --container-name="snuba" \
-&& /devinfra/scripts/k8s/k8s-deploy.py \
+&& k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --type="cronjob" \
   --container-name="cleanup" \
   --container-name="optimize" \
   --container-name="cardinality-report" \
-&& /devinfra/scripts/k8s/k8s-deploy.py \
+&& k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-central1-docker.pkg.dev/sentryio/snuba/image:${GO_REVISION_SNUBA_REPO}" \
   --type="statefulset" \

--- a/gocd/templates/bash/migrate-reverse.sh
+++ b/gocd/templates/bash/migrate-reverse.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(region-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate-reverse" \

--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -6,10 +6,10 @@
 # This script should be merged with migrate.sh if we can figure
 # out a common migration script for all regions.
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+/k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate" \

--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+/k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate" \

--- a/gocd/templates/bash/s4s-clickhouse-queries.sh
+++ b/gocd/templates/bash/s4s-clickhouse-queries.sh
@@ -18,10 +18,10 @@ fi
 SNUBA_COMPONENT_NAME="query-${SNUBA_CMD_TYPE}-gocd"
 SNUBA_CMD="query-${SNUBA_CMD_TYPE} ${ARGS[@]}"
 
-eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8s-spawn-job.py \
+k8s-spawn-job \
   --label-selector="service=snuba,component=${SNUBA_COMPONENT_NAME}" \
   --container-name="${SNUBA_COMPONENT_NAME}" \
   --try-deployments-and-statefulsets \

--- a/gocd/templates/bash/saas-ddog-health-check.sh
+++ b/gocd/templates/bash/saas-ddog-health-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
+checks-datadog-monitor-status --dry-run=true \
   113296727 \
   42722121
 

--- a/gocd/templates/bash/saas-sentry-error-check.sh
+++ b/gocd/templates/bash/saas-sentry-error-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/sentry/release_error_events.py \
+checks-sentry-release-error-events \
   --project-id=300688 \
   --project-slug=snuba \
   --release="${GO_REVISION_SNUBA_REPO}" \

--- a/gocd/templates/bash/saas-sentry-health-check.sh
+++ b/gocd/templates/bash/saas-sentry-health-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/sentry/release_new_issues.py \
+checks-sentry-release-new-issues \
   --project-id=300688 \
   --project-slug=snuba \
   --release="${GO_REVISION_SNUBA_REPO}" \


### PR DESCRIPTION


<!-- Describe your PR here. -->

GoCD agent scripts now support console script entry points.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
