### PR TITLE
feat(health-check): add limit to individual health check cluster wait

### DIFF
--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -72,15 +72,9 @@ def get_shutdown() -> bool:
 
 
 def _execute_show_tables(cluster: ClickhouseCluster) -> bool:
-    try:
-        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.QUERY)
-        clickhouse.execute("show tables").results
-        return True
-    except Exception as err:
-        with sentry_sdk.new_scope() as scope:
-            scope.set_tag("health_cluster_name", cluster.get_clickhouse_cluster_name())
-            logger.error(err)
-        return False
+    clickhouse = cluster.get_query_connection(ClickhouseClientSettings.QUERY)
+    clickhouse.execute("show tables").results
+    return True
 
 
 @dataclass

--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -148,13 +148,13 @@ def filter_checked_storages(filtered_storages: List[Storage]) -> None:
             filtered_storages.append(storage)
 
 
-def sanity_check_clickhouse_connections(timeout_seconds: float = 0.1) -> bool:
+def sanity_check_clickhouse_connections(timeout_seconds: float = 0.5) -> bool:
     """
     Check if at least a single clickhouse query node is operable,
     returns True if so, False otherwise.
 
     Every individual query node check is limited to a `timeout_seconds` timeout
-    (default 0.1 or 100ms).
+    (default 0.5 or 500ms).
     """
     storages: List[Storage] = []
     timeout_seconds = get_float_config("health_check.timeout_override_seconds", timeout_seconds)  # type: ignore


### PR DESCRIPTION
During a recent incident, the liveness check was exceeding 30s regularly, probably due to a single cluster being unreachable. This created a lot of flapping in the API, and so we want to minimize the amount that any individual cluster can affect the `/health` endpoint performance.

In this change, we use a thread pool executor and `as_completed()` to limit concurrent query node health checks to 500ms. This is more than p99 for how long the `/health` endpoint usually takes to respond. Additionally, I've added run-time config to make it 2s temporarily in our busiest environments