### PR TITLE
ref(logger): ignore clickhouse_driver.connection instead

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -33,7 +33,7 @@ from snuba.reader import Reader, Result, build_result_transformer
 from snuba.utils.metrics.gauge import ThreadSafeGauge
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
-ignore_logger("clickhouse_driver.log")
+ignore_logger("clickhouse_driver.connection")
 
 logger = logging.getLogger("snuba.clickhouse")
 trace_logger = logging.getLogger("clickhouse_driver.log")


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/7716 didn't seem to do anything, doubled checked and the `logger` in the sentry warning is `clickhouse_driver.connection`, so this updates that.