### PR TITLE
feat(devservices): Use arm image if on machines using arm architecture

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -109,7 +109,6 @@ services:
       ENABLE_GROUP_ATTRIBUTES_CONSUMER: ${ENABLE_GROUP_ATTRIBUTES_CONSUMER:-}
       ENABLE_LW_DELETIONS_CONSUMER: ${ENABLE_LW_DELETIONS_CONSUMER:-}
       SENTRY_SPOTLIGHT: 'http://host.docker.internal:8969/stream'
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -139,7 +138,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -169,7 +167,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -199,7 +196,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -229,7 +225,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -259,7 +254,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -289,7 +283,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -319,7 +312,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -349,7 +341,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:
@@ -379,7 +370,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 1
-    platform: linux/amd64
     extra_hosts:
       host.docker.internal: host-gateway
     networks:


### PR DESCRIPTION
We publish arm images now, use them for developing on apple silicon