### PR TITLE
feat(eap): add deletion_settings to eap_items storage definition

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -156,6 +156,17 @@ query_processors:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
 
+deletion_settings:
+  is_enabled: 1
+  max_rows_to_delete: 2000000
+  tables:
+    - eap_items_1_local
+  allowed_columns:
+    - project_id
+    - organization_id
+    - trace_id
+    - item_type
+
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer
     args:


### PR DESCRIPTION
Start allowing lightweight deletes processor to handle eap_items. So far, this won't touch downsampled copies