### PR TITLE
feat(eap): enable sampling for GetTraces single item queries

### DIFF
--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -270,7 +270,7 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC, metaclass=RegisteredClass)
             OutcomesBasedRoutingStrategy,
         )
 
-        with sentry_sdk.start_span(op="decide_tier"):
+        with sentry_sdk.start_span(op="decide_tier") as span:
             try:
                 routing_context.timer.mark(_START_ESTIMATION_MARK)
                 routing_decision = self._get_routing_decision(routing_context)
@@ -297,7 +297,7 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC, metaclass=RegisteredClass)
 
                 if settings.RAISE_ON_ROUTING_STRATEGY_FAILURES:
                     raise e
-
+            span.set_data("decided_tier", routing_decision.tier)
             return routing_decision
 
     @final

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -25,6 +25,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
 
+from snuba import state
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
@@ -90,6 +91,7 @@ _ADDITIONAL_SPANS = [
 @pytest.fixture(autouse=False)
 def setup_teardown(clickhouse_db: None, redis_db: None) -> None:
     items_storage = get_storage(StorageKey("eap_items"))
+    state.set_config("enable_trace_sampling", True)
 
     write_raw_unprocessed_events(items_storage, _SPANS)  # type: ignore
     write_raw_unprocessed_events(items_storage, _ADDITIONAL_SPANS)  # type: ignore


### PR DESCRIPTION
We have timeouts on GetTraces for big customers. Use the sampling recommendation provided by the RPC layer in the snuba query. 