### PR TITLE
fix(search_issues): stop truncating timestamp_ms in search_issues

### DIFF
--- a/tests/datasets/test_search_issues_processor.py
+++ b/tests/datasets/test_search_issues_processor.py
@@ -1,7 +1,7 @@
 import copy
 import uuid
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, MutableMapping, Union
 
 import pytest
@@ -128,8 +128,12 @@ class TestSearchIssuesMessageProcessor:
         processed = self.process_message(message_base)
         self.assert_required_columns(processed)
         insert_row = processed.rows[0]
-        assert insert_row["timestamp_ms"].isoformat() + "Z" == message_base["datetime"]
-        assert insert_row["timestamp_ms"] == insert_row["client_timestamp"]
+        client_timestamp_utc = insert_row["client_timestamp"].replace(
+            tzinfo=timezone.utc
+        )
+        assert insert_row["timestamp_ms"] == int(
+            client_timestamp_utc.timestamp() * 1000
+        )
 
     def test_extract_user(self, message_base):
         message_with_user = message_base

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -505,4 +505,4 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         )
         data = json.loads(response.data)
 
-        assert data["data"] == [{"timestamp_ms": now_ms}]
+        assert datetime.fromisoformat(data["data"][0]["timestamp_ms"]) == now_ms

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -483,10 +483,10 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
     def test_eventstream_timestamp_ms_precision(self) -> None:
         """Test that timestamp_ms preserves millisecond precision through the full eventstream"""
         now = datetime.utcnow()
-        now_ms = now + timedelta(milliseconds=123)
+        now_ms = now.replace(microsecond=0) + timedelta(milliseconds=123)
 
         insert_row = base_insert_event(now_ms)
-        insert_row[2]["data"]["client_timestamp"] = now_ms
+        insert_row[2]["datetime"] = now_ms.isoformat() + "Z"
 
         response = self.app.post(
             "/tests/search_issues/eventstream", data=json.dumps(insert_row)


### PR DESCRIPTION
In https://github.com/getsentry/snuba/pull/7362, we populate `timestamp_ms` in `search_issues` by just copying the `timestamp` of the event, since the event timestamp had all the precision we needed. I had assumed that Clickhouse was the one that truncated the `timestamp` to seconds, but it turns out there's also JSONRowEncoder, which forcefully takes `datetime` objects and chops off the milliseconds: https://github.com/getsentry/snuba/blob/799e027def8bc187c3eb4353b635baee908060fc/snuba/clickhouse/http.py#L54-L55

https://github.com/getsentry/snuba/blob/7bfa538516882dc58b2bed2f3e93e87360a6719c/snuba/clickhouse/__init__.py#L1

I don't want to change DATETIME_FORMAT, since that would be very impactful to a lot of existing schemas. To work around this, we make `timestamp_ms` an actual timestamp in milliseconds and pass it to clickhouse, which then successfully does the conversion to DateTime64(3), and will populate `timestamp_ms` with timestamps that have the appropriate amount of precision. 

One alternative I considered was wrapping `timestamp_ms` in a special DateTimeWithMorePrecision class and special-casing it in `http.py`, but I think that just adds more indirection for this specific feature — if we have more columns that need additional precision that are managed by JSONRowEncoder, I think that would be an appropriate followup.