### PR TITLE
fix(lw-deletions): Use runtime config for max_ongoing_mutations

### DIFF
--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -169,7 +169,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
         max_ongoing_mutations = typing.cast(
             int,
             get_int_config(
-                "max_ongoing_mutatations_for_delete",
+                "max_ongoing_mutations_for_delete",
                 default=settings.MAX_ONGOING_MUTATIONS_FOR_DELETE,
             ),
         )


### PR DESCRIPTION
The `get_int_config` result for `max_ongoing_mutatations_for_delete` was being
immediately overwritten by the hardcoded `settings.MAX_ONGOING_MUTATIONS_FOR_DELETE`
value, making the runtime config key a no-op for the lightweight deletes consumer.

This removes the overwrite so the runtime config is actually respected, matching
the behavior in the synchronous delete path (`web/delete_query.py`). The
`settings.MAX_ONGOING_MUTATIONS_FOR_DELETE` value is still used as the default
fallback when no runtime config is set.