### PR TITLE
fix(capman/cbrs): dont capture QueryExceptions where the cause is AllocationPolicyViolations in Sentry

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -91,6 +91,7 @@ def setup_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         spotlight=None if settings.DEBUG else False,
+        before_send=before_send,
         integrations=[
             FlaskIntegration(),
             GnuBacktraceIntegration(),


### PR DESCRIPTION
when we get an influx of queries we organically reject more of them, but this shows up as Sentry errors which blocks deploy: https://sentry.sentry.io/issues/alerts/rules/details/5241/?alert=228884&referrer=metric_alert_slack&detection_type=static&notification_uuid=8997ca67-bbc0-41fd-985a-ae8d02eed787

we remove these errors but we monitor them using:
- https://app.datadoghq.com/monitors/230264191 (for non-eap queries)
- https://app.datadoghq.com/monitors/230265720 (for eap queries)


tested locally that these type of errors did not raise in Sentry issues