### PR TITLE
fix(TraceItemTable): use islice to slice results rather than array slicing

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -518,7 +518,6 @@ class ResolverTraceItemTableEAPItems(ResolverTraceItemTable):
         routing_decision.routing_context.query_result = res
         # we added 1 to the limit to know if there are more rows to fetch
         # so we need to remove the last row
-        # TODO maybe use islice instead
         total_rows = len(res.result.get("data", []))
         data = iter(res.result.get("data", []))
 


### PR DESCRIPTION
an array slice makes a copy of the references in the table, an islice just makes a pointer so we save some memory