### PR TITLE
feat(admin): Preserve SQL shell history across page navigation

### DIFF
--- a/snuba/admin/static/index.tsx
+++ b/snuba/admin/static/index.tsx
@@ -8,6 +8,7 @@ import Body from "SnubaAdmin/body";
 import { NAV_ITEMS } from "SnubaAdmin/data";
 import Client from "SnubaAdmin/api_client";
 import { MantineProvider } from "@mantine/core";
+import { ShellStateProvider } from "SnubaAdmin/sql_shell/shell_context";
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 
@@ -72,13 +73,15 @@ function App() {
 
   return (
     <MantineProvider withGlobalStyles withNormalizeCSS>
-      <div style={containerStyle}>
-        <Header />
-        <div style={bodyStyle}>
-          <Nav active={activeTab} navigate={navigate} api={client} />
-          {activeTab && <Body active={activeTab} api={client} />}
+      <ShellStateProvider>
+        <div style={containerStyle}>
+          <Header />
+          <div style={bodyStyle}>
+            <Nav active={activeTab} navigate={navigate} api={client} />
+            {activeTab && <Body active={activeTab} api={client} />}
+          </div>
         </div>
-      </div>
+      </ShellStateProvider>
     </MantineProvider>
   );
 }

--- a/snuba/admin/static/sql_shell/shell_context.tsx
+++ b/snuba/admin/static/sql_shell/shell_context.tsx
@@ -1,0 +1,129 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode } from "react";
+import { ShellState, ShellHistoryEntry, ShellMode } from "SnubaAdmin/sql_shell/types";
+
+const MAX_HISTORY_ENTRIES = 500;
+
+function getCommandHistoryKey(mode: ShellMode): string {
+  return mode === "tracing" ? "sql_shell_command_history" : "system_shell_command_history";
+}
+
+function loadCommandHistory(mode: ShellMode): string[] {
+  try {
+    const saved = sessionStorage.getItem(getCommandHistoryKey(mode));
+    return saved ? JSON.parse(saved) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveCommandHistory(mode: ShellMode, history: string[]) {
+  try {
+    sessionStorage.setItem(
+      getCommandHistoryKey(mode),
+      JSON.stringify(history.slice(-100))
+    );
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+function createInitialState(mode: ShellMode): ShellState {
+  return {
+    currentStorage: null,
+    currentHost: null,
+    currentPort: null,
+    profileEnabled: true,
+    traceFormatted: true,
+    sudoEnabled: false,
+    history: [],
+    commandHistory: loadCommandHistory(mode),
+    historyIndex: -1,
+    isExecuting: false,
+  };
+}
+
+interface ShellStateContextValue {
+  tracingState: ShellState;
+  systemState: ShellState;
+  setTracingState: React.Dispatch<React.SetStateAction<ShellState>>;
+  setSystemState: React.Dispatch<React.SetStateAction<ShellState>>;
+  addHistoryEntry: (mode: ShellMode, entry: ShellHistoryEntry) => void;
+  addCommandToHistory: (mode: ShellMode, command: string) => void;
+  clearHistory: (mode: ShellMode) => void;
+}
+
+const ShellStateContext = createContext<ShellStateContextValue | null>(null);
+
+interface ShellStateProviderProps {
+  children: ReactNode;
+}
+
+export function ShellStateProvider({ children }: ShellStateProviderProps) {
+  const [tracingState, setTracingState] = useState<ShellState>(() => createInitialState("tracing"));
+  const [systemState, setSystemState] = useState<ShellState>(() => createInitialState("system"));
+
+  const addHistoryEntry = useCallback((mode: ShellMode, entry: ShellHistoryEntry) => {
+    const setState = mode === "tracing" ? setTracingState : setSystemState;
+    setState((prev) => {
+      const newHistory = [...prev.history, entry];
+      return {
+        ...prev,
+        history: newHistory.length > MAX_HISTORY_ENTRIES
+          ? newHistory.slice(-MAX_HISTORY_ENTRIES)
+          : newHistory,
+      };
+    });
+  }, []);
+
+  const addCommandToHistory = useCallback((mode: ShellMode, command: string) => {
+    const setState = mode === "tracing" ? setTracingState : setSystemState;
+    setState((prev) => {
+      const newCmdHistory = [...prev.commandHistory, command];
+      saveCommandHistory(mode, newCmdHistory);
+      return {
+        ...prev,
+        commandHistory: newCmdHistory,
+        historyIndex: -1,
+      };
+    });
+  }, []);
+
+  const clearHistory = useCallback((mode: ShellMode) => {
+    const setState = mode === "tracing" ? setTracingState : setSystemState;
+    setState((prev) => ({ ...prev, history: [] }));
+  }, []);
+
+  return (
+    <ShellStateContext.Provider
+      value={{
+        tracingState,
+        systemState,
+        setTracingState,
+        setSystemState,
+        addHistoryEntry,
+        addCommandToHistory,
+        clearHistory,
+      }}
+    >
+      {children}
+    </ShellStateContext.Provider>
+  );
+}
+
+export function useShellState(mode: ShellMode) {
+  const context = useContext(ShellStateContext);
+  if (!context) {
+    throw new Error("useShellState must be used within a ShellStateProvider");
+  }
+
+  const state = mode === "tracing" ? context.tracingState : context.systemState;
+  const setState = mode === "tracing" ? context.setTracingState : context.setSystemState;
+
+  return {
+    state,
+    setState,
+    addHistoryEntry: (entry: ShellHistoryEntry) => context.addHistoryEntry(mode, entry),
+    addCommandToHistory: (command: string) => context.addCommandToHistory(mode, command),
+    clearHistory: () => context.clearHistory(mode),
+  };
+}


### PR DESCRIPTION
## Summary
- Add React Context (`ShellStateProvider`) to hold shell state at the app level
- Shell history, settings (storage, host, profile, trace, sudo), and command history are now preserved when navigating between pages
- Both tracing shell and system shell states are maintained independently
- Show full query results without row truncation (was limited to 100 rows), cell truncation (was limited to 300px with ellipsis), or profile event truncation (was limited to 100 chars)
- Auto-focus the input field reliably on every page navigation

## Test plan
- [ ] Open the Tracing Shell, run some commands (USE storage, execute queries)
- [ ] Navigate to a different page (e.g., Runtime Config)
- [ ] Return to Tracing Shell - verify history and settings are preserved
- [ ] Repeat for System Shell
- [ ] Run a query returning >100 rows - verify all rows are displayed
- [ ] Run a query with long cell values - verify full content is shown (wrapped, not truncated)
- [ ] Navigate away and back to a shell page - verify the input field is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)