### PR TITLE
fix(TraceItemTable): Account for flexible time windows with no results

### DIFF
--- a/snuba/web/rpc/storage_routing/routing_strategies/outcomes_flex_time.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/outcomes_flex_time.py
@@ -139,7 +139,6 @@ class OutcomesFlexTimeRoutingStrategy(BaseRoutingStrategy):
         original_time_window = _get_request_time_window(routing_context)
         original_end_ts = original_time_window.end_timestamp.seconds
         original_start_ts = original_time_window.start_timestamp.seconds
-
         max_items = self.get_config_value("max_items_to_query")
 
         ingested_items = self.get_ingested_items_for_timerange(

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -430,7 +430,6 @@ def _get_page_token(
     # time window of the current request after any adjustments by routing strategies
     time_window: TimeWindow | None,
 ) -> PageToken:
-    breakpoint()
     current_offset = _get_offset_from_page_token(request.page_token)
     num_rows_in_response = len(response[0].results) if response else 0
     if time_window is not None:

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -430,10 +430,9 @@ def _get_page_token(
     # time window of the current request after any adjustments by routing strategies
     time_window: TimeWindow | None,
 ) -> PageToken:
-    if not response:
-        return PageToken(offset=0)
+    breakpoint()
     current_offset = _get_offset_from_page_token(request.page_token)
-    num_rows_in_response = len(response[0].results)
+    num_rows_in_response = len(response[0].results) if response else 0
     if time_window is not None:
         if num_rows_returned > request.limit:
             # there are more rows in this window so we maintain the same time window and advance the offset
@@ -443,7 +442,6 @@ def _get_page_token(
                 current_offset + num_rows_in_response,
             ).encode()
         else:
-
             if time_window.start_timestamp.seconds <= original_time_window.start_timestamp.seconds:
                 # this is the last window because our start timestamp is the same as the original start timestamp
                 # we tell the client that there is no more data to fetch

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
@@ -22,6 +22,9 @@ from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.web.rpc.storage_routing.routing_strategies.outcomes_flex_time import (
+    OutcomesFlexTimeRoutingStrategy,
+)
 from snuba.web.rpc.v1.endpoint_trace_item_table import EndpointTraceItemTable
 from tests.helpers import write_raw_unprocessed_events
 from tests.web.rpc.v1.routing_strategies.common import (
@@ -92,9 +95,6 @@ def _store_logs_and_outcomes(data_points: list[LogOutcomeDataPoint]) -> None:
 @pytest.mark.redis_db
 class TestTraceItemTableFlexTime:
     def test_paginate_within_time_window(self, eap: Any) -> None:
-        from snuba.web.rpc.storage_routing.routing_strategies.outcomes_flex_time import (
-            OutcomesFlexTimeRoutingStrategy,
-        )
 
         data_points = []
         for hour in range(25):
@@ -179,10 +179,6 @@ class TestTraceItemTableFlexTime:
         ]
 
         _store_logs_and_outcomes(data_points)
-
-        from snuba.web.rpc.storage_routing.routing_strategies.outcomes_flex_time import (
-            OutcomesFlexTimeRoutingStrategy,
-        )
 
         num_hours_to_query = 4
         # every hour we store 120 items 2 hours ago, and none before that, prentending it's 10 million every hour

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
@@ -181,7 +181,7 @@ class TestTraceItemTableFlexTime:
         _store_logs_and_outcomes(data_points)
 
         num_hours_to_query = 4
-        # every hour we store 120 items 2 hours ago, and none before that, prentending it's 10 million every hour
+        # every hour we store 120 items 3 hours ago, and none before that, prentending it's 10 million every hour
         strategy = OutcomesFlexTimeRoutingStrategy()
         # we tell the routing strategy that the most items we can query is 20_000_000
         # this means that if we query a four hour time range, it will get split in two
@@ -195,8 +195,8 @@ class TestTraceItemTableFlexTime:
         limit_per_query = 120
 
         # querying 4 hours of data, split into two windows,
-        # each window queries has 240 datapoints, 120 points at a time
-        # means that we will run the query  a total of 4 times
+        # only the second window will have data of 120 items
+        # so we will run the query 2 times
 
         times_queried = 0
         expected_times_queried = 2

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
@@ -164,7 +164,7 @@ class TestTraceItemTableFlexTime:
             OutcomesFlexTimeRoutingStrategy,
         )
 
-        num_hours_to_query = 2
+        num_hours_to_query = 4
         # we store
         strategy = OutcomesFlexTimeRoutingStrategy()
         # we tell the routing strategy that the most items we can query is 20_000_000
@@ -214,7 +214,6 @@ class TestTraceItemTableFlexTime:
             response = EndpointTraceItemTable().execute(message)
             assert isinstance(response, TraceItemTableResponse)
             result_size = len(response.column_values[0].results)
-            breakpoint()
             page_token = response.page_token
             assert result_size == limit_per_query
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_trace_item_table_flex_time.py
@@ -34,6 +34,66 @@ _ORG_ID = 1
 _PROJECT_ID = 1
 
 
