### PR TITLE
feat(ci): run bootstrap with SNUBA_NO_WORKERS, only soft fail if Kafka isn't connectable

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -28,10 +28,8 @@ def devserver(*, bootstrap: bool, workers: bool, log_level: str) -> None:
 
     if bootstrap:
         cmd = ["snuba", "bootstrap", "--force", "--no-migrate"]
-        if not workers:
-            cmd.append("--no-kafka")
         returncode = call(cmd)
-        if returncode > 0:
+        if returncode > 0 and workers:
             sys.exit(returncode)
 
         # Run migrations


### PR DESCRIPTION
While investigating following @asottile-sentry's comment on https://github.com/getsentry/getsentry/pull/17858#discussion_r2190737551

I found that we were in fact running `snuba bootstrap --force` on snuba devserver start (which is the command run by the docker container), but *only* if SNUBA_NO_WORKERS was not set (and Sentry's CI always passes the `--no-workers` flag). 

This change lets `snuba bootstrap` get run by `snuba devserver` regardless of the SNUBA_NO_WORKERS environment variable, and it may make https://github.com/getsentry/getsentry/pull/17858/files and https://github.com/getsentry/sentry/pull/93445/files unnecessary (though it will still need testing).

Testing:
- ran with SNUBA_NO_WORKERS/--no-workers and saw that topics were created
- ran without --no-workers and saw that topics were created
- shut down the Kafka docker container and saw that `snuba devserver` still succeeds even if it can't create the Kafka topics (it tries for ~1 minute)