### PR TITLE
feat(consumers): Retry consumer write failures

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3230,6 +3230,7 @@ version = "0.1.0"
 dependencies = [
  "adler",
  "anyhow",
+ "bytes",
  "cadence",
  "chrono",
  "criterion",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -57,6 +57,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = { version = "1.5.0", features = ["v4", "v7"] }
 zstd = "0.12.3"
+bytes = "1.0"
 
 
 [dev-dependencies]

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -28,6 +28,7 @@ fn clickhouse_task_runner(
             let batch_len = insert_batch.len();
             let (rows, empty_batch) = insert_batch.take();
             let encoded_rows = rows.into_encoded_rows();
+            let num_bytes = encoded_rows.len();
 
             let write_start = SystemTime::now();
 
@@ -58,6 +59,7 @@ fn clickhouse_task_runner(
             }
 
 
+            counter!("insertions.batch_write_bytes", num_bytes as i64);
             counter!("insertions.batch_write_msgs", batch_len as i64);
             empty_batch.record_message_latency();
 

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -165,13 +165,17 @@ impl ClickhouseClient {
         const MAX_RETRIES: usize = 4;
         const INITIAL_BACKOFF_MS: u64 = 50;
 
+        // Convert to Bytes once for efficient cloning since sending the request
+        // moves the body into the request body.
+        let body_bytes = bytes::Bytes::from(body);
+
         for attempt in 0..=MAX_RETRIES {
             let res = self
                 .client
                 .post(&self.url)
                 .headers(self.headers.clone())
                 .query(&[("query", &self.query)])
-                .body(reqwest::Body::from(body.clone()))
+                .body(reqwest::Body::from(body_bytes.clone()))
                 .send()
                 .await;
 

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -307,18 +307,4 @@ mod tests {
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("after 5 attempts"));
     }
-
-    #[tokio::test]
-    async fn test_retry_fails_after_max_attempts() {
-        // This test is redundant with the previous one since both test the same scenario
-        // (network errors causing all retries to fail)
-        // The previous test already covers this case
-    }
-
-    #[tokio::test]
-    async fn test_retry_with_network_errors() {
-        // This test is also covered by the first test since network errors
-        // are the primary failure mode when connecting to a non-existent server
-        // The first test already verifies the retry behavior with network errors
-    }
 }

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -205,6 +205,8 @@ impl ClickhouseClient {
                     }
                 }
                 Err(e) => {
+                    counter!("rust_consumer.clickhouse_insert_error", 1, "status" => "network_error");
+
                     if attempt == MAX_RETRIES {
                         anyhow::bail!(
                             "error writing to clickhouse after {} attempts: {}",


### PR DESCRIPTION
To make the consumer more resilient to failures, add some retries when it fails to write to clickhouse. 

**Implementation details**
In order for this to be possible the payload has to be reference counted since `reqwest` takes ownership of the body. This is what the `bytes` library was specifically designed for. 

**Extra stuff**
* Revive the bytes written metric for the V2 consumer
* also log metrics for network failures, not just bad status codes