### PR TITLE
debug(deletes): log out data so we can inspect allowlist not working

### DIFF
--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -38,7 +38,7 @@ TPayload = TypeVar("TPayload")
 
 import logging
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class LWDeleteQueryException(Exception):


### PR DESCRIPTION
this doesn't seem to be working as expected (every query is getting skipped as if the allowlist is empty in `de`)