### PR TITLE
fix(get_traces): make cross-item query limit explicit and configurable

### DIFF
--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -479,6 +479,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
             convert_trace_filters_to_trace_item_filter_with_type(list(in_msg.filters)),
             self.routing_decision.tier,
             self._timer,
+            limit=in_msg.limit if in_msg.limit > 0 else None,
         )
 
         # Get metadata using subquery

--- a/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
+++ b/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
@@ -8,6 +8,7 @@ from sentry_protos.snuba.v1.request_common_pb2 import (
     TraceItemFilterWithType,
 )
 
+from snuba import state
 from snuba.attribution.appid import AppID
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.datasets.entities.entity_key import EntityKey
@@ -49,6 +50,7 @@ def get_trace_ids_sql_for_cross_item_query(
     trace_filters: list[TraceItemFilterWithType],
     sampling_tier: Tier,
     timer: Timer,
+    limit: int | None = None,
 ) -> tuple[str, QueryResult]:
     """
     Returns the SQL query string and query result for getting trace IDs matching the given filters.
@@ -132,7 +134,7 @@ def get_trace_ids_sql_for_cross_item_query(
                 expression=f.max(column("timestamp")),
             ),
         ],
-        limit=getattr(original_request, "limit", None) or _TRACE_LIMIT,
+        limit=limit or state.get_config("trace_ids_cross_item_query_limit", _TRACE_LIMIT),
     )
 
     treeify_or_and_conditions(query)


### PR DESCRIPTION
Previously, get_trace_ids_sql_for_cross_item_query extracted the limit from the original request, but different endpoints have different semantics for their limit fields. This changes the function to take an explicit limit parameter instead.

The impact of this was a data bug where `TraceItemTable` requests with cross item queries only had one or two span samples when there were actually thousands:

<img width="788" height="498" alt="image" src="https://github.com/user-attachments/assets/d4774c8d-7cc0-4e1e-9417-9f2fbc6911cb" />


Changes:
- Add optional limit parameter to get_trace_ids_sql_for_cross_item_query
- EndpointGetTraces now passes its request limit explicitly
- EndpointTimeSeries and EndpointTraceItemTable use default limit
- Make default limit runtime configurable via state.get_config

The trace limit can now be configured at runtime using the trace_ids_cross_item_query_limit config key, with a default of 10,000.