### PR TITLE
ref(outcomes): fix partitioning for daily table

### DIFF
--- a/snuba/snuba_migrations/outcomes/0010_outcomes_daily_fixed_partitioning.py
+++ b/snuba/snuba_migrations/outcomes/0010_outcomes_daily_fixed_partitioning.py
@@ -1,0 +1,122 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, DateTime, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+daily_columns: Sequence[Column[Modifiers]] = [
+    Column("org_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("key_id", UInt(64)),
+    Column("timestamp", DateTime()),
+    Column("outcome", UInt(8)),
+    Column("reason", String(Modifiers(low_cardinality=True))),
+    Column("category", UInt(8)),
+    Column("quantity", UInt(64)),
+    Column("times_seen", UInt(64)),
+]
+
+materialized_view_columns: Sequence[Column[Modifiers]] = [
+    Column("org_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("key_id", UInt(64)),
+    Column("timestamp", DateTime()),
+    Column("outcome", UInt(8)),
+    Column("reason", String()),
+    Column("category", UInt(8)),
+    Column("quantity", UInt(64)),
+    Column("times_seen", UInt(64)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Fixes partitioning: toMonth(timestamp) -> toStartOfMonth(timestamp)
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_local_v2",
+                columns=daily_columns,
+                engine=table_engines.SummingMergeTree(
+                    storage_set=StorageSetKey.OUTCOMES,
+                    order_by="(org_id, project_id, key_id, outcome, reason, timestamp, category)",
+                    partition_by="(toStartOfMonth(timestamp))",
+                    ttl="timestamp + toIntervalMonth(13)",
+                ),
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.OUTCOMES,
+                view_name="outcomes_mv_daily_local_v2",
+                destination_table_name="outcomes_daily_local_v2",
+                columns=materialized_view_columns,
+                query="""
+                    SELECT
+                        org_id,
+                        project_id,
+                        ifNull(key_id, 0) AS key_id,
+                        toStartOfDay(timestamp) AS timestamp,
+                        outcome,
+                        ifNull(reason, 'none') AS reason,
+                        category,
+                        count() AS times_seen,
+                        sum(quantity) AS quantity
+                    FROM outcomes_raw_local
+                    GROUP BY org_id, project_id, key_id, timestamp, outcome, reason, category
+                """,
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_dist_v2",
+                columns=daily_columns,
+                engine=table_engines.Distributed(
+                    local_table_name="outcomes_daily_local_v2",
+                    sharding_key="org_id",
+                ),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            # Remove old tables with wrong partitioning
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_daily_local",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_local",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        # We don't need to recreate the tables we dropped since those
+        # we wrong to begin with (and not used)
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_dist_v2",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_daily_local_v2",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_daily_local_v2",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
The same as https://github.com/getsentry/snuba/pull/7356 except fix the partitioning from `toMonth(timestamp)` -> `toStartOfMonth(timestamp)` 