### PR TITLE
fix(eap): Add existence check for subscriptable references in timeseries

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -37,6 +37,7 @@ from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
 from snuba.web.query import run_query
 from snuba.web.rpc.common.common import (
+    add_existence_check_to_subscriptable_references,
     base_conditions_and,
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
@@ -366,6 +367,7 @@ def build_query(request: TimeSeriesRequest) -> Query:
         ],
     )
     treeify_or_and_conditions(res)
+    add_existence_check_to_subscriptable_references(res)
     return res
 
 

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series.py
@@ -1731,6 +1731,7 @@ class TestTimeSeriesApi(BaseApiTest):
         granularity_secs = 300
         query_duration = 60 * 30
 
+        # does not match the `url.path = "a"` filter
         store_spans_timeseries(
             BASE_TIME,
             1,
@@ -1738,6 +1739,7 @@ class TestTimeSeriesApi(BaseApiTest):
             metrics=[DummyMetric("gen_ai.usage.total_tokens", get_value=lambda x: 1)],
         )
 
+        # matches the `url.path = "a"` filter
         store_spans_timeseries(
             BASE_TIME,
             1,
@@ -1746,6 +1748,7 @@ class TestTimeSeriesApi(BaseApiTest):
             attributes={"url.path": AnyValue(string_value="a")},
         )
 
+        # matches the `url.path = "a"` filter because it's coalesced using `http.target`
         store_spans_timeseries(
             BASE_TIME,
             1,


### PR DESCRIPTION
Without the existence check on subscriptable references, filters on the coalesced elements will only check the first attribute as it'll default to empty string and never try other attributes.
