### PR TITLE
feat(eap): Insert a timestamp of when the item is added to the batch

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use chrono::DateTime;
+use chrono::Utc;
 use prost::Message;
 use seq_macro::seq;
 use serde::Serialize;
@@ -35,6 +36,10 @@ pub fn process_message(
 
     eap_item.retention_days = retention_days;
     eap_item.downsampled_retention_days = downsampled_retention_days;
+    eap_item.attributes.insert_int(
+        "sentry._internal.ingested_at".into(),
+        Utc::now().timestamp_millis(),
+    );
 
     InsertBatch::from_rows([eap_item], origin_timestamp)
 }


### PR DESCRIPTION
Product team wants to know when we stored an item. Closest thing we can do is save the timestamp when the item gets added to the batch.