### PR TITLE
ref(gocd): Bump gocd lib version to v2.17.0

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.13.0"
+      "version": "v2.17.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "6ddc943ae87444b48e16995639dfe89f33a0f444",
-      "sum": "NH9U5jQ8oCSPXLuBw27OqAaPLBUDqMGHvRLxfo84hNQ="
+      "version": "d0490a3079bfb0490016ce2cc14627f5fb90e522",
+      "sum": "eZZ8rwc3QIKR4Q6IIq/504XKoCB/rcx6WL4KkklWAz0="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
* Adds s4s2 as test region
* fix(tests): Fixing pipedream tests by @IanWoodard in https://github.com/getsentry/gocd-jsonnet/pull/81
* feat: Add support for doing pipedream stages in parallel by @rgibert in https://github.com/getsentry/gocd-jsonnet/pull/80