### PR TITLE
feat(eap): Improve trace_id index performance

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0045_improve_trace_id_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0045_improve_trace_id_index.py
@@ -4,10 +4,9 @@ from snuba.migrations.operations import OperationTarget, SqlOperation
 
 storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
 table_name = "eap_items_1_local"
-index_name = "bf_trace_id"
+index_name = "bf_trace_id_00001"
 index_expression = "trace_id"
-current_index_type = "bloom_filter"
-new_index_type = "bloom_filter(0.0001)"
+index_type = "bloom_filter(0.0001)"
 granularity = 1
 target = OperationTarget.LOCAL
 
@@ -17,18 +16,12 @@ class Migration(migration.ClickhouseNodeMigration):
 
     def forwards_ops(self) -> list[SqlOperation]:
         return [
-            operations.DropIndex(
-                storage_set=storage_set,
-                table_name=table_name,
-                index_name=index_name,
-                target=target,
-            ),
             operations.AddIndex(
                 storage_set=storage_set,
                 table_name=table_name,
                 index_name=index_name,
                 index_expression=index_expression,
-                index_type=new_index_type,
+                index_type=index_type,
                 granularity=granularity,
                 target=target,
             ),
@@ -40,15 +33,6 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=storage_set,
                 table_name=table_name,
                 index_name=index_name,
-                target=target,
-            ),
-            operations.AddIndex(
-                storage_set=storage_set,
-                table_name=table_name,
-                index_name=index_name,
-                index_expression=index_expression,
-                index_type=current_index_type,
-                granularity=granularity,
                 target=target,
             ),
         ]

--- a/snuba/snuba_migrations/events_analytics_platform/0045_improve_trace_id_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0045_improve_trace_id_index.py
@@ -1,0 +1,54 @@
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+table_name = "eap_items_1_local"
+index_name = "bf_trace_id"
+index_expression = "trace_id"
+current_index_type = "bloom_filter"
+new_index_type = "bloom_filter(0.0001)"
+granularity = 1
+target = OperationTarget.LOCAL
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> list[SqlOperation]:
+        return [
+            operations.DropIndex(
+                storage_set=storage_set,
+                table_name=table_name,
+                index_name=index_name,
+                target=target,
+            ),
+            operations.AddIndex(
+                storage_set=storage_set,
+                table_name=table_name,
+                index_name=index_name,
+                index_expression=index_expression,
+                index_type=new_index_type,
+                granularity=granularity,
+                target=target,
+            ),
+        ]
+
+    def backwards_ops(self) -> list[SqlOperation]:
+        return [
+            operations.DropIndex(
+                storage_set=storage_set,
+                table_name=table_name,
+                index_name=index_name,
+                target=target,
+            ),
+            operations.AddIndex(
+                storage_set=storage_set,
+                table_name=table_name,
+                index_name=index_name,
+                index_expression=index_expression,
+                index_type=current_index_type,
+                granularity=granularity,
+                target=target,
+            ),
+        ]


### PR DESCRIPTION
With the current settings, the false positive rate of the `trace_id` index is 2.5%. The index size is 8GB for each replica. When we try to load a trace for the trace view, we see that it's trying to scan 4 billions rows (after dropping granules based on the index) for a trace in the Sentry organization.

By tweaking the false positive rate to something very small, we see the amount of granules drop significantly, the number of rows scanned drop a lot and the size of index increases to 20GB only.

This would speed up selecting items for a given trace ID in projects ingesting a lot of data.