### PR TITLE
fix: add PYTHONHOME

### DIFF
--- a/scripts/rust-envvars
+++ b/scripts/rust-envvars
@@ -4,5 +4,8 @@
 export SNUBA_TEST_PYTHONPATH="$(python -c 'import sys; print(":".join(sys.path))')"
 export SNUBA_TEST_PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
 
+# https://github.com/astral-sh/uv/issues/8821
+export PYTHONHOME="$(dirname $(dirname $(realpath $(which python))))"
+
 # load cargo envvars explicitly in case user forgot
 . "${CARGO_HOME:-$HOME/.cargo}/env"


### PR DESCRIPTION
`cargo test` doesn't work without this

this workaround is already being used in streams and is needed if using pythons from https://github.com/astral-sh/python-build-standalone (currently via devenv, will be via uv in https://github.com/getsentry/snuba/pull/7368)

only reason this hasn't been noticed till recently even though devenv was intro'd 6mo ago was that no one recreated their venvs / was still using either homebrew or pyenv pythons 