### PR TITLE
fix(ignore_case): Handle ignoring casing for LIKE/NOT LIKE

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -251,7 +251,7 @@ def trace_item_filters_to_expression(
                     "the NOT LIKE comparison is only supported on string keys"
                 )
             comparison_function = (
-                f.notILike if item_filter.comparison_filter.ignore_case else f.notiLike
+                f.notILike if item_filter.comparison_filter.ignore_case else f.notLike
             )
             expr = comparison_function(k_expression, v_expression)
             # we redefine the way not like works for nulls


### PR DESCRIPTION
- This adds support for casing with like and not like by using `ilike` and `notilike`