### PR TITLE
feat(eap): Add columns to store client and server sample rates

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0048_add_client_and_server_sample_rates.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0048_add_client_and_server_sample_rates.py
@@ -102,8 +102,8 @@ class Migration(migration.ClickhouseNodeMigration):
                         target=target,
                     )
                     for suffix, target in [
-                        ("local", OperationTarget.LOCAL),
                         ("dist", OperationTarget.DISTRIBUTED),
+                        ("local", OperationTarget.LOCAL),
                     ]
                     for new_column_name in new_column_names
                 ]


### PR DESCRIPTION
We want to store client and server sample rates to then provide modes to downsample only with one of them.

https://github.com/getsentry/snuba/pull/7472