### PR TITLE
perf(lw-deletions): Sample too_many_ongoing_mutations metric at 1%

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -141,6 +141,7 @@ DOGSTATSD_HOST, DOGSTATSD_PORT = get_statsd_addr()
 DOGSTATSD_SAMPLING_RATES = {
     "metrics.processor.set.size": 0.1,
     "metrics.processor.distribution.size": 0.1,
+    "lw_deletions_consumer.too_many_ongoing_mutations": 0.01,
 }
 DDM_METRICS_SAMPLE_RATE = float(os.environ.get("SNUBA_DDM_METRICS_SAMPLE_RATE", 0.01))
 


### PR DESCRIPTION
The `too_many_ongoing_mutations` metric is emitted very frequently during backpressure periods. Add a 1% sample rate via `DOGSTATSD_SAMPLING_RATES` to reduce Datadog ingest volume while still providing sufficient signal for monitoring and alerting.