### PR TITLE
gocd: update path filters to match gocd-yaml-config-plugin docs

### DIFF
--- a/gocd/templates/pipelines/snuba-py.libsonnet
+++ b/gocd/templates/pipelines/snuba-py.libsonnet
@@ -161,7 +161,7 @@ function(region) {
       shallow_clone: false,
       branch: 'master',
       destination: 'snuba',
-      filter: ['rust_snuba/**'],
+      ignore: ['rust_snuba/**'],
     },
   },
   stages: [

--- a/gocd/templates/pipelines/snuba-rs.libsonnet
+++ b/gocd/templates/pipelines/snuba-rs.libsonnet
@@ -118,14 +118,13 @@ function(region) {
       shallow_clone: false,
       branch: 'master',
       destination: 'snuba',
-      filter: [
+      includes: [
         'rust_snuba/**',
         'snuba/datasets/configuration/**',
         'snuba/settings/**',
         'Dockerfile',
         'snuba/cli/**',
       ],
-      inverse_filter: true,
     },
   },
   stages: [

--- a/gocd/templates/snuba-py.jsonnet
+++ b/gocd/templates/snuba-py.jsonnet
@@ -9,7 +9,7 @@ local py_pipedream_config = {
       shallow_clone: true,
       branch: 'master',
       destination: 'snuba',
-      filter: ['rust_snuba/**'],
+      ignore: ['rust_snuba/**'],
     },
   },
   rollback: {

--- a/gocd/templates/snuba-rs.jsonnet
+++ b/gocd/templates/snuba-rs.jsonnet
@@ -9,14 +9,13 @@ local rs_pipedream_config = {
       shallow_clone: true,
       branch: 'master',
       destination: 'snuba',
-      filter: [
+      includes: [
         'rust_snuba/**',
         'snuba/datasets/configuration/**',
         'snuba/settings/**',
         'Dockerfile',
         'snuba/cli/**',
       ],
-      inverse_filter: true,
     },
   },
   rollback: {


### PR DESCRIPTION
According to @IanWoodard we should follow these conventions rather than their GoCD internally-named counterparts: https://github.com/tomzo/gocd-yaml-config-plugin?tab=readme-ov-file#git