### PR TITLE
feat(eap): Add timestamp_ns column to eap_items_1 table

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0052_add_timestamp_ns_column.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0052_add_timestamp_ns_column.py
@@ -1,5 +1,6 @@
 from typing import List, Sequence
 
+from snuba.clickhouse.columns import Column, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.operations import OperationTarget
@@ -9,6 +10,9 @@ class Migration(migration.ClickhouseNodeMigration):
     """
     Adds timestamp_ns column to eap_items_1 table and modifies the sort key
     to include it after timestamp.
+
+    Note: This migration is non-reversible due to ClickHouse limitations.
+    ClickHouse does not allow removing a column from the middle of a sorting key.
     """
 
     blocking = False
@@ -28,35 +32,18 @@ class Migration(migration.ClickhouseNodeMigration):
                 """,
                 target=OperationTarget.LOCAL,
             ),
-            operations.RunSql(
+            operations.AddColumn(
                 storage_set=self.storage_set_key,
-                statement=f"ALTER TABLE {self.dist_table_name} ADD COLUMN IF NOT EXISTS timestamp_ns UInt16 AFTER timestamp",
+                table_name=self.dist_table_name,
+                column=Column("timestamp_ns", UInt(16)),
+                after="timestamp",
                 target=OperationTarget.DISTRIBUTED,
             ),
         ]
         return ops
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
-        ops: List[operations.SqlOperation] = [
-            operations.DropColumn(
-                storage_set=self.storage_set_key,
-                table_name=self.dist_table_name,
-                column_name="timestamp_ns",
-                target=OperationTarget.DISTRIBUTED,
-            ),
-            operations.RunSql(
-                storage_set=self.storage_set_key,
-                statement=f"""
-                    ALTER TABLE {self.local_table_name}
-                    MODIFY ORDER BY (organization_id, project_id, item_type, timestamp, trace_id, item_id)
-                """,
-                target=OperationTarget.LOCAL,
-            ),
-            operations.DropColumn(
-                storage_set=self.storage_set_key,
-                table_name=self.local_table_name,
-                column_name="timestamp_ns",
-                target=OperationTarget.LOCAL,
-            ),
-        ]
-        return ops
+        # Non-reversible: ClickHouse does not allow removing a column with data
+        # from the sorting key because it would change the order of data on disk.
+        # To reverse this migration, stop writing to timestamp_ns.
+        return []


### PR DESCRIPTION
Add a new `timestamp_ns` column of type `UInt16` to the `eap_items_1` table for storing sub-second timestamp precision.

The migration:
- Adds the `timestamp_ns` column after the existing `timestamp` column
- Modifies the sort key to include `timestamp_ns` after `timestamp`: `(organization_id, project_id, item_type, timestamp, timestamp_ns, trace_id, item_id)`
- Includes proper backwards migration to revert the sort key and drop the column