### PR TITLE
ref(gocd): add healthcheck to de

### DIFF
--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -69,7 +69,7 @@ local s4s_health_check(region) =
 
 // Snuba deploy to ST is blocked till SaaS deploy is healthy
 local saas_health_check(region) =
-  if region == 'us' || region = 'de' then
+  if region == 'us' || region == 'de' then
     [
       {
         health_check: {


### PR DESCRIPTION
Added filtering by env a while back in https://github.com/getsentry/snuba/pull/7075 - but `de` doesn't have canary or a health check, and there have been a handful of incidents where `de` health check would have blocked `us` deploys and would have saved us some time on incident resolution. 