### PR TITLE
fix(ci): bump timeout for venv recreation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
   config-validation:
     name: "Dataset Config Validation"
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         name: Checkout code


### PR DESCRIPTION
this timeout needs to be bumped to allow for venv recreation after https://github.com/getsentry/snuba/pull/7368 which invalidated venv caches in ci

2 minutes isn't enough for creating a venv from scratch (uncached)