### PR TITLE
feat(deletes): add EAP deletes allowlist for launch

### DIFF
--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -66,7 +66,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
 
     # TODO: _is_execute_enabled is for EAP testing purposes, this should be removed after launch
     def _is_execute_enabled(self, conditions: Sequence[ConditionsBag]) -> bool:
-        if self.__storage.get_storage_key != StorageKey.EAP_ITEMS:
+        if self.__storage.get_storage_key() != StorageKey.EAP_ITEMS:
             return True
 
         query_org_ids: list[int] = [


### PR DESCRIPTION
With this change, we see if an incoming delete is for an org ID that's part of our allowlist. If not, we bypass execution, emit a metric, and commit the offset.

If allowlist is not present, all deletes are executed as normal.

Setting this up so we can test for launch on specific orgs without dialing up globally