### PR TITLE
feat(rust-consumer): Increase ClickHouse insert max retries to 9

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -132,7 +132,7 @@ impl Default for RetryConfig {
     fn default() -> Self {
         Self {
             initial_backoff_ms: 500.0,
-            max_retries: 4,
+            max_retries: 9,
             jitter_factor: 0.2,
         }
     }


### PR DESCRIPTION
## Summary
- Increases the default `max_retries` from 4 to 9 (10 total attempts) for ClickHouse inserts in the rust consumer
- With exponential backoff (500ms initial), the new retry schedule is:
  - Attempt 0: 500ms
  - Attempt 1: 1s
  - Attempt 2: 2s
  - Attempt 3: 4s
  - Attempt 4: 8s
  - Attempt 5: 16s
  - Attempt 6: 32s
  - Attempt 7: 64s
  - Attempt 8: 128s
  - Total max delay: ~4 minutes across all retries

## Test plan
- [ ] Verify rust tests pass
- [ ] Deploy to staging and monitor ClickHouse insert error rates

🤖 Generated with [Claude Code](https://claude.ai/code)