### PR TITLE
spike: delegate to storage to do translation mapping

### DIFF
--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -31,7 +31,6 @@ from snuba.web.delete_query import (
     TooManyOngoingMutationsError,
     _execute_query,
     _num_ongoing_mutations,
-    _preprocess_for_items,
 )
 
 TPayload = TypeVar("TPayload")
@@ -104,8 +103,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
             query_settings.set_clickhouse_settings({"lightweight_deletes_sync": lw_sync})
 
         for table in self.__tables:
-            where_clause = construct_or_conditions(conditions)
-            where_clause = _preprocess_for_items(self.__storage, where_clause)
+            where_clause = construct_or_conditions(self.__storage, conditions)
             query = construct_query(self.__storage, table, where_clause)
             start = time.time()
             try:

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -33,7 +33,6 @@ from snuba.web.delete_query import (
     _construct_condition,
     _enforce_max_rows,
     _get_attribution_info,
-    _preprocess_for_items,
     deletes_are_enabled,
 )
 
@@ -283,8 +282,7 @@ def delete_from_tables(
     highest_rows_to_delete = 0
     result: dict[str, Result] = {}
     for table in tables:
-        where_clause = _construct_condition(conditions)
-        where_clause = _preprocess_for_items(storage, where_clause)
+        where_clause = _construct_condition(storage, conditions)
         query = construct_query(storage, table, where_clause)
         try:
             num_rows_to_delete = _enforce_max_rows(query)
@@ -320,13 +318,14 @@ def delete_from_tables(
 
 
 def construct_or_conditions(
+    storage: WritableTableStorage,
     conditions: Sequence[ConditionsBag],
 ) -> Expression:
     """
     Combines multiple AND conditions: (equals(project_id, 1) AND in(group_id, (2, 3, 4, 5))
     into OR conditions for a bulk delete
     """
-    return combine_or_conditions([_construct_condition(cond) for cond in conditions])
+    return combine_or_conditions([_construct_condition(storage, cond) for cond in conditions])
 
 
 def should_use_killswitch(storage_name: str, project_id: str) -> bool:

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -134,8 +134,7 @@ def _delete_from_table(
 ) -> Result:
     cluster_name = storage.get_cluster().get_clickhouse_cluster_name()
     on_cluster = literal(cluster_name) if cluster_name else None
-    where_clause = _construct_condition(ConditionsBag(column_conditions=conditions))
-    where_clause = _preprocess_for_items(storage, where_clause)
+    where_clause = _construct_condition(storage, ConditionsBag(column_conditions=conditions))
     query = Query(
         from_clause=Table(
             table,
@@ -370,7 +369,9 @@ def _execute_query(
         raise error or Exception("No error or result when running query, this should never happen")
 
 
-def _construct_condition(conditions_bag: ConditionsBag) -> Expression:
+def _construct_condition(
+    storage: WritableTableStorage, conditions_bag: ConditionsBag
+) -> Expression:
     columns = conditions_bag.column_conditions
     attr_conditions = conditions_bag.attribute_conditions
     and_conditions = []
@@ -397,4 +398,5 @@ def _construct_condition(conditions_bag: ConditionsBag) -> Expression:
                 )
             and_conditions.append(exp)
 
-    return combine_and_conditions(and_conditions)
+    where_clause = combine_and_conditions(and_conditions)
+    return _preprocess_for_items(storage, where_clause)


### PR DESCRIPTION
Try to get rid of specialized eap_items bucketing logic in snuba/web/delete_query in #7570 

I think this is a good compromise between running a full query pipeline and duplicating bucketing logic in delete_query. It will continue to execute column translations as configuration is changed in the entity/storage YAMLs, increasing decoupling but doesn't bring in a ton of extra scope.

Why not run the entire query pipeline? Unfortunately, this would require coupling all deletes to *entity* definitions (these mappers exist on the entity), but we configure and pass around delete queries based on the storage. 

Tested end-to-end with this flow: https://www.notion.so/sentry/e2e-attribute-testing-2ab8b10e4b5d80cea5cfdc255cff5305