### PR TITLE
fix(issues): Process new group_first_seen field on ingest

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1589,7 +1589,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2890,7 +2890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3551,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6d01b6accc6a9eee92dbdc9c16a0c6a34e7f47f7bc39ab3d359629eee89462"
+checksum = "ce43d02aa04244bfad3ad55ce2d02d8a50c0dfbfde76a527c71f9360e97d5411"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/rust_snuba/src/processors/errors.rs
+++ b/rust_snuba/src/processors/errors.rs
@@ -112,6 +112,8 @@ struct ErrorMessage {
     datetime: StringToIntDatetime64,
     event_id: Uuid,
     group_id: u64,
+    #[serde(default)]
+    group_first_seen: StringToIntDatetime64,
     message: String,
     primary_hash: String,
     project_id: u64,
@@ -370,6 +372,7 @@ struct ErrorRow {
     #[serde(rename = "exception_stacks.value")]
     exception_stacks_value: Vec<Option<String>>,
     group_id: u64,
+    group_first_seen: u64,
     http_method: Option<String>,
     http_referer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -719,6 +722,7 @@ impl ErrorRow {
             flags_key,
             flags_value,
             group_id: from.group_id,
+            group_first_seen: from.group_first_seen.0,
             http_method: from_request.method.0,
             http_referer,
             ip_address_v4,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__events-.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__events-.snap
@@ -4,6 +4,13 @@ expression: diff
 ---
 [
     Change {
+        path: ".<anyOf:0>.2",
+        change: PropertyAdd {
+            lhs_additional_properties: true,
+            added: "group_first_seen",
+        },
+    },
+    Change {
         path: ".<anyOf:0>.2.data.contexts.<anyOf:0>",
         change: PropertyAdd {
             lhs_additional_properties: true,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__error-with-null-threads.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__error-with-null-threads.json.snap
@@ -264,6 +264,7 @@ expression: snapshot_payload
     ],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 124,
     "http_method": null,
     "http_referer": null,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__error-with-null-values-threads.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__error-with-null-values-threads.json.snap
@@ -264,6 +264,7 @@ expression: snapshot_payload
     ],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 124,
     "http_method": null,
     "http_referer": null,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__error-with-threads.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__error-with-threads.json.snap
@@ -265,6 +265,7 @@ expression: snapshot_payload
     ],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 124,
     "http_method": null,
     "http_referer": null,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__errors1.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__errors1.json.snap
@@ -27,6 +27,7 @@ expression: snapshot_payload
     "exception_stacks.value": [],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 124,
     "http_method": null,
     "http_referer": null,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__null-tag-keys.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__null-tag-keys.json.snap
@@ -27,6 +27,7 @@ expression: snapshot_payload
     "exception_stacks.value": [],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 123123123,
     "http_method": null,
     "http_referer": null,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__null-values.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__null-values.json.snap
@@ -27,6 +27,7 @@ expression: snapshot_payload
     "exception_stacks.value": [],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 124,
     "http_method": null,
     "http_referer": null,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__sdk-info-java.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__sdk-info-java.json.snap
@@ -27,6 +27,7 @@ expression: snapshot_payload
     "exception_stacks.value": [],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 123123,
     "http_method": null,
     "http_referer": null,

--- a/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__weird-transaction-source.json.snap
+++ b/rust_snuba/src/processors/snapshots/rust_snuba__processors__tests__schemas@events-ErrorsProcessor-events__1__weird-transaction-source.json.snap
@@ -27,6 +27,7 @@ expression: snapshot_payload
     "exception_stacks.value": [],
     "flags.key": [],
     "flags.value": [],
+    "group_first_seen": 0,
     "group_id": 123,
     "http_method": null,
     "http_referer": null,

--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -90,6 +90,7 @@ class SearchIssueEvent(TypedDict, total=False):
     project_id: int
     event_id: str
     group_id: int
+    group_first_seen: str
     platform: str
     primary_hash: str
     message: str
@@ -267,6 +268,14 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
                 )
             client_timestamp = _client_timestamp
 
+        group_first_seen = None
+        if "group_first_seen" in event:
+            group_first_seen = _ensure_valid_date(
+                datetime.strptime(
+                    event["group_first_seen"], settings.PAYLOAD_DATETIME_FORMAT
+                )
+            )
+
         fingerprints = event_occurrence_data["fingerprint"]
         fingerprints = fingerprints[: self.FINGERPRINTS_HARD_LIMIT_SIZE - 1]
 
@@ -310,6 +319,7 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
         return [
             {
                 "group_id": event["group_id"],
+                "group_first_seen": group_first_seen,
                 **fields,
                 "message_timestamp": metadata.timestamp,
                 "retention_days": retention_days,

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -49,6 +49,9 @@ class ErrorEvent:
             "retention_days": 58,
             "event_id": self.event_id,
             "group_id": self.group_id,
+            "group_first_seen": (self.timestamp - timedelta(days=2)).strftime(
+                PAYLOAD_DATETIME_FORMAT
+            ),
             "project_id": self.project_id,
             "platform": self.platform,
             "message": "",
@@ -348,6 +351,9 @@ class ErrorEvent:
             "retention_days": 90,
             "deleted": 0,
             "group_id": self.group_id,
+            "group_first_seen": int(
+                (self.timestamp - timedelta(days=2)).timestamp() * 1000
+            ),
             "primary_hash": "04233d08-ac90-cf6f-c015-b1be5932e7e2",
             "received": int(
                 self.received_timestamp.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
This is part of an effort to fix issue search's sort-by-age. To do so, we're adding a new `group_first_seen` field.

This PR processes the new field on ingestion of both errors & search_issues events.

Note that I couldn't get the snapshot tests to run locally due to devenv problems, so the snapshot changes in this PR are merely taken from CI.