### PR TITLE
chore: upgrade sentry-redis-tools version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1127,13 +1127,13 @@ wheels = [
 
 [[package]]
 name = "sentry-redis-tools"
-version = "0.5.0"
+version = "0.5.1"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "redis", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_redis_tools-0.5.0-py2.py3-none-any.whl", hash = "sha256:3a1c1e1082df07bc502689baad0becbe69c0b70f2672cf6a14ea69bcd2871a18" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_redis_tools-0.5.1-py2.py3-none-any.whl", hash = "sha256:1ea34c1a8d735ea1044eb661457157f9212b1411ca31e73acf66f8cb0c9cf9a0" },
 ]
 
 [[package]]
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "snuba"
-version = "25.10.0.dev0"
+version = "25.11.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "blinker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
I recently merged [this pr](https://github.com/getsentry/sentry-redis-tools/pull/26) in sentry-redis-tools to fix a potentially unsafe redis connection. This PR upgrades the version of the sentry-redis-tools package so we have this fix.