### PR TITLE
feat(gocd): Block rust consumer deploys to US during peak hours

### DIFF
--- a/gocd/templates/bash/check-peak-hours.sh
+++ b/gocd/templates/bash/check-peak-hours.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Prevent rust consumer deploys to US during peak hours (6am-10am PT)
+# to avoid expensive kafka rebalances that cause backlog processing
+# and high clickhouse insert load (especially eap-items).
+
+current_hour=$(TZ="America/Los_Angeles" date +"%H")
+
+if [ "$current_hour" -ge 6 ] && [ "$current_hour" -lt 10 ]; then
+  echo "ERROR: Rust consumer deploys to US are blocked during peak hours (6am-10am PT)."
+  echo "Current time in PT: $(TZ='America/Los_Angeles' date +'%H:%M %Z')"
+  echo "Deploys cause expensive kafka rebalances that backlog processing"
+  echo "and can cause too many inserts/s on clickhouse."
+  echo "You can feel free to override this via the GoCD UI for an urgent change."
+  exit 1
+fi
+
+echo "Current time in PT: $(TZ='America/Los_Angeles' date +'%H:%M %Z') - outside peak hours, proceeding."

--- a/gocd/templates/pipelines/snuba-rs.libsonnet
+++ b/gocd/templates/pipelines/snuba-rs.libsonnet
@@ -64,6 +64,25 @@ local saas_health_check(region) =
     [];
 
 
+local peak_hours_check(region) =
+  if region == 'us' then
+    [
+      {
+        'check-peak-hours': {
+          jobs: {
+            'check-peak-hours': {
+              elastic_profile_id: 'snuba',
+              tasks: [
+                gocdtasks.script(importstr '../bash/check-peak-hours.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ]
+  else
+    [];
+
 local deploy_canary_stage(region) =
   if region == 'us' then
     [
@@ -169,7 +188,7 @@ function(region) {
       },
     },
 
-  ] + deploy_canary_stage(region) + [
+  ] + peak_hours_check(region) + deploy_canary_stage(region) + [
 
     {
       'deploy-primary': {


### PR DESCRIPTION
Block rust consumer deploys to the US region during peak hours (6am-10am PT) to avoid expensive kafka rebalances that cause processing backlogs and excessive clickhouse insert rates, particularly from eap-items.

Adds a `check-peak-hours` stage to the `snuba-rs` US pipeline that runs after the existing checks but before canary/primary deploy. The stage checks the current Pacific Time and fails with a descriptive error if it's within the peak window. Other regions are unaffected. The check can be overridden via the GoCD UI for urgent changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)