### PR TITLE
feat(clickhouse): Add runtime override for INSERT load balancing settings

### DIFF
--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -144,6 +144,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
             self.storage_config.clickhouse_table_name.clone(),
             false,
             &self.clickhouse_concurrency,
+            self.storage_config.name.clone(),
         );
 
         let accumulator = Arc::new(
@@ -325,6 +326,7 @@ impl ConsumerStrategyFactoryV2 {
             self.storage_config.clickhouse_cluster.clone(),
             self.storage_config.clickhouse_table_name.clone(),
             &self.clickhouse_concurrency,
+            self.storage_config.name.clone(),
         );
 
         let accumulator = Arc::new(

--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -48,6 +48,29 @@ pub fn get_str_config(key: &str) -> Result<Option<String>, Error> {
     rv
 }
 
+pub struct LoadBalancingConfig {
+    pub load_balancing: String,
+    pub first_offset: Option<String>,
+}
+
+pub fn get_load_balancing_config(storage_name: &str) -> LoadBalancingConfig {
+    let load_balancing = get_str_config(&format!("clickhouse_load_balancing:{storage_name}"))
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "in_order".to_string());
+
+    let first_offset = get_str_config(&format!(
+        "clickhouse_load_balancing_first_offset:{storage_name}"
+    ))
+    .ok()
+    .flatten();
+
+    LoadBalancingConfig {
+        load_balancing,
+        first_offset,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -57,5 +80,30 @@ mod tests {
         crate::testutils::initialize_python();
         let config = get_str_config("test");
         assert_eq!(config.unwrap(), None);
+    }
+
+    #[test]
+    fn test_load_balancing_config_defaults() {
+        crate::testutils::initialize_python();
+        let config = get_load_balancing_config("lb_defaults_test");
+        assert_eq!(config.load_balancing, "in_order");
+        assert_eq!(config.first_offset, None);
+    }
+
+    #[test]
+    fn test_load_balancing_config_overrides() {
+        crate::testutils::initialize_python();
+        patch_str_config_for_test(
+            "clickhouse_load_balancing:lb_overrides_test",
+            Some("first_or_random"),
+        );
+        patch_str_config_for_test(
+            "clickhouse_load_balancing_first_offset:lb_overrides_test",
+            Some("1"),
+        );
+
+        let config = get_load_balancing_config("lb_overrides_test");
+        assert_eq!(config.load_balancing, "first_or_random");
+        assert_eq!(config.first_offset, Some("1".to_string()));
     }
 }

--- a/rust_snuba/src/strategies/clickhouse/row_binary_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/row_binary_writer.rs
@@ -10,10 +10,12 @@ use sentry_arroyo::types::Message;
 use sentry_arroyo::{counter, timer};
 
 use crate::config::ClickhouseConfig;
+use crate::runtime_config::get_load_balancing_config;
 use crate::types::BytesInsertBatch;
 
 struct RowBinaryTaskRunner<T> {
     client: clickhouse::Client,
+    storage_name: String,
     table: String,
     _phantom: std::marker::PhantomData<T>,
 }
@@ -22,6 +24,7 @@ impl<T> Clone for RowBinaryTaskRunner<T> {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
+            storage_name: self.storage_name.clone(),
             table: self.table.clone(),
             _phantom: std::marker::PhantomData,
         }
@@ -34,14 +37,13 @@ where
     // across threads via RunTaskInThreads.
     T: clickhouse::Row + serde::Serialize + Send + Sync + 'static,
 {
-    fn new(config: &ClickhouseConfig, table: String) -> Self {
+    fn new(config: &ClickhouseConfig, table: String, storage_name: String) -> Self {
         let scheme = if config.secure { "https" } else { "http" };
         let client = clickhouse::Client::default()
             .with_url(format!("{}://{}:{}", scheme, config.host, config.http_port))
             .with_user(&config.user)
             .with_password(&config.password)
             .with_database(&config.database)
-            .with_option("load_balancing", "in_order")
             // Wait for data to be written to all shards before returning success.
             // Without this, inserts return immediately after writing to the local
             // node and data is forwarded asynchronously, risking data loss on failure.
@@ -50,6 +52,7 @@ where
 
         Self {
             client,
+            storage_name,
             table,
             _phantom: std::marker::PhantomData,
         }
@@ -71,6 +74,7 @@ where
     ) -> RunTaskFunc<BytesInsertBatch<()>, anyhow::Error> {
         let client = self.client.clone();
         let table = self.table.clone();
+        let lb_config = get_load_balancing_config(&self.storage_name);
 
         Box::pin(async move {
             let (empty_message, insert_batch) = message.take();
@@ -85,7 +89,7 @@ where
                 tracing::debug!("performing row binary write");
 
                 for attempt in 0..=MAX_RETRIES {
-                    match write_rows(&client, &table, &rows).await {
+                    match write_rows(&client, &table, &rows, &lb_config).await {
                         Ok(()) => break,
                         Err(e) => {
                             if attempt == MAX_RETRIES {
@@ -135,8 +139,14 @@ async fn write_rows<T: clickhouse::Row + serde::Serialize>(
     client: &clickhouse::Client,
     table: &str,
     rows: &[T],
+    lb_config: &crate::runtime_config::LoadBalancingConfig,
 ) -> Result<(), clickhouse::error::Error> {
-    let mut insert = client.insert(table)?;
+    let mut insert = client
+        .insert(table)?
+        .with_option("load_balancing", &lb_config.load_balancing);
+    if let Some(offset) = &lb_config.first_offset {
+        insert = insert.with_option("load_balancing_first_offset", offset);
+    }
     for row in rows {
         insert.write(row).await?;
     }
@@ -158,8 +168,9 @@ where
         cluster_config: ClickhouseConfig,
         table: String,
         concurrency: &ConcurrencyConfig,
+        storage_name: String,
     ) -> Self {
-        let task_runner = RowBinaryTaskRunner::<T>::new(&cluster_config, table);
+        let task_runner = RowBinaryTaskRunner::<T>::new(&cluster_config, table, storage_name);
 
         let inner = RunTaskInThreads::new(
             next_step,

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -13,6 +13,7 @@ use sentry_arroyo::types::Message;
 use sentry_arroyo::{counter, timer};
 
 use crate::config::ClickhouseConfig;
+use crate::runtime_config::get_load_balancing_config;
 use crate::types::{BytesInsertBatch, RowData};
 
 fn clickhouse_task_runner(
@@ -83,11 +84,16 @@ where
         table: String,
         skip_write: bool,
         concurrency: &ConcurrencyConfig,
+        storage_name: String,
     ) -> Self {
         let inner = RunTaskInThreads::new(
             next_step,
             clickhouse_task_runner(
-                Arc::new(ClickhouseClient::new(&cluster_config.clone(), &table)),
+                Arc::new(ClickhouseClient::new(
+                    &cluster_config.clone(),
+                    &table,
+                    storage_name,
+                )),
                 skip_write,
             ),
             concurrency,
@@ -142,12 +148,13 @@ impl Default for RetryConfig {
 pub struct ClickhouseClient {
     client: Client,
     headers: HeaderMap<HeaderValue>,
-    url: String,
+    base_url: String,
+    storage_name: String,
     query: String,
 }
 
 impl ClickhouseClient {
-    pub fn new(config: &ClickhouseConfig, table: &str) -> ClickhouseClient {
+    pub fn new(config: &ClickhouseConfig, table: &str, storage_name: String) -> ClickhouseClient {
         let mut headers = HeaderMap::with_capacity(6);
         headers.insert(CONNECTION, HeaderValue::from_static("keep-alive"));
         headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip,deflate"));
@@ -168,16 +175,28 @@ impl ClickhouseClient {
         let host = &config.host;
         let port = &config.http_port;
 
-        let query_params = "load_balancing=in_order&insert_distributed_sync=1".to_string();
-        let url = format!("{scheme}://{host}:{port}?{query_params}");
+        let base_url = format!("{scheme}://{host}:{port}?insert_distributed_sync=1");
         let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
 
         ClickhouseClient {
             client: Client::new(),
             headers,
-            url,
+            base_url,
+            storage_name,
             query,
         }
+    }
+
+    fn build_url(&self) -> String {
+        let lb_config = get_load_balancing_config(&self.storage_name);
+        let mut url = format!(
+            "{}&load_balancing={}",
+            self.base_url, lb_config.load_balancing
+        );
+        if let Some(offset) = lb_config.first_offset {
+            url.push_str(&format!("&load_balancing_first_offset={offset}"));
+        }
+        url
     }
 
     pub async fn send(&self, body: Vec<u8>, retry_config: RetryConfig) -> anyhow::Result<Response> {
@@ -186,9 +205,10 @@ impl ClickhouseClient {
         let body_bytes = bytes::Bytes::from(body);
 
         for attempt in 0..=retry_config.max_retries {
+            let url = self.build_url();
             let res = self
                 .client
-                .post(&self.url)
+                .post(&url)
                 .headers(self.headers.clone())
                 .query(&[("query", &self.query)])
                 .body(reqwest::Body::from(body_bytes.clone()))
@@ -273,9 +293,8 @@ mod tests {
     use super::*;
     use tokio::time::Instant;
 
-    #[tokio::test]
-    async fn it_works() -> Result<(), reqwest::Error> {
-        let config = ClickhouseConfig {
+    fn make_test_config() -> ClickhouseConfig {
+        ClickhouseConfig {
             host: std::env::var("CLICKHOUSE_HOST").unwrap_or("127.0.0.1".to_string()),
             port: std::env::var("CLICKHOUSE_PORT")
                 .unwrap_or("9000".to_string())
@@ -292,20 +311,54 @@ mod tests {
             user: std::env::var("CLICKHOUSE_USER").unwrap_or("default".to_string()),
             password: std::env::var("CLICKHOUSE_PASSWORD").unwrap_or("".to_string()),
             database: std::env::var("CLICKHOUSE_DATABASE").unwrap_or("default".to_string()),
-        };
-        println!("config: {:?}", config);
-        let client: ClickhouseClient = ClickhouseClient::new(&config, "querylog_local");
+        }
+    }
 
-        assert!(client.url.contains("load_balancing"));
-        assert!(client.url.contains("insert_distributed_sync"));
+    #[tokio::test]
+    async fn it_works() -> Result<(), reqwest::Error> {
+        crate::testutils::initialize_python();
+        let config = make_test_config();
+        println!("config: {:?}", config);
+        let client = ClickhouseClient::new(&config, "querylog_local", "test_storage".to_string());
+
+        let url = client.build_url();
+        assert!(url.contains("load_balancing=in_order"));
+        assert!(url.contains("insert_distributed_sync"));
         println!("running test");
         let res = client.send(b"[]".to_vec(), RetryConfig::default()).await;
         println!("Response status {}", res.unwrap().status());
         Ok(())
     }
 
+    #[test]
+    fn test_url_with_runtime_config_override() {
+        crate::testutils::initialize_python();
+        let config = make_test_config();
+        let client = ClickhouseClient::new(&config, "test_table", "writer_v2_lb_test".to_string());
+
+        // Default: in_order
+        let url = client.build_url();
+        assert!(url.contains("load_balancing=in_order"));
+        assert!(!url.contains("load_balancing_first_offset"));
+
+        // Override to first_or_random with offset
+        crate::runtime_config::patch_str_config_for_test(
+            "clickhouse_load_balancing:writer_v2_lb_test",
+            Some("first_or_random"),
+        );
+        crate::runtime_config::patch_str_config_for_test(
+            "clickhouse_load_balancing_first_offset:writer_v2_lb_test",
+            Some("1"),
+        );
+
+        let url = client.build_url();
+        assert!(url.contains("load_balancing=first_or_random"));
+        assert!(url.contains("load_balancing_first_offset=1"));
+    }
+
     #[tokio::test]
     async fn test_retry_with_exponential_backoff() {
+        crate::testutils::initialize_python();
         // Test that retry logic works by using a non-existent server
         // This will trigger network errors that should be retried
         let config = ClickhouseConfig {
@@ -318,7 +371,7 @@ mod tests {
             database: "default".to_string(),
         };
 
-        let client = ClickhouseClient::new(&config, "test_table");
+        let client = ClickhouseClient::new(&config, "test_table", "test_storage".to_string());
 
         let start_time = Instant::now();
         let result = client


### PR DESCRIPTION
Add per-storage runtime config keys to override ClickHouse load balancing
strategy

- `clickhouse_load_balancing:{storage_name}` — override `load_balancing` (e.g. `first_or_random`)
- `clickhouse_load_balancing_first_offset:{storage_name}` — set `load_balancing_first_offset`

When restarting `-1` hostname-suffixed ClickHouse nodes, `in_order` load
balancing causes disproportionate failures because it prefers the first
replica. This change lets us temporarily route insert traffic away from the
node being restarted by switching to `first_or_random` with an offset.

Both the HTTP writer (`writer_v2`) and RowBinary writer now read these
config keys per-request/per-insert rather than baking `load_balancing`
into the client at construction time. The RowBinary writer uses the
`clickhouse` crate's per-insert `with_option()` API, while the HTTP writer
builds the URL fresh each request.

**Operational workflow** (e.g. to restart the `-1` node for storage `errors`):
1. snuba config set clickhouse_load_balancing:errors first_or_random (via snuba-admin)
2. snuba config set clickhouse_load_balancing_first_offset:errors 1 (via snuba-admin)
3. verify that writes go to `-2` node for the cluster
4. restart node (note that when this happens we expect writes to shift to `-3` on 
   the shard, since first will be `-2` and the offset is set to 1.
    the important thing is that writes stay off `-1` while we restart `-1`)
5. when replication delay on `-1` is back to normal, delete both keys to revert