### PR TITLE
chore(gocd): bump gocd-jsonnet to v2.19.0 to disable fetch_materials on pipeline-complete

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.18.0"
+      "version": "v2.19.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "3b7e3b151fb20d21d66c2f04d17a740ba0b09ac0",
-      "sum": "cgfkKWTz+bBKHa8WVji1v4Ke5JM3bTeMnqPtYZuy9VM="
+      "version": "56cc4d91cbaac4569b37b4911998b48c2f9c2ac4",
+      "sum": "J0D//go/146qfReWFTTL5xWWCVlkTjqhnALYPH4Z9rE="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
- Bumps `gocd-jsonnet` from v2.18.0 to v2.19.0
- v2.19.0 sets `fetch_materials: false` on all `pipeline-complete` stages, eliminating unnecessary git material fetching that was causing multi-minute delays on the single static GoCD agent
- Addresses [DI-1685](https://linear.app/getsentry/issue/DI-1685)

Note: this should make your pipelines faster by a few seconds.