### PR TITLE
RFC3339 for audit log timestamps

### DIFF
--- a/snuba/admin/audit_log/base.py
+++ b/snuba/admin/audit_log/base.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Mapping, MutableMapping, Optional, Union
 
 import structlog
@@ -27,7 +27,7 @@ class AuditLog:
         data: Mapping[str, Union[str, int]],
         notify: Optional[bool] = False,
     ) -> None:
-        timestamp = datetime.now().strftime("%B %d, %Y %H:%M:%S %p")
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.logger.info(
             event=action.value,
             user=user,

--- a/snuba/admin/audit_log/query.py
+++ b/snuba/admin/audit_log/query.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from functools import partial
 from typing import Callable, MutableMapping, TypeVar, Union
 
-DATETIME_FORMAT = "%B %d, %Y %H:%M:%S %p"
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 from snuba.admin.audit_log.action import AuditLogAction
 from snuba.admin.audit_log.base import AuditLog

--- a/snuba/admin/audit_log/query.py
+++ b/snuba/admin/audit_log/query.py
@@ -42,11 +42,11 @@ def audit_log(fn: Callable[[str, str], Return]) -> Callable[[str, str], Return]:
             result = fn(query, user)
         except Exception:
             data["status"] = QueryExecutionStatus.FAILED.value
-            data["end_timestamp"] = datetime.now().strftime(DATETIME_FORMAT)
+            data["end_timestamp"] = datetime.now(timezone.utc).strftime(DATETIME_FORMAT)
             audit_log_notify(data=data)
             raise
         data["status"] = QueryExecutionStatus.SUCCEEDED.value
-        data["end_timestamp"] = datetime.now().strftime(DATETIME_FORMAT)
+        data["end_timestamp"] = datetime.now(timezone.utc).strftime(DATETIME_FORMAT)
         audit_log_notify(data=data)
         return result
 


### PR DESCRIPTION
"July 15, 2025 21:28:52 PM" as a timezone format isn't easily sortable and add an AM/PM for a 24hr clock. Use RFC3339 instead.
