### PR TITLE
ref(outcomes): add daily local and mv tables

### DIFF
--- a/snuba/snuba_migrations/outcomes/0009_outcomes_daily_table.py
+++ b/snuba/snuba_migrations/outcomes/0009_outcomes_daily_table.py
@@ -10,9 +10,9 @@ daily_columns: Sequence[Column[Modifiers]] = [
     Column("project_id", UInt(64)),
     Column("key_id", UInt(64)),
     Column("timestamp", DateTime()),
-    Column("category", UInt(8)),
     Column("outcome", UInt(8)),
     Column("reason", String(Modifiers(low_cardinality=True))),
+    Column("category", UInt(8)),
     Column("quantity", UInt(64)),
     Column("times_seen", UInt(64)),
 ]
@@ -22,9 +22,9 @@ materialized_view_columns: Sequence[Column[Modifiers]] = [
     Column("project_id", UInt(64)),
     Column("key_id", UInt(64)),
     Column("timestamp", DateTime()),
-    Column("category", UInt(8)),
     Column("outcome", UInt(8)),
     Column("reason", String()),
+    Column("category", UInt(8)),
     Column("quantity", UInt(64)),
     Column("times_seen", UInt(64)),
 ]

--- a/snuba/snuba_migrations/outcomes/0009_outcomes_daily_table.py
+++ b/snuba/snuba_migrations/outcomes/0009_outcomes_daily_table.py
@@ -1,0 +1,101 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, DateTime, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+daily_columns: Sequence[Column[Modifiers]] = [
+    Column("org_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("key_id", UInt(64)),
+    Column("timestamp", DateTime()),
+    Column("category", UInt(8)),
+    Column("outcome", UInt(8)),
+    Column("reason", String(Modifiers(low_cardinality=True))),
+    Column("quantity", UInt(64)),
+    Column("times_seen", UInt(64)),
+]
+
+materialized_view_columns: Sequence[Column[Modifiers]] = [
+    Column("org_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("key_id", UInt(64)),
+    Column("timestamp", DateTime()),
+    Column("category", UInt(8)),
+    Column("outcome", UInt(8)),
+    Column("reason", String()),
+    Column("quantity", UInt(64)),
+    Column("times_seen", UInt(64)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigrationLegacy):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_local",
+                columns=daily_columns,
+                engine=table_engines.SummingMergeTree(
+                    storage_set=StorageSetKey.OUTCOMES,
+                    order_by="(org_id, project_id, key_id, outcome, reason, timestamp, category)",
+                    partition_by="(toMonth(timestamp))",
+                    ttl="timestamp + toIntervalMonth(13)",
+                ),
+            ),
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.OUTCOMES,
+                view_name="outcomes_mv_daily_local",
+                destination_table_name="outcomes_daily_local",
+                columns=materialized_view_columns,
+                query="""
+                    SELECT
+                        org_id,
+                        project_id,
+                        ifNull(key_id, 0) AS key_id,
+                        toStartOfDay(timestamp) AS timestamp,
+                        outcome,
+                        ifNull(reason, 'none') AS reason,
+                        category,
+                        count() AS times_seen,
+                        sum(quantity) AS quantity
+                    FROM outcomes_raw_local
+                    GROUP BY org_id, project_id, key_id, timestamp, outcome, reason, category
+                """,
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_daily_local",
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_local",
+            ),
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_dist",
+                columns=daily_columns,
+                engine=table_engines.Distributed(
+                    local_table_name="outcomes_daily_local",
+                    sharding_key="org_id",
+                ),
+            ),
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES, table_name="outcomes_daily_dist"
+            ),
+        ]

--- a/snuba/snuba_migrations/outcomes/0009_outcomes_daily_table.py
+++ b/snuba/snuba_migrations/outcomes/0009_outcomes_daily_table.py
@@ -31,6 +31,11 @@ materialized_view_columns: Sequence[Column[Modifiers]] = [
 
 
 class Migration(migration.ClickhouseNodeMigration):
+    """
+    Outcomes daily table(s) will be used to query outcomes for data that
+    exceeds 90 day retention. It's rolled up by day instead of hour.
+    """
+
     blocking = False
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:


### PR DESCRIPTION
The outcomes table is used as part of our routing strategy to determine when to query downsampled data. Now that we are making the move to increase the retention of our data, we'll want to be able to query more than 90 days worth of outcomes to route data accordingly. 

The outcomes hourly table in US has about 2GB worth of data per partition (it's actually a bit less), and we partition by week. So assuming we increased the TTL on that table to 13 months, thats 56 weeks.

```
56 weeks * 2GB = 112GB
```

And with the daily table that should cut down even more since we'll be rolling up by day, not hour

```
112GB / 24 = ~5GB
```

Even if these numbers are slightly off, this shouldn't add a ton of load to the outcomes cluster. And the outcomes consumers should have more than enough headroom to accommodate the overhead a matview adds to inserts