### PR TITLE
feat: stop capturing 400 exceptions in RPC endpoints in sentry

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -22,9 +22,9 @@ from snuba.utils.registered_class import (
 from snuba.web import QueryException
 from snuba.web.rpc.common.common import Tin, Tout
 from snuba.web.rpc.common.exceptions import (
-    BadSnubaRPCRequestException,
     RPCRequestException,
     convert_rpc_exception_to_proto,
+    is_400,
 )
 from snuba.web.rpc.storage_routing.defaults import get_default_routing_decision
 from snuba.web.rpc.storage_routing.load_retriever import get_cluster_loadinfo
@@ -278,18 +278,19 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         self._timer.mark("rpc_end")
         self._timer.send_metrics_to(self.metrics)
         if error is not None:
-            sentry_sdk.capture_exception(error)
-            if isinstance(error, BadSnubaRPCRequestException):
+            if isinstance(error, RPCRequestException) and is_400(error.status_code):
                 self.metrics.increment(
                     "request_invalid",
                     tags=self._timer.tags,
                 )
             elif isinstance(error, AllocationPolicyViolations):
+                sentry_sdk.capture_exception(error)
                 self.metrics.increment(
                     "request_rate_limited",
                     tags=self._timer.tags,
                 )
             else:
+                sentry_sdk.capture_exception(error)
                 self.metrics.increment(
                     "request_error",
                     tags=self._timer.tags,

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -24,7 +24,6 @@ from snuba.web.rpc.common.common import Tin, Tout
 from snuba.web.rpc.common.exceptions import (
     RPCRequestException,
     convert_rpc_exception_to_proto,
-    is_400,
 )
 from snuba.web.rpc.storage_routing.defaults import get_default_routing_decision
 from snuba.web.rpc.storage_routing.load_retriever import get_cluster_loadinfo
@@ -278,7 +277,10 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         self._timer.mark("rpc_end")
         self._timer.send_metrics_to(self.metrics)
         if error is not None:
-            if isinstance(error, RPCRequestException) and is_400(error.status_code):
+            if (
+                isinstance(error, RPCRequestException)
+                and 400 <= error.status_code < 500
+            ):
                 self.metrics.increment(
                     "request_invalid",
                     tags=self._timer.tags,

--- a/snuba/web/rpc/common/exceptions.py
+++ b/snuba/web/rpc/common/exceptions.py
@@ -29,3 +29,10 @@ def convert_rpc_exception_to_proto(
         inferred_status = 429
 
     return ErrorProto(code=inferred_status, message=str(exc))
+
+
+def is_400(status_code: int) -> bool:
+    """
+    Returns True iff the status code is a 4xx error.
+    """
+    return int(status_code / 100) == 4

--- a/snuba/web/rpc/common/exceptions.py
+++ b/snuba/web/rpc/common/exceptions.py
@@ -29,10 +29,3 @@ def convert_rpc_exception_to_proto(
         inferred_status = 429
 
     return ErrorProto(code=inferred_status, message=str(exc))
-
-
-def is_400(status_code: int) -> bool:
-    """
-    Returns True iff the status code is a 4xx error.
-    """
-    return int(status_code / 100) == 4


### PR DESCRIPTION
When returning 400 errors to clients for invalid requests, from the RPC endpoints, we used to record all these in sentrys but its clogging the feed w irrelevant errors, so this PR stops capturing them.