### PR TITLE
fix(tests): Fix flaky errors storage selector test

### DIFF
--- a/tests/datasets/entities/storage_selectors/test_errors.py
+++ b/tests/datasets/entities/storage_selectors/test_errors.py
@@ -109,11 +109,12 @@ def test_query_storage_selector(
     use_readable: bool,
     expected_storage: Storage,
 ) -> None:
+    if use_readable:
+        state.set_config("enable_events_readonly_table", True)
+
     query = parse_snql_query(str(snql_query), dataset)
     assert isinstance(query, Query)
 
-    if use_readable:
-        state.set_config("enable_events_readonly_table", True)
     selected_storage = selector.select_storage(
         query, HTTPQuerySettings(referrer="r"), storage_connections
     )


### PR DESCRIPTION
Maybe fixes https://linear.app/getsentry/issue/EAP-429/fix-or-ignore-flaky-unit-test-failure-in-test-query-storage-selector 🤷 

Move `set_config` call before `parse_snql_query` in `test_query_storage_selector` to fix an intermittent test failure.

`parse_snql_query` internally calls `state.get_configs()` (via `_replace_time_condition`), which populates the in-memory memoize cache on `get_raw_configs` with an empty dict from the freshly-flushed Redis. When `set_config` then writes to Redis, the memoize cache is not invalidated. The subsequent `get_config` call inside the storage selector can return the stale cached empty dict if `time.time()` hasn't advanced between the two `get_raw_configs` calls — the memoize uses strict `>` with `CONFIG_MEMOIZE_TIMEOUT=0`, so identical timestamps cause a cache hit.

By setting the config before parsing, the value is already in Redis when `get_raw_configs` first populates the cache, so the selector always sees it.

Reproduced locally by freezing `time.time()` to a constant value, which reliably triggers the stale-cache path and produces the exact `WritableTableStorage != ReadableTableStorage` assertion error seen in CI.