### PR TITLE
feat: make target for install-proto-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,9 @@ gocd:
 	cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./snuba-rs.jsonnet
 	cd ./gocd/generated-pipelines && find . -type f \( -name '*.yaml' \) -print0 | xargs -n 1 -0 yq -p json -o yaml -i
 .PHONY: gocd
+
+install-proto-dev:
+	devenv sync && \
+	uv pip install -e ../sentry-protos/py --config-settings editable_mode=compat && \
+	echo "Installed local sentry-protos, please restart the vscode language server. Run 'uv pip uninstall sentry-protos && uv sync' to go back to the original version."
+.PHONY: install-proto-dev


### PR DESCRIPTION
**Does this ever happen to you?**
You are developing a new [sentry-protos](https://github.com/getsentry/sentry-protos) change and want to test it locally, so you do `pip install -e ../sentry-protos/py`. But alas, vscode language server just cant keep up:
<img width="722" height="265" alt="Screenshot 2026-02-05 at 5 11 58 PM" src="https://github.com/user-attachments/assets/0362da2d-82df-4938-8787-a3502b7e1cb4" />

**Well not anymore!**
Introducing... `install-proto-dev` Makefile target. Now developing your protobufs locally is as easy as `make install-proto-dev` and refreshing your vscode window!
<img width="722" height="80" alt="Screenshot 2026-02-05 at 5 20 48 PM" src="https://github.com/user-attachments/assets/fcaf48e3-0f75-4db1-99e5-4b7835d50a88" />
<img width="722" height="252" alt="Screenshot 2026-02-05 at 5 21 58 PM" src="https://github.com/user-attachments/assets/82339063-ab83-4419-a3c6-fa899cf23c07" />
*ta da* 🎉 