### PR TITLE
ref: Add Claude Code project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,87 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(pwd:*)",
+      "Bash(find:*)",
+      "Bash(file:*)",
+      "Bash(stat:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(cat:*)",
+      "Bash(tree:*)",
+
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git tag:*)",
+      "Bash(git stash list:*)",
+      "Bash(git rev-parse:*)",
+
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run logs:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh api:*)",
+
+      "Bash(python --version:*)",
+      "Bash(python3 --version:*)",
+      "Bash(uv pip list:*)",
+      "Bash(uv tree:*)",
+
+      "Bash(node --version:*)",
+      "Bash(yarn list:*)",
+      "Bash(yarn info:*)",
+      "Bash(yarn why:*)",
+      "Bash(tsc --version:*)",
+
+      "Bash(rustc --version:*)",
+      "Bash(cargo --version:*)",
+      "Bash(cargo tree:*)",
+      "Bash(cargo metadata:*)",
+
+      "Bash(docker --version:*)",
+      "Bash(docker ps:*)",
+      "Bash(docker images:*)",
+      "Bash(docker-compose ps:*)",
+      "Bash(docker-compose config:*)",
+
+      "Bash(make --version:*)",
+      "Bash(make -n:*)",
+
+      "Skill(sentry-skills:commit)",
+      "Skill(sentry-skills:create-pr)",
+      "Skill(sentry-skills:code-review)",
+      "Skill(sentry-skills:find-bugs)",
+      "Skill(sentry-skills:iterate-pr)",
+      "Skill(sentry-skills:claude-settings-audit)",
+      "Skill(sentry-skills:agents-md)",
+      "Skill(sentry-skills:brand-guidelines)",
+      "Skill(sentry-skills:doc-coauthoring)",
+      "Skill(sentry-skills:security-review)",
+      "Skill(sentry-skills:django-perf-review)",
+      "Skill(sentry-skills:code-simplifier)",
+      "Skill(sentry-skills:skill-creator)",
+
+      "WebFetch(domain:docs.sentry.io)",
+      "WebFetch(domain:develop.sentry.dev)",
+      "WebFetch(domain:docs.github.com)",
+      "WebFetch(domain:cli.github.com)",
+      "WebFetch(domain:flask.palletsprojects.com)",
+      "WebFetch(domain:docs.docker.com)",
+      "WebFetch(domain:docs.rs)",
+      "WebFetch(domain:doc.rust-lang.org)"
+    ],
+    "deny": []
+  }
+}


### PR DESCRIPTION
Add shared `.claude/settings.json` with auto-allow rules for read-only
commands so contributors using Claude Code don't get prompted for every
non-mutating operation.

Covers: git read commands, gh CLI, uv/yarn/cargo introspection, docker
and make read-only commands, Sentry skills, and documentation domains
for WebFetch.