### PR TITLE
feat(deletes): add support for delete by attribute in config

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -147,6 +147,9 @@ deletion_settings:
     - organization_id
     - trace_id
     - item_type
+  allowed_attributes_by_item_type:
+    occurrence:
+      - group_id
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -615,6 +615,14 @@ DELETION_SETTINGS_SCHEMA = {
             "type": "integer",
         },
         "bulk_delete_only": {"type": "boolean"},
+        "allowed_attributes_by_item_type": {
+            "type": "object",
+            "description": "Mapping of item_type to list of allowed attributes for deletion.",
+            "additionalProperties": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
     },
     "required": ["is_enabled", "tables"],
     "additionalProperties": False,

--- a/snuba/datasets/deletion_settings.py
+++ b/snuba/datasets/deletion_settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Sequence
+from typing import Dict, List, Sequence
 
 MAX_ROWS_TO_DELETE_DEFAULT = 100000
 
@@ -13,3 +13,4 @@ class DeletionSettings:
     bulk_delete_only: bool = False
     allowed_columns: Sequence[str] = field(default_factory=list)
     max_rows_to_delete: int = MAX_ROWS_TO_DELETE_DEFAULT
+    allowed_attributes_by_item_type: Dict[str, List[str]] = field(default_factory=dict)


### PR DESCRIPTION
Add support to create an allowlist for attributes where lightweight deletes can be used against eap_items. Set it to the single possibility of `group_id` for type `occurrence`