### PR TITLE
fix(cross_item): add distributed_product_mode setting to eap items

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items.yaml
@@ -130,6 +130,7 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
 
 delete_allocation_policies: []
 

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512.yaml
@@ -129,6 +129,7 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
@@ -130,6 +130,7 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8.yaml
@@ -129,6 +129,8 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
 
 
 mandatory_condition_checkers:


### PR DESCRIPTION
using the `GLOBAL IN` makes the requester run a distributed query and store the results in a local table in RAM

https://clickhouse.com/docs/sql-reference/operators/in#distributed-subqueries
https://clickhouse.com/docs/operations/settings/settings#distributed_product_mode