### PR TITLE
Update distribution metric naming convention

### DIFF
--- a/snuba/utils/metrics/backends/dualwrite.py
+++ b/snuba/utils/metrics/backends/dualwrite.py
@@ -71,7 +71,7 @@ class SentryDatadogMetricsBackend(MetricsBackend):
         if self._use_sentry():
             self.sentry.timing(name, value, tags, unit)
         if self._write_timings_as_distributions():
-            self.datadog.distribution(name, value, tags, unit)
+            self.datadog.distribution(f"{name}.distribution", value, tags, unit)
 
     def distribution(
         self,


### PR DESCRIPTION
It seems like if you datadog histogram metrics named a certain key, even though they include the `.95percentile` once they show up, you don't get the distribution metric as well.

I'm adding a suffix to the timing metric we double write as a distribution so that it shows up
