### PR TITLE
chore: increase max buckets for alerts timeseries

### DIFF
--- a/snuba/web/rpc/v1/endpoint_time_series.py
+++ b/snuba/web/rpc/v1/endpoint_time_series.py
@@ -38,8 +38,8 @@ _VALID_GRANULARITY_SECS = set(
     ]
 )
 
-# MAX 1 minute granularity over 7 days (10080 buckets) + 1 bucket to allow for partial time buckets on
-_MAX_BUCKETS_IN_REQUEST = 10081
+# MAX 1 minute granularity over 7 days (10080 buckets) + additional buckets to allow for partial time buckets on
+_MAX_BUCKETS_IN_REQUEST = 10100
 
 
 def _enforce_no_duplicate_labels(request: TimeSeriesRequest) -> None:


### PR DESCRIPTION
We initially increased the max timeseries buckets in this PR:  https://github.com/getsentry/snuba/pull/7482
But the number of buckets was still higher than this value and is throwing errors on alerts/monitors like [this one](https://sentry.sentry.io/monitors/2809118/?project=-1&statsPeriod=7d). This was the error snuba was throwing: https://sentry.sentry.io/issues/7084207705/?project=1&query=is%3Aunresolved%20user.email%3Awilliam.mak%40sentry.io&referrer=issue-stream

Seems like the quantizing the timeseries range is resulting in varying bucket numbers. We're increasing the max buckets a little more to account for any of these quantizing discrepancies.
