### PR TITLE
chore(spans): Deprecate spans dataset

### DIFF
--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -6,7 +6,7 @@ storage:
   key: spans
   set_key: spans
 
-readiness_state: complete
+readiness_state: deprecate
 
 schema:
   columns:


### PR DESCRIPTION
The spans dataset is being deprecate since we moved all tracing related data to the EAP.