### PR TITLE
feat(gocd): make ST deploys actually split rs/py

### DIFF
--- a/gocd/templates/bash/deploy-st-py.sh
+++ b/gocd/templates/bash/deploy-st-py.sh
@@ -2,10 +2,36 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/get-cluster-credentials
-
-k8s-deploy \
+/devinfra/scripts/get-cluster-credentials \
+&& k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
-  --container-name="snuba" \
-  --container-name="snuba-admin"
+  --container-name="api" \
+  --container-name="eap-items-subscriptions-executor" \
+  --container-name="eap-items-subscriptions-scheduler" \
+  --container-name="errors-replacer" \
+  --container-name="events-subscriptions-consumer" \
+  --container-name="generic-metrics-counters-subscriptions-executor" \
+  --container-name="generic-metrics-counters-subscriptions-scheduler" \
+  --container-name="generic-metrics-distributions-subscriptions-executor" \
+  --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+  --container-name="generic-metrics-sets-subscriptions-executor" \
+  --container-name="generic-metrics-sets-subscriptions-scheduler" \
+  --container-name="generic-metrics-gauges-subscriptions-executor" \
+  --container-name="generic-metrics-gauges-subscriptions-scheduler" \
+  --container-name="group-attributes-consumer" \
+  --container-name="lw-deletions-search-issues-consumer" \
+  --container-name="lw-deletions-eap-items-consumer" \
+  --container-name="metrics-counters-subscriptions-scheduler" \
+  --container-name="metrics-sets-subscriptions-scheduler" \
+  --container-name="metrics-subscriptions-executor" \
+  --container-name="search-issues-consumer" \
+  --container-name="snuba-admin" \
+  --container-name="transactions-subscriptions-consumer" \
+&& k8s-deploy \
+  --label-selector="${LABEL_SELECTOR}" \
+  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  --type="cronjob" \
+  --container-name="optimize" \
+  --container-name="cleanup" \
+  --container-name="cardinality-report"

--- a/gocd/templates/bash/deploy-st-rs.sh
+++ b/gocd/templates/bash/deploy-st-rs.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
-echo "TODO fix"
-echo "This is a no-op for single-tenants. deploy-snuba-py handles everything"
-echo "(and traffic is low enough that we don't have rebalance issues)"
+eval $(regions-project-env-vars --region="${SENTRY_REGION}")
+
+/devinfra/scripts/get-cluster-credentials \
+&& k8s-deploy \
+  --label-selector="${LABEL_SELECTOR}" \
+  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  --container-name="consumer" \
+  --container-name="eap-items-consumer" \
+  --container-name="generic-metrics-counters-consumer" \
+  --container-name="generic-metrics-distributions-consumer" \
+  --container-name="generic-metrics-sets-consumer" \
+  --container-name="loadbalancer-outcomes-consumer" \
+  --container-name="metrics-consumer" \
+  --container-name="outcomes-billing-consumer" \
+  --container-name="outcomes-consumer" \
+  --container-name="profile-chunks-consumer" \
+  --container-name="profiles-consumer" \
+  --container-name="profiling-functions-consumer" \
+  --container-name="querylog-consumer" \
+  --container-name="replays-consumer" \
+  --container-name="transactions-consumer"


### PR DESCRIPTION
This was confusing me a bit when I was rolling out consumer metrics, I think it's useful to split these to get consistent behavior with de/us (even though 99% of the time `py` is going to roll out any changes first)