### PR TITLE
feat(autocomplete): Add boolean key attributes to RPC autocomplete

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0051_add_bool_keys_to_autocomplete.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0051_add_bool_keys_to_autocomplete.py
@@ -63,7 +63,6 @@ FROM eap_items_1_local
 
 
 class Migration(migration.ClickhouseNodeMigration):
-
     blocking = False
     storage_set_key = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
 


### PR DESCRIPTION
Add support for boolean attribute keys in the autocomplete functionality by:
- Creating migration 0051 to add `attributes_bool` column to autocomplete tables
- Updating the materialized view to extract boolean keys from `attributes_bool`
- Modifying the RPC endpoint to query the new boolean column for TYPE_BOOLEAN requests