### PR TITLE
ref(logger): ignore clickhouse_driver.log

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -24,6 +24,7 @@ from uuid import UUID
 import sentry_sdk
 from clickhouse_driver import Client, errors
 from dateutil.tz import tz
+from sentry_sdk.integrations.logging import ignore_logger
 
 from snuba import environment, settings, state
 from snuba.clickhouse.errors import ClickhouseError
@@ -31,6 +32,8 @@ from snuba.clickhouse.formatter.nodes import FormattedQuery
 from snuba.reader import Reader, Result, build_result_transformer
 from snuba.utils.metrics.gauge import ThreadSafeGauge
 from snuba.utils.metrics.wrapper import MetricsWrapper
+
+ignore_logger("clickhouse_driver.log")
 
 logger = logging.getLogger("snuba.clickhouse")
 trace_logger = logging.getLogger("clickhouse_driver.log")


### PR DESCRIPTION
We added the `clickhouse_driver.log` in https://github.com/getsentry/snuba/pull/2304 for snuba admin tracing tooling. However, by adding the logger we get (millions) of logger warnings sent to sentry e.g. [SNUBA-1V1](https://sentry.sentry.io/issues/1642155259/?project=300688&query=is%3Aunresolved&referrer=issue-stream). These warnings aren't really useful and any exceptions from clickhouse driver should be handled in the `execute` function, so I think we can ignore these logs by using [`ignore_logger` ](https://docs.sentry.io/platforms/python/integrations/logging/#ignoring-a-logger)


Validated that [`test_capture_trace`](https://github.com/getsentry/snuba/blob/6d794577abe3f2b20cd5480ff357f17e839d9f42/tests/test_clickhouse.py#L63) still passes so this shouldn't affect getting tracing data, should only prevent us from sending the logs to sentry. 