### PR TITLE
ref(subscriptions): crash schedulers that dont have LogAppendTime on default topic

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -258,7 +258,7 @@ class SchedulerBuilder:
         except AssertionError:
             raise
         except Exception:
-            # if we are unable to load the topic config for some reason, probably shoudln't
+            # if we are unable to load the topic config for some reason, probably shouldn't
             # crash the consumer
             logger.exception(
                 f"failed to confirm LogAppendTime for {default_topic_spec.get_physical_topic_name()} topic"

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -252,7 +252,9 @@ class SchedulerBuilder:
         try:
             default_topic_spec = stream_loader.get_default_topic_spec()
             default_topic_config = default_topic_spec.topic_current_config_values
-            assert default_topic_config["message.timestamp.type"] == "LogAppendTime"
+            assert (
+                default_topic_config["message.timestamp.type"] == "LogAppendTime"
+            ), f"{default_topic_spec.get_physical_topic_name()} topic requires LogAppendTime"
         except AssertionError:
             raise
         except Exception:

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -249,6 +249,19 @@ class SchedulerBuilder:
         assert commit_log_topic_spec is not None
         self.__commit_log_topic_spec = commit_log_topic_spec
 
+        try:
+            default_topic_spec = stream_loader.get_default_topic_spec()
+            default_topic_config = default_topic_spec.topic_current_config_values
+            assert default_topic_config["message.timestamp.type"] == "LogAppendTime"
+        except AssertionError:
+            raise
+        except Exception:
+            # if we are unable to load the topic config for some reason, probably shoudln't
+            # crash the consumer
+            logger.exception(
+                f"failed to confirm LogAppendTime for {default_topic_spec.get_physical_topic_name()} topic"
+            )
+
         scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
         assert scheduled_topic_spec is not None
         self.__scheduled_topic_spec = scheduled_topic_spec

--- a/snuba/utils/manage_topics.py
+++ b/snuba/utils/manage_topics.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Sequence
 
 from confluent_kafka import KafkaError, KafkaException
@@ -35,3 +36,36 @@ def create_topics(
         except KafkaException as err:
             if err.args[0].code() != KafkaError.TOPIC_ALREADY_EXISTS:
                 logger.error("Failed to create topic %s", topic, exc_info=err)
+
+
+def recreate_topic(client: AdminClient, topic: Topic, num_partitions: int = 1) -> None:
+    topic_spec = KafkaTopicSpec(topic)
+
+    topic_to_recreate = NewTopic(
+        topic_spec.topic_name,
+        num_partitions=num_partitions,
+        replication_factor=1,
+        config=topic_spec.topic_creation_config,
+    )
+    logger.info(f"Deleting Kafka topic {topic_spec.topic_name} ...")
+    future = client.delete_topics([topic_spec.topic_name])[topic_spec.topic_name]
+    try:
+        future.result()
+        logger.info("Topic %s deleted", topic)
+    except KafkaException as err:
+        if err.args[0].code() != KafkaError.TOPIC_ALREADY_EXISTS:
+            logger.error("Failed to create topic %s", topic, exc_info=err)
+
+    # wait for sometime before re-creating
+    time.sleep(2)
+
+    logger.info(f"Recreating Kafka topic {topic_spec.topic_name} ...")
+    for topic, future in client.create_topics(
+        [topic_to_recreate], operation_timeout=1
+    ).items():
+        try:
+            future.result()
+            logger.info("Topic %s recreated", topic)
+        except KafkaException as err:
+            if err.args[0].code() != KafkaError.TOPIC_ALREADY_EXISTS:
+                logger.error("Failed to recreate topic %s", topic, exc_info=err)

--- a/tests/datasets/test_table_storage.py
+++ b/tests/datasets/test_table_storage.py
@@ -34,3 +34,13 @@ def test_partitions_number() -> None:
 
     topic_spec = KafkaTopicSpec(Topic.REPLAYEVENTS)
     assert topic_spec.partitions_number == 1
+
+
+def test_topic_current_config_values() -> None:
+    admin_client = AdminClient(get_default_kafka_configuration())
+    create_topics(admin_client, [SnubaTopic.REPLAYEVENTS])
+
+    topic_spec = KafkaTopicSpec(Topic.REPLAYEVENTS)
+    config = topic_spec.topic_current_config_values
+
+    assert config["message.timestamp.type"] in ("CreateTime", "LogAppendTime")

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -202,7 +202,7 @@ def test_scheduler_logappendtime_check(
     mock_config.return_value = config
 
     admin_client = AdminClient(get_default_kafka_configuration())
-    create_topics(admin_client, [SnubaTopic.EVENTS], 2)
+    create_topics(admin_client, [SnubaTopic.EVENTS], 1)
     create_topics(admin_client, [SnubaTopic.COMMIT_LOG], 1)
 
     metrics_backend = TestingMetricsBackend()

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -180,30 +180,16 @@ def test_scheduler_logappendtime_check_dontcrash(
     However, if we run into some issue getting the config and cant determine the setting,
     then we log the exception but continue spinning up the consumer.
     """
-    settings.KAFKA_TOPIC_MAP = {
-        "events": "events-scheduler-consumer-test",
-        "snuba-commit-log": "snuba-commit-log-test",
-    }
     importlib.reload(scheduler_consumer)
 
-    admin_client = AdminClient(get_default_kafka_configuration())
-    create_topics(admin_client, [SnubaTopic.EVENTS], 1)
-    create_topics(admin_client, [SnubaTopic.COMMIT_LOG], 1)
-
     metrics_backend = TestingMetricsBackend()
-    entity_name = "events"
-    entity_key = EntityKey(entity_name)
-    entity = get_entity(entity_key)
-    storage = entity.get_writable_storage()
-    assert storage is not None
-
+    entity_name = "eap_items"
     mock_scheduler_producer = mock.Mock()
-    entity = get_entity(EntityKey.EVENTS)
 
     scheduler_consumer.SchedulerBuilder(
         entity_name,
         str(uuid.uuid1().hex),
-        "events",
+        "eap_items",
         [],
         mock_scheduler_producer,
         "latest",
@@ -228,31 +214,17 @@ def test_scheduler_logappendtime_crash(mock_config: mock.Mock, tmpdir: Path) -> 
     If we have the topic config and can verify LogAppendTime then we raise
     an AssertionError if the setting is incorrect, crashing the consumer.
     """
-    settings.KAFKA_TOPIC_MAP = {
-        "events": "events-scheduler-consumer-test",
-        "snuba-commit-log": "snuba-commit-log-test",
-    }
     importlib.reload(scheduler_consumer)
 
-    admin_client = AdminClient(get_default_kafka_configuration())
-    create_topics(admin_client, [SnubaTopic.EVENTS], 1)
-    create_topics(admin_client, [SnubaTopic.COMMIT_LOG], 1)
-
     metrics_backend = TestingMetricsBackend()
-    entity_name = "events"
-    entity_key = EntityKey(entity_name)
-    entity = get_entity(entity_key)
-    storage = entity.get_writable_storage()
-    assert storage is not None
-
+    entity_name = "eap_items"
     mock_scheduler_producer = mock.Mock()
-    entity = get_entity(EntityKey.EVENTS)
 
     with pytest.raises(AssertionError):
         scheduler_consumer.SchedulerBuilder(
             entity_name,
             str(uuid.uuid1().hex),
-            "events",
+            "eap_items",
             [],
             mock_scheduler_producer,
             "latest",

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -170,8 +170,13 @@ def test_scheduler_consumer(tmpdir: Path) -> None:
     return_value="invalid_config",
     new_callable=mock.PropertyMock,
 )
+@mock.patch(
+    "snuba.datasets.table_storage.KafkaTopicSpec.partitions_number",
+    return_value=2,
+    new_callable=mock.PropertyMock,
+)
 def test_scheduler_logappendtime_check_dontcrash(
-    mock_config: mock.Mock, tmpdir: Path
+    mock_config: mock.Mock, mock_paritions_num: mock.Mock, tmpdir: Path
 ) -> None:
     """
     The scheduler needs the original topic (the one the commit log topic follows)

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -165,6 +165,87 @@ def test_scheduler_consumer(tmpdir: Path) -> None:
     del stream_loader.get_default_topic_spec().partitions_number
 
 
+@pytest.mark.parametrize(
+    "config, should_crash",
+    [
+        pytest.param(
+            {"message.timestamp.type": "CreateTime"},
+            True,
+            id="assert error",
+        ),
+        pytest.param("invalid_config", False, id="non assert error"),
+    ],
+)
+@mock.patch(
+    "snuba.datasets.table_storage.KafkaTopicSpec.topic_current_config_values",
+    new_callable=mock.PropertyMock,
+)
+def test_scheduler_logappendtime_check(
+    mock_config: mock.Mock, config: Any, should_crash: bool, tmpdir: Path
+) -> None:
+    """
+    The scheduler needs the original topic (the one the commit log topic follows)
+    to have ``LogAppend`` time set as the ``"message.timestamp.type"``.
+
+    Here we test the two following cases:
+    * We have the topic config and can verify LogAppendTime, and subsequently
+      raise an AssertionError if the setting is incorrect, crashing the consumer
+    * We run into some issue getting the config and cant determine the setting,
+      in which case we log the exception but continue spinning up the consumer
+    """
+    settings.KAFKA_TOPIC_MAP = {
+        "events": "events-scheduler-consumer-test",
+        "snuba-commit-log": "snuba-commit-log-test",
+    }
+    importlib.reload(scheduler_consumer)
+
+    mock_config.return_value = config
+
+    admin_client = AdminClient(get_default_kafka_configuration())
+    create_topics(admin_client, [SnubaTopic.EVENTS], 2)
+    create_topics(admin_client, [SnubaTopic.COMMIT_LOG], 1)
+
+    metrics_backend = TestingMetricsBackend()
+    entity_name = "events"
+    entity_key = EntityKey(entity_name)
+    entity = get_entity(entity_key)
+    storage = entity.get_writable_storage()
+    assert storage is not None
+
+    mock_scheduler_producer = mock.Mock()
+    entity = get_entity(EntityKey.EVENTS)
+
+    if should_crash:
+        with pytest.raises(AssertionError):
+            scheduler_consumer.SchedulerBuilder(
+                entity_name,
+                str(uuid.uuid1().hex),
+                "events",
+                [],
+                mock_scheduler_producer,
+                "latest",
+                False,
+                60 * 5,
+                None,
+                metrics_backend,
+                health_check_file=str(tmpdir / "health.txt"),
+            )
+    else:
+        scheduler_consumer.SchedulerBuilder(
+            entity_name,
+            str(uuid.uuid1().hex),
+            "events",
+            [],
+            mock_scheduler_producer,
+            "latest",
+            False,
+            60 * 5,
+            None,
+            metrics_backend,
+            health_check_file=str(tmpdir / "health.txt"),
+        )
+
+
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
 def test_scheduler_consumer_rpc_subscriptions(tmpdir: Path) -> None:


### PR DESCRIPTION
Address [EAP-167](https://linear.app/getsentry/issue/EAP-167/inc-1248-crash-subscriptions-scheduler-if-logappendtopic-is-not-found)

For subscriptions you have the following topics:

`default_topic -> commit_log_topic -> scheduled_topic -> results_topic`

The `message.timestamp.type` configuration of the original topic (the `default_topic`) being followed by the commit log topic should be set to `LogAppendTime`

This adds a check for the `LogAppendTime` topic configuration
