### PR TITLE
feat(gocd): Add canary deployment stage for DE region

### DIFF
--- a/gocd/templates/pipelines/snuba-py.libsonnet
+++ b/gocd/templates/pipelines/snuba-py.libsonnet
@@ -144,6 +144,30 @@ local deploy_canary_stage(region) =
         },
       },
     ]
+  else if region == 'de' then
+    [
+      {
+        'deploy-canary': {
+          fetch_materials: true,
+          jobs: {
+            'deploy-canary': {
+              timeout: 1200,
+              elastic_profile_id: 'snuba',
+              environment_variables: {
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
+                DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
+                DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
+                LABEL_SELECTOR: 'service=snuba,is_canary=true',
+              },
+              tasks: [
+                gocdtasks.script(importstr '../bash/deploy-py.sh'),
+                gocdtasks.script(importstr '../bash/canary-ddog-health-check.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ]
   else
     [];
 

--- a/gocd/templates/pipelines/snuba-rs.libsonnet
+++ b/gocd/templates/pipelines/snuba-rs.libsonnet
@@ -101,6 +101,30 @@ local deploy_canary_stage(region) =
         },
       },
     ]
+  else if region == 'de' then
+    [
+      {
+        'deploy-canary': {
+          fetch_materials: true,
+          jobs: {
+            'deploy-canary': {
+              timeout: 1200,
+              elastic_profile_id: 'snuba',
+              environment_variables: {
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
+                DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
+                DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
+                LABEL_SELECTOR: 'service=snuba,is_canary=true',
+              },
+              tasks: [
+                gocdtasks.script(importstr '../bash/deploy-rs.sh'),
+                gocdtasks.script(importstr '../bash/canary-ddog-health-check.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ]
   else
     [];
 


### PR DESCRIPTION
https://linear.app/getsentry/issue/EAP-394/inc-2030-de-primary-shouldnt-have-deployed-when-the-canary-failed

- Add deploy-canary job to DE region in both snuba-py and snuba-rs pipelines
- the job does healthchecks (https://app.datadoghq.com/monitors/140973101)

