### PR TITLE
feat(errors): Add group_first_seen column to issues platform entity

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -68,6 +68,11 @@ schema:
     { name: partition, type: UInt, args: { size: 16 } },
     { name: offset, type: UInt, args: { size: 64 } },
     { name: retention_days, type: UInt, args: { size: 16 } },
+    {
+      name: group_first_seen,
+      type: DateTime,
+      args: { schema_modifiers: [nullable] },
+    },
   ]
 
 storages:


### PR DESCRIPTION
We want to denormalize the `first_seen` column from the `grouped_messages` table to the `search_issues` table.

The purpose here is that we want to be able to sort queries on `errors` by the group's first-seen time.

This sounds similar to #7305 because it is... we discovered that the issues search uses data from both tables, so both will need the new column.