### PR TITLE
ref(eap-deletes): actually handle clickhouse errors

### DIFF
--- a/tests/web/test_delete_query.py
+++ b/tests/web/test_delete_query.py
@@ -27,23 +27,46 @@ from snuba.web import QueryException
 from snuba.web.delete_query import _execute_query
 
 
-def get_delete_query() -> Query:
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_delete_query_clickhouse_error() -> None:
     from_clause = Table(
-        "search_issues_local_v2",
+        "eap_items_1_local",
         ColumnSet([]),
-        storage_key=StorageKey.SEARCH_ISSUES,
+        storage_key=StorageKey.EAP_ITEMS,
         allocation_policies=[],
     )
-    group_id = 10
-    return Query(
+
+    query = Query(
         from_clause=from_clause,
         condition=and_cond(
-            equals(column("group_id"), literal(group_id)),
-            equals(column("project_id"), literal(3)),
+            equals(column("organization_id"), literal(10)),
+            equals(column("bad_column_name"), literal(3)),
         ),
         on_cluster=None,
         is_delete=True,
     )
+
+    storage = get_writable_storage(StorageKey("eap_items"))
+    attr_into = AttributionInfo(
+        get_app_id("blah"),
+        {"project_id": 123, "referrer": "r"},
+        "blah",
+        None,
+        None,
+        None,
+    )
+    with pytest.raises(QueryException) as excinfo:
+        _execute_query(
+            query=query,
+            storage=storage,
+            table="eap_items_1_local",
+            cluster_name="cluster_name",
+            attribution_info=attr_into,
+            query_settings=HTTPQuerySettings(),
+        )
+
+    assert "bad_column_name" in excinfo.value.message
 
 
 def test_delete_query_with_rejecting_allocation_policy() -> None:
@@ -92,14 +115,27 @@ def test_delete_query_with_rejecting_allocation_policy() -> None:
     with mock.patch(
         "snuba.web.delete_query._get_delete_allocation_policies",
         return_value=[
-            RejectPolicy(
-                ResourceIdentifier(StorageKey("doesntmatter")), ["a", "b", "c"], {}
-            )
+            RejectPolicy(ResourceIdentifier(StorageKey("doesntmatter")), ["a", "b", "c"], {})
         ],
     ):
+        query = Query(
+            from_clause=Table(
+                "search_issues_local_v2",
+                ColumnSet([]),
+                storage_key=StorageKey.SEARCH_ISSUES,
+                allocation_policies=[],
+            ),
+            condition=and_cond(
+                equals(column("group_id"), literal(10)),
+                equals(column("project_id"), literal(3)),
+            ),
+            on_cluster=None,
+            is_delete=True,
+        )
+
         with pytest.raises(QueryException) as excinfo:
             _execute_query(
-                query=get_delete_query(),
+                query=query,
                 storage=storage,
                 table="search_issues_local_v2",
                 cluster_name="cluster_name",


### PR DESCRIPTION
FIXES [SNUBA-ST-C0](https://sentry-st.sentry.io/issues/6960873359/?environment=st-sentry4sentry&project=4509515398381569&query=is%3Aunresolved&referrer=issue-stream)

We weren't catching the `ClickhouseError` and setting it as the error which is how we ran into not having an error or result (which is the cause of the `AssertionError` we see in the Sentry issue linked above
