### PR TITLE
fix(api): add quota allowance to clickhouse errors

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -486,6 +486,9 @@ def _raw_query(
                 calculated_cause = RateLimitExceeded(
                     "Query scanned more than the allocated amount of bytes"
                 )
+                # Since we overwrite the original cause with a new error, we need to
+                # manually add the quota_allowance attribute to the new exception
+                calculated_cause.quota_allowance = stats["quota_allowance"]
 
             with configure_scope() as scope:
                 fingerprint = ["{{default}}", str(cause.code), dataset_name]

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1370,6 +1370,45 @@ class TestSnQLApi(BaseApiTest):
                 == "Query scanned more than the allocated amount of bytes"
             )
 
+            expected_quota_allowance = {
+                "details": {
+                    "MaxBytesPolicy123": {
+                        "can_run": True,
+                        "max_threads": 0,
+                        "max_bytes_to_read": 1,
+                        "explanation": {
+                            "storage_key": "doesntmatter",
+                        },
+                        "is_throttled": True,
+                        "throttle_threshold": MAX_THRESHOLD,
+                        "rejection_threshold": MAX_THRESHOLD,
+                        "quota_used": 0,
+                        "quota_unit": NO_UNITS,
+                        "suggestion": NO_SUGGESTION,
+                    }
+                },
+                "summary": {
+                    "threads_used": 0,
+                    "max_bytes_to_read": 1,
+                    "is_successful": False,
+                    "is_rejected": False,
+                    "is_throttled": True,
+                    "rejection_storage_key": None,
+                    "throttle_storage_key": "doesntmatter",
+                    "rejected_by": {},
+                    "throttled_by": {
+                        "policy": "MaxBytesPolicy123",
+                        "quota_used": 0,
+                        "quota_unit": NO_UNITS,
+                        "suggestion": NO_SUGGESTION,
+                        "storage_key": "doesntmatter",
+                        "throttle_threshold": MAX_THRESHOLD,
+                    },
+                },
+            }
+
+            assert response.json["quota_allowance"] == expected_quota_allowance
+
     def test_allocation_policy_violation(self) -> None:
         with patch(
             "snuba.web.db_query._get_allocation_policies",
@@ -1436,6 +1475,8 @@ class TestSnQLApi(BaseApiTest):
                 response.json["error"]["message"]
                 == f"Query on could not be run due to allocation policies, info: {info}"
             )
+
+            assert response.json["quota_allowance"] == info
 
     def test_tags_key_column(self) -> None:
         response = self.post(


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/96151#discussion_r2231549589, we saw a small issue where for the max byte scanning policies, we didn't return a `quota_allowance` in the API response since we were overwriting the original error. This manually puts the `quota_allowance` back on.