### PR TITLE
fix(cbrs): divide subclasses according to their namespaces

### DIFF
--- a/snuba/configs/configuration.py
+++ b/snuba/configs/configuration.py
@@ -478,6 +478,11 @@ class ConfigurableComponent(ABC, metaclass=RegisteredClass):
     @classmethod
     def all_names(cls) -> list[str]:
         """Returns all registered class names that belong to this component's namespace."""
+        # If called on ConfigurableComponent itself, return all registered classes
+        if cls is ConfigurableComponent:
+            return list(getattr(cls, "_registry").all_names())
+
+        # For subclasses, return only classes in the same namespace
         namespaced_classes = []
         for registered_cls in getattr(cls, "_registry").all_classes():
             if (

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -789,12 +789,6 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
 
 
 @pytest.mark.redis_db
-def test_namespaces(admin_api: FlaskClient) -> None:
-    print("jdkflakjdla", BaseRoutingStrategy.all_names())
-    assert False
-
-
-@pytest.mark.redis_db
 def test_set_routing_strategy_config(admin_api: FlaskClient) -> None:
 
     auditlog_records = []


### PR DESCRIPTION
`RegisteredClass` [has a shared registry for a base class and all of its subclasses](https://github.com/getsentry/snuba/blob/master/snuba/utils/registered_class.py#L84-L94), so in the context of `ConfigurableComponent`, this causes subclasses across different namespaces to share the same registry, because they all inherit from `ConfigurableComponent`. 

So, when calling `BaseRoutingStrategy.all_names()`, we will get non-routing strategies ie:
```
['AllocationPolicy.AllocationPolicy', 'AllocationPolicy.PassthroughPolicy', 'AllocationPolicy.BaseConcurrentRateLimitAllocationPolicy', 'AllocationPolicy.ConcurrentRateLimitAllocationPolicy', 'AllocationPolicy.DeleteConcurrentRateLimitAllocationPolicy', 'AllocationPolicy.ReferrerGuardRailPolicy', 'AllocationPolicy.CrossOrgQueryAllocationPolicy', 'AllocationPolicy.BytesScannedRejectingPolicy', 'AllocationPolicy.BytesScannedWindowAllocationPolicy', 'RoutingStrategy.BaseRoutingStrategy', 'RoutingStrategy.OutcomesBasedRoutingStrategy']
```

This makes no sense because it shouldn't include allocation policies but this happens because all configurable component classes share the same registry

This PR makes it so that calling `SomeBaseClass.all_names()` will only return subclasses in the same namespace, while still preserving the behavior that calling `ConfigurableComponent.all_names()` will return all ConfigurableComponent classes across all namespaces