### PR TITLE
fix: make pytest param ids unique, set config explicitly

### DIFF
--- a/tests/datasets/entities/storage_selectors/test_errors.py
+++ b/tests/datasets/entities/storage_selectors/test_errors.py
@@ -114,6 +114,8 @@ def test_query_storage_selector(
 
     if use_readable:
         state.set_config("enable_events_readonly_table", True)
+    else:
+        state.set_config("enable_events_readonly_table", False)
     selected_storage = selector.select_storage(
         query, HTTPQuerySettings(referrer="r"), storage_connections
     )


### PR DESCRIPTION
not sure why  `test_query_storage_selector` tests on master are failing because the recent changes I've made haven't changed that test. since the ids of the tests are the same, its hard to tell which is which so making the ids unique. also setting the `enable_events_readonly_table` config explicitly when its not `use_readable` since that might be the issues