### PR TITLE
feat(EAP): Implement cross event query support in get traces

### DIFF
--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -441,7 +441,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                             filters=filters_by_item_type[item_type],
                         ),
                     ),
-                    (attribute_key_to_expression_eap_items),
+                    (attribute_key_to_expression),
                 ),
             )
 

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -519,7 +519,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
         elif request.meta.trace_item_type != TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
             item_type = request.meta.trace_item_type
         else:
-            raise BadSnubaRPCRequestException("No item type specified")
+            item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
 
         trace_item_filters_expression = trace_item_filters_to_expression(
             TraceItemFilter(
@@ -599,6 +599,10 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
             trace_item_filters_expression = filter_expressions_by_item_type[
                 request.meta.trace_item_type
             ]
+        elif len(filter_expressions_by_item_type) == 1:
+            trace_item_filters_expression = next(
+                iter(filter_expressions_by_item_type.values())
+            )
         elif len(filter_expressions_by_item_type) > 1:
             trace_item_filters_expression = or_cond(
                 *[expression for expression in filter_expressions_by_item_type.values()]

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -458,7 +458,10 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
         ), "At least two item types are required for a cross-event query"
 
         trace_item_filters_and_expression = and_cond(
-            *[expression for expression in filter_expressions_by_item_type.values()]
+            *[
+                f.greater(f.countIf(expression), 0)
+                for expression in filter_expressions_by_item_type.values()
+            ]
         )
         trace_item_filters_or_expression = or_cond(
             *[expression for expression in filter_expressions_by_item_type.values()]

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -441,7 +441,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                             filters=filters_by_item_type[item_type],
                         ),
                     ),
-                    (attribute_key_to_expression),
+                    attribute_key_to_expression,
                 ),
             )
 
@@ -530,7 +530,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                     filters=[f.filter for f in request.filters],
                 ),
             ),