+def _store_logs_and_outcomes() -> None:
+    items_storage = get_storage(StorageKey("eap_items"))
+
+    messages = []
+    messages.extend(
+        [
+            gen_item_message(
+                start_timestamp=BASE_TIME - timedelta(hours=3),
+                item_id=int("123456781234567d", 16).to_bytes(16, byteorder="little"),
+                type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                attributes={
+                    "color": AnyValue(
+                        string_value=random.choice(
+                            [
+                                "red",
+                                "green",
+                                "blue",
+                            ]
+                        )
+                    ),
+                    "eap.measurement": AnyValue(
+                        int_value=random.choice(
+                            [
+                                1,
+                                100,
+                                1000,
+                            ]
+                        )
+                    ),
+                    "location": AnyValue(
+                        string_value=random.choice(
+                            [
+                                "mobile",
+                                "frontend",
+                                "backend",
+                            ]
+                        )
+                    ),
+                    "custom_measurement": AnyValue(double_value=420.0),
+                    "custom_tag": AnyValue(string_value="blah"),
+                },
+                project_id=_PROJECT_ID,
+                organization_id=_ORG_ID,
+            )
+            for i in range(_LOG_COUNT)
+        ]
+    )
+    write_raw_unprocessed_events(items_storage, messages)  # type: ignore
+
+    # pretend we have 10 million log items every hour
+    outcome_data = []
+    for hour in range(25):
+        time = BASE_TIME - timedelta(hours=hour)
+        outcome_data.append((time, 10_000_000))
+
+    store_outcomes_data(
+        outcome_data, OutcomeCategory.LOG_ITEM, org_id=_ORG_ID, project_id=_PROJECT_ID
+    )
+
+
 @pytest.fixture(autouse=False)
 def setup_teardown(eap: None, redis_db: None) -> None:
     items_storage = get_storage(StorageKey("eap_items"))
@@ -104,8 +164,8 @@ class TestTraceItemTableFlexTime:
             OutcomesFlexTimeRoutingStrategy,
         )
 
-        num_hours_to_query = 4
-        # every hour we store 120 items and in outcomes we pretend it's 10 million items stored
+        num_hours_to_query = 2
+        # we store
         strategy = OutcomesFlexTimeRoutingStrategy()
         # we tell the routing strategy that the most items we can query is 20_000_000
         # this means that if we query a four hour time range, it will get split in two
@@ -126,7 +186,7 @@ class TestTraceItemTableFlexTime:
         expected_times_queried = 4
         end_pagination = PageToken(end_pagination=True)
         page_token = PageToken(offset=0)
-        result_size = 1
+        result_size = 120
         while page_token != end_pagination:
             times_queried += 1
             message = TraceItemTableRequest(
@@ -154,7 +214,74 @@ class TestTraceItemTableFlexTime:
             response = EndpointTraceItemTable().execute(message)
             assert isinstance(response, TraceItemTableResponse)
             result_size = len(response.column_values[0].results)
+            breakpoint()
             page_token = response.page_token
             assert result_size == limit_per_query
+
+        assert times_queried == expected_times_queried
+
+    def test_paginate_first_page_empty(self, eap: Any) -> None:
+        _store_logs_and_outcomes()
+
+        from snuba.web.rpc.storage_routing.routing_strategies.outcomes_flex_time import (
+            OutcomesFlexTimeRoutingStrategy,
+        )
+
+        num_hours_to_query = 4
+        # every hour we store 120 items 2 hours ago, and none before that, prentending it's 10 million every hour
+        strategy = OutcomesFlexTimeRoutingStrategy()
+        # we tell the routing strategy that the most items we can query is 20_000_000
+        # this means that if we query a four hour time range, it will get split in two
+        strategy.set_config_value("max_items_to_query", 20_000_000)
+
+        start_timestamp = Timestamp(
+            seconds=int((BASE_TIME - timedelta(hours=num_hours_to_query)).timestamp())
+        )
+        end_timestamp = Timestamp(seconds=int(BASE_TIME.timestamp()))
+
+        limit_per_query = 120
+
+        # querying 4 hours of data, split into two windows,
+        # each window queries has 240 datapoints, 120 points at a time
+        # means that we will run the query  a total of 4 times
+
+        times_queried = 0
+        expected_times_queried = 2
+        end_pagination = PageToken(end_pagination=True)
+        page_token = PageToken(offset=0)
+        while page_token != end_pagination:
+            times_queried += 1
+            message = TraceItemTableRequest(
+                meta=RequestMeta(
+                    project_ids=[1],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    start_timestamp=start_timestamp,
+                    end_timestamp=end_timestamp,
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                    downsampled_storage_config=DownsampledStorageConfig(
+                        mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY_FLEXTIME
+                    ),
+                ),
+                filter=TraceItemFilter(
+                    exists_filter=ExistsFilter(
+                        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="color")
+                    )
+                ),
+                columns=[Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="location"))],
+                limit=limit_per_query,
+                page_token=page_token,
+            )
+            response = EndpointTraceItemTable().execute(message)
+            assert isinstance(response, TraceItemTableResponse)
+            page_token = response.page_token
+            result_size = len(response.column_values[0].results) if response.column_values else 0
+            if times_queried == 1:
+                assert result_size == 0
+            elif times_queried == 2:
+                assert result_size == 120
+            else:
+                assert False
 
         assert times_queried == expected_times_queried


### PR DESCRIPTION
If the time window we shrunk to doesn't have any results to show, we should not send `PageToken(offset=0)`, we should send the next window