### PR TITLE
fix(docker): Fix Node.js and Yarn installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,11 +102,9 @@ ENV NODE_VERSION=20
 COPY ./snuba/admin ./snuba/admin
 RUN set -ex; \
     mkdir -p snuba/admin/dist/; \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh | bash -s -- ${NODE_VERSION} &&\
-    apt-get update && \
-    apt-get install -y yarn nodejs --no-install-recommends && \
+    curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    apt-get install -y nodejs --no-install-recommends && \
+    npm install -g yarn && \
     cd snuba/admin && \
     yarn install && \
     yarn run build


### PR DESCRIPTION
Replaces old docker logic for installing node and yarn with new, better logic.

Below is a detailed description of the PR generated by Cursor:
## Summary

Fixes the Node.js and Yarn installation in the Dockerfile which was broken due to several issues in the previous implementation.

## Diff

```diff
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh | bash -s -- ${NODE_VERSION} &&\
-    apt-get update && \
-    apt-get install -y yarn nodejs --no-install-recommends && \
+    curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    apt-get install -y nodejs --no-install-recommends && \
+    npm install -g yarn && \
```

## Line-by-line explanation

### Old commands (removed)

1. **`curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -`**
   - Downloaded Yarn's GPG public key and added it to apt's trusted keys
   - Uses deprecated `apt-key` method

2. **`echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list`**
   - Added Yarn's Debian repository to apt sources list
   - `tee` writes to the file while also outputting to stdout

3. **`curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh | bash -s -- ${NODE_VERSION}`**
   - **BUG**: The `-O` flag saves the file locally instead of piping to bash, so the script never actually runs
   - **BUG**: References `nsolid_setup_deb.sh` (N|Solid enterprise runtime) instead of the standard Node.js setup script

4. **`apt-get update`**
   - Refreshes apt package index

5. **`apt-get install -y yarn nodejs --no-install-recommends`**
   - Installs Yarn and Node.js from apt repositories
   - `-y` auto-confirms prompts
   - `--no-install-recommends` keeps image smaller

### New commands (added)

1. **`curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -`**
   - Downloads and executes NodeSource's official Node.js setup script
   - `-f`: Fail on HTTP errors (don't output error page HTML)
   - `-s`: Silent mode (no progress bar)
   - `-S`: Show errors even in silent mode
   - `-L`: Follow HTTP redirects
   - `setup_${NODE_VERSION}.x`: Gets latest Node.js in major version 20 (e.g., 20.11.0)
   - `| bash -`: Pipes script directly to bash for execution

2. **`apt-get install -y nodejs --no-install-recommends`**
   - Installs Node.js from the NodeSource repository (configured by the setup script above)
   - `-y`: Auto-confirms installation prompts
   - `--no-install-recommends`: Skips optional packages to keep image smaller

3. **`npm install -g yarn`**
   - Installs Yarn globally using npm (which comes bundled with Node.js)
   - Simpler than maintaining a separate apt repository for Yarn

## Test plan

- [x] Built Docker image successfully with `docker build -t snuba-test .`
- [x] Verified admin frontend was compiled: `docker run --rm --entrypoint "" snuba-test ls -la snuba/admin/dist/` shows bundle.js, bundle.css, etc.