### PR TITLE
feat(eap): Split LW deletions batch by org_ids_delete_allowlist

### DIFF
--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -78,36 +78,40 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
     def poll(self) -> None:
         self.__next_step.poll()
 
-    # TODO: _is_execute_enabled is for EAP testing purposes, this should be removed after launch
-    def _is_execute_enabled(self, conditions: Sequence[ConditionsBag]) -> bool:
+    # TODO: _filter_allowed_conditions is for EAP testing purposes, this should be removed after launch
+    def _filter_allowed_conditions(
+        self, conditions: Sequence[ConditionsBag]
+    ) -> Sequence[ConditionsBag]:
         if self.__storage.get_storage_key() != StorageKey.EAP_ITEMS:
-            return True
+            return conditions
 
-        query_org_ids: list[int] = [
-            int(org_id)
-            for cond in conditions
-            for org_id in cond.column_conditions.get("organization_id", [])
-        ]
-        assert len(query_org_ids) > 0, "No organization IDs found in conditions"
-        # allowlist not being set implicitly allows all
-        if get_str_config("org_ids_delete_allowlist", "") == "":
-            return True
-        else:
-            str_config = get_str_config("org_ids_delete_allowlist", "")
-            assert str_config
-            org_ids_delete_allowlist = set([int(org_id) for org_id in str_config.split(",")])
-            logger.info(f"query conditions: {conditions}, allowlist: {org_ids_delete_allowlist}")
-            return org_ids_delete_allowlist.issuperset(query_org_ids)
+        str_config = get_str_config("org_ids_delete_allowlist", "")
+        if not str_config:
+            return conditions  # allowlist not set → allow all
+
+        org_ids_delete_allowlist = set(int(org_id) for org_id in str_config.split(","))
+
+        allowed = []
+        for cond in conditions:
+            query_org_ids = [
+                int(org_id) for org_id in cond.column_conditions.get("organization_id", [])
+            ]
+            assert len(query_org_ids) > 0, "No organization IDs found in conditions"
+            if org_ids_delete_allowlist.issuperset(query_org_ids):
+                allowed.append(cond)
+            else:
+                self.__metrics.increment("delete_skipped")
+        return allowed
 
     def submit(self, message: Message[ValuesBatch[KafkaPayload]]) -> None:
         decode_messages = [rapidjson.loads(m.payload.value) for m in message.value.payload]
         conditions = self.__formatter.format(decode_messages)
 
+        allowed_conditions = self._filter_allowed_conditions(conditions)
+
         try:
-            if self._is_execute_enabled(conditions):
-                self._execute_delete(conditions)
-            else:
-                self.__metrics.increment("delete_skipped")
+            if allowed_conditions:
+                self._execute_delete(allowed_conditions)
         except TooManyOngoingMutationsError:
             # backpressure is applied while we wait for the
             # currently ongoing mutations to finish

--- a/tests/lw_deletions/test_lw_deletions.py
+++ b/tests/lw_deletions/test_lw_deletions.py
@@ -14,7 +14,7 @@ from snuba.clusters.cluster import ClickhouseNode
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.lw_deletions.batching import BatchStepCustom
-from snuba.lw_deletions.formatters import SearchIssuesFormatter
+from snuba.lw_deletions.formatters import EAPItemsFormatter, SearchIssuesFormatter
 from snuba.lw_deletions.strategy import FormatQuery, increment_by
 from snuba.lw_deletions.types import ConditionsType
 from snuba.redis import RedisClientKey, get_redis_client
@@ -485,3 +485,147 @@ def test_partition_date_filtering(mock_execute: Mock, mock_num_mutations: Mock) 
     ]
     assert len(filtered_calls) == 1
     assert filtered_calls[0][1]["value"] == 2
