### PR TITLE
fix(inc-1340): Make snuba more resilient to redis failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN set -ex; \
         g++ \
         gnupg \
         protobuf-compiler \
+        iproute2 \
+        iputils-ping \
     '; \
     runtimeDeps=' \
         curl \
@@ -150,8 +152,8 @@ ENV LD_PRELOAD=/usr/src/snuba/libjemalloc.so.2 \
 
 USER snuba
 EXPOSE 1218 1219
-ENTRYPOINT [ "./docker_entrypoint.sh" ]
-CMD [ "api" ]
+# ENTRYPOINT [ "./docker_entrypoint.sh" ]
+# CMD [ "api" ]
 
 FROM application_base AS application
 USER 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN set -ex; \
         g++ \
         gnupg \
         protobuf-compiler \
-        iproute2 \
-        iputils-ping \
     '; \
     runtimeDeps=' \
         curl \
@@ -152,8 +150,8 @@ ENV LD_PRELOAD=/usr/src/snuba/libjemalloc.so.2 \
 
 USER snuba
 EXPOSE 1218 1219
-# ENTRYPOINT [ "./docker_entrypoint.sh" ]
-# CMD [ "api" ]
+ENTRYPOINT [ "./docker_entrypoint.sh" ]
+CMD [ "api" ]
 
 FROM application_base AS application
 USER 0

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -127,9 +127,7 @@ class AllocationPolicyViolations(SerializableException):
 
     @property
     def quota_allowance(self) -> dict[str, dict[str, Any]]:
-        return cast(
-            dict[str, dict[str, Any]], self.extra_data.get("quota_allowances", {})
-        )
+        return cast(dict[str, dict[str, Any]], self.extra_data.get("quota_allowances", {}))
 
     @property
     def summary(self) -> dict[str, Any]:
@@ -393,10 +391,7 @@ class AllocationPolicy(ConfigurableComponent, ABC, metaclass=RegisteredClass):
 
     @property
     def is_active(self) -> bool:
-        return (
-            bool(self.get_config_value(IS_ACTIVE))
-            and settings.ALLOCATION_POLICY_ENABLED
-        )
+        return bool(self.get_config_value(IS_ACTIVE)) and settings.ALLOCATION_POLICY_ENABLED
 
     @property
     def is_enforced(self) -> bool:
@@ -480,6 +475,7 @@ class AllocationPolicy(ConfigurableComponent, ABC, metaclass=RegisteredClass):
                 suggestion=NO_SUGGESTION,
             )
         except Exception:
+            self.metrics.increment("fail_open", 1, tags={"method": "get_quota_allowance"})
             logger.exception(
                 "Allocation policy failed to get quota allowance, this is a bug, fix it"
             )
@@ -537,6 +533,7 @@ class AllocationPolicy(ConfigurableComponent, ABC, metaclass=RegisteredClass):
             # the policy did not do anything because the tenants were invalid, updating is also not necessary
             pass
         except Exception:
+            self.metrics.increment("fail_open", 1, tags={"method": "update_quota_balance"})
             logger.exception(
                 "Allocation policy failed to update quota balance, this is a bug, fix it"
             )

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -61,9 +61,7 @@ def _initialize_redis_cluster(config: settings.RedisClusterConfig) -> RedisClien
         startup_nodes = config["cluster_startup_nodes"]
         if startup_nodes is None:
             startup_nodes = [{"host": config["host"], "port": config["port"]}]
-        startup_cluster_nodes = [
-            ClusterNode(n["host"], n["port"]) for n in startup_nodes
-        ]
+        startup_cluster_nodes = [ClusterNode(n["host"], n["port"]) for n in startup_nodes]
         return RetryingRedisCluster(
             startup_nodes=startup_cluster_nodes,
             socket_keepalive=True,
@@ -92,6 +90,7 @@ _default_redis_client: RedisClientType = _initialize_redis_cluster(
         "db": settings.REDIS_DB,
         "ssl": settings.REDIS_SSL,
         "reinitialize_steps": settings.REDIS_REINITIALIZE_STEPS,
+        "socket_timeout": settings.REDIS_SOCKET_TIMEOUT,
     }
 )
 
