### PR TITLE
ref(redis): increase changes limit from 25 to 100

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -40,7 +40,7 @@ config_hash = "snuba-config"
 config_description_hash = "snuba-config-description"
 config_history_hash = "snuba-config-history"
 config_changes_list = "snuba-config-changes"
-config_changes_list_limit = 25
+config_changes_list_limit = 100
 rate_limit_config_key = "snuba-ratelimit-config:"
 
 # Rate Limiting and Deduplication


### PR DESCRIPTION
Allow for more change history in snuba admin. It was set to `25` seven years ago https://github.com/getsentry/snuba/pull/198 so I think we can bump this. 