### PR TITLE
ref(devenv): allow more mem for CH

### DIFF
--- a/devservices/clickhouse/config.xml
+++ b/devservices/clickhouse/config.xml
@@ -1,5 +1,5 @@
 <yandex>
-    <max_server_memory_usage_to_ram_ratio>0.3</max_server_memory_usage_to_ram_ratio>
+    <max_server_memory_usage_to_ram_ratio>0.5</max_server_memory_usage_to_ram_ratio>
     <merge_tree>
         <old_parts_lifetime>1</old_parts_lifetime>
     </merge_tree>


### PR DESCRIPTION
Been seeing a lot of clickhouse errors related to memory in local env

```
DB::Exception: (total) memory limit exceeded: would use 4.68 GiB
```

I want to try and see if raising the `max_server_memory_usage_to_ram_ratio` limit helps. The default is `0.9`, and maybe clickhouse version `25.3` uses more memory. Also possible that there is memory leak 