### PR TITLE
gocd: add filter for deploys for snuba-{py,rs}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ gocd:
 	cd ./gocd/templates && jb install && jb update
 	find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnetfmt -i
 	find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
+	cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./snuba-py.jsonnet
+	cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./snuba-rs.jsonnet
 	cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./snuba.jsonnet
 	cd ./gocd/generated-pipelines && find . -type f \( -name '*.yaml' \) -print0 | xargs -n 1 -0 yq -p json -o yaml -i
 .PHONY: gocd

--- a/gocd/templates/snuba-py.jsonnet
+++ b/gocd/templates/snuba-py.jsonnet
@@ -9,6 +9,7 @@ local py_pipedream_config = {
       shallow_clone: true,
       branch: 'master',
       destination: 'snuba',
+      filter: ['rust_snuba/**'],
     },
   },
   rollback: {

--- a/gocd/templates/snuba-rs.jsonnet
+++ b/gocd/templates/snuba-rs.jsonnet
@@ -9,6 +9,14 @@ local rs_pipedream_config = {
       shallow_clone: true,
       branch: 'master',
       destination: 'snuba',
+      filter: [
+        'rust_snuba/**',
+        'snuba/datasets/configuration/**',
+        'snuba/settings/**',
+        'Dockerfile',
+        'snuba/cli/**',
+      ],
+      inverse_filter: true,
     },
   },
   rollback: {


### PR DESCRIPTION
Deploy snuba-rs if any of
```
'rust_snuba/**',
'snuba/datasets/configuration/**',
'snuba/settings/**',
'Dockerfile',
'snuba/cli/**',
```

changes. Deploy snuba-py if changes are all outside
```
'rust_snuba/**'
```

Note that filters are deny lists by default, so inverse_filter=true means that you're making it an allow