### PR TITLE
feat(admin): Add workload DDL copying to copy tables

### DIFF
--- a/snuba/admin/static/copy_tables/index.tsx
+++ b/snuba/admin/static/copy_tables/index.tsx
@@ -177,6 +177,27 @@ function CopyTables(props: {
             </div>
           </div>
 
+          {copyTableResult.workloads && (
+            <div style={resultSectionStyle}>
+              <h3>Workloads Copied</h3>
+              <div style={tableListStyle}>
+                {copyTableResult.workloads.split(',').map((val, inx) => (
+                  <div key={inx}><code>{val}</code></div>
+                ))}
+              </div>
+              {copyTableResult.workload_errors && Object.keys(copyTableResult.workload_errors).length > 0 && (
+                <div style={unverifiedHostsContainerStyle}>
+                  <p style={missingTablesStyle}><strong>Workload Errors:</strong></p>
+                  {Object.entries(copyTableResult.workload_errors).map(([node, error]) => (
+                    <div key={node} style={hostItemStyle}>
+                      <p><strong>Node:</strong> <code>{node}</code></p>
+                      <p style={missingTablesStyle}><strong>Error:</strong> {error}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
         </div>
       )}

--- a/snuba/admin/static/copy_tables/types.tsx
+++ b/snuba/admin/static/copy_tables/types.tsx
@@ -35,6 +35,8 @@ type CopyTableResult = {
   cluster_name: string
   incomplete_hosts?: Record<string, string>
   verified?: number
+  workloads?: string
+  workload_errors?: Record<string, string>
 }
 
 export { ClickhouseNodeData, CopyTableHostsState, CopyTableRequest, CopyTableResult };

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -507,7 +507,7 @@ def _raw_query(
             cause.__class__.__name__,
             cause.message if isinstance(cause, ClickhouseError) else str(cause),
             {
-                "stats": stats,
+                "stats": dict(stats),
                 "sql": sql,
                 "experiments": clickhouse_query.get_experiments(),
             },
@@ -521,7 +521,7 @@ def _raw_query(
         return QueryResult(
             result,
             {
-                "stats": stats,
+                "stats": dict(stats),
                 "sql": sql,
                 "experiments": clickhouse_query.get_experiments(),
             },
@@ -575,7 +575,8 @@ def _record_bytes_scanned(
     custom_metrics = MetricsWrapper(environment.metrics, "allocation_policy")
 
     if result_or_error.query_result:
-        progress_bytes_scanned = cast(int, result_or_error.query_result.result.get("profile", {}).get("progress_bytes", 0))  # type: ignore
+        profile = result_or_error.query_result.result.get("profile") or {}
+        progress_bytes_scanned = cast(int, profile.get("progress_bytes", 0))
         custom_metrics.increment(
             "bytes_scanned",
             progress_bytes_scanned,
@@ -684,7 +685,7 @@ def db_query(
             AllocationPolicyViolations.__name__,
             "Query cannot be run due to allocation policies",
             extra={
-                "stats": stats,
+                "stats": dict(stats),
                 "sql": "no sql run",
                 "experiments": {},
             },
@@ -699,7 +700,7 @@ def db_query(
             e.__class__.__name__,
             str(e),
             {
-                "stats": stats,
+                "stats": dict(stats),
                 "sql": "",
                 "experiments": clickhouse_query.get_experiments(),
             },
@@ -751,7 +752,6 @@ def _add_quota_info(
     action: str,
     quota_and_policy: _QuotaAndPolicy | None = None,
 ) -> None:
-
     quota_info: dict[str, Any] = {}
     summary[action] = quota_info
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -507,7 +507,7 @@ def _raw_query(
             cause.__class__.__name__,
             cause.message if isinstance(cause, ClickhouseError) else str(cause),
             {
-                "stats": dict(stats),
+                "stats": stats,
                 "sql": sql,
                 "experiments": clickhouse_query.get_experiments(),
             },
@@ -521,7 +521,7 @@ def _raw_query(
         return QueryResult(
             result,
             {
-                "stats": dict(stats),
+                "stats": stats,
                 "sql": sql,
                 "experiments": clickhouse_query.get_experiments(),
             },
@@ -575,8 +575,7 @@ def _record_bytes_scanned(
     custom_metrics = MetricsWrapper(environment.metrics, "allocation_policy")
 
     if result_or_error.query_result:
-        profile = result_or_error.query_result.result.get("profile") or {}
-        progress_bytes_scanned = cast(int, profile.get("progress_bytes", 0))
+        progress_bytes_scanned = cast(int, result_or_error.query_result.result.get("profile", {}).get("progress_bytes", 0))  # type: ignore
         custom_metrics.increment(
             "bytes_scanned",
             progress_bytes_scanned,
@@ -685,7 +684,7 @@ def db_query(
             AllocationPolicyViolations.__name__,
             "Query cannot be run due to allocation policies",
             extra={
-                "stats": dict(stats),
+                "stats": stats,
                 "sql": "no sql run",
                 "experiments": {},
             },
@@ -700,7 +699,7 @@ def db_query(
             e.__class__.__name__,
             str(e),
             {
-                "stats": dict(stats),
+                "stats": stats,
                 "sql": "",
                 "experiments": clickhouse_query.get_experiments(),
             },
@@ -752,6 +751,7 @@ def _add_quota_info(
     action: str,
     quota_and_policy: _QuotaAndPolicy | None = None,
 ) -> None:
+
     quota_info: dict[str, Any] = {}
     summary[action] = quota_info
 


### PR DESCRIPTION
## Summary
- Extend the COPY TABLES admin functionality to automatically copy ClickHouse workload definitions when provisioning new nodes
- Add `WorkloadStatement` dataclass and `get_workloads()` to query `system.workloads` table
- Add topological sort to ensure parent workloads are created before children
- Add `copy_workloads()` to copy workloads per-node (not ON CLUSTER)
- Integrate into `copy_tables()` for automatic workload copying
- Update frontend to display copied workloads and any errors
- Add unit tests for topological sort

## Test plan
- [x] Unit tests for topological sort pass
- [x] Manual test via admin UI with dry_run=true - should show workloads in response
- [x] Execute copy and verify: `SELECT name FROM system.workloads` on all nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)