### PR TITLE
Revert "Revert "ref(gocd): Bump gocd lib version to v2.18.0""

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.17.0"
+      "version": "v2.18.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "d0490a3079bfb0490016ce2cc14627f5fb90e522",
-      "sum": "eZZ8rwc3QIKR4Q6IIq/504XKoCB/rcx6WL4KkklWAz0="
+      "version": "3b7e3b151fb20d21d66c2f04d17a740ba0b09ac0",
+      "sum": "cgfkKWTz+bBKHa8WVji1v4Ke5JM3bTeMnqPtYZuy9VM="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Reverts getsentry/snuba#7628

The s4s2 migration issue is now fixed