### PR TITLE
feat(outcomes): Add discard reason `invalid`

### DIFF
--- a/rust_snuba/src/processors/outcomes.rs
+++ b/rust_snuba/src/processors/outcomes.rs
@@ -27,6 +27,8 @@ const CLIENT_DISCARD_REASONS: &[&str] = &[
     "insufficient_data",
     // an event was dropped due to an internal SDK error (eg: web worker crash)
     "internal_sdk_error",
+    // an event was dropped due to an invalid payload
+    "invalid",
     // events were dropped because of network errors and were not retried.
     "network_error",
     // a SDK internal queue (eg: transport queue) overflowed


### PR DESCRIPTION
Adds a new client discard reason `invalid`. The primary intention behind this one is to distinguish dropped replays that could not be sent vs that are in itself invalid. This is generic enough to be used for other, similar use cases.

closes https://linear.app/getsentry/issue/FE-688/add-invalid-reason-in-snuba
ref https://github.com/getsentry/sentry-javascript/issues/18316