### PR TITLE
feat(search_issues): populate `timestamp_ms` on `search_issues`

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -73,6 +73,7 @@ schema:
       type: DateTime,
       args: { schema_modifiers: [nullable] },
     },
+    { name: timestamp_ms, type: DateTime64, args: { precision: 3, schema_modifiers: [nullable] } },
   ]
 
 storages:

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -64,6 +64,7 @@ schema:
         type: DateTime,
         args: { schema_modifiers: [nullable] },
       },
+      { name: timestamp_ms, type: DateTime64, args: { precision: 3, schema_modifiers: [nullable] } },
     ]
   local_table_name: search_issues_local_v2
   dist_table_name: search_issues_dist_v2

--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -225,6 +225,11 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
         else:
             processed["transaction_duration"] = 0
 
+    def _process_timestamp_ms(
+        self, event_data: IssueEventData, processed: MutableMapping[str, Any]
+    ) -> None:
+        processed["timestamp_ms"] = processed["client_timestamp"]
+
     def process_insert_v1(
         self, event: SearchIssueEvent, metadata: KafkaMessageMetadata
     ) -> Sequence[Mapping[str, Any]]:
@@ -293,6 +298,9 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
 
         # start_timestamp, timestamp
         self._process_transaction_duration(event_data, fields)
+
+        # timestamp_ms
+        self._process_timestamp_ms(event_data, fields)
 
         return [
             {

--- a/tests/datasets/test_search_issues_processor.py
+++ b/tests/datasets/test_search_issues_processor.py
@@ -124,6 +124,13 @@ class TestSearchIssuesMessageProcessor:
         self.process_message(with_data_client_timestamp)
         self.process_message(with_event_datetime)
 
+    def test_extract_timestamp_ms(self, message_base):
+        processed = self.process_message(message_base)
+        self.assert_required_columns(processed)
+        insert_row = processed.rows[0]
+        assert insert_row["timestamp_ms"].isoformat() + "Z" == message_base["datetime"]
+        assert insert_row["timestamp_ms"] == insert_row["client_timestamp"]
+
     def test_extract_user(self, message_base):
         message_with_user = message_base
         message_with_user["data"]["user"] = {


### PR DESCRIPTION
Follow up to https://github.com/getsentry/snuba/pull/7358. Populate the new `timestamp_ms` field on `search_issues` with `client_timestamp`, which is the canonical timestamp for `search_issues` https://github.com/getsentry/snuba/blob/32b9536c2d01b8e40fbbe4c8de4684d5b698c05e/snuba/datasets/configuration/issues/entities/search_issues.yaml#L84-L89

`timestamp_ms` copies `client_timestamp` exactly, since the messages themselves have timestamps with millisecond precision, but the column is Datetime64 with more precision and won't be truncated by clickhouse.