### PR TITLE
fix(trace-item-stats): Include all attributes as part of the response

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -20,16 +20,7 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
-from snuba.query.dsl import (
-    arrayJoin,
-    column,
-    count,
-    in_cond,
-    literal,
-    literals_array,
-    not_cond,
-    tupleElement,
-)
+from snuba.query.dsl import arrayJoin, column, count, tupleElement
 from snuba.query.expressions import FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
@@ -60,23 +51,6 @@ MAX_BUCKETS = 100
 DEFAULT_BUCKETS = 10
 
 COUNT_LABEL = "count()"
-
-# These are attributes that were not stored in attr_str_ or attr_num_ in eap_spans because they were stored in columns.
-# Since we store these in the attribute columns in eap_items, we need to exclude them in endpoints that don't expect them to be in the attribute columns.
-ATTRIBUTES_TO_EXCLUDE_IN_EAP_ITEMS: set[str] = {
-    "sentry.raw_description",
-    "sentry.transaction",
-    "sentry.start_timestamp_precise",
-    "sentry.end_timestamp_precise",
-    "sentry.duration_ms",
-    "sentry.event_id",
-    "sentry.exclusive_time_ms",
-    "sentry.is_segment",
-    "sentry.parent_span_id",
-    "sentry.profile_id",
-    "sentry.received",
-    "sentry.segment_id",
-}
 
 
 def _transform_results(
@@ -189,14 +163,6 @@ def _build_attr_distribution_query(
         condition=base_conditions_and(
             in_msg.meta,
             trace_item_filters_expression,
-            not_cond(
-                in_cond(
-                    attrs_string_keys,
-                    literals_array(
-                        None, list(map(literal, ATTRIBUTES_TO_EXCLUDE_IN_EAP_ITEMS))
-                    ),
-                ),
-            ),
         ),
         order_by=[
             OrderBy(


### PR DESCRIPTION
We excluded some attributes from the response so we can be backwards compatible with the response that was sent when we were still using the old `eap_spans` table.

In the end, excluding attributes we don't need should really be a responsibility of the caller and should be passed through filters. The users of this endpoint have expressed a new to query some fields from that list and will modify their query to exclude the rest.

