### PR TITLE
feat(get_traces): add limit to get_traces queries

### DIFF
--- a/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
+++ b/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
@@ -16,7 +16,7 @@ from snuba.attribution.attribution_info import AttributionInfo
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
-from snuba.query import SelectedExpression
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import and_cond, column, or_cond
@@ -132,6 +132,7 @@ def get_trace_ids_for_cross_item_query(
             column("trace_id"),
         ],
         having=trace_item_filters_and_expression,
+        order_by=[OrderBy(OrderByDirection.ASC, column("trace_id"))],
         limit=_TRACE_LIMIT,
     )
 
@@ -250,6 +251,7 @@ def get_trace_ids_sql_for_cross_item_query(
             column("trace_id"),
         ],
         having=trace_item_filters_and_expression,
+        order_by=[OrderBy(OrderByDirection.ASC, column("trace_id"))],
         limit=_TRACE_LIMIT,
     )
 


### PR DESCRIPTION
There is currently no limit on GetTraces queries. This means that if you do a cross item query that will hit basically every trace in the project, it will try to load all of them. Start with a reasonably large limit 