### PR TITLE
feat: add metric that tracks "partitions left to optimize"

### DIFF
--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -326,9 +326,9 @@ def optimize_partition_runner(
         partitions_to_optimize = deque(partitions)
         partitions_remaining = len(partitions)
         tags = _get_metrics_tags(table, clickhouse_host)
-        metrics.gauge("partitions_left_to_optimize", partitions_remaining, tags=tags)
 
         while partitions_to_optimize:
+            metrics.gauge("partitions_left_to_optimize", partitions_remaining, tags=tags)
             configured_num_threads = get_num_threads(default_parallel_threads)
             schedule = scheduler.get_next_schedule(partitions_to_optimize)
             logger.info(
@@ -356,7 +356,6 @@ def optimize_partition_runner(
             for future in completed_futures:
                 future.result()
                 partitions_remaining -= 1
-            metrics.gauge("partitions_left_to_optimize", partitions_remaining, tags=tags)
 
 
 def optimize_partitions(


### PR DESCRIPTION
https://linear.app/getsentry/issue/EAP-341/track-optimized-partitions-as-a-metric
this PR adds a datadog metric that tracks "partitions left to optimize" for running optimize jobs. This will allow us to see how much progress the optimize jobs are making before failing.

sorry theres a lot of formatting changes in the PR, the actual changes are [lines 327-330](https://github.com/getsentry/snuba/pull/7620/changes#diff-fb97ede04634458aaa8ca52ac172447bbd893822cc750d7765f1272f4d1a7a0fR327-R330) and [358-359](https://github.com/getsentry/snuba/pull/7620/changes#diff-fb97ede04634458aaa8ca52ac172447bbd893822cc750d7765f1272f4d1a7a0fR358-R359)