### PR TITLE
ref(ci): add fast revert bot

### DIFF
--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -38,7 +38,7 @@ jobs:
         co_authored_by: >-
           ${{ github.event.inputs.co_authored_by || format('{0}\n<{1}+{0}@users.noreply.github.com>', github.event.sender.login, github.event.sender.id) }}
         committer_name: sentry-snuba-fast-revert-bot[bot]
-        committer_email: 1027539+sentry-snuba-fast-revert-bot[bot]@users.noreply.github.com
+        committer_email: 257653817+sentry-snuba-fast-revert-bot[bot]@users.noreply.github.com
         token: ${{ steps.token.outputs.token }}
     - name: comment on failure
       run: |


### PR DESCRIPTION
Fast revert wasn't working due to the bot permissions. Previously the getsentry-bot was under **Repository Admin** role and in our github ruleset we have the bypass mode (meaning in what conditions can we bypass our ruleset) on "Allow for pull requests only" for **Repository Admin** role. We tried before to changes this to "Always allow" but that means people can mistakenly push to master.

So a new bot was born! the Fast Revert Bot (which was created following https://www.notion.so/sentry/GitHub-Apps-9d87ed7de5604f20b90c55dd7deefcbb#592d80b1959f470184d08cb0b7339f59) and I basically copied the [workflow used in ops](https://github.com/getsentry/ops/blob/master/.github/workflows/fast-revert.yml) for our usecase. The `FAST_REVERT_BOT_APP_ID` and `GH_FAST_REVERT_PRIVATE_KEY` are already added to our repo's secrets.
