### PR TITLE
fix: bug in recording allocationpolicy rejections

### DIFF
--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -328,13 +328,9 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         self._timer.mark("rpc_end")
         self._timer.send_metrics_to(self.metrics)
         if error is not None:
-            # Check if this is an allocation policy violation (either direct or as cause)
-            # This matches the before_send filter in snuba/environment.py to ensure
-            # metrics are consistent with what Sentry receives
             is_allocation_violation = isinstance(error, RPCAllocationPolicyException) or isinstance(
                 getattr(error, "__cause__", None), AllocationPolicyViolations
             )
-
             if is_allocation_violation:
                 self.metrics.increment(
                     "request_rate_limited",


### PR DESCRIPTION
I noticed [errors logged in datadog for one of the RPC endpoints](https://app.datadoghq.com/dashboard/eeq-3bs-gy4/kyles-rpc-dashboard-red?fromUser=true&refresh_mode=paused&tpl_var_endpoint_name%5B0%5D=endpointtraceitemtable&tpl_var_group_by%5B0%5D=endpoint_name&tpl_var_sentry_region%5B0%5D=us&from_ts=1768587545851&to_ts=1768587896632&live=false&tile_focus=2866834314845489) [but no corresponding errors for it in sentry](https://sentry.sentry.io/issues/?end=2026-01-16T10%3A50%3A59&environment=us&groupStatsPeriod=auto&project=300688&query=level%3A%EF%80%8DContains%EF%80%8Derror&referrer=issue-list&sort=freq&start=2026-01-16T10%3A00%3A00)... weird.

Digging into the codebase you can see that [AllocationPolicyViolations will get wrapped in a QueryException](https://github.com/getsentry/snuba/blob/dae39bdc36af67023ce67d5dbbeac818b871f5e2/snuba/web/db_query.py#L683-L692) but when we do our metric logging later on [it will only get marked as allocation policy if the instance of the exception is allocation policy exception](https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/__init__.py#L330-L334) but in this case we can see it wont be, itll actually be in the cause. So I added that edge case so its also caught, [this is also consistent with filtering we do in the sentry sdk](https://github.com/getsentry/snuba/blob/319e8baa5b46a29bf01d7e0f32d682568770009b/snuba/environment.py#L87-L91)