### PR TITLE
chore: enable trace pagination support by default

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -456,7 +456,7 @@ MAX_ONGOING_MUTATIONS_FOR_DELETE = 5
 SNQL_DISABLED_DATASETS: set[str] = set([])
 
 ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS: int = 0  # 0 means no limit
-ENABLE_TRACE_PAGINATION_DEFAULT = 0
+ENABLE_TRACE_PAGINATION_DEFAULT = 1
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:


### PR DESCRIPTION
this feature flag has been enabled in prod for a very long time at this point. (note this doesnt mean pagination is always applied, it just means pagination is supported if the user explicitly passes a limit)