### PR TITLE
fix: rust envvars need to be set before devenv/uv sync

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -14,13 +14,13 @@ fi
 
 PATH_add "${PWD}/.devenv/bin"
 
+PATH_add /opt/homebrew/opt/rustup/bin
+
+. scripts/rust-envvars
+
 if [ ! -d .venv ]; then
     devenv sync
 fi
 
 export VIRTUAL_ENV="${PWD}/.venv"
 PATH_add "${PWD}/.venv/bin"
-
-PATH_add /opt/homebrew/opt/rustup/bin
-
-. scripts/rust-envvars


### PR DESCRIPTION
if .venv doesnt exist then devenv/uv sync makes it but it'll need to source rust envvars first