### PR TITLE
fix(eap-items): Serialize EAPValue as untagged in attributes_array

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -177,6 +177,7 @@ macro_rules! seq_attrs {
 }
 
 #[derive(Debug, Serialize, PartialEq)]
+#[serde(untagged)]
 enum EAPValue {
     String(String),
     Bool(bool),

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -53,23 +53,9 @@ Tout = TypeVar("Tout", bound=ProtobufMessage)
 BUCKET_COUNT = 40
 
 
-def transform_array_value(value: dict[str, str]) -> Any:
-    for t, v in value.items():
-        if t == "Int":
-            return int(v)
-        if t == "Double":
-            return float(v)
-        if t in {"String", "Bool"}:
-            return v
-    raise BadSnubaRPCRequestException(f"array value type unknown: {type(v)}")
-
-
 def process_arrays(raw: str) -> dict[str, list[Any]]:
     parsed = json.loads(raw) or {}
-    arrays = {}
-    for key, values in parsed.items():
-        arrays[key] = [transform_array_value(v) for v in values]
-    return arrays
+    return {key: list(values) for key, values in parsed.items()}
 
 
 def _check_non_string_values_cannot_ignore_case(

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -54,8 +54,7 @@ BUCKET_COUNT = 40
 
 
 def process_arrays(raw: str) -> dict[str, list[Any]]:
-    parsed = json.loads(raw) or {}
-    return {key: list(values) for key, values in parsed.items()}
+    return json.loads(raw) or {}
 
 
 def _check_non_string_values_cannot_ignore_case(

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -215,7 +215,9 @@ def _build_query(
         SelectedExpression("attributes_bool", column("attributes_bool", alias="attributes_bool")),
         SelectedExpression(
             "attributes_array",
-            FunctionCall("attributes_array", "toJSONString", (column("attributes_array"),)),
+            FunctionCall(
+                "attributes_array", "CAST", (column("attributes_array"), literal("String"))
+            ),
         ),
     ]
 

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -230,8 +230,8 @@ def _build_query(
                 name="attributes_array",
                 expression=FunctionCall(
                     "attributes_array",
-                    "toJSONString",
-                    (column("attributes_array"),),
+                    "CAST",
+                    (column("attributes_array"), literal("String")),
                 ),
             ),
         ]


### PR DESCRIPTION
Add `#[serde(untagged)]` to the `EAPValue` enum so that array attribute
values in `attributes_array` are serialized as plain values (e.g. `123`,
`"hello"`, `3.14`, `true`) instead of tagged objects (e.g. `{"Int": 123}`,
`{"String": "hello"}`).

The tagged representation included the enum variant name as a key, which
is not expected by downstream consumers that only need the raw values.


Agent transcript: https://claudescope.sentry.dev/share/Q6CFyxDoBsOrL1Z2w3da6gOTLnKW426exXCS65Bhk-Q