### PR TITLE
feat: support reliability for formulas in timeseries endpoint

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -457,7 +457,7 @@ SNQL_DISABLED_DATASETS: set[str] = set([])
 
 # this is the fallback default for enable_formula_reliability
 # will be overwritten by get_config i.e. snuba admin runtime config
-ENABLE_FORMULA_RELIABILITY_DEFAULT = 0
+ENABLE_FORMULA_RELIABILITY_DEFAULT = 1
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -457,7 +457,7 @@ SNQL_DISABLED_DATASETS: set[str] = set([])
 
 # this is the fallback default for enable_formula_reliability
 # will be overwritten by get_config i.e. snuba admin runtime config
-ENABLE_FORMULA_RELIABILITY_DEFAULT = 1
+ENABLE_FORMULA_RELIABILITY_DEFAULT = 0
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -129,12 +129,13 @@ def _convert_result_timeseries(
 
     # the aggregations that we will include in the result
     aggregation_labels = set([expr.label for expr in request.expressions])
-    # we also want to grab all the subchildren of formulas,
-    # this is used for computing reliabilities and they will be removed later so they
-    # arent actually included in the result
-    vis = GetSubformulaLabelsVisitor()
-    vis.visit(request)
-    aggregation_labels.update(vis.labels)
+    if get_int_config("enable_formula_reliability", ENABLE_FORMULA_RELIABILITY_DEFAULT):
+        # we also want to grab all the subchildren of formulas,
+        # this is used for computing reliabilities and they will be removed later so they
+        # arent actually included in the result
+        vis = GetSubformulaLabelsVisitor()
+        vis.visit(request)
+        aggregation_labels.update(vis.labels)
 
     group_by_labels = set([attr.name for attr in request.group_by])
 
@@ -208,7 +209,8 @@ def _convert_result_timeseries(
                 else:
                     timeseries.data_points.append(DataPoint(data=0, data_present=False))
 
-    _compute_formula_reliabilities(request.expressions, result_timeseries)
+    if get_int_config("enable_formula_reliability", ENABLE_FORMULA_RELIABILITY_DEFAULT):
+        _compute_formula_reliabilities(request.expressions, result_timeseries)
     return result_timeseries.values()
 
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -186,7 +186,6 @@ def _convert_result_timeseries(
 
     # Go through every possible time bucket in the query, if there's row data for it, fill in its data
     # otherwise put a dummy datapoint in
-
     for bucket in time_buckets:
         for timeseries_key, timeseries in result_timeseries.items():
             row_data = result_timeseries_timestamp_to_row.get(timeseries_key, {}).get(
@@ -212,7 +211,7 @@ def _convert_result_timeseries(
                     timeseries.data_points.append(DataPoint(data=0, data_present=False))
 
     if get_int_config("enable_formula_reliability", ENABLE_FORMULA_RELIABILITY_DEFAULT):
-        frc = FormulaReliabilityCalculator(request, data)
+        frc = FormulaReliabilityCalculator(request, data, time_buckets)
         for timeseries in result_timeseries.values():
             if timeseries.label in frc:
                 reliabilities = frc.get(timeseries.label)

--- a/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
+++ b/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
@@ -29,6 +29,9 @@ class FormulaReliabilityCalculator:
         children = vis.labels
         # stores the keys of formulas that will have the reliability calculated
         self.keys_cache = set(children.keys())
+        if len(self.keys_cache) == 0:
+            # theres no formulas to calculate reliability for
+            return
         # a list of reliability contexts for each time bucket
         self.contexts: list[FormulaReliabilityContext | None] = []
 

--- a/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
+++ b/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
@@ -34,7 +34,9 @@ class FormulaReliabilityCalculator:
                         curr_row_reliabilities[formula] = context.reliability
                     else:
                         curr_row_reliabilities[formula] = min(
-                            context.reliability, curr_row_reliabilities[formula]
+                            context.reliability,
+                            curr_row_reliabilities[formula],
+                            key=reliability_priority,
                         )
                 if formula not in self.reliabilities:
                     self.reliabilities[formula] = []
@@ -48,3 +50,12 @@ class FormulaReliabilityCalculator:
 
     def __contains__(self, value: str) -> bool:
         return value in self.keys_cache
+
+
+def reliability_priority(reliablity: Reliability.ValueType) -> int:
+    priority_map = {
+        Reliability.RELIABILITY_HIGH: 2,
+        Reliability.RELIABILITY_LOW: 1,
+        Reliability.RELIABILITY_UNSPECIFIED: 0,
+    }
+    return priority_map[reliablity]

--- a/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
+++ b/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 from typing import Any, Dict
 
+from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Reliability
 
@@ -14,39 +16,45 @@ class FormulaReliabilityCalculator:
         self,
         request: TimeSeriesRequest,
         clickhouse_data: list[Dict[str, Any]],
+        time_buckets: list[Timestamp],
     ) -> None:
         """
         Inputs:
             expressions: list of expressions requested by the user in the protobuf TimeSeriesRequest.expressions field
-            clickhouse_data: the data returned from the clickhouse query
+            result_timeseries: the data returned from the clickhouse query
+            time_buckets: a sorted list of time buckets for the query
         """
         vis = GetSubformulaLabelsVisitor()
         vis.visit(request)
         children = vis.labels
+        # stores the keys of formulas that will have the reliability calculated
+        self.keys_cache = set(children.keys())
+        # a list of reliability contexts for each time bucket
+        self.contexts: list[FormulaReliabilityContext | None] = []
 
-        self.reliabilities: dict[str, list[Reliability.ValueType]] = {}
+        context_map: dict[int, FormulaReliabilityContext | None] = {}
         for row in clickhouse_data:
-            curr_row_reliabilities: dict[str, Reliability.ValueType] = {}
-            for formula, children_labels in children.items():
-                for child in children_labels:
-                    context = ExtrapolationContext.from_row(child, row)
-                    if formula not in curr_row_reliabilities:
-                        curr_row_reliabilities[formula] = context.reliability
-                    else:
-                        curr_row_reliabilities[formula] = min(
-                            context.reliability,
-                            curr_row_reliabilities[formula],
-                            key=reliability_priority,
-                        )
-                if formula not in self.reliabilities:
-                    self.reliabilities[formula] = []
-                self.reliabilities[formula].append(curr_row_reliabilities[formula])
-        self.keys_cache = set(self.reliabilities.keys())
+            reliability_context = FormulaReliabilityContext.from_row(children, row)
+            context_map[reliability_context.bucket] = reliability_context
+
+        for bucket in time_buckets:
+            if bucket.seconds in context_map:
+                self.contexts.append(context_map[bucket.seconds])
+            else:
+                self.contexts.append(None)
 
     def get(self, label: str) -> list[Reliability.ValueType]:
-        if label not in self.reliabilities:
-            raise ValueError(f"Label {label} not found in reliabilities")
-        return self.reliabilities[label]
+        """
+        Returns:
+            a list of reliabilities for the formula for each time bucket
+        """
+        res = []
+        for bucket_context in self.contexts:
+            if bucket_context is None:
+                res.append(Reliability.RELIABILITY_UNSPECIFIED)
+            else:
+                res.append(bucket_context.get(label))
+        return res
 
     def __contains__(self, value: str) -> bool:
         return value in self.keys_cache
@@ -59,3 +67,51 @@ def reliability_priority(reliablity: Reliability.ValueType) -> int:
         Reliability.RELIABILITY_UNSPECIFIED: 0,
     }
     return priority_map[reliablity]
+
+
+class FormulaReliabilityContext:
+    # the reliabilities of the formulas for this current row of data
+    formula_reliabilities: dict[str, Reliability.ValueType]
+    bucket: int
+
+    def __init__(self) -> None:
+        self.formula_reliabilities = {}
+        self.bucket = -1
+
+    def get(self, label: str) -> Reliability.ValueType:
+        return self.formula_reliabilities[label]
+
+    @staticmethod
+    def from_row(
+        formulas_to_children: dict[str, list[str]], row: dict[str, Any]
+    ) -> "FormulaReliabilityContext":
+        """
+        Inputs:
+            formulas_to_children: a dictionary that maps the formula keys their childrens keys
+                ex: {"sum(k) + sum(f)": ["sum(k)", "sum(f)"]}
+
+            row: a row of data from the clickhouse query
+
+        Returns:
+            a FormulaReliabilityContext object
+        """
+        reliability_context = FormulaReliabilityContext()
+
+        reliability_context.bucket = int(
+            datetime.fromisoformat(row["time"]).timestamp()
+        )
+
+        for formula, children in formulas_to_children.items():
+            for child in children:
+                context = ExtrapolationContext.from_row(child, row)
+                if formula not in reliability_context.formula_reliabilities:
+                    reliability_context.formula_reliabilities[
+                        formula
+                    ] = context.reliability
+                else:
+                    reliability_context.formula_reliabilities[formula] = min(
+                        context.reliability,
+                        reliability_context.formula_reliabilities[formula],
+                        key=reliability_priority,
+                    )
+        return reliability_context

--- a/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
+++ b/snuba/web/rpc/v1/resolvers/common/formula_reliability.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict
+
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Reliability
+
+from snuba.web.rpc.v1.resolvers.common.aggregation import ExtrapolationContext
+from snuba.web.rpc.v1.visitors.time_series_request_visitor import (
+    GetSubformulaLabelsVisitor,
+)
+
+
+class FormulaReliabilityCalculator:
+    def __init__(
+        self,
+        request: TimeSeriesRequest,
+        clickhouse_data: list[Dict[str, Any]],
+    ) -> None:
+        """
+        Inputs:
+            expressions: list of expressions requested by the user in the protobuf TimeSeriesRequest.expressions field
+            clickhouse_data: the data returned from the clickhouse query
+        """
+        vis = GetSubformulaLabelsVisitor()
+        vis.visit(request)
+        children = vis.labels
+
+        self.reliabilities: dict[str, list[Reliability.ValueType]] = {}
+        for row in clickhouse_data:
+            curr_row_reliabilities: dict[str, Reliability.ValueType] = {}
+            for formula, children_labels in children.items():
+                for child in children_labels:
+                    context = ExtrapolationContext.from_row(child, row)
+                    if formula not in curr_row_reliabilities:
+                        curr_row_reliabilities[formula] = context.reliability
+                    else:
+                        curr_row_reliabilities[formula] = min(
+                            context.reliability, curr_row_reliabilities[formula]
+                        )
+                if formula not in self.reliabilities:
+                    self.reliabilities[formula] = []
+                self.reliabilities[formula].append(curr_row_reliabilities[formula])
+        self.keys_cache = set(self.reliabilities.keys())
+
+    def get(self, label: str) -> list[Reliability.ValueType]:
+        if label not in self.reliabilities:
+            raise ValueError(f"Label {label} not found in reliabilities")
+        return self.reliabilities[label]
+
+    def __contains__(self, value: str) -> bool:
+        return value in self.keys_cache

--- a/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
+++ b/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
@@ -141,9 +141,9 @@ class RejectTimestampAsStringVisitor(RequestVisitor):
 
 class GetSubformulaLabelsVisitor(RequestVisitor):
     """
-    given a formula, returns a list that looks like:
-    [myformlabel.left, myformlabel.right, myformlabel.left.left, ...]
-    depending on the depth of the formula.
+    given a formula, returns a list of the expected labels for the leaf nodes (non-formula nodes)
+    of the formula:
+    ex: for (a+b)+c it would be [myformlabel.right, myformlabel.left.left, formula.left.right...]
     """
 
     def __init__(self) -> None:
@@ -158,12 +158,15 @@ class GetSubformulaLabelsVisitor(RequestVisitor):
     def visit_BinaryFormula(
         self, node: Expression.BinaryFormula, curr_label: str = ""
     ) -> None:
-        self.labels.append(curr_label + ".left")
-        self.labels.append(curr_label + ".right")
         if node.left.WhichOneof("expression") == "formula":
             self.visit(node.left.formula, curr_label + ".left")
+        else:
+            self.labels.append(curr_label + ".left")
+
         if node.right.WhichOneof("expression") == "formula":
             self.visit(node.right.formula, curr_label + ".right")
+        else:
+            self.labels.append(curr_label + ".right")
 
 
 def preprocess_expression_labels(msg: TimeSeriesRequest) -> None:

--- a/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
+++ b/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
@@ -147,12 +147,15 @@ class GetSubformulaLabelsVisitor(RequestVisitor):
     """
 
     def __init__(self) -> None:
-        self.labels: list[str] = []
+        self.labels: dict[str, list[str]] = {}
+        self.curr_formula: str = ""
         super().__init__()
 
     def visit_TimeSeriesRequest(self, node: TimeSeriesRequest) -> None:
         for expr in node.expressions:
             if expr.WhichOneof("expression") == "formula":
+                self.curr_formula = expr.label
+                self.labels[self.curr_formula] = []
                 self.visit(expr.formula, expr.label)
 
     def visit_BinaryFormula(
@@ -169,12 +172,12 @@ class GetSubformulaLabelsVisitor(RequestVisitor):
     def visit_AttributeAggregation(
         self, node: AttributeAggregation, curr_label: str = ""
     ) -> None:
-        self.labels.append(curr_label)
+        self.labels[self.curr_formula].append(curr_label)
 
     def visit_AttributeConditionalAggregation(
         self, node: AttributeConditionalAggregation, curr_label: str = ""
     ) -> None:
-        self.labels.append(curr_label)
+        self.labels[self.curr_formula].append(curr_label)
 
     def visit_Literal(self, node: Literal, curr_label: str = "") -> None:
         return

--- a/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
+++ b/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
@@ -158,15 +158,26 @@ class GetSubformulaLabelsVisitor(RequestVisitor):
     def visit_BinaryFormula(
         self, node: Expression.BinaryFormula, curr_label: str = ""
     ) -> None:
-        if node.left.WhichOneof("expression") == "formula":
-            self.visit(node.left.formula, curr_label + ".left")
-        else:
-            self.labels.append(curr_label + ".left")
+        self.visit(node.left, curr_label + ".left")
+        self.visit(node.right, curr_label + ".right")
 
-        if node.right.WhichOneof("expression") == "formula":
-            self.visit(node.right.formula, curr_label + ".right")
-        else:
-            self.labels.append(curr_label + ".right")
+    def visit_Expression(self, node: Expression, curr_label: str = "") -> None:
+        expr_type = node.WhichOneof("expression")
+        assert expr_type is not None
+        self.visit(getattr(node, expr_type), curr_label)
+
+    def visit_AttributeAggregation(
+        self, node: AttributeAggregation, curr_label: str = ""
+    ) -> None:
+        self.labels.append(curr_label)
+
+    def visit_AttributeConditionalAggregation(
+        self, node: AttributeConditionalAggregation, curr_label: str = ""
+    ) -> None:
+        self.labels.append(curr_label)
+
+    def visit_Literal(self, node: Literal, curr_label: str = "") -> None:
+        return
 
 
 def preprocess_expression_labels(msg: TimeSeriesRequest) -> None:

--- a/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
+++ b/snuba/web/rpc/v1/visitors/time_series_request_visitor.py
@@ -157,6 +157,8 @@ class GetSubformulaLabelsVisitor(RequestVisitor):
                 self.curr_formula = expr.label
                 self.labels[self.curr_formula] = []
                 self.visit(expr.formula, expr.label)
+                if self.labels[self.curr_formula] == []:
+                    del self.labels[self.curr_formula]
 
     def visit_BinaryFormula(
         self, node: Expression.BinaryFormula, curr_label: str = ""

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -732,15 +732,95 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
             ),
         ]
 
-    def test_formula_reliability(self) -> None:
+    def test_formula_reliability_basic(self) -> None:
         set_config("enable_formula_reliability", True)
         """
-        this tests that formula reliability works in the following cases:
-        * a simple formula that adds two reliable aggregates returns reliable
-        * a simple formula that adds a reliable and an unreliable aggregate returns unreliable
-        * a nested formula that adds two reliable aggregatesand an unreliable aggregate returns unreliable
+        this tests a simple formula that adds two reliable aggregates is reliable
         """
+        # store metrics every 10 seconds for 10 minutes
+        granularity_secs = 120
+        query_duration = 600  # Reduced from 3600 to 600 seconds (10 minutes)
+        sample_rate1 = 0.5
+        sample_rate2 = 0.01
+        metric_value1 = 10
+        metric_value2 = 1
+        interval_secs = 10
+        store_timeseries(
+            BASE_TIME,
+            interval_secs,  # Reduced from 1 to 10 second intervals
+            600,  # Reduced duration
+            metrics=[DummyMetric("my_test_metric1", get_value=lambda x: metric_value1)],
+            server_sample_rate=lambda s: sample_rate1,
+        )
+        store_timeseries(
+            BASE_TIME,
+            interval_secs,  # Reduced from 1 to 10 second intervals
+            600,  # Reduced duration
+            metrics=[DummyMetric("my_test_metric2", get_value=lambda x: metric_value2)],
+            server_sample_rate=lambda s: sample_rate2,
+        )
+        expr1 = Expression(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM,
+                key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="my_test_metric1"),
+                extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+            ),
+            label="expr1",
+        )
+        # high reliable + high reliable = high reliable
+        form2 = Expression(
+            formula=Expression.BinaryFormula(
+                op=Expression.BinaryFormula.OP_ADD,
+                left=expr1,
+                right=expr1,
+            ),
+            label="form2",
+        )
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            expressions=[form2],
+            granularity_secs=granularity_secs,
+        )
+        response = EndpointTimeSeries().execute(message)
+        expected_buckets = [
+            Timestamp(seconds=int(BASE_TIME.timestamp()) + secs)
+            for secs in range(0, query_duration, granularity_secs)
+        ]
+        expected_expr1 = (
+            granularity_secs // interval_secs * metric_value1
+        ) / sample_rate1
+        expected_form2 = expected_expr1 + expected_expr1
+        expected = [
+            TimeSeries(
+                label="form2",
+                buckets=expected_buckets,
+                data_points=[
+                    DataPoint(
+                        data=expected_form2,
+                        data_present=True,
+                        reliability=Reliability.RELIABILITY_HIGH,
+                    )
+                    for _ in range(len(expected_buckets))
+                ],
+            ),
+        ]
+        assert response.result_timeseries == expected
 
+    def test_formula_reliability_unreliable(self) -> None:
+        set_config("enable_formula_reliability", True)
+        """
+        this tests a simple formula that adds a reliable and an unreliable aggregate returns unreliable
+        """
         # store metrics every 10 seconds for 10 minutes
         granularity_secs = 120
         query_duration = 600  # Reduced from 3600 to 600 seconds (10 minutes)
@@ -788,16 +868,95 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
             ),
             label="myform",
         )
-        # high reliable + high reliable = high reliable
-        form2 = Expression(
-            formula=Expression.BinaryFormula(
-                op=Expression.BinaryFormula.OP_ADD,
-                left=expr1,
-                right=expr1,
+        message = TimeSeriesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int(BASE_TIME.timestamp() + query_duration)
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
-            label="form2",
+            expressions=[myform],
+            granularity_secs=granularity_secs,
         )
 
+        response = EndpointTimeSeries().execute(message)
+        expected_buckets = [
+            Timestamp(seconds=int(BASE_TIME.timestamp()) + secs)
+            for secs in range(0, query_duration, granularity_secs)
+        ]
+        expected_expr1 = (
+            granularity_secs // interval_secs * metric_value1
+        ) / sample_rate1
+
+        expected_expr2 = (
+            granularity_secs // interval_secs * metric_value2
+        ) / sample_rate2
+        expected_form1 = expected_expr1 + expected_expr2
+        actual = sorted(response.result_timeseries, key=lambda x: x.label)
+        expected = [
+            TimeSeries(
+                label="myform",
+                buckets=expected_buckets,
+                data_points=[
+                    DataPoint(
+                        data=expected_form1,
+                        data_present=True,
+                        reliability=Reliability.RELIABILITY_LOW,
+                    )
+                    for _ in range(len(expected_buckets))
+                ],
+            ),
+        ]
+        assert actual == expected
+
+    def test_formula_reliability_nested(self) -> None:
+        set_config("enable_formula_reliability", True)
+        """
+        this tests that a nested formula that adds two reliable aggregates and an unreliable aggregate returns unreliable
+        """
+        # store metrics every 10 seconds for 10 minutes
+        granularity_secs = 120
+        query_duration = 600  # Reduced from 3600 to 600 seconds (10 minutes)
+        sample_rate1 = 0.5
+        sample_rate2 = 0.01
+        metric_value1 = 10
+        metric_value2 = 1
+        interval_secs = 10
+        store_timeseries(
+            BASE_TIME,
+            interval_secs,  # Reduced from 1 to 10 second intervals
+            600,  # Reduced duration
+            metrics=[DummyMetric("my_test_metric1", get_value=lambda x: metric_value1)],
+            server_sample_rate=lambda s: sample_rate1,
+        )
+        store_timeseries(
+            BASE_TIME,
+            interval_secs,  # Reduced from 1 to 10 second intervals
+            600,  # Reduced duration
+            metrics=[DummyMetric("my_test_metric2", get_value=lambda x: metric_value2)],
+            server_sample_rate=lambda s: sample_rate2,
+        )
+        expr1 = Expression(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM,
+                key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="my_test_metric1"),
+                extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+            ),
+            label="expr1",
+        )
+        expr2 = Expression(
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM,
+                key=AttributeKey(type=AttributeKey.TYPE_FLOAT, name="my_test_metric2"),
+                extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+            ),
+            label="expr2",
+        )
         # still works w nested formulas
         form3 = Expression(
             formula=Expression.BinaryFormula(
@@ -825,10 +984,9 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 ),
                 trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
-            expressions=[myform, form2, form3],
+            expressions=[form3],
             granularity_secs=granularity_secs,
         )
-
         response = EndpointTimeSeries().execute(message)
         expected_buckets = [
             Timestamp(seconds=int(BASE_TIME.timestamp()) + secs)
@@ -841,42 +999,15 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         expected_expr2 = (
             granularity_secs // interval_secs * metric_value2
         ) / sample_rate2
-
-        expected_form1 = expected_expr1 + expected_expr2
-        expected_form2 = expected_expr1 + expected_expr1
         expected_form3 = expected_expr1 + expected_expr1 + expected_expr2
         actual = sorted(response.result_timeseries, key=lambda x: x.label)
         expected = [
-            TimeSeries(
-                label="form2",
-                buckets=expected_buckets,
-                data_points=[
-                    DataPoint(
-                        data=expected_form2,
-                        data_present=True,
-                        reliability=Reliability.RELIABILITY_HIGH,
-                    )
-                    for _ in range(len(expected_buckets))
-                ],
-            ),
             TimeSeries(
                 label="form3",
                 buckets=expected_buckets,
                 data_points=[
                     DataPoint(
                         data=expected_form3,
-                        data_present=True,
-                        reliability=Reliability.RELIABILITY_LOW,
-                    )
-                    for _ in range(len(expected_buckets))
-                ],
-            ),
-            TimeSeries(
-                label="myform",
-                buckets=expected_buckets,
-                data_points=[
-                    DataPoint(
-                        data=expected_form1,
                         data_present=True,
                         reliability=Reliability.RELIABILITY_LOW,
                     )

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -825,7 +825,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                 ),
                 trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             ),
-            expressions=[myform, form2, form3, expr1, expr2],
+            expressions=[myform, form2, form3],
             granularity_secs=granularity_secs,
         )
 
@@ -837,46 +837,16 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         expected_expr1 = (
             granularity_secs // interval_secs * metric_value1
         ) / sample_rate1
-        expected_e1_ts = TimeSeries(
-            label="expr1",
-            buckets=expected_buckets,
-            data_points=[
-                DataPoint(
-                    data=expected_expr1,
-                    data_present=True,
-                    avg_sampling_rate=sample_rate1,
-                    sample_count=granularity_secs // interval_secs,
-                    reliability=Reliability.RELIABILITY_HIGH,
-                )
-                for _ in range(len(expected_buckets))
-            ],
-        )
 
         expected_expr2 = (
             granularity_secs // interval_secs * metric_value2
         ) / sample_rate2
-        expected_e2_ts = TimeSeries(
-            label="expr2",
-            buckets=expected_buckets,
-            data_points=[
-                DataPoint(
-                    data=expected_expr2,
-                    data_present=True,
-                    avg_sampling_rate=sample_rate2,
-                    sample_count=granularity_secs // interval_secs,
-                    reliability=Reliability.RELIABILITY_LOW,
-                )
-                for _ in range(len(expected_buckets))
-            ],
-        )
 
         expected_form1 = expected_expr1 + expected_expr2
         expected_form2 = expected_expr1 + expected_expr1
         expected_form3 = expected_expr1 + expected_expr1 + expected_expr2
         actual = sorted(response.result_timeseries, key=lambda x: x.label)
         expected = [
-            expected_e1_ts,
-            expected_e2_ts,
             TimeSeries(
                 label="form2",
                 buckets=expected_buckets,

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -22,6 +22,7 @@ from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.state import set_config
 from snuba.web.rpc.v1.endpoint_time_series import EndpointTimeSeries
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
@@ -654,6 +655,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         ]
 
     def test_formula(self) -> None:
+        set_config("enable_formula_reliability", True)
         # store a a test metric with a value of 1, every second for an hour
         granularity_secs = 120
         query_duration = 3600
@@ -731,6 +733,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         ]
 
     def test_formula_reliability(self) -> None:
+        set_config("enable_formula_reliability", True)
         """
         this tests that formula reliability works in the following cases:
         * a simple formula that adds two reliable aggregates returns reliable

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -655,7 +655,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         ]
 
     def test_formula(self) -> None:
-        set_config("enable_formula_reliability", True)
+        set_config("enable_formula_reliability_ts", True)
         # store a a test metric with a value of 1, every second for an hour
         granularity_secs = 120
         query_duration = 3600
@@ -733,7 +733,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         ]
 
     def test_formula_reliability_basic(self) -> None:
-        set_config("enable_formula_reliability", True)
+        set_config("enable_formula_reliability_ts", True)
         """
         this tests a simple formula that adds two reliable aggregates is reliable
         """
@@ -817,7 +817,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         assert response.result_timeseries == expected
 
     def test_formula_reliability_unreliable(self) -> None:
-        set_config("enable_formula_reliability", True)
+        set_config("enable_formula_reliability_ts", True)
         """
         this tests a simple formula that adds a reliable and an unreliable aggregate returns unreliable
         """
@@ -915,7 +915,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
         assert actual == expected
 
     def test_formula_reliability_nested(self) -> None:
-        set_config("enable_formula_reliability", True)
+        set_config("enable_formula_reliability_ts", True)
         """
         this tests that a nested formula that adds two reliable aggregates and an unreliable aggregate returns unreliable
         """

--- a/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_time_series/test_endpoint_time_series_extrapolation.py
@@ -723,6 +723,7 @@ class TestTimeSeriesApiWithExtrapolation(BaseApiTest):
                     DataPoint(
                         data=expected_sum_plus_sum,
                         data_present=True,
+                        reliability=Reliability.RELIABILITY_HIGH,
                     )
                     for _ in range(len(expected_buckets))
                 ],


### PR DESCRIPTION
This PR enables reliabilities to be returned for formulas. The reliability of a formula is defined to be reliable iff each of its parts is reliable. ex: `(agg1 + agg2) / agg3` is reliable iff `agg1, agg2, agg3` are all reliable.

## implementation
its implemented in 2 main parts
1. step 1, add the leaf nodes of a formula to the request. when a user requests `(agg1 + agg2) / agg3` we traverse this formula to also add `agg1, agg2, agg3` to the request. this is necessary to know their reliabilities are later on. they will have the labels set to `form_label.left.left, form_label.left.right, form_label.right` respectively.
2. step 2, traverse the results to find the reliabilities of the leaf nodes and use them to compute the reliability of the formula. and then afterwards remove the extra colums `agg1,agg2,agg3` from the result so we dont actually return it to the user when they didnt explicitly request it (remember these were added in step 1).

# testing
I added a single large unit test that tests reliability of formula works in 3 different cases.