+
+
+def _get_eap_message(rows: int, conditions: ConditionsType) -> DeleteQueryMessage:
+    return {
+        "rows_to_delete": rows,
+        "storage_name": "eap_items",
+        "conditions": conditions,
+        "tenant_ids": {"project_id": 1, "organization_id": 1},
+    }
+
+
+def _make_eap_message(
+    rows: int = 10, conditions: ConditionsType | None = None
+) -> Message[KafkaPayload]:
+    if conditions is None:
+        conditions = {"organization_id": [1], "project_id": [1]}
+    return Message(
+        BrokerValue(
+            KafkaPayload(
+                None,
+                rapidjson.dumps(_get_eap_message(rows, conditions)).encode("utf-8"),
+                [],
+            ),
+            Partition(Topic(SnubaTopic.LW_DELETIONS_GENERIC_EVENTS.value), 0),
+            0,
+            datetime(1970, 1, 1),
+        )
+    )
+
+
+@patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
+@patch("snuba.lw_deletions.strategy._execute_query")
+@pytest.mark.redis_db
+def test_allowlist_partial_batch(mock_execute: Mock, mock_num_mutations: Mock) -> None:
+    """
+    Batch with 2 conditions (org 1 and org 2), allowlist = "1".
+    Only org 1's conditions should be executed; org 2 is skipped.
+    Offsets are always committed.
+    """
+    commit_step = Mock()
+    metrics = Mock()
+    storage = get_writable_storage(StorageKey("eap_items"))
+
+    state.set_config("org_ids_delete_allowlist", "1")
+
+    format_query = FormatQuery(commit_step, storage, EAPItemsFormatter(), metrics)
+
+    # Build a batch with two messages: org 1 (allowed) and org 2 (not allowed)
+    msg1 = _make_eap_message(5, {"organization_id": [1], "project_id": [1]})
+    msg2 = _make_eap_message(5, {"organization_id": [2], "project_id": [2]})
+
+    strategy = BatchStepCustom(
+        max_batch_size=20,
+        max_batch_time=1000,
+        next_step=format_query,
+        increment_by=increment_by,
+    )
+    strategy.submit(msg1)
+    strategy.submit(msg2)
+    strategy.join(2.0)
+
+    # _execute_query is called once per table (4 tables) but only with org 1's conditions
+    assert mock_execute.call_count == 4
+    assert commit_step.submit.call_count == 1
+
+    # delete_skipped metric incremented once (for org 2)
+    skipped_calls = [c for c in metrics.increment.call_args_list if c[0][0] == "delete_skipped"]
+    assert len(skipped_calls) == 1
+
+
+@patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
+@patch("snuba.lw_deletions.strategy._execute_query")
+@pytest.mark.redis_db
+def test_allowlist_all_blocked(mock_execute: Mock, mock_num_mutations: Mock) -> None:
+    """
+    All conditions have unallowed org IDs. _execute_query should not be called,
+    but offsets should still be committed.
+    """
+    commit_step = Mock()
+    metrics = Mock()
+    storage = get_writable_storage(StorageKey("eap_items"))
+
+    state.set_config("org_ids_delete_allowlist", "999")
+
+    format_query = FormatQuery(commit_step, storage, EAPItemsFormatter(), metrics)
+
+    msg1 = _make_eap_message(5, {"organization_id": [1], "project_id": [1]})
+    msg2 = _make_eap_message(5, {"organization_id": [2], "project_id": [2]})
+
+    strategy = BatchStepCustom(
+        max_batch_size=20,
+        max_batch_time=1000,
+        next_step=format_query,
+        increment_by=increment_by,
+    )
+    strategy.submit(msg1)
+    strategy.submit(msg2)
+    strategy.join(2.0)
+
+    # No deletes executed
+    assert mock_execute.call_count == 0
+    # Offsets still committed
+    assert commit_step.submit.call_count == 1
+
+    # delete_skipped incremented for each blocked condition
+    skipped_calls = [c for c in metrics.increment.call_args_list if c[0][0] == "delete_skipped"]
+    assert len(skipped_calls) == 2
+
+
+@patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
+@patch("snuba.lw_deletions.strategy._execute_query")
+@pytest.mark.redis_db
+def test_allowlist_all_allowed(mock_execute: Mock, mock_num_mutations: Mock) -> None:
+    """
+    All conditions have allowed org IDs. Normal execution, no delete_skipped.
+    """
+    commit_step = Mock()
+    metrics = Mock()
+    storage = get_writable_storage(StorageKey("eap_items"))
+
+    state.set_config("org_ids_delete_allowlist", "1,2")
+
+    format_query = FormatQuery(commit_step, storage, EAPItemsFormatter(), metrics)
+
+    msg1 = _make_eap_message(5, {"organization_id": [1], "project_id": [1]})
+    msg2 = _make_eap_message(5, {"organization_id": [2], "project_id": [2]})
+
+    strategy = BatchStepCustom(
+        max_batch_size=20,
+        max_batch_time=1000,
+        next_step=format_query,
+        increment_by=increment_by,
+    )
+    strategy.submit(msg1)
+    strategy.submit(msg2)
+    strategy.join(2.0)
+
+    # Normal execution: 4 tables
+    assert mock_execute.call_count == 4
+    assert commit_step.submit.call_count == 1
+
+    # No delete_skipped
+    skipped_calls = [c for c in metrics.increment.call_args_list if c[0][0] == "delete_skipped"]
+    assert len(skipped_calls) == 0


### PR DESCRIPTION
Split the `org_ids_delete_allowlist` filtering in the LW deletions consumer
from all-or-nothing to per-condition. Previously if any org ID in a batch
wasn't in the allowlist, the entire batch was skipped. Now each condition is
evaluated independently — allowed orgs proceed with deletion while unallowed
ones are skipped with a `delete_skipped` metric. Offsets are always committed
regardless, so the consumer advances in either case

Renames `_is_execute_enabled` → `_filter_allowed_conditions` which returns
the filtered `Sequence[ConditionsBag]` instead of a boolean. The `submit()`
method executes only if the filtered list is non-empty.

This is safe because `EAPItemsFormatter` produces one `ConditionsBag` per
Kafka message with no cross-message merging, so org IDs are never mixed
across conditions.