### PR TITLE
chore(eap): Remove option to customize the subscription entity

### DIFF
--- a/snuba/web/rpc/v1/create_subscription.py
+++ b/snuba/web/rpc/v1/create_subscription.py
@@ -8,7 +8,6 @@ from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
-from snuba import state
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.web.rpc import RPCEndpoint
@@ -42,7 +41,7 @@ class CreateSubscriptionRequest(
         )
 
         dataset = PluggableDataset(name="eap", all_entities=[])
-        entity_key = EntityKey(subscription_entity_name())
+        entity_key = EntityKey("eap_items")
 
         if (
             in_msg.time_series_request.meta.trace_item_type
@@ -56,14 +55,3 @@ class CreateSubscriptionRequest(
         )
 
         return CreateSubscriptionResponse(subscription_id=str(identifier))
-
-
-def subscription_entity_name() -> str:
-    default = "eap_items_span"
-    return (
-        state.get_str_config(
-            "CreateSubscriptionRequest.entity_name",
-            default,
-        )
-        or default
-    )

--- a/tests/web/rpc/v1/test_create_subscription.py
+++ b/tests/web/rpc/v1/test_create_subscription.py
@@ -26,7 +26,6 @@ from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.utils.manage_topics import create_topics
 from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic as SnubaTopic
-from snuba.web.rpc.v1.create_subscription import subscription_entity_name
 from tests.base import BaseApiTest
 from tests.web.rpc.v1.test_endpoint_time_series.test_endpoint_time_series import (
     DummyMetric,
@@ -244,7 +243,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
         rpc_subscription_data = list(
             RedisSubscriptionDataStore(
                 get_redis_client(RedisClientKey.SUBSCRIPTION_STORE),
-                EntityKey(subscription_entity_name()),
+                EntityKey("eap_items"),
                 PartitionId(partition),
             ).all()
         )[0][1]


### PR DESCRIPTION
This is not needed anymore now that all regions use `snuba-items` and subscriptions are tied to that topic.