### PR TITLE
fix(rust-consumer): Remove consumer-version

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -184,7 +184,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     "--consumer-version",
     default="v2",
     type=click.Choice(["v1", "v2"]),
-    help="Specify which consumer version to use, v1 is stable, v2 is experimental",
+    help="DEPRECATED: value is ignored.",
 )
 def rust_consumer(
     *,


### PR DESCRIPTION
Partially remove consumer version so there's no crashes.

Keep the CLI flag as it is still referenced in ops repo

Like: #7464 and #7465