### PR TITLE
feat(errors): Add group_first_seen column to issues platform storage

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -59,6 +59,11 @@ schema:
       { name: partition, type: UInt, args: { size: 16 } },
       { name: offset, type: UInt, args: { size: 64 } },
       { name: retention_days, type: UInt, args: { size: 16 } },
+      {
+        name: group_first_seen,
+        type: DateTime,
+        args: { schema_modifiers: [nullable] },
+      },
     ]
   local_table_name: search_issues_local_v2
   dist_table_name: search_issues_dist_v2


### PR DESCRIPTION
We want to denormalize the `first_seen` column from the `grouped_messages` table to the `search_issues` table.

The purpose here is that we want to be able to sort queries on `errors` by the group's first-seen time.

This sounds similar to #7305 because it is... we discovered that the issues search uses data from both tables, so both will need the new column.