### PR TITLE
fix(issues): resolve u32/u64 group_first_seen bug

### DIFF
--- a/rust_snuba/src/processors/errors.rs
+++ b/rust_snuba/src/processors/errors.rs
@@ -372,7 +372,7 @@ struct ErrorRow {
     #[serde(rename = "exception_stacks.value")]
     exception_stacks_value: Vec<Option<String>>,
     group_id: u64,
-    group_first_seen: u64,
+    group_first_seen: u32,
     http_method: Option<String>,
     http_referer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -722,7 +722,7 @@ impl ErrorRow {
             flags_key,
             flags_value,
             group_id: from.group_id,
-            group_first_seen: from.group_first_seen.0,
+            group_first_seen: (from.group_first_seen.0 / 1000) as u32,
             http_method: from_request.method.0,
             http_referer,
             ip_address_v4,

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -335,7 +335,7 @@ class ErrorEvent:
             "retention_days": 90,
             "deleted": 0,
             "group_id": self.group_id,
-            "group_first_seen": int((self.timestamp - timedelta(days=2)).timestamp() * 1000),
+            "group_first_seen": int((self.timestamp - timedelta(days=2)).timestamp()),
             "primary_hash": "04233d08-ac90-cf6f-c015-b1be5932e7e2",
             "received": int(
                 self.received_timestamp.replace(tzinfo=timezone.utc)


### PR DESCRIPTION
I recently set up ingestion for group_first_seen. This column is defined as `DateTime`.

When I set up the rust processor, I was basing my processing on the `datetime` field, since I knew that the two were sent over identically from `sentry/**/eventstream/snuba.py`. This included using the `StringToIntDatetime64` deserializer, which I still believe is correct. Unfortunately I followed that 64 further than I should've and set the field to be a `u64` in the row — when it should've been a `u32`.

This PR fixes that to make future ingestions correct. (I based my changes on the `timestamp` field's parsing, which is similarly a `DateTime` (no 64) column.)
