### PR TITLE
fix: fix broken ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
               tests/sentry/snuba \
               tests/sentry/eventstream/kafka \
               tests/sentry/post_process_forwarder \
-              tests/sentry/eventstore/snuba \
+              tests/sentry/services/eventstore/snuba \
               tests/sentry/search/events \
               tests/sentry/event_manager \
               tests/sentry/api/endpoints/test_organization_profiling_functions.py \


### PR DESCRIPTION
the sentry integrations test part of ci is broken bc there was recently a PR that moved around the file structure of their tests in the sentry repo. this fixes it.

see here https://github.com/getsentry/sentry/pull/97636/files#diff-f906c21df5a1c48e1a69e8bf1dc7af22d113ffab0f8fa7696b844bd58bfc3f72
and here https://github.com/getsentry/snuba/actions/runs/16947408152/job/48031925559?pr=7331