-            (attribute_key_to_expression),
+            attribute_key_to_expression,
         )
         selected_columns: list[SelectedExpression] = [
             SelectedExpression(

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -32,10 +32,10 @@ from snuba.web.rpc.v1.endpoint_get_traces import EndpointGetTraces
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 from tests.web.rpc.v1.test_utils import (
-    create_comparison_filter,
-    create_or_filter,
+    comparison_filter,
     create_request_meta,
     gen_item_message,
+    or_filter,
 )
 
 _TRACE_IDS = [uuid.uuid4().hex for _ in range(10)]
@@ -656,19 +656,19 @@ class TestGetTraces(BaseApiTest):
         write_cross_item_data_to_storage(all_items)
 
         filters = [
-            create_trace_filter(
-                create_comparison_filter("span.attr1", "val1"),
+            trace_filter(
+                comparison_filter("span.attr1", "val1"),
                 TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
-            create_trace_filter(
-                create_comparison_filter("log.attr2", "val2"),
+            trace_filter(
+                comparison_filter("log.attr2", "val2"),
                 TraceItemType.TRACE_ITEM_TYPE_LOG,
             ),
-            create_trace_filter(
-                create_or_filter(
+            trace_filter(
+                or_filter(
                     [
-                        create_comparison_filter("error.attr3", "val3"),
-                        create_comparison_filter("error.attr4", "val4"),
+                        comparison_filter("error.attr3", "val3"),
+                        comparison_filter("error.attr4", "val4"),
                     ]
                 ),
                 TraceItemType.TRACE_ITEM_TYPE_ERROR,
@@ -704,12 +704,12 @@ class TestGetTraces(BaseApiTest):
         write_cross_item_data_to_storage(all_items)
 
         filters = [
-            create_trace_filter(
-                create_comparison_filter("span.attr1", "val1"),
+            trace_filter(
+                comparison_filter("span.attr1", "val1"),
                 TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
-            create_trace_filter(
-                create_comparison_filter("log.attr2", "val2"),
+            trace_filter(
+                comparison_filter("log.attr2", "val2"),
                 TraceItemType.TRACE_ITEM_TYPE_LOG,
             ),
         ]
@@ -744,12 +744,12 @@ class TestGetTraces(BaseApiTest):
         write_cross_item_data_to_storage(all_items)
 
         filters = [
-            create_trace_filter(
-                create_comparison_filter("span.attr1", "val1"),
+            trace_filter(
+                comparison_filter("span.attr1", "val1"),
                 TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
-            create_trace_filter(
-                create_comparison_filter("log.attr2", "val2"),
+            trace_filter(
+                comparison_filter("log.attr2", "val2"),
                 TraceItemType.TRACE_ITEM_TYPE_LOG,
             ),
         ]
@@ -891,7 +891,7 @@ def create_cross_item_test_data() -> tuple[list[str], list[bytes], datetime, dat
     return trace_ids, all_items, start_time, end_time
 
 
-def create_trace_filter(
+def trace_filter(
     filter: TraceItemFilter,
     item_type: TraceItemType.ValueType,
 ) -> GetTracesRequest.TraceFilter:

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -646,6 +646,9 @@ class TestGetTraces(BaseApiTest):
         ):
             EndpointGetTraces().execute(message)
 
+    def test_with_data_and_cross_event_query(self, setup_teardown: Any) -> None:
+        pass
+
 
 def generate_spans(spans_data: list[bytes]) -> list[TraceItem]:
     spans: list[TraceItem] = []

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -31,7 +31,12 @@ from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.endpoint_get_traces import EndpointGetTraces
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
-from tests.web.rpc.v1.test_utils import gen_item_message
+from tests.web.rpc.v1.test_utils import (
+    create_comparison_filter,
+    create_or_filter,
+    create_request_meta,
+    gen_item_message,
+)
 
 _TRACE_IDS = [uuid.uuid4().hex for _ in range(10)]
 _BASE_TIME = datetime.now(tz=timezone.utc).replace(
@@ -647,7 +652,128 @@ class TestGetTraces(BaseApiTest):
             EndpointGetTraces().execute(message)
 
     def test_with_data_and_cross_event_query(self, setup_teardown: Any) -> None:
-        pass
+        trace_ids, all_items, start_time, end_time = create_cross_item_test_data()
+        write_cross_item_data_to_storage(all_items)
+
+        filters = [
+            create_trace_filter(
+                create_comparison_filter("span.attr1", "val1"),
+                TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            create_trace_filter(
+                create_comparison_filter("log.attr2", "val2"),
+                TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+            create_trace_filter(
+                create_or_filter(
+                    [
+                        create_comparison_filter("error.attr3", "val3"),
+                        create_comparison_filter("error.attr4", "val4"),
+                    ]
+                ),
+                TraceItemType.TRACE_ITEM_TYPE_ERROR,
+            ),
+        ]
+
+        message = GetTracesRequest(
+            meta=create_request_meta(start_time, end_time),
+            attributes=[
+                TraceAttribute(key=TraceAttribute.Key.KEY_TRACE_ID),
+            ],
+            filters=filters,
+        )
+
+        response = EndpointGetTraces().execute(message)
+
+        assert len(response.traces) == 3
+
+        returned_trace_ids = set()
+        for trace in response.traces:
+            returned_trace_ids.add(trace.attributes[0].value.val_str)
+
+        # Only the first 3 traces should match all filter conditions
+        expected_trace_ids = set(trace_ids[:3])
+        assert (
+            returned_trace_ids == expected_trace_ids
+        ), f"Expected {expected_trace_ids}, got {returned_trace_ids}"
+
+    def test_cross_item_filtered_count_with_span_restriction(
+        self, setup_teardown: Any
+    ) -> None:
+        trace_ids, all_items, start_time, end_time = create_cross_item_test_data()
+        write_cross_item_data_to_storage(all_items)
+
+        filters = [
+            create_trace_filter(
+                create_comparison_filter("span.attr1", "val1"),
+                TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            create_trace_filter(
+                create_comparison_filter("log.attr2", "val2"),
+                TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+        ]
+
+        message = GetTracesRequest(
+            meta=create_request_meta(
+                start_time, end_time, TraceItemType.TRACE_ITEM_TYPE_SPAN
+            ),
+            attributes=[
+                TraceAttribute(
+                    key=TraceAttribute.Key.KEY_FILTERED_ITEM_COUNT,
+                    type=AttributeKey.TYPE_INT,
+                ),
+            ],
+            filters=filters,
+        )
+
+        response = EndpointGetTraces().execute(message)
+
+        assert len(response.traces) == 3
+        for trace in response.traces:
+            count_attr = trace.attributes[0]
+
+            assert (
+                count_attr.value.val_int == 1
+            ), f"Expected count of 1 span per trace, got {count_attr.value.val_int}"
+
+    def test_cross_item_filtered_count_without_restriction(
+        self, setup_teardown: Any
+    ) -> None:
+        trace_ids, all_items, start_time, end_time = create_cross_item_test_data()
+        write_cross_item_data_to_storage(all_items)
+
+        filters = [
+            create_trace_filter(
+                create_comparison_filter("span.attr1", "val1"),
+                TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            create_trace_filter(
+                create_comparison_filter("log.attr2", "val2"),
+                TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+        ]
+
+        # Request without meta type restriction - should count all matching items
+        message = GetTracesRequest(
+            meta=create_request_meta(start_time, end_time),
+            attributes=[
+                TraceAttribute(
+                    key=TraceAttribute.Key.KEY_FILTERED_ITEM_COUNT,
+                    type=AttributeKey.TYPE_INT,
+                ),
+            ],
+            filters=filters,
+        )
+
+        response = EndpointGetTraces().execute(message)
+
+        assert len(response.traces) == 3
+        for trace in response.traces:
+            count_attr = trace.attributes[0]
+            assert (
+                count_attr.value.val_int == 2
+            ), f"Expected count of 2 items per trace (1 span + 1 log), got {count_attr.value.val_int}"
 
 
 def generate_spans(spans_data: list[bytes]) -> list[TraceItem]:
@@ -675,3 +801,108 @@ def generate_trace_id_timestamp_data(
         for trace_id, timestamp in start_timestamp_per_trace_id.items()
     }
     return start_timestamp_per_trace_id, trace_id_per_start_timestamp
+
+
+def create_cross_item_test_data() -> tuple[list[str], list[bytes], datetime, datetime]:
+    """
+    Create test data with 6 traces. The first 3 traces have items with the following attributes:
+    - span.attr1 = val1
+    - log.attr2 = val2
+    - error.attr3 = val3
+    - error.attr4 = val4
+    The last 3 traces have items with the following attributes:
+    - span.attr1 = other_val1
+    - log.attr2 = other_val2
+    - error.attr3 = other_val3
+    - error.attr4 = other_val4
+    """
+    # Use today's date with a fixed time range (12am to 1am)
+    today = datetime.now(tz=timezone.utc).date()
+    start_time = datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc)
+    end_time = start_time + timedelta(hours=1)
+
+    # Create 6 traces - 3 should match all conditions, 3 should not
+    trace_ids = [uuid.uuid4().hex for _ in range(6)]
+    all_items = []
+
+    for i, trace_id in enumerate(trace_ids):
+        # Spread items evenly across the 1-hour window
+        item_time = start_time + timedelta(minutes=i * 10)
+
+        if i < 3:  # First 3 traces have matching span attributes
+            span_attrs = {
+                "span.attr1": AnyValue(string_value="val1"),
+            }
+        else:  # Last 3 traces have different span attributes
+            span_attrs = {
+                "span.attr1": AnyValue(string_value="other_val1"),
+            }
+
+        all_items.append(
+            gen_item_message(
+                start_timestamp=item_time,
+                trace_id=trace_id,
+                type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                attributes=span_attrs,
+                remove_default_attributes=True,
+            )
+        )
+
+        if i < 3:  # First 3 traces have matching log attributes
+            log_attrs = {
+                "log.attr2": AnyValue(string_value="val2"),
+            }
+        else:  # Last 3 traces have different log attributes
+            log_attrs = {
+                "log.attr2": AnyValue(string_value="other_val2"),
+            }
+
+        all_items.append(
+            gen_item_message(
+                start_timestamp=item_time + timedelta(seconds=10),
+                trace_id=trace_id,
+                type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                attributes=log_attrs,
+                remove_default_attributes=True,
+            )
+        )
+
+        if i < 3:  # First 3 traces have matching error attributes
+            error_attrs = {
+                "error.attr3": AnyValue(string_value="val3"),
+                "error.attr4": AnyValue(string_value="val4"),
+            }
+        else:  # Last 3 traces have different error attributes
+            error_attrs = {
+                "error.attr3": AnyValue(string_value="other_val3"),
+                "error.attr4": AnyValue(string_value="other_val4"),
+            }
+
+        all_items.append(
+            gen_item_message(
+                start_timestamp=item_time + timedelta(seconds=20),
+                trace_id=trace_id,
+                type=TraceItemType.TRACE_ITEM_TYPE_ERROR,
+                attributes=error_attrs,
+                remove_default_attributes=True,
+            )
+        )
+
+    return trace_ids, all_items, start_time, end_time
+
+
+def create_trace_filter(
+    filter: TraceItemFilter,
+    item_type: TraceItemType.ValueType,
+) -> GetTracesRequest.TraceFilter:
+    """Create a trace filter for the specified field and item type."""
+    return GetTracesRequest.TraceFilter(
+        item_type=item_type,
+        filter=filter,
+    )
+
+
+def write_cross_item_data_to_storage(items: list[bytes]) -> None:
+    """Write cross-item test data to storage."""
+    storage = get_storage(StorageKey("eap_items"))
+    write_raw_unprocessed_events(storage, items)  # type: ignore


### PR DESCRIPTION
Implement get traces functionality for cross item queries as described here: https://www.notion.so/sentry/Cross-Item-Queries-21b8b10e4b5d804d84e0f75405bc56bc?source=copy_link#21b8b10e4b5d8074b55cf757e2965311
Closes https://linear.app/getsentry/issue/EAP-141/implement-cross-item-queries-in-the-gettraces-endpoint