### PR TITLE
ref(INC-1584): job to delete event data by a tag,value pair

### DIFF
--- a/snuba/manual_jobs/delete_events_by_tag_key_value.py
+++ b/snuba/manual_jobs/delete_events_by_tag_key_value.py
@@ -48,7 +48,7 @@ AND timestamp < toDateTime('{end_datetime}')"""
         else:
             cluster_name = None
         query = self._get_query(cluster_name)
-        logger.info("Executing query: {query}")
+        logger.info(f"Executing query: {query}")
         result = connection.execute(
             query=query, settings={"mutations_sync": 0, "lightweight_deletes_sync": 0}
         )

--- a/snuba/manual_jobs/recreate_eap_dist_tables.py
+++ b/snuba/manual_jobs/recreate_eap_dist_tables.py
@@ -50,12 +50,12 @@ class RecreateEAPDistTables(Job):
                 storage_node,
             )
             for statement in statements:
-                logger.info("Run create table statement: {statement}")
+                logger.info(f"Run create table statement: {statement}")
                 connection.execute(query=statement)
 
             for table_name in tables:
                 statement = f"RENAME TABLE {table_name} TO old_{table_name}, new_{table_name} TO {table_name}"
-                logger.info("Rename table: {statement}")
+                logger.info(f"Rename table: {statement}")
                 connection.execute(query=statement)
 
         logger.info("complete")

--- a/snuba/manual_jobs/recreate_missing_eap_spans_materialized_views.py
+++ b/snuba/manual_jobs/recreate_missing_eap_spans_materialized_views.py
@@ -23,7 +23,7 @@ class RecreateMissingEAPSpansMaterializedViews(Job):
                 storage_node,
             )
             for query in materialized_views:
-                logger.info("Executing query: {query}")
+                logger.info(f"Executing query: {query}")
                 connection.execute(query=query)
 
         logger.info("complete")

--- a/snuba/manual_jobs/scrub_ips_from_eap_spans.py
+++ b/snuba/manual_jobs/scrub_ips_from_eap_spans.py
@@ -40,7 +40,7 @@ AND _sort_timestamp < toDateTime('{end_datetime}')"""
         else:
             cluster_name = None
         query = self._get_query(cluster_name)
-        logger.info("Executing query: {query}")
+        logger.info(f"Executing query: {query}")
         result = connection.execute(query=query, settings={"mutations_sync": 0})
 
         logger.info("complete")

--- a/snuba/manual_jobs/scrub_ips_from_spans.py
+++ b/snuba/manual_jobs/scrub_ips_from_spans.py
@@ -40,7 +40,7 @@ AND end_timestamp < toDateTime('{end_datetime}')"""
         else:
             cluster_name = None
         query = self._get_query(cluster_name)
-        logger.info("Executing query: {query}")
+        logger.info(f"Executing query: {query}")
         result = connection.execute(query=query, settings={"mutations_sync": 0})
         logger.info("complete")
         logger.info(repr(result))

--- a/snuba/manual_jobs/scrub_ips_from_spans_dictionary.py
+++ b/snuba/manual_jobs/scrub_ips_from_spans_dictionary.py
@@ -64,7 +64,7 @@ AND end_timestamp < toDateTime('{end_datetime}')"""
             query=self._dictionary_query(cluster_name), settings={"mutations_sync": 2}
         )
         query = self._get_query(cluster_name)
-        logger.info("Executing query: {query}")
+        logger.info(f"Executing query: {query}")
         result = connection.execute(
             query=query,
             settings={

--- a/snuba/manual_jobs/scrub_user_from_spans.py
+++ b/snuba/manual_jobs/scrub_user_from_spans.py
@@ -72,7 +72,7 @@ AND end_timestamp < toDateTime('{end_datetime}')"""
         else:
             cluster_name = None
         query = self._get_query(cluster_name)
-        logger.info("Executing query: {query}")
+        logger.info(f"Executing query: {query}")
         result = connection.execute(query=query, settings={"mutations_sync": self._mutations_sync})
         logger.info("complete")
         logger.info(repr(result))

--- a/snuba/manual_jobs/scrub_users_from_eap_spans.py
+++ b/snuba/manual_jobs/scrub_users_from_eap_spans.py
@@ -43,7 +43,7 @@ AND _sort_timestamp < toDateTime('{end_datetime}')"""
         else:
             cluster_name = None
         query = self._get_query(cluster_name)
-        logger.info("Executing query: {query}")
+        logger.info(f"Executing query: {query}")
         result = connection.execute(query=query, settings={"mutations_sync": 2})
 
         logger.info("complete")

--- a/snuba/manual_jobs/scrub_users_from_eap_spans_str_attrs.py
+++ b/snuba/manual_jobs/scrub_users_from_eap_spans_str_attrs.py
@@ -50,7 +50,7 @@ AND timestamp < toDateTime('{end_datetime}')"""
         else:
             cluster_name = None
         query = self._get_query(cluster_name)
-        logger.info("Executing query: {query}")
+        logger.info(f"Executing query: {query}")
         result = connection.execute(query=query, settings={"mutations_sync": 0})
 
         logger.info("complete")


### PR DESCRIPTION
We tried running the [getsentry script](https://github.com/getsentry/getsentry/blob/master/bin/deletion_scripts/delete-events-by-tag-value) to delete events by the tag value and that isn't seemingly working for the snuba data. I'm not sure why that is but in the mean time I've added a manual job that should let us delete the data.

Im using `DELETE FROM` since the errors cluster should being running optimize which should force merges, which in turn should force all the data to be deleted

Corresponding ops PR: https://github.com/getsentry/ops/pull/18865