### PR TITLE
fix(observability): raise a specific error for query timeouts

### DIFF
--- a/snuba/web/rpc/common/exceptions.py
+++ b/snuba/web/rpc/common/exceptions.py
@@ -18,6 +18,16 @@ class BadSnubaRPCRequestException(RPCRequestException):
         super().__init__(400, message)
 
 
+class HighAccuracyQueryTimeoutException(RPCRequestException):
+    def __init__(self, message: str):
+        super().__init__(408, message)
+
+
+class QueryTimeoutException(RPCRequestException):
+    def __init__(self, message: str):
+        super().__init__(408, message)
+
+
 def convert_rpc_exception_to_proto(
     exc: Union[RPCRequestException, QueryException]
 ) -> ErrorProto:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -59,7 +59,10 @@ from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column as snuba_column
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint
-from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+from snuba.web.rpc.common.exceptions import (
+    BadSnubaRPCRequestException,
+    QueryTimeoutException,
+)
 from snuba.web.rpc.proto_visitor import (
     AggregationToConditionalAggregationVisitor,
     TraceItemTableRequestWrapper,
@@ -262,9 +265,9 @@ class TestTraceItemTable(BaseApiTest):
                 ),
             ),
         ):
-            with pytest.raises(QueryException) as e:
+            with pytest.raises(QueryTimeoutException) as e:
                 EndpointTraceItemTable().execute(message)
-            assert "DB::Exception: Timeout exceeded" in str(e.value)
+            assert "Query timed out" in str(e.value)
 
             metrics_mock.increment.assert_any_call(
                 "timeout_query",


### PR DESCRIPTION
We have sentry errors clogging our feed whenever requests time out. Most of these are requests from HIGHEST_ACCURACY queries, which we expect to time out some of the time.

Raise a different error for timeouts based on the downsampling mode so we can know how many normal requests are timing out and we should take action on