### PR TITLE
feat(cogs): add query-time COGS tracking for EAP

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -35,12 +35,13 @@ _ITEM_TYPE_TO_APP_FEATURE: dict[str, str] = {
     "TRACE_ITEM_TYPE_ATTACHMENT": "attachments",
     "TRACE_ITEM_TYPE_PREPROD": "preprod",
     "TRACE_ITEM_TYPE_USER_SESSION": "sessions",
+    "TRACE_ITEM_TYPE_UNSPECIFIED": "null",
 }
 
 
 def _get_eap_app_feature(request: Request) -> str:
     item_type = request.original_body.get("meta", {}).get("traceItemType", "")
-    return _ITEM_TYPE_TO_APP_FEATURE.get(item_type, "eap")
+    return _ITEM_TYPE_TO_APP_FEATURE.get(item_type, "null")
 
 
 def _record_timer_metrics(


### PR DESCRIPTION
EAP-382

  The EAP ClickHouse cluster was not
  tracked for query-time COGS. Some products 
  ingest relatively little data but generate heavy query load, so their
  actual compute cost was invisible.

  This emits per-item-type app_feature
  (spans/errors/our_logs/uptime/etc.), matching the same app_feature
  values used by the Rust EAPItemsProcessor at ingest time.

  The Terraform cluster_clickhouse module labels GCP compute instances
  with shared_resource_id = node_shared_resource_id (subsystem=compute)
  and GCP disks with shared_resource_id = storage_shared_resource_id
  (subsystem=storage). All EAP ClickHouse nodes have
  node_shared_resource_id=clickhouse, so compute billing for those
  nodes carries shared_resource_id=clickhouse in the GCP billing export.
  Emitting resource_id=clickhouse from the Snuba API therefore maps
  directly onto that compute billing — queries consume compute, not disk.
  Disk costs (storage_shared_resource_id=storage) remain attributed
  via the existing ingest-time proxy in the ETL, which is correct since
  storage size is driven by ingest volume, not query patterns.

  The ETL shared_resources_app_feature_ratio.sql already has a fallback
  mapping clickhouse → [eap_items_processor] for days with no
  query emissions. Once this change is live and
  snuba_api_eap_cogs_probability is ramped, direct query-time ratios
  take over automatically; no ETL or ops changes are needed.

