### PR TITLE
feat(search_issues): add `timestamp_ms` column on `search_issues`

### DIFF
--- a/snuba/snuba_migrations/search_issues/0011_add_timestamp_ms.py
+++ b/snuba/snuba_migrations/search_issues/0011_add_timestamp_ms.py
@@ -1,0 +1,77 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.operations import (
+    AddColumn,
+    DropColumn,
+    OperationTarget,
+    SqlOperation,
+)
+from snuba.utils import schemas
+from snuba.utils.schemas import Column
+
+
+class Migration(ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            AddColumn(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_local_v2",
+                column=Column(
+                    "timestamp_ms",
+                    schemas.DateTime64(
+                        3,
+                        modifiers=MigrationModifiers(
+                            nullable=True,
+                            low_cardinality=False,
+                            default=None,
+                            materialized=None,
+                            codecs=None,
+                            ttl=None,
+                        ),
+                    ),
+                ),
+                after="group_first_seen",
+                target=OperationTarget.LOCAL,
+            ),
+            AddColumn(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_dist_v2",
+                column=Column(
+                    "timestamp_ms",
+                    schemas.DateTime64(
+                        3,
+                        modifiers=MigrationModifiers(
+                            nullable=True,
+                            low_cardinality=False,
+                            default=None,
+                            materialized=None,
+                            codecs=None,
+                            ttl=None,
+                        ),
+                    ),
+                ),
+                after="group_first_seen",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            DropColumn(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_dist_v2",
+                column_name="timestamp_ms",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            DropColumn(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_local_v2",
+                column_name="timestamp_ms",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
Similar to https://github.com/getsentry/snuba/pull/7115 (in effect) and https://github.com/getsentry/snuba/pull/73345 (in implementation). We want more precision on replays breadcrumb ordering, and replays query both errors and issue platform, which is `search_issues` in snuba, so we want to add an additional column that has millisecond precision. Column is exactly the same as `timestamp_ms` in errors.

Refs https://linear.app/getsentry/issue/ID-605/precise-error-ordering-on-replay-breadcrumbs-queries