### PR TITLE
chore: bump sentry-sdk to 2.33.2

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
 jsonschema2md==0.4.0
 fastjsonschema==2.16.2
-sentry-sdk==2.18.0
+sentry-sdk==2.33.2
 myst-parser==0.18.0
 sphinx==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ sentry-kafka-schemas==1.3.7
 sentry-protos==0.3.0
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.5
-sentry-sdk==2.18.0
+sentry-sdk==2.33.2
 simplejson==3.17.6
 snuba-sdk==3.0.39
 structlog==22.3.0


### PR DESCRIPTION
I added some changes in the sentry-python sdk that are now in https://github.com/getsentry/sentry-python/releases/tag/2.33.2 so bumping snuba's sentry-sdk version to get those changes
