### PR TITLE
ci: tag latest version only for calver release

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -76,7 +76,6 @@ jobs:
           docker buildx imagetools create \
             --tag ghcr.io/getsentry/snuba:${{ github.sha }} \
             --tag ghcr.io/getsentry/snuba:nightly \
-            --tag ghcr.io/getsentry/snuba:latest \
             ghcr.io/getsentry/snuba:${{ github.sha }}-amd64 \
             ghcr.io/getsentry/snuba:${{ github.sha }}-arm64
 

--- a/.github/workflows/release-ghcr-version-tag.yml
+++ b/.github/workflows/release-ghcr-version-tag.yml
@@ -20,3 +20,9 @@ jobs:
           docker buildx imagetools create --tag \
            ghcr.io/getsentry/snuba:${{ github.ref_name }} \
            ghcr.io/getsentry/snuba:${{ github.sha }}
+
+      - name: Tag latest version
+        run: |
+          docker buildx imagetools create --tag \
+           ghcr.io/getsentry/snuba:latest \
+           ghcr.io/getsentry/snuba:${{ github.sha }}


### PR DESCRIPTION
`latest` should point at CalVer release, and `nightly` should point at `master`/`main` branch. We're cleaning things up for self-hosted users.

