### PR TITLE
ref: move test requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          make install-python-dependencies
+          python -m pip install -r requirements-test.txt
       - uses: getsentry/paths-filter@v2
         id: files
         with:

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ reset-python:
 	rm -rf .venv
 .PHONY: reset-python
 
-develop: install-python-dependencies install-brew-dev install-rs-dev setup-git
+develop: install-python-dependencies install-brew-dev install-rs-dev
+	make setup-git
 
 setup-git:
 	mkdir -p .git/hooks && cd .git/hooks && ln -sf ../../config/hooks/* ./
-	pip install 'pre-commit==3.6.0'
 	pre-commit install --install-hooks
 
 test:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
+pre-commit==3.6.0
+
 black==24.3.0
 devservices==1.2.1
 flake8==7.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,13 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
+black==24.3.0
+devservices==1.2.1
+flake8==7.0.0
+freezegun==1.2.2
+honcho==1.1.0
+pytest==8.3.3
+pytest-cov==4.1.0
+pytest-watch==4.2.0
 time-machine==2.13.0
 
 # for typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,14 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
-black==24.3.0
 blinker==1.5
 click==8.1.7
 clickhouse-driver==0.2.9
 confluent-kafka==2.7.0
 datadog==0.21.0
-devservices==1.2.1
-flake8==7.0.0
 Flask==2.2.5
 google-cloud-storage==2.18.0
 googleapis-common-protos==1.63.2
 google-api-core==2.19.1
-honcho==1.1.0
 python-jose[cryptography]==3.3.0
 jsonschema==4.23.0
 fastjsonschema==2.16.2
@@ -21,9 +17,6 @@ parsimonious==0.10.0
 progressbar2==4.2.0
 protobuf==5.29.5
 proto-plus==1.24.0
-pytest==8.3.3
-pytest-cov==4.1.0
-pytest-watch==4.2.0
 python-dateutil==2.8.2
 python-rapidjson==1.8
 redis==4.5.4
@@ -46,4 +39,3 @@ PyYAML==6.0
 sqlparse==0.5.0
 google-api-python-client==2.88.0
 sentry-usage-accountant==0.0.11
-freezegun==1.2.2

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -3,7 +3,6 @@ import sys
 from subprocess import call, list2cmdline
 
 import click
-from honcho.manager import Manager
 
 from snuba import settings
 
@@ -23,6 +22,8 @@ COMMON_RUST_CONSUMER_DEV_OPTIONS = [
 )
 def devserver(*, bootstrap: bool, workers: bool, log_level: str) -> None:
     "Starts all Snuba processes for local development."
+
+    from honcho.manager import Manager
 
     os.environ["PYTHONUNBUFFERED"] = "1"
 


### PR DESCRIPTION
this consolidates all dev dependencies (pre-commit, pytest, honcho, ...) into requirements-test.txt (which should be called requirements-dev.txt - but one change at a time)

i was already doing this for uv (https://github.com/getsentry/snuba/pull/7309), but this'll make the diff smaller and easier for me personally to resync my PR as requirements txts are updated
