### PR TITLE
feat: add request_id to sentry error context

### DIFF
--- a/snuba/pipeline/stages/query_execution.py
+++ b/snuba/pipeline/stages/query_execution.py
@@ -251,7 +251,7 @@ def _format_storage_query_and_run(
                     robust=robust,
                 )
             except Exception as e:
-                sentry_sdk.set_context("snuba_request_id", {"uuid": query_metadata.request.id})
+                sentry_sdk.set_context("snuba", {"request_id": query_metadata.request.id})
                 raise e
 
         if concurrent_queries_gauge is not None:


### PR DESCRIPTION
recently I was trying to debug some of the query exceptions we have in our sentry issues like this one https://sentry.sentry.io/issues/6895313867/?project=300688&query=http.referer%3Aapi.dashboards.widget.line-chart.find-topn&referrer=issue-stream&seerDrawer=true but I noticed that the request_id for the request that caused this issue is nowhere in the issue, making it very hard to go to the snuba querylog and find the corresponding erroring query. This PR adds the request_id to the context when an error happens while querying clickhouse, this should make it quick and easy to find the corresponding entry in the querylog for an issue. 