### PR TITLE
feat(ast): add ArbitrarySQL AST node to allow for subquery optimization

### DIFF
--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -10,10 +10,10 @@ from snuba.query.conditions import (
     get_first_level_or_conditions,
 )
 from snuba.query.expressions import (
-    ArbitrarySQL,
     Argument,
     Column,
     CurriedFunctionCall,
+    DangerousRawSQL,
     Expression,
     ExpressionVisitor,
     FunctionCall,
@@ -180,10 +180,10 @@ class ExpressionFormatterBase(ExpressionVisitor[str], ABC):
         ret = f"{', '.join(parameters)} -> {exp.transformation.accept(self)}"
         return self._alias(ret, exp.alias)
 
-    def visit_arbitrary_sql(self, exp: ArbitrarySQL) -> str:
+    def visit_dangerous_raw_sql(self, exp: DangerousRawSQL) -> str:
         """
-        Format ArbitrarySQL by passing through the SQL content directly without
-        any escaping or validation. This is intentional as ArbitrarySQL is meant
+        Format DangerousRawSQL by passing through the SQL content directly without
+        any escaping or validation. This is intentional as DangerousRawSQL is meant
         for pre-validated SQL in query optimization scenarios.
         """
         return self._alias(exp.sql, exp.alias)

--- a/snuba/clickhouse/translators/snuba/mapping.py
+++ b/snuba/clickhouse/translators/snuba/mapping.py
@@ -25,10 +25,10 @@ from snuba.clickhouse.translators.snuba.defaults import (
 )
 from snuba.datasets.plans.translator.mapper import apply_mappers
 from snuba.query.expressions import (
-    ArbitrarySQL,
     Argument,
     Column,
     CurriedFunctionCall,
+    DangerousRawSQL,
     FunctionCall,
     Lambda,
     Literal,
@@ -177,8 +177,8 @@ class SnubaClickhouseMappingTranslator(SnubaClickhouseStrictTranslator):
         self.__cache[exp] = ret
         return ret
 
-    def visit_arbitrary_sql(self, exp: ArbitrarySQL) -> Expression:
-        # ArbitrarySQL is passed through unchanged during translation
+    def visit_dangerous_raw_sql(self, exp: DangerousRawSQL) -> Expression:
+        # DangerousRawSQL is passed through unchanged during translation
         # since it contains pre-formatted SQL that should not be modified
         return exp
 

--- a/snuba/query/dsl_mapper.py
+++ b/snuba/query/dsl_mapper.py
@@ -5,10 +5,10 @@ from snuba.query import LimitBy, OrderBy, SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import (
-    ArbitrarySQL,
     Argument,
     Column,
     CurriedFunctionCall,
+    DangerousRawSQL,
     Expression,
     ExpressionVisitor,
     FunctionCall,
@@ -184,9 +184,9 @@ class DSLMapperVisitor(ExpressionVisitor[str]):
     def visit_lambda(self, exp: Lambda) -> str:
         return repr(exp)
 
-    def visit_arbitrary_sql(self, exp: ArbitrarySQL) -> str:
+    def visit_dangerous_raw_sql(self, exp: DangerousRawSQL) -> str:
         alias_str = f", {repr(exp.alias)}" if exp.alias else ", None"
-        return f"ArbitrarySQL({alias_str}, {repr(exp.sql)})"
+        return f"DangerousRawSQL({alias_str}, {repr(exp.sql)})"
 
     def visit_selected_expression(self, exp: SelectedExpression) -> str:
         return f"SelectedExpression({repr(exp.name)}, {exp.expression.accept(self)})"

--- a/snuba/query/joins/classifier.py
+++ b/snuba/query/joins/classifier.py
@@ -15,10 +15,10 @@ from typing import (
 )
 
 from snuba.query.expressions import (
-    ArbitrarySQL,
     Argument,
     Column,
     CurriedFunctionCall,
+    DangerousRawSQL,
     Expression,
     ExpressionVisitor,
     FunctionCall,
@@ -297,7 +297,7 @@ class BranchCutter(ExpressionVisitor[SubExpression]):
             main_expression=Lambda(exp.alias, exp.parameters, transformed.main_expression),
         )
 
-    def visit_arbitrary_sql(self, exp: ArbitrarySQL) -> SubExpression:
+    def visit_dangerous_raw_sql(self, exp: DangerousRawSQL) -> SubExpression:
         return UnclassifiedExpression(exp)
 
 

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -5,10 +5,10 @@ from snuba import environment
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import LogicalDataSource
 from snuba.query.expressions import (
-    ArbitrarySQL,
     Argument,
     Column,
     CurriedFunctionCall,
+    DangerousRawSQL,
     Expression,
     ExpressionVisitor,
     FunctionCall,
@@ -252,5 +252,5 @@ class AliasExpanderVisitor(ExpressionVisitor[Expression]):
             ),
         )
 
-    def visit_arbitrary_sql(self, exp: ArbitrarySQL) -> Expression:
+    def visit_dangerous_raw_sql(self, exp: DangerousRawSQL) -> Expression:
         return exp

--- a/snuba/query/processors/logical/filter_in_select_optimizer.py
+++ b/snuba/query/processors/logical/filter_in_select_optimizer.py
@@ -5,10 +5,10 @@ from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import (
-    ArbitrarySQL,
     Argument,
     Column,
     CurriedFunctionCall,
+    DangerousRawSQL,
     ExpressionVisitor,
     FunctionCall,
     Lambda,
@@ -80,7 +80,9 @@ class FindConditionalAggregateFunctionsVisitor(
     def visit_lambda(self, exp: Lambda) -> list[FunctionCall | CurriedFunctionCall]:
         return self._matches
 
-    def visit_arbitrary_sql(self, exp: ArbitrarySQL) -> list[FunctionCall | CurriedFunctionCall]:
+    def visit_dangerous_raw_sql(
+        self, exp: DangerousRawSQL
+    ) -> list[FunctionCall | CurriedFunctionCall]:
         return self._matches
 
 

--- a/snuba/query/processors/physical/tuple_unaliaser.py
+++ b/snuba/query/processors/physical/tuple_unaliaser.py
@@ -2,10 +2,10 @@ from dataclasses import replace
 
 from snuba.clickhouse.query import Query
 from snuba.query.expressions import (
-    ArbitrarySQL,
     Argument,
     Column,
     CurriedFunctionCall,
+    DangerousRawSQL,
     Expression,
     ExpressionVisitor,
     FunctionCall,
@@ -59,7 +59,7 @@ class _TupleUnaliasVisitor(ExpressionVisitor[Expression]):
     def visit_argument(self, exp: Argument) -> Expression:
         return exp
 
-    def visit_arbitrary_sql(self, exp: ArbitrarySQL) -> Expression:
+    def visit_dangerous_raw_sql(self, exp: DangerousRawSQL) -> Expression:
         return exp
 
 


### PR DESCRIPTION
For cross item queries to work, we need to be able to put a subquery into an AST node. Rather than modifying the whole query pipeline to be able to do this, take a shortcut and add an `ArbitrarySQL` node that is not transformed in any way by the query pipeline but can be inserted into a manually constructed EAP query (as we do in EAP)

The query I want to be able to build is :

```
SELECT * FROM eap_items_1_dist WHERE trace_id IN (SELECT trace_id FROM eap_items_1_dist WHERE...)
```