### PR TITLE
feat(lw-deletions): Add --no-batch CLI flag to process deletes individually

### DIFF
--- a/snuba/cli/lw_deletions_consumer.py
+++ b/snuba/cli/lw_deletions_consumer.py
@@ -86,6 +86,12 @@ logger = logging.getLogger(__name__)
     default=None,
     help="Kafka group instance id. passing a value here will run kafka with static membership.",
 )
+@click.option(
+    "--no-batch",
+    is_flag=True,
+    default=False,
+    help="Disable batching. Each delete message is processed individually.",
+)
 def lw_deletions_consumer(
     *,
     consumer_group: str,
@@ -99,6 +105,7 @@ def lw_deletions_consumer(
     queued_min_messages: int,
     log_level: str,
     group_instance_id: Optional[str],
+    no_batch: bool,
 ) -> None:
     setup_logging(log_level)
     setup_sentry()
@@ -172,6 +179,7 @@ def lw_deletions_consumer(
             storage=writable_storage,
             formatter=formatter,
             metrics=metrics,
+            no_batch=no_batch,
         )
 
         consumer = consumer_builder.build_lw_deletions_consumer(strategy_factory)

--- a/snuba/lw_deletions/formatters.py
+++ b/snuba/lw_deletions/formatters.py
@@ -62,7 +62,10 @@ class SearchIssuesFormatter(Formatter):
 
         return [
             ConditionsBag(
-                column_conditions={"project_id": [project_id], "group_id": list(group_ids)}
+                column_conditions={
+                    "project_id": [project_id],
+                    "group_id": list(group_ids),
+                }
             )
             for project_id, group_ids in mapping.items()
         ]
@@ -109,7 +112,5 @@ class EAPItemsFormatter(Formatter):
 
 STORAGE_FORMATTER: Mapping[str, Type[Formatter]] = {
     StorageKey.SEARCH_ISSUES.value: SearchIssuesFormatter,
-    # TODO: We will probably do something more sophisticated here in the future
-    # but it won't make much of a difference until we support delete by attribute
     StorageKey.EAP_ITEMS.value: EAPItemsFormatter,
 }

--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -18,7 +18,7 @@ from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.lw_deletions.batching import BatchStepCustom, ValuesBatch
+from snuba.lw_deletions.batching import BatchStepCustom, NoBatchStep, ValuesBatch
 from snuba.lw_deletions.formatters import Formatter
 from snuba.lw_deletions.types import ConditionsBag
 from snuba.query.allocation_policies import AllocationPolicyViolations
@@ -211,24 +211,29 @@ class LWDeletionsConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
         storage: WritableTableStorage,
         formatter: Formatter,
         metrics: MetricsBackend,
+        no_batch: bool = False,
     ) -> None:
         self.max_batch_size = max_batch_size
         self.max_batch_time_ms = max_batch_time_ms
         self.storage = storage
         self.formatter = formatter
         self.metrics = metrics
+        self.no_batch = no_batch
 
     def create_with_partitions(
         self,
         commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
-        batch_step = BatchStepCustom(
-            max_batch_size=self.max_batch_size,
-            max_batch_time=(self.max_batch_time_ms / 1000),
-            next_step=FormatQuery(
-                CommitOffsets(commit), self.storage, self.formatter, self.metrics
-            ),
-            increment_by=increment_by,
+        format_query = FormatQuery(
+            CommitOffsets(commit), self.storage, self.formatter, self.metrics
         )
-        return batch_step
+        if self.no_batch:
+            return NoBatchStep(next_step=format_query)
+        else:
+            return BatchStepCustom(
+                max_batch_size=self.max_batch_size,
+                max_batch_time=(self.max_batch_time_ms / 1000),
+                next_step=format_query,
+                increment_by=increment_by,
+            )


### PR DESCRIPTION
Add a `--no-batch` flag to the lightweight deletions consumer CLI that
causes each delete message to be processed individually instead of being
accumulated into batches.

The consumer currently batches messages using `BatchStepCustom`, which
accumulates Kafka messages until a row count threshold (default 100k) or
time threshold (default 120s) is reached. Since we've observed some mutations
that max out CPU, take a very long time, and have extremely complicated batching conditions
(`"attributes_string["group_id"] = x OR attributes_string["group_id"] = y ...` * 100)
we want to see if CPU usage can be reduced by reducing the complexity of
scanning (but also probably slowing down processing)

Changes:
- Add `NoBatchStep` processing strategy in `batching.py` that wraps each
  message into a single-element batch and submits immediately
- Add `no_batch` parameter to `LWDeletionsConsumerStrategyFactory` to
  select between `BatchStepCustom` and `NoBatchStep`
- Add `--no-batch` click option to the CLI entry point