### PR TITLE
feat(api): return TOO_MANY_BYTES as clickhouse error instead of 429

### DIFF
--- a/snuba/web/constants.py
+++ b/snuba/web/constants.py
@@ -16,6 +16,8 @@ ACCEPTABLE_CLICKHOUSE_ERROR_CODES = {
     *CLICKHOUSE_TYPING_ERROR_CODES,
     # queries that can never return the amount of data requested by the user are not an internal error
     ErrorCodes.MEMORY_LIMIT_EXCEEDED,
+    # query exceeded the max_bytes_to_read limit set by an allocation policy
+    ErrorCodes.TOO_MANY_BYTES,
 }
 
 NON_RETRYABLE_CLICKHOUSE_ERROR_CODES = {

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -476,12 +476,6 @@ def _raw_query(
         elif isinstance(cause, ClickhouseError):
             error_code = cause.code
             status = get_query_status_from_error_codes(error_code)
-            if error_code == ErrorCodes.TOO_MANY_BYTES:
-                calculated_cause = RateLimitExceeded(
-                    "Query scanned more than the allocated amount of bytes",
-                    quota_allowance=stats["quota_allowance"],
-                )
-
             with configure_scope() as scope:
                 fingerprint = ["{{default}}", str(cause.code), dataset_name]
                 if error_code not in constants.CLICKHOUSE_SYSTEMATIC_FAILURES:

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1375,9 +1375,7 @@ class TestSnQLApi(BaseApiTest):
                 },
             }
 
-            assert (
-                response.json["stats"]["quota_allowance"] == expected_quota_allowance
-            )
+            assert response.json["stats"]["quota_allowance"] == expected_quota_allowance
 
     def test_allocation_policy_violation(self) -> None:
         with patch(

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1329,15 +1329,10 @@ class TestSnQLApi(BaseApiTest):
                     }
                 ),
             )
-            # TOO_MANY_BYTES is a clickhouse error, not a rate limit.
-            # The response should surface the clickhouse error type and code
-            # so that consumers (e.g. sentry) can distinguish it from
-            # snuba-level rate limiting.
             assert response.status_code == 400
             assert response.json["error"]["type"] == "clickhouse"
             assert response.json["error"]["code"] == 307
 
-            # quota_allowance should still be available in stats
             expected_quota_allowance = {
                 "details": {
                     "MaxBytesPolicy123": {

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1329,13 +1329,15 @@ class TestSnQLApi(BaseApiTest):
                     }
                 ),
             )
-            assert response.status_code == 429
+            # TOO_MANY_BYTES is a clickhouse error, not a rate limit.
+            # The response should surface the clickhouse error type and code
+            # so that consumers (e.g. sentry) can distinguish it from
+            # snuba-level rate limiting.
+            assert response.status_code == 400
+            assert response.json["error"]["type"] == "clickhouse"
+            assert response.json["error"]["code"] == 307
 
-            assert (
-                response.json["error"]["message"]
-                == "Query scanned more than the allocated amount of bytes"
-            )
-
+            # quota_allowance should still be available in stats
             expected_quota_allowance = {
                 "details": {
                     "MaxBytesPolicy123": {
@@ -1373,7 +1375,9 @@ class TestSnQLApi(BaseApiTest):
                 },
             }
 
-            assert response.json["quota_allowance"] == expected_quota_allowance
+            assert (
+                response.json["stats"]["quota_allowance"] == expected_quota_allowance
+            )
 
     def test_allocation_policy_violation(self) -> None:
         with patch(


### PR DESCRIPTION
Stop converting ClickHouse TOO_MANY_BYTES (code 307) errors into RateLimitExceeded. This lets consumers (e.g. sentry) distinguish "query scanned too many bytes" from snuba-level rate limiting.