@@ -118,9 +117,7 @@ class RedisClientKey(Enum):
 
 
 _redis_clients: Mapping[RedisClientKey, RedisClientType] = {
-    RedisClientKey.CACHE: _initialize_specialized_redis_cluster(
-        settings.REDIS_CLUSTERS["cache"]
-    ),
+    RedisClientKey.CACHE: _initialize_specialized_redis_cluster(settings.REDIS_CLUSTERS["cache"]),
     RedisClientKey.RATE_LIMITER: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["rate_limiter"]
     ),
@@ -130,12 +127,8 @@ _redis_clients: Mapping[RedisClientKey, RedisClientType] = {
     RedisClientKey.REPLACEMENTS_STORE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["replacements_store"]
     ),
-    RedisClientKey.CONFIG: _initialize_specialized_redis_cluster(
-        settings.REDIS_CLUSTERS["config"]
-    ),
-    RedisClientKey.DLQ: _initialize_specialized_redis_cluster(
-        settings.REDIS_CLUSTERS["dlq"]
-    ),
+    RedisClientKey.CONFIG: _initialize_specialized_redis_cluster(settings.REDIS_CLUSTERS["config"]),
+    RedisClientKey.DLQ: _initialize_specialized_redis_cluster(settings.REDIS_CLUSTERS["dlq"]),
     RedisClientKey.OPTIMIZE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["optimize"]
     ),

--- a/snuba/replacers/projects_query_flags.py
+++ b/snuba/replacers/projects_query_flags.py
@@ -96,9 +96,7 @@ class ProjectsQueryFlags:
                 break
 
         p.zadd(key, group_id_data)
-        ProjectsQueryFlags._truncate_group_id_replacement_set(
-            p, key, now, max_group_ids_exclude
-        )
+        ProjectsQueryFlags._truncate_group_id_replacement_set(p, key, now, max_group_ids_exclude)
         p.expire(key, int(settings.REPLACER_KEY_TTL))
 
         # store the replacement type data
@@ -122,37 +120,42 @@ class ProjectsQueryFlags:
 
         - Searches through Redis for relevant replacements info
         - Splits up results from pipeline into something that makes sense
+
+        Fails open, in case redis is unavailable, query goes through
         """
         s_project_ids = set(project_ids)
 
-        p = redis_client.pipeline()
+        try:
+            p = redis_client.pipeline()
 
-        with sentry_sdk.start_span(op="function", description="build_redis_pipeline"):
-            cls._query_redis(s_project_ids, state_name, p)
+            with sentry_sdk.start_span(op="function", description="build_redis_pipeline"):
+                cls._query_redis(s_project_ids, state_name, p)
 
-        with sentry_sdk.start_span(
-            op="function", description="execute_redis_pipeline"
-        ) as span:
-            results = p.execute()
-            # getting size of str(results) since sys.getsizeof() doesn't count recursively
-            span.set_tag("results_size", sys.getsizeof(str(results)))
+            with sentry_sdk.start_span(op="function", description="execute_redis_pipeline") as span:
+                results = p.execute()
+                # getting size of str(results) since sys.getsizeof() doesn't count recursively
+                span.set_tag("results_size", sys.getsizeof(str(results)))
 
-        with sentry_sdk.start_span(
-            op="function", description="process_redis_results"
-        ) as span:
-            flags = cls._process_redis_results(results, len(s_project_ids))
-            span.set_tag("projects", s_project_ids)
-            span.set_tag("exclude_groups", flags.group_ids_to_exclude)
-            span.set_tag("len(exclude_groups)", len(flags.group_ids_to_exclude))
-            span.set_tag("latest_replacement_time", flags.latest_replacement_time)
-            span.set_tag("replacement_types", flags.replacement_types)
+            with sentry_sdk.start_span(op="function", description="process_redis_results") as span:
+                flags = cls._process_redis_results(results, len(s_project_ids))
+                span.set_tag("projects", s_project_ids)
+                span.set_tag("exclude_groups", flags.group_ids_to_exclude)
+                span.set_tag("len(exclude_groups)", len(flags.group_ids_to_exclude))
+                span.set_tag("latest_replacement_time", flags.latest_replacement_time)
+                span.set_tag("replacement_types", flags.replacement_types)
 
-        return flags
+            return flags
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            return cls(
+                needs_final=False,
+                group_ids_to_exclude=set([]),
+                replacement_types=set([]),
+                latest_replacement_time=None,
+            )
 
     @classmethod
-    def _process_redis_results(
-        cls, results: List[Any], len_projects: int
-    ) -> ProjectsQueryFlags:
+    def _process_redis_results(cls, results: List[Any], len_projects: int) -> ProjectsQueryFlags:
         """
         Produces readable data from flattened list of Redis pipeline results.
 
