### PR TITLE
Revert "feat(gocd): make ST deploys actually split rs/py"

### DIFF
--- a/gocd/templates/bash/deploy-st-py.sh
+++ b/gocd/templates/bash/deploy-st-py.sh
@@ -2,36 +2,10 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-/devinfra/scripts/get-cluster-credentials \
-&& k8s-deploy \
+/devinfra/scripts/get-cluster-credentials
+
+k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
-  --container-name="api" \
-  --container-name="eap-items-subscriptions-executor" \
-  --container-name="eap-items-subscriptions-scheduler" \
-  --container-name="errors-replacer" \
-  --container-name="events-subscriptions-consumer" \
-  --container-name="generic-metrics-counters-subscriptions-executor" \
-  --container-name="generic-metrics-counters-subscriptions-scheduler" \
-  --container-name="generic-metrics-distributions-subscriptions-executor" \
-  --container-name="generic-metrics-distributions-subscriptions-scheduler" \
-  --container-name="generic-metrics-sets-subscriptions-executor" \
-  --container-name="generic-metrics-sets-subscriptions-scheduler" \
-  --container-name="generic-metrics-gauges-subscriptions-executor" \
-  --container-name="generic-metrics-gauges-subscriptions-scheduler" \
-  --container-name="group-attributes-consumer" \
-  --container-name="lw-deletions-search-issues-consumer" \
-  --container-name="lw-deletions-eap-items-consumer" \
-  --container-name="metrics-counters-subscriptions-scheduler" \
-  --container-name="metrics-sets-subscriptions-scheduler" \
-  --container-name="metrics-subscriptions-executor" \
-  --container-name="search-issues-consumer" \
-  --container-name="snuba-admin" \
-  --container-name="transactions-subscriptions-consumer" \
-&& k8s-deploy \
-  --label-selector="${LABEL_SELECTOR}" \
-  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
-  --type="cronjob" \
-  --container-name="optimize" \
-  --container-name="cleanup" \
-  --container-name="cardinality-report"
+  --container-name="snuba" \
+  --container-name="snuba-admin"

--- a/gocd/templates/bash/deploy-st-rs.sh
+++ b/gocd/templates/bash/deploy-st-rs.sh
@@ -1,23 +1,5 @@
 #!/bin/bash
 
-eval $(regions-project-env-vars --region="${SENTRY_REGION}")
-
-/devinfra/scripts/get-cluster-credentials \
-&& k8s-deploy \
-  --label-selector="${LABEL_SELECTOR}" \
-  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
-  --container-name="consumer" \
-  --container-name="eap-items-consumer" \
-  --container-name="generic-metrics-counters-consumer" \
-  --container-name="generic-metrics-distributions-consumer" \
-  --container-name="generic-metrics-sets-consumer" \
-  --container-name="loadbalancer-outcomes-consumer" \
-  --container-name="metrics-consumer" \
-  --container-name="outcomes-billing-consumer" \
-  --container-name="outcomes-consumer" \
-  --container-name="profile-chunks-consumer" \
-  --container-name="profiles-consumer" \
-  --container-name="profiling-functions-consumer" \
-  --container-name="querylog-consumer" \
-  --container-name="replays-consumer" \
-  --container-name="transactions-consumer"
+echo "TODO fix"
+echo "This is a no-op for single-tenants. deploy-snuba-py handles everything"
+echo "(and traffic is low enough that we don't have rebalance issues)"


### PR DESCRIPTION
This didn't work. In STs all containers are named snuba or snuba-admin. s4s2 probably changes this by unifying to the SaaS configuration

Reverts getsentry/snuba#7606