### PR TITLE
update CLICKHOUSE_SERVER_MAX_VERSION to 25.3.6.10034

### DIFF
--- a/snuba/migrations/clickhouse.py
+++ b/snuba/migrations/clickhouse.py
@@ -1,4 +1,4 @@
 CLICKHOUSE_SERVER_MIN_VERSION = "23.8.11.29"
 # Note: SaaS, self-hosted, and sentry dev
 # environements should all be on 23.8.11.29
-CLICKHOUSE_SERVER_MAX_VERSION = "24.8.14.10459"
+CLICKHOUSE_SERVER_MAX_VERSION = "25.3.6.10034"


### PR DESCRIPTION
We are already running `25.3.6.10034` in `s4s` and some `de` clusters