### PR TITLE
feat(errors): Add group_first_seen column on issues platform

### DIFF
--- a/snuba/snuba_migrations/search_issues/0010_add_group_first_seen.py
+++ b/snuba/snuba_migrations/search_issues/0010_add_group_first_seen.py
@@ -1,8 +1,8 @@
 from typing import Sequence
 
-from snuba.migrations.columns import MigrationModifiers
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
 from snuba.migrations.operations import OperationTarget
 from snuba.utils.schemas import Column, DateTime
 

--- a/snuba/snuba_migrations/search_issues/0010_add_group_first_seen.py
+++ b/snuba/snuba_migrations/search_issues/0010_add_group_first_seen.py
@@ -1,0 +1,48 @@
+from typing import Sequence
+
+from snuba.migrations.columns import MigrationModifiers
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import Column, DateTime
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        ops = [
+            [
+                operations.AddColumn(
+                    storage_set=StorageSetKey.SEARCH_ISSUES,
+                    table_name=table_name,
+                    column=Column(
+                        "group_first_seen", DateTime(MigrationModifiers(nullable=True))
+                    ),
+                    after="message",
+                    target=target,
+                ),
+            ]
+            for table_name, target in [
+                ("search_issues_local_v2", OperationTarget.LOCAL),
+                ("search_issues_dist_v2", OperationTarget.DISTRIBUTED),
+            ]
+        ]
+        return ops[0] + ops[1]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        ops = [
+            [
+                operations.DropColumn(
+                    storage_set=StorageSetKey.SEARCH_ISSUES,
+                    table_name=table_name,
+                    column_name="group_first_seen",
+                    target=target,
+                ),
+            ]
+            for table_name, target in [
+                ("search_issues_dist_v2", OperationTarget.DISTRIBUTED),
+                ("search_issues_local_v2", OperationTarget.LOCAL),
+            ]
+        ]
+        return ops[0] + ops[1]

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -748,7 +748,7 @@ def test_prod_snql_query_invalid_query(admin_api: FlaskClient) -> None:
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_force_overwrite(admin_api: FlaskClient) -> None:
-    migration_id = "0009_add_message"
+    migration_id = "0010_add_group_first_seen"
     migrations = json.loads(admin_api.get("/migrations/search_issues/list").data)
     downgraded_migration = [
         m for m in migrations if m.get("migration_id") == migration_id


### PR DESCRIPTION
We want to denormalize the `first_seen` column from the `grouped_messages` table to the `search_issues` table.

The purpose here is that we want to be able to sort queries on `errors` by the group's first-seen time.

This sounds similar to #7305 because it is... we discovered that the issues search uses data from both tables, so both will need the new column.