### PR TITLE
feat(eap): Reduce max_threads to 2 for low_priority_deletes workload

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0054_reduce_deletes_workload_max_threads.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0054_reduce_deletes_workload_max_threads.py
@@ -1,0 +1,47 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    storage_set_key = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        alter_workload = """
+            CREATE OR REPLACE WORKLOAD low_priority_deletes
+            IN all
+            SETTINGS
+                priority = 100,
+                max_requests = 2,
+                max_threads = 2;
+        """
+
+        return [
+            operations.RunSql(
+                storage_set=self.storage_set_key,
+                statement=alter_workload,
+                target=OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        # Restore max_threads = 4
+        alter_workload = """
+            CREATE OR REPLACE WORKLOAD low_priority_deletes
+            IN all
+            SETTINGS
+                priority = 100,
+                max_requests = 2,
+                max_threads = 4;
+        """
+
+        return [
+            operations.RunSql(
+                storage_set=self.storage_set_key,
+                statement=alter_workload,
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
Brute force only fails if you don't apply enough force. CPU is still elevated during big deletes, therefore we want to try reducing max_threads from 4 to 2 for the low_priority_deletes workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)