### PR TITLE
ref(eap-deletes): refactor metrics/error handling

### DIFF
--- a/snuba/web/constants.py
+++ b/snuba/web/constants.py
@@ -23,6 +23,13 @@ NON_RETRYABLE_CLICKHOUSE_ERROR_CODES = {
     ErrorCodes.TOO_SLOW,
 }
 
+LW_DELETE_NON_RETRYABLE_CLICKHOUSE_ERROR_CODES = {
+    # Code: 159. DB::Exception: Distributed DDL task <task> is not finished
+    ErrorCodes.TIMEOUT_EXCEEDED,
+    ErrorCodes.MEMORY_LIMIT_EXCEEDED,
+    ErrorCodes.TOO_SLOW,
+}
+
 
 def get_http_status_for_clickhouse_error(cause: ClickhouseError) -> int:
     """


### PR DESCRIPTION
Okay so a couple more updates on metrics and error handling for lw deletes. In some earlier test it didn't seem like we were executing queries for the other tables in eap, only saw `eap_items_1_local` - I think was due to the fact that the consumer would crash before getting to the other queries. And we ended up in crashloops because of the poor error handling (which was somewhat fixed in https://github.com/getsentry/snuba/pull/7471. 

But even with that I think we need the following changes:
1. Only record timing metric when query succeeds, technically this is true now because we never make it to the metric if we fail but now it is explicitly so
2. Metric added for when query fails (including non-retryable reasons)
3. Don't raise exceptions for `LW_DELETE_NON_RETRYABLE_CLICKHOUSE_ERROR_CODES`, which is newly added in this PR
4. When we do raise have it be `LWDeleteQueryException` instead of just a `QueryException`, following the pattern we added for subscriptions in https://github.com/getsentry/snuba/pull/7299