### PR TITLE
ci: bump action-build-and-push-images to latest commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         # it can be used as a docker tag
         run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> "$GITHUB_OUTPUT"
 
-      - uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+      - uses: getsentry/action-build-and-push-images@f6e4a98f7ed028edcfb1159f3a2905b30e51f1fd
         with:
           image_name: 'snuba-ci'
           platforms: 'linux/amd64'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+    - uses: getsentry/action-build-and-push-images@f6e4a98f7ed028edcfb1159f3a2905b30e51f1fd
       with:
         image_name: 'snuba'
         platforms: linux/${{ matrix.platform }}
@@ -42,7 +42,7 @@ jobs:
     if: ${{ github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
+      - uses: getsentry/action-build-and-push-images@f6e4a98f7ed028edcfb1159f3a2905b30e51f1fd
         with:
           image_name: 'snuba'
           platforms: linux/amd64


### PR DESCRIPTION
Redo of #7409 with another fix and from a branch of the repo (to hopefully avoid permission issues).