@@ -196,17 +199,13 @@ class ProjectsQueryFlags:
             for replacement_type in groups_replacement_types_result
         }
 
-        replacement_types = groups_replacement_types.union(
-            needs_final_replacement_types
-        )
+        replacement_types = groups_replacement_types.union(needs_final_replacement_types)
 
         latest_replacement_time = cls._process_latest_replacement(
             needs_final, needs_final_result, latest_exclude_groups_result
         )
 
-        flags = cls(
-            needs_final, exclude_groups, replacement_types, latest_replacement_time
-        )
+        flags = cls(needs_final, exclude_groups, replacement_types, latest_replacement_time)
         return flags
 
     @staticmethod
@@ -223,9 +222,7 @@ class ProjectsQueryFlags:
         above this class.
         """
         needs_final_keys_and_type_keys = [
-            ProjectsQueryFlags._build_project_needs_final_key_and_type_key(
-                project_id, state_name
-            )
+            ProjectsQueryFlags._build_project_needs_final_key_and_type_key(project_id, state_name)
             for project_id in project_ids
         ]
 
@@ -305,11 +302,7 @@ class ProjectsQueryFlags:
                 [(_, timestamp)] = latest_exclude_groups
                 latest_replacements.add(timestamp)
 
-        return (
-            datetime.fromtimestamp(max(latest_replacements))
-            if latest_replacements
-            else None
-        )
+        return datetime.fromtimestamp(max(latest_replacements)) if latest_replacements else None
 
     @staticmethod
     def _build_project_needs_final_key_and_type_key(

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -149,7 +149,7 @@ class RedisClusterConfig(TypedDict):
     db: int
     ssl: bool
     reinitialize_steps: int
-    socket_timeout: int
+    socket_timeout: float
 
 
 # The default cluster is configured using these global constants. If a config
@@ -165,8 +165,8 @@ REDIS_DB = int(os.environ.get("REDIS_DB", 1))
 REDIS_SSL = bool(os.environ.get("REDIS_SSL", False))
 REDIS_INIT_MAX_RETRIES = 3
 REDIS_REINITIALIZE_STEPS = 10
-# command timeout in seconds
-REDIS_SOCKET_TIMEOUT = 5
+# default redis command timeout in seconds for redis commands (e.g. configs, rate limits) which are meant to be quick and fail-open
+REDIS_SOCKET_TIMEOUT = 0.1
 
 
 class RedisClusters(TypedDict):


### PR DESCRIPTION
If redis calls start hangin', snuba aint bangin', and that's a problem

rate limiters, caches, and replacement groups are all good to have but they shouldn't impede snuba queries from being served.

Add timeouts on all our redis calls, fix some bugs that were found when I replaces our redis instance with a fake one that slept for 5 seconds and then returned an error