### PR TITLE
feat(errors): Add group_first_seen column to errors storage

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -260,6 +260,11 @@ schema:
         type: Float,
         args: { schema_modifiers: [nullable], size: 64 },
       },
+      {
+        name: group_first_seen,
+        type: DateTime,
+        args: { schema_modifiers: [nullable] },
+      },
     ]
   local_table_name: errors_local
   dist_table_name: errors_dist

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -260,6 +260,11 @@ schema:
         type: Float,
         args: { schema_modifiers: [nullable], size: 64 },
       },
+      {
+        name: group_first_seen,
+        type: DateTime,
+        args: { schema_modifiers: [nullable] },
+      },
     ]
   local_table_name: errors_local
   dist_table_name: errors_dist_ro


### PR DESCRIPTION
We want to denormalize the `first_seen` column from the `grouped_messages` table to the `errors` table.

The purpose here is that we want to be able to sort queries on errors by the group's first-seen time.

This PR updates the error storage.