### PR TITLE
chore(replay): Add context to error message

### DIFF
--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -184,16 +184,17 @@ pub fn deserialize_message(
             }]
         }
         ReplayPayload::EventLinkEvent(event) => {
-            let level_id = event
+            event
                 .debug_id
                 .or(event.error_id)
                 .or(event.fatal_id)
                 .or(event.info_id)
                 .or(event.warning_id)
-                .unwrap_or_default();
-            if level_id.is_nil() {
-                return Err(anyhow!("missing level id"));
-            }
+                .ok_or(anyhow!(
+                    "missing level id {} {}",
+                    replay_message.project_id,
+                    event.event_hash
+                ))?;
 
             vec![ReplayRow {
                 debug_id: event.debug_id.unwrap_or_default(),

--- a/rust_snuba/src/processors/replays.rs
+++ b/rust_snuba/src/processors/replays.rs
@@ -1,7 +1,6 @@
 use crate::config::ProcessorConfig;
 use anyhow::{anyhow, Context};
 use chrono::DateTime;
-use sentry::{add_breadcrumb, Breadcrumb, Level};
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -193,15 +192,11 @@ pub fn deserialize_message(
                 .or(event.warning_id)
                 .ok_or(anyhow!("missing level id"));
             if result.is_err() {
-                add_breadcrumb(Breadcrumb {
-                    category: Some("meta".into()),
-                    message: Some(format!(
-                        "Project id: {}\nEvent Hash: {}",
-                        replay_message.project_id, event.event_hash
-                    )),
-                    level: Level::Info,
-                    ..Default::default()
-                });
+                tracing::info!(
+                    "Project: {}, Event Hash: {}",
+                    replay_message.project_id,
+                    event.event_hash
+                );
             }
 
             vec![ReplayRow {


### PR DESCRIPTION
Error message now includes the event hash and the project id.  With the intent to help solve https://sentry.sentry.io/issues/5661155781/events/latest/?project=300688&query=is%3Aunresolved&referrer=latest-event&stream_index=3