### PR TITLE
feat(consumers): use batching consumer by default

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -196,7 +196,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
 )
 @click.option(
     "--consumer-version",
-    default="v1",
+    default="v2",
     type=click.Choice(["v1", "v2"]),
     help="Specify which consumer version to use, v1 is stable, v2 is experimental",
 )


### PR DESCRIPTION
Now that latency issues on eap items are fixed with the kafka routing key and throughput testing shows this consumer is fast enough (and it has survived peak traffic in US), we can add use this everywhere and start making improvements