### PR TITLE
feat(consumer): Emit batch_write_bytes metric from RowBinary writer

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/row_binary_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/row_binary_writer.rs
@@ -79,6 +79,7 @@ where
         Box::pin(async move {
             let (empty_message, insert_batch) = message.take();
             let batch_len = insert_batch.len();
+            let num_bytes = insert_batch.num_bytes();
             let (rows, empty_batch) = insert_batch.take();
 
             let write_start = SystemTime::now();
@@ -126,6 +127,7 @@ where
                 }
             }
 
+            counter!("insertions.batch_write_bytes", num_bytes as i64);
             counter!("insertions.batch_write_msgs", batch_len as i64);
             empty_batch.record_message_latency();
             empty_batch.emit_item_type_metrics();


### PR DESCRIPTION
## Summary
- Adds the `insertions.batch_write_bytes` counter to the RowBinary ClickHouse writer, matching what the JSONEachRow writer already emits
- This is Phase 0 of the [byte-based batching rollout](https://github.com/getsentry/eap-rollout-plans/pull/1) — we need to observe batch byte sizes on `eap_items` in s4s2/de (which use RowBinary) to pick a data-driven threshold for `--max-batch-size-calculation=bytes`

Refs EAP-460

## Test plan
- [x] `cargo check` passes
- [x] Deploy to s4s2 and confirm `insertions.batch_write_bytes` appears in DataDog for RowBinary consumers
- [x] Use DataDog arithmetic (bytes/msgs) to approximate per-batch byte size distributions across all environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)