### PR TITLE
feat(eap): Add max_threads=4 to low_priority_deletes workload

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0053_alter_deletes_workload_max_threads.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0053_alter_deletes_workload_max_threads.py
@@ -11,7 +11,8 @@ class Migration(migration.ClickhouseNodeMigration):
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:
         alter_workload = """
-            ALTER WORKLOAD low_priority_deletes
+            CREATE OR REPLACE WORKLOAD low_priority_deletes
+            IN all
             SETTINGS
                 priority = 100,
                 max_requests = 2,
@@ -29,7 +30,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
         # Restore original settings without max_threads
         alter_workload = """
-            ALTER WORKLOAD low_priority_deletes
+            CREATE OR REPLACE WORKLOAD low_priority_deletes
+            IN all
             SETTINGS
                 priority = 100,
                 max_requests = 2;


### PR DESCRIPTION
Adds migration to alter the low_priority_deletes workload to include max_threads=4, while retaining the existing priority and max_requests settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)