### PR TITLE
fix(eap): Apply FINAL on GetTrace queries

### DIFF
--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from operator import attrgetter
 from typing import Any, Dict, Iterable, Type
 
+import sentry_sdk
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import (
@@ -151,6 +152,10 @@ def _build_query(request: GetTraceRequest, item: GetTraceRequest.TraceItem) -> Q
 
     if random.random() < _get_apply_final_rollout_percentage():
         query.set_final(True)
+
+    span = sentry_sdk.get_current_span()
+    if span:
+        span.set_data("is_final", query.get_final())
 
     treeify_or_and_conditions(query)
 

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -48,6 +48,7 @@ NORMALIZED_COLUMNS_TO_INCLUDE_EAP_ITEMS = [
     "trace_id",
     "sampling_factor",
 ]
+APPLY_FINAL_ROLLOUT_PERCENTAGE = "EndpointGetTrace.apply_final_rollout_percentage"
 
 
 def _build_query(request: GetTraceRequest, item: GetTraceRequest.TraceItem) -> Query:
@@ -159,7 +160,7 @@ def _build_query(request: GetTraceRequest, item: GetTraceRequest.TraceItem) -> Q
 def _get_apply_final_rollout_percentage() -> float:
     return (
         state.get_float_config(
-            "EndpointGetTrace.etapply_final_rollout_percentage",
+            APPLY_FINAL_ROLLOUT_PERCENTAGE,
             0.0,
         )
         or 0.0

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -19,9 +19,15 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
 
+from snuba import state
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.web.rpc.v1.endpoint_get_trace import EndpointGetTrace, _value_to_attribute
+from snuba.web.rpc.v1.endpoint_get_trace import (
+    APPLY_FINAL_ROLLOUT_PERCENTAGE,
+    EndpointGetTrace,
+    _build_query,
+    _value_to_attribute,
+)
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 from tests.web.rpc.v1.test_utils import SERVER_NAME, gen_item_message
@@ -92,9 +98,7 @@ def get_attributes(
                 name=key,
                 type=_PROTOBUF_TO_SENTRY_PROTOS[value_type][1],
             )
-            args = {
-                _PROTOBUF_TO_SENTRY_PROTOS[value_type][0]: getattr(value, value_type)
-            }
+            args = {_PROTOBUF_TO_SENTRY_PROTOS[value_type][0]: getattr(value, value_type)}
         else:
             continue
 
@@ -132,9 +136,7 @@ class TestGetTrace(BaseApiTest):
             ),
             trace_id=uuid.uuid4().hex,
         )
-        response = self.app.post(
-            "/rpc/EndpointGetTrace/v1", data=message.SerializeToString()
-        )
+        response = self.app.post("/rpc/EndpointGetTrace/v1", data=message.SerializeToString())
         error_proto = ErrorProto()
         if response.status_code != 200:
             error_proto.ParseFromString(response.data)
@@ -255,6 +257,55 @@ class TestGetTrace(BaseApiTest):
         )
         assert MessageToDict(response) == MessageToDict(expected_response)
 
+    def test_build_query_with_final(store_outcomes_data: Any) -> None:
+        ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))
+        three_hours_later = int((_BASE_TIME + timedelta(hours=3)).timestamp())
+        item = GetTraceRequest.TraceItem(
+            item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            attributes=[
+                AttributeKey(
+                    name="server_name",
+                    type=AttributeKey.Type.TYPE_STRING,
+                ),
+                AttributeKey(
+                    name="sentry.parent_span_id",
+                    type=AttributeKey.Type.TYPE_STRING,
+                ),
+            ],
+        )
+
+        message = GetTraceRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=ts,
+                end_timestamp=Timestamp(seconds=three_hours_later),
+                request_id=_REQUEST_ID,
+            ),
+            trace_id=_TRACE_ID,
+            items=[item],
+        )
+
+        state.set_config(
+            APPLY_FINAL_ROLLOUT_PERCENTAGE,
+            1.0,
+        )
+
+        query = _build_query(message, item)
+
+        assert query.get_final() == True
+
+        state.set_config(
+            APPLY_FINAL_ROLLOUT_PERCENTAGE,
+            0.0,
+        )
+
+        query = _build_query(message, item)
+
+        assert query.get_final() == False
+
 
 def generate_spans_and_timestamps() -> tuple[list[TraceItem], list[Timestamp]]:
     timestamps: list[Timestamp] = []
@@ -264,8 +315,7 @@ def generate_spans_and_timestamps() -> tuple[list[TraceItem], list[Timestamp]]:
         span.ParseFromString(payload)
         timestamp = Timestamp()
         timestamp.FromNanoseconds(
-            int(span.attributes["sentry.start_timestamp_precise"].double_value * 1e6)
-            * 1000
+            int(span.attributes["sentry.start_timestamp_precise"].double_value * 1e6) * 1000
         )
         timestamps.append(timestamp)
         spans.append(span)
@@ -274,6 +324,12 @@ def generate_spans_and_timestamps() -> tuple[list[TraceItem], list[Timestamp]]:
 
 def get_span_id(span: TraceItem) -> str:
     # cut the 0x prefix
-    return hex(int.from_bytes(span.item_id, byteorder="little", signed=False,))[
+    return hex(
+        int.from_bytes(
+            span.item_id,
+            byteorder="little",
+            signed=False,
+        )
+    )[
         2:
     ].rjust(16, "0")


### PR DESCRIPTION
Some calls to GetTrace returns duplicate data because the trace was ingested twice. Adding `FINAL` for those queries will force ClickHouse to deduplicate the data and make the query longer.

P99 of the query is well under 1s most of the time, applying `FINAL` will 2-3x this duration.

<img width="1162" height="262" alt="Screenshot 2025-09-17 at 11 30 56 AM" src="https://github.com/user-attachments/assets/65f460fa-c53c-4f65-bdaa-025cee7df1a6" />

https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p90%28span.duration%29%22%5D%7D&interval=1h&project=300688&query=span.description%3A%22%2Aeap_items%2Aequals%28trace_id%2A%22%20transaction%3AEndpointGetTrace__v1%20span.duration%3A%3C30s&statsPeriod=14d

