### PR TITLE
ci: Remove DockerHub from Craft release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -10,13 +10,4 @@ statusProvider:
       - 'build-arm64'
       - 'assemble'
 targets:
-  - id: release
-    name: docker
-    source: ghcr.io/getsentry/snuba
-    target: getsentry/snuba
-  - id: latest
-    name: docker
-    source: ghcr.io/getsentry/snuba
-    target: getsentry/snuba
-    targetFormat: '{{{target}}}:latest'
   - name: github


### PR DESCRIPTION
We've migrated to GHCR, last month release showed that DockerHub is very flaky, let's remove it for next month's release



