### PR TITLE
chore: bump sentry-sdk to 2.33.2 again

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,5 +1,5 @@
 jsonschema2md==0.4.0
 fastjsonschema==2.16.2
-sentry-sdk==2.18.0
+sentry-sdk==2.33.2
 myst-parser==0.18.0
 sphinx==5.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ sentry-kafka-schemas==2.0.1
 sentry-protos==0.3.3
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.5
-sentry-sdk==2.18.0
+sentry-sdk==2.33.2
 simplejson==3.17.6
 snuba-sdk==3.0.39
 structlog==22.3.0


### PR DESCRIPTION
A retry of https://github.com/getsentry/snuba/pull/7300

It's still unclear what specific behavior in the sdk that changed to make `get_current_span()` not return a span when it did before in certain case but we [already fixed](https://github.com/getsentry/snuba/pull/7302) what caused the incident last time bumped the sdk

I think it's okay to bump the version again though because the missing `trace_id` that were added to the querylog payload isn't actually a trace we capture in sentry - I think the change in behavior may have to do with the way we do sampling, and how we depend on sentry to pass through the sampling decisions. 
https://github.com/getsentry/snuba/blob/8cb85e84a61027d0d1c4631f451e119fbafc4f26/snuba/environment.py#L91

https://github.com/getsentry/snuba/blob/8cb85e84a61027d0d1c4631f451e119fbafc4f26/snuba/settings/__init__.py#L207

There is more context on snuba's sampling in https://github.com/getsentry/snuba/pull/3018#discussion_r936942174