### PR TITLE
Tidy up repeated pre-commit-hooks invocation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,8 @@ repos:
       - id: trailing-whitespace
       - id: fix-encoding-pragma
         args: ["--remove"]
+      - id: no-commit-to-branch
+        args: ['--branch', 'master']
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
@@ -32,11 +34,6 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
-    hooks:
-      - id: no-commit-to-branch
-        args: ['--branch', 'master']
   - repo: local
     hooks:
       - id: validate-configs-syntax


### PR DESCRIPTION

I noticed there's a repeated listing of `pre-commit/pre-commit-hooks`  in the pre commit config, just tidying this up. 


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
