### PR TITLE
fix(inc-1266): use empty trace_id

### DIFF
--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -133,7 +133,7 @@ def _construct_hacky_querylog_payload(
                 "end_timestamp": in_message_meta.end_timestamp.seconds,
                 "stats": _get_stats_dict(routing_decision),
                 "status": "0",
-                "trace_id": cur_span.trace_id if cur_span else "no_current_span",
+                "trace_id": cur_span.trace_id if cur_span else "",
                 "profile": {
                     "time_range": None,
                     "table": "eap_items",


### PR DESCRIPTION
okie so something changed  (in my sdk upgrade https://github.com/getsentry/snuba/pull/7300) so that the current span trace_id isn't always present and anyway then we hit the error

In our code `no_current_span` was the default 

```python
"trace_id": cur_span.trace_id if cur_span else "no_current_span",
```
but our tests assumes empty string

https://github.com/getsentry/snuba/blob/cf1cc65f67f46ee4b1d3c9c430e06070216e3a63/rust_snuba/src/processors/querylog.rs#L475

if you run the test with `no_current_span` as the trace_id you will see the same error we see in the InvalidMessage
> invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `n` at 1