### PR TITLE
feat(errors): Add group_first_seen column to errors entity

### DIFF
--- a/snuba/datasets/configuration/events/entities/events.yaml
+++ b/snuba/datasets/configuration/events/entities/events.yaml
@@ -233,6 +233,11 @@ schema:
       type: Float,
       args: { schema_modifiers: [nullable], size: 64 },
     },
+    {
+      name: group_first_seen,
+      type: DateTime,
+      args: { schema_modifiers: [nullable] },
+    },
   ]
 required_time_column: timestamp
 storages:


### PR DESCRIPTION
We want to denormalize the `first_seen` column from the `grouped_messages` table to the `errors` table.

The purpose here is that we want to be able to sort queries on errors by the group's first-seen time.

This PR updates the error entity.