### PR TITLE
chore: bump sentry-sdk 2.35.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ sentry-kafka-schemas==2.0.4
 sentry-protos==0.3.3
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.5
-sentry-sdk==2.33.2
+sentry-sdk==2.35.0
 simplejson==3.17.6
 snuba-sdk==3.0.39
 structlog==22.3.0

--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -252,14 +252,12 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC, metaclass=RegisteredClass)
     ) -> None:
         name = _SAMPLING_IN_STORAGE_PREFIX + name
         metrics_backend_func(name, value, tags, None)
-        span = sentry_sdk.get_current_span()
         routing_context.extra_info[name] = {
             "type": metrics_backend_func.__name__,
             "value": value,
             "tags": tags,
         }
-        if span is not None:
-            span.set_data(name, value)
+        sentry_sdk.update_current_span(attributes={name: value})
 
     def _get_routing_decision(self, routing_context: RoutingContext) -> RoutingDecision:
         raise NotImplementedError


### PR DESCRIPTION
okay so I had to add a fix (https://github.com/getsentry/sentry-python/pull/4688) to the earlier change (https://github.com/getsentry/sentry-python/pull/4598) I made in the sentry-python sdk. 

so now I'm bumping the sentry-sdk to `2.35.0` to grab that fix. I added the `update_current_span ` convenience funtion that was also in this release https://github.com/getsentry/sentry-python/pull/4673