### PR TITLE
chore(gocd): remove outcomes-billing consumer from python deploys

### DIFF
--- a/gocd/templates/bash/deploy-py.sh
+++ b/gocd/templates/bash/deploy-py.sh
@@ -24,7 +24,6 @@ eval $(regions-project-env-vars --region="${SENTRY_REGION}")
   --container-name="metrics-counters-subscriptions-scheduler" \
   --container-name="metrics-sets-subscriptions-scheduler" \
   --container-name="metrics-subscriptions-executor" \
-  --container-name="outcomes-billing-consumer" \
   --container-name="search-issues-consumer" \
   --container-name="snuba-admin" \
   --container-name="transactions-subscriptions-executor" \


### PR DESCRIPTION
We're using the rust version in prod: https://app.datadoghq.com/s/FH6-Y3/2q4-zdj-jru

Checked and it's already part of the rust deploy