### PR TITLE
fix(ci): typo on craft's default release branch name

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -57,7 +57,7 @@ jobs:
 
   assemble:
     needs: [build-multiplatform]
-    if: ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'releases/')) && github.event_name != 'pull_request' }}
+    if: ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
According to [Craft's README](https://github.com/getsentry/craft/blob/master/README.md), the default release branch is `release` rather than `releases`. On other repositories, `releases` is used and it's being defined on the `.craft.yml` file. On this repo, it's not. Therefore `assemble` job will never run.


