### PR TITLE
ref(gocd): add eap-accepted-outcomes-consumer

### DIFF
--- a/gocd/templates/bash/deploy-rs.sh
+++ b/gocd/templates/bash/deploy-rs.sh
@@ -7,6 +7,7 @@ eval $(regions-project-env-vars --region="${SENTRY_REGION}")
   --label-selector="${LABEL_SELECTOR}" \
   --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
   --container-name="consumer" \
+  --container-name="eap-accepted-outcomes-consumer" \
   --container-name="eap-items-consumer" \
   --container-name="errors-replacer" \
   --container-name="generic-metrics-counters-consumer" \


### PR DESCRIPTION
Need this in order to be able to deploy https://github.com/getsentry/ops/pull/19551 via k8s