### PR TITLE
feat(outcomes): Add 'ignored' reason to client discard reasons list

### DIFF
--- a/rust_snuba/src/processors/outcomes.rs
+++ b/rust_snuba/src/processors/outcomes.rs
@@ -21,6 +21,8 @@ const CLIENT_DISCARD_REASONS: &[&str] = &[
     "cache_overflow",
     // an event was dropped by an event processor; may also be used for ignored exceptions / errors
     "event_processor",
+    // an event was dropped by an SDK ignore config (e.g. an `ignore_spans` deny list)
+    "ignored",
     // an event was dropped due to a lack of data in the event (eg: not enough samples in a profile)
     "insufficient_data",
     // an event was dropped due to an internal SDK error (eg: web worker crash)


### PR DESCRIPTION
Adds a new discard reason `'ignored'` to the list of allowed reasons. The intention is to use this new reason to primarily surface when spans were ignored via the `ignoreSpans` deny list (an SDK option). 

I chose a rather general name here because we have other ignore lists (e.g. `ignoreErrors`) which could in the future use the same reason. Given the reason is combined with the item category, this should still be clear enough.

Open to other suggestions if reviewers have other opinions. Also please let me know if something else needs to be changed in Snuba.

ref https://linear.app/getsentry/issue/FE-678/add-new-ignore-discard-reason-for-client-reports