### PR TITLE
fix(traceitemstats): only downgrade traceitemstats for AI clients

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_stats.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_stats.py
@@ -55,10 +55,11 @@ class EndpointTraceItemStats(RPCEndpoint[TraceItemStatsRequest, TraceItemStatsRe
             )
         resolver = self.get_resolver(in_msg.meta.trace_item_type)
         # the stats endpoint is quite costly to run so we use one tier lower than the
-        # routing system recommends
+        # routing system recommends for AI endpoints
         if (
             in_msg.meta.downsampled_storage_config.mode
             != DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+            and in_msg.meta.referrer == "seer.rpc"
         ):
             self.routing_decision.tier = downgrade_tier(self.routing_decision.tier)
         return resolver.resolve(in_msg, self.routing_decision)


### PR DESCRIPTION
A while ago, we did this auto downgrading thing  to speed up the TraceItemStats endpoint for the Trace Explorer AI Queries context caching step

Always downgrading it is causing issues with Comparative Workflows (the original use for the Stats endpoint). For example, [in this issue here](https://sentry.sentry.io/issues/6889700889/events/latest/?project=6178942&query=is%3Aunresolved&referrer=latest-event), even though there is very little data and it originally routes to tier_1,  because it downgrades the tier, it seems like no data is being returned from stats the query for the suspect data. We can see it [downgrading as expected in this trace](https://sentry.sentry.io/issues/trace/d6cca4241ee34447a7b23d054df12c40/?fov=0%2C23586672.56640625&groupId=6889700889&node=span-a4409cb86c880b7e&pageEnd=2025-09-24T05%3A55%3A12.451&pageStart=2025-09-23T05%3A55%3A12.451&project=6178942&query=is%3Aunresolved&referrer=latest-event&source=issue_details&timestamp=1758650112.425)

Only do this for seer rpc calls