### PR TITLE
ref(eap-rpc): Do not send ClickHouse timeouts as Sentry errors

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -181,12 +181,14 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
                 and e.extra["stats"]["error_code"] == 159
             ):
                 tags = {"endpoint": str(self.__class__.__name__)}
+
+                if hasattr(in_msg.meta, "referrer"):
+                    tags["referrer"] = in_msg.meta.referrer
                 if self._uses_storage_routing(in_msg):
                     tags["storage_routing_mode"] = DownsampledStorageConfig.Mode.Name(
                         in_msg.meta.downsampled_storage_config.mode  # type: ignore
                     )
                 self.metrics.increment("timeout_query", 1, tags)
-                sentry_sdk.capture_exception(e)
             if (
                 "error_code" in e.extra["stats"]
                 and e.extra["stats"]["error_code"] == 160


### PR DESCRIPTION
We already track them via a metric. I added capturing the `referrer` so we can keep track of them and eventually find them more easily in the query log.