### PR TITLE
chore: decrease timeout for rate_limiter redis connection

### DIFF
--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -128,7 +128,7 @@ _redis_clients: Mapping[RedisClientKey, RedisClientType] = {
         socket_timeout=1,
     ),
     RedisClientKey.RATE_LIMITER: _initialize_specialized_redis_cluster(
-        settings.REDIS_CLUSTERS["rate_limiter"], socket_timeout=1
+        settings.REDIS_CLUSTERS["rate_limiter"], socket_timeout=0.5
     ),
     RedisClientKey.SUBSCRIPTION_STORE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["subscription_store"],


### PR DESCRIPTION
We saw a large number of connection timeouts here from consumers in inc-1447, and degraded consumption speed on them. We suspect that this could be coming from long wait times from the timeout, so we lower it. https://www.notion.so/sentry/INC-1447-us-errors-subscription-executor-backlogging-2898b10e4b5d81dfaac3ff82c36af7e4