### PR TITLE
fix(profiling): handle null profile context

### DIFF
--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -431,7 +431,7 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
 
         # The profile_id, profiler_id and replay_id are promoted as columns, so no need to store them
         # again in the context array
-        profile_ctx = sanitized_context.get("profile", {})
+        profile_ctx = sanitized_context.get("profile", {}) or {}
         if profile_ctx is not None:
             profile_ctx.pop("profile_id", None)
             profile_ctx.pop("profiler_id", None)


### PR DESCRIPTION
This fixes an error that raises when we try to pop certain fields from the `profile_context` but such context is `None/null`.

Usually this happens when an item is deleted due to errors or PII

On a protocol level, we need to expect `null/None` anywhere.