### PR TITLE
fix: scripts/rust-envvars needs .venv/bin/python

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,11 +16,13 @@ PATH_add "${PWD}/.devenv/bin"
 
 PATH_add /opt/homebrew/opt/rustup/bin
 
-. scripts/rust-envvars
-
 if [ ! -d .venv ]; then
+    # make sure PYTHONHOME isn't set until we've created the .venv
+    unset PYTHONHOME
     devenv sync
 fi
 
 export VIRTUAL_ENV="${PWD}/.venv"
 PATH_add "${PWD}/.venv/bin"
+
+. scripts/rust-envvars

--- a/scripts/rust-envvars
+++ b/scripts/rust-envvars
@@ -1,3 +1,10 @@
+export REPOROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -f "${REPOROOT}/.venv/bin/python" ]; then
+  echo "cannot source this file unless ${REPOROOT}/.venv/bin/python exists, please run devenv sync"
+  exit 1
+fi
+
 # Related thread: https://github.com/PyO3/pyo3/issues/1741
 
 # This is required for the tests in python.rs
@@ -5,7 +12,7 @@ export SNUBA_TEST_PYTHONPATH="$(python -c 'import sys; print(":".join(sys.path))
 export SNUBA_TEST_PYTHONEXECUTABLE="$(python -c 'import sys; print(sys.executable)')"
 
 # https://github.com/astral-sh/uv/issues/8821
-export PYTHONHOME="$(dirname $(dirname $(realpath $(which python))))"
+export PYTHONHOME="$(dirname $(dirname $(realpath "${REPOROOT}/.venv/bin/python")))"
 
 # load cargo envvars explicitly in case user forgot
 if [ -n "$FISH_VERSION" ]; then


### PR DESCRIPTION
#7381 wasn't really the right thing to do - this should be a universal fix for `ModuleNotFoundError: No module named 'encodings'` when recreating the venv

@xurui-c was running into this and I found her PYTHONHOME was `/Users` - before the venv's created, there was no `python` on her PATH otherwise (this isn't an unusual case, as vanilla macos only has /usr/bin/python3), so it was silently resolving to `/Users` during scripts/rust-envvars which totally breaks any python.
