### PR TITLE
fix(admin): add quotes around cluster name in ON CLUSTER clause

### DIFF
--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -59,7 +59,7 @@ def get_create_table_statements(
 
         if cluster_name:
             table_statement = table_statement.replace(
-                db_table, f"{db_table} ON CLUSTER {cluster_name}"
+                db_table, f"{db_table} ON CLUSTER '{cluster_name}'"
             )
 
         table_statements.append(

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -13,7 +13,7 @@ from snuba.migrations import table_engines
 from snuba.migrations.groups import MigrationGroup
 
 OUTCOMES_DAILY_TABLE = """
-CREATE TABLE IF NOT EXISTS {db}.outcomes_daily_local_v2 ON CLUSTER test_cluster
+CREATE TABLE IF NOT EXISTS {db}.outcomes_daily_local_v2 ON CLUSTER 'test_cluster'
 (
     `org_id` UInt64,
     `project_id` UInt64,
@@ -33,7 +33,7 @@ SETTINGS index_granularity = 8192
 """
 
 OUTCOMES_DAILY_MV = """
-CREATE MATERIALIZED VIEW IF NOT EXISTS {db}.outcomes_mv_daily_local_v2 ON CLUSTER test_cluster TO {db}.outcomes_daily_local_v2
+CREATE MATERIALIZED VIEW IF NOT EXISTS {db}.outcomes_mv_daily_local_v2 ON CLUSTER 'test_cluster' TO {db}.outcomes_daily_local_v2
 (
     `org_id` UInt64,
     `project_id` UInt64,


### PR DESCRIPTION
The ON CLUSTER clause in ClickHouse needs quotes for cluster names with hyphens. This PR updates the table copy logic to wrap `cluster_name` in single quotes when constructing the CREATE TABLE statements.

## Test plan
- [x] Updated test expectations in `tests/admin/clickhouse/test_copy_tables.py`
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)