### PR TITLE
chore: add metric to see how many GetTrace request have a user provided limit

### DIFF
--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -513,14 +513,9 @@ class EndpointGetTrace(RPCEndpoint[GetTraceRequest, GetTraceResponse]):
         return GetTraceResponse
 
     def _execute(self, in_msg: GetTraceRequest) -> GetTraceResponse:
-        if in_msg.limit != 0:
-            self.metrics.increment(
-                "eap_trace_request_with_limit", 1, tags={"referrer": in_msg.meta.referrer}
-            )
-        else:
-            self.metrics.increment(
-                "eap_trace_request_without_limit", 1, tags={"referrer": in_msg.meta.referrer}
-            )
+        self.metrics.increment(
+            "eap_trace_request_without_limit", 1, tags={"referrer": in_msg.meta.referrer}
+        )
 
         enable_pagination = state.get_int_config(
             "enable_trace_pagination", ENABLE_TRACE_PAGINATION_DEFAULT


### PR DESCRIPTION
I am beginning to rollout GetTrace endpoint pagination, [see this PR. ](https://github.com/getsentry/snuba/pull/7508) Right now the user must opt-in to pagination by providing a limit. Eventually we would like to enforce a global max limit that is always enforced, but before we can do that we need all of our users to be ready to support pagination. I.e. they need to be able to handle receiving the results in multiple pages.

I will tell product to add this support, and then begin sending a `limit` in their request. Once all user queries contain a `limit`, I can enable global max.