### PR TITLE
fix(trace-item-stats): Apply eap item type filter

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -20,6 +20,7 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
+from snuba.query.dsl import Functions as f
 from snuba.query.dsl import arrayJoin, column, count, tupleElement
 from snuba.query.expressions import FunctionCall, Literal
 from snuba.query.logical import Query
@@ -153,12 +154,14 @@ def _build_attr_distribution_query(
         in_msg.filter,
         (attribute_key_to_expression),
     )
+    item_type_filter = f.equals(column("item_type"), in_msg.meta.trace_item_type)
     query = Query(
         from_clause=EAP_ITEMS_ENTITY,
         selected_columns=selected_columns,
         condition=base_conditions_and(
             in_msg.meta,
             trace_item_filters_expression,
+            item_type_filter,
         ),
         order_by=[
             OrderBy(


### PR DESCRIPTION
The stats query didn't include an item type filter. We want to honour the item type in the request meta.

Example query before
```
SELECT (tupleElement((arrayJoin((mapConcat(attributes_string_0,...attributes_string_39) AS attr_str_concat)) AS attributes_string), 1) AS attr_key), (tupleElement(attributes_string, 2) AS attr_value), (count() AS _count) FROM eap_items_1_local WHERE in(project_id, [4557090429140993]) AND equals(organization_id, 4557090429075456) AND less(timestamp, toDateTime('2025-11-10 19:34:21')) AND greaterOrEquals(timestamp, toDateTime('2025-08-12 19:34:21')) AND true GROUP BY attr_key, attr_value ORDER BY count() DESC LIMIT 75 BY attr_key LIMIT 10000 OFFSET 0
```

and after
```
SELECT (tupleElement((arrayJoin((mapConcat(attributes_string_0,...attributes_string_39) AS attr_str_concat)) AS attributes_string), 1) AS attr_key), (tupleElement(attributes_string, 2) AS attr_value), (count() AS _count) FROM eap_items_1_local WHERE in(project_id, [4557090438184962]) AND equals(organization_id, 4557090438184960) AND less(timestamp, toDateTime('2025-11-10 19:36:40')) AND greaterOrEquals(timestamp, toDateTime('2025-08-12 19:36:40')) AND true AND equals(item_type, 1) GROUP BY attr_key, attr_value ORDER BY count() DESC LIMIT 75 BY attr_key LIMIT 10000 OFFSET 0
```