### PR TITLE
fix(COGS): unique labels for resource_ids

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -139,7 +139,7 @@ def _record_cogs(
     if cluster_name.startswith("snuba-events-analytics-platform"):
         if random() < (state.get_config("snuba_api_cogs_probability") or 0):
             record_cogs(
-                resource_id="clickhouse",
+                resource_id="eap_clickhouse",
                 app_feature=_get_eap_app_feature(request),
                 amount=bytes_scanned,
                 usage_type=UsageUnit.BYTES,


### PR DESCRIPTION
https://www.notion.so/sentry/DACI-shared_resource_id-generic-vs-prefixed-with-eap-3368b10e4b5d800c9ca2c9a62f400647?source=copy_link