### PR TITLE
feat(consumers): add an assigned_partitions tag to the consumer

### DIFF
--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -64,12 +64,17 @@ pub struct ConsumerStrategyFactoryV2 {
 
 impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
     fn update_partitions(&self, partitions: &HashMap<Partition, u64>) {
-        let assigned_partitions = partitions
+        let mut assigned_partitions = partitions
             .keys()
-            .map(|partition| partition.index.to_string())
-            .collect::<Vec<_>>()
+            .map(|partition| partition.index)
+            .collect::<Vec<_>>();
+        assigned_partitions.sort_unstable();
+        let assigned_partitions_string = assigned_partitions
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<String>>()
             .join("-");
-        set_global_tag("assigned_partitions".to_owned(), assigned_partitions);
+        set_global_tag("assigned_partitions".to_owned(), assigned_partitions_string);
 
         match partitions.keys().map(|partition| partition.index).min() {
             Some(min) => set_global_tag("min_partition".to_owned(), min.to_string()),


### PR DESCRIPTION
It's very annoying to have to piece together which consumer was assigned which partitions. Instead, concatenate them into a string which contains the partition assignments. Sort them so the tag stays the same if the same partitions were assigned