### PR TITLE
feat: blq feature flag can be updated without restart

### DIFF
--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use sentry_options::options;
-
 use chrono::TimeDelta;
 use sentry::{Hub, SentryFutureExt};
 use sentry_arroyo::backends::kafka::config::KafkaConfig;
@@ -277,11 +275,9 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
         );
 
         let next_step: Box<dyn ProcessingStrategy<KafkaPayload>> =
-            if let (true, Some(blq_producer_config), Some(blq_topic)) = (
-                self.should_use_blq(),
-                &self.blq_producer_config,
-                self.blq_topic,
-            ) {
+            if let (Some(blq_producer_config), Some(blq_topic)) =
+                (&self.blq_producer_config, self.blq_topic)
+            {
                 tracing::info!(
                 "Routing all messages older than {:?} to the topic {:?} with static_friction {:?}",
                 BLQ_STALE_THRESHOLD,
@@ -322,15 +318,6 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
 }
 
 impl ConsumerStrategyFactoryV2 {
-    fn should_use_blq(&self) -> bool {
-        let flag = options("snuba")
-            .ok()
-            .and_then(|o| o.get("consumer.blq_enabled").ok())
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        flag && self.blq_producer_config.is_some() && self.blq_topic.is_some()
-    }
-
     fn create_row_binary_pipeline<
         T: clickhouse::Row
             + serde::Serialize
@@ -440,11 +427,9 @@ impl ConsumerStrategyFactoryV2 {
         );
 
         let next_step: Box<dyn ProcessingStrategy<KafkaPayload>> =
-            if let (true, Some(blq_producer_config), Some(blq_topic)) = (
-                self.should_use_blq(),
-                &self.blq_producer_config,
-                self.blq_topic,
-            ) {
+            if let (Some(blq_producer_config), Some(blq_topic)) =
+                (&self.blq_producer_config, self.blq_topic)
+            {
                 tracing::info!(
                 "Routing all messages older than {:?} to the topic {:?} with static_friction {:?}",
                 BLQ_STALE_THRESHOLD,
@@ -511,15 +496,10 @@ impl TaskRunner<KafkaPayload, KafkaPayload, anyhow::Error> for SchemaValidator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sentry_arroyo::backends::kafka::config::KafkaConfig;
     use sentry_arroyo::processing::strategies::{
         CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
     };
     use sentry_arroyo::types::{BrokerMessage, InnerMessage, Partition, Topic};
-    use sentry_options::init_with_schemas;
-    use sentry_options::testing::override_options;
-    use serde_json::json;
-    use std::sync::Once;
     use std::sync::{Arc, Mutex};
 
     // ----------- BYTES_INSERT_BATCH ------------------
@@ -747,110 +727,5 @@ mod tests {
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].len(), 5);
         assert_eq!(batches[0].num_bytes(), 200_000); // 5 * 40KB accumulated but didn't trigger flush
-    }
-
-    // --------- BLQ -------------
-    fn make_factory(
-        blq_producer_config: Option<KafkaConfig>,
-        blq_topic: Option<Topic>,
-    ) -> ConsumerStrategyFactoryV2 {
-        ConsumerStrategyFactoryV2 {
-            storage_config: config::StorageConfig {
-                name: "test".to_string(),
-                clickhouse_table_name: "test".to_string(),
-                clickhouse_cluster: config::ClickhouseConfig {
-                    host: "localhost".to_string(),
-                    port: 9000,
-                    secure: false,
-                    http_port: 8123,
-                    user: "default".to_string(),
-                    password: "".to_string(),
-                    database: "default".to_string(),
-                },
-                message_processor: config::MessageProcessorConfig {
-                    python_class_name: "Test".to_string(),
-                    python_module: "test".to_string(),
-                },
-            },
-            env_config: config::EnvConfig::default(),
-            logical_topic_name: "test".to_string(),
-            max_batch_size: 100,
-            max_batch_time: Duration::from_secs(1),
-            processing_concurrency: ConcurrencyConfig::new(1),
-            clickhouse_concurrency: ConcurrencyConfig::new(1),
-            commitlog_concurrency: ConcurrencyConfig::new(1),
-            replacements_concurrency: ConcurrencyConfig::new(1),
-            async_inserts: false,
-            python_max_queue_depth: None,
-            use_rust_processor: false,
-            health_check_file: None,
-            enforce_schema: false,
-            commit_log_producer: None,
-            replacements_config: None,
-            physical_consumer_group: "test".to_string(),
-            physical_topic_name: Topic::new("test"),
-            accountant_topic_config: config::TopicConfig {
-                physical_topic_name: "test".to_string(),
-                logical_topic_name: "test".to_string(),
-                broker_config: HashMap::new(),
-                quantized_rebalance_consumer_group_delay_secs: None,
-            },
-            stop_at_timestamp: None,
-            batch_write_timeout: None,
-            join_timeout_ms: None,
-            health_check: "arroyo".to_string(),
-            use_row_binary: false,
-            blq_producer_config,
-            blq_topic,
-            max_batch_size_calculation: config::BatchSizeCalculation::Rows,
-        }
-    }
-
-    static INIT: Once = Once::new();
-    fn init_config() {
-        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
-    }
-
-    fn blq_kafka_config() -> KafkaConfig {
-        KafkaConfig::new_config(vec!["localhost:9092".to_string()], None)
-    }
-
-    #[test]
-    fn test_should_not_use_blq_when_no_flag() {
-        init_config();
-        let factory = make_factory(Some(blq_kafka_config()), Some(Topic::new("blq")));
-        assert!(!factory.should_use_blq());
-    }
-
-    #[test]
-    fn test_should_not_use_blq_when_flag_disabled() {
-        init_config();
-        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(false))]).unwrap();
-        let factory = make_factory(Some(blq_kafka_config()), Some(Topic::new("blq")));
-        assert!(!factory.should_use_blq());
-    }
-
-    #[test]
-    fn test_should_not_use_blq_when_no_producer_config() {
-        init_config();
-        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
-        let factory = make_factory(None, Some(Topic::new("blq")));
-        assert!(!factory.should_use_blq());
-    }
-
-    #[test]
-    fn test_should_not_use_blq_when_no_topic() {
-        init_config();
-        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
-        let factory = make_factory(Some(blq_kafka_config()), None);
-        assert!(!factory.should_use_blq());
-    }
-
-    #[test]
-    fn test_should_use_blq_when_all_conditions_met() {
-        init_config();
-        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
-        let factory = make_factory(Some(blq_kafka_config()), Some(Topic::new("blq")));
-        assert!(factory.should_use_blq());
     }
 }

--- a/rust_snuba/src/strategies/blq_router.rs
+++ b/rust_snuba/src/strategies/blq_router.rs
@@ -42,6 +42,7 @@ use sentry_arroyo::processing::strategies::{
     CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
 };
 use sentry_arroyo::types::{Message, Topic, TopicOrPartition};
+use sentry_options::options;
 
 #[derive(Debug, PartialEq)]
 enum State {
@@ -122,6 +123,14 @@ where
     ///     Best practice would be no greater than a small percent of stable_threshold like 10%
     ///     ex: stale_threshold=10m, static_friction=1m
     ///     and the implication is 9m old messages will now be sent to the BLQ in some cases
+    fn is_enabled(&self) -> bool {
+        options("snuba")
+            .ok()
+            .and_then(|o| o.get("consumer.blq_enabled").ok())
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
     fn new_with_strategy(
         next_step: Next,
         blq_producer: ProduceStrategy,
@@ -153,6 +162,10 @@ where
     ProduceStrategy: ProcessingStrategy<KafkaPayload> + 'static,
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
+        if !self.is_enabled() {
+            return self.next_step.poll();
+        }
+
         let produce_result = self.producer.poll();
         let next_step_result = self.next_step.poll();
         match &mut self.state {
@@ -167,6 +180,10 @@ where
     }
 
     fn submit(&mut self, message: Message<KafkaPayload>) -> Result<(), SubmitError<KafkaPayload>> {
+        if !self.is_enabled() {
+            return self.next_step.submit(message);
+        }
+
         let msg_ts = message
             .timestamp()
             .expect("Expected kafka message to always have a timestamp, but there wasn't one");
@@ -241,6 +258,15 @@ mod tests {
     use super::*;
     use chrono::DateTime;
     use sentry_arroyo::types::{Partition, Topic};
+    use sentry_options::init_with_schemas;
+    use sentry_options::testing::override_options;
+    use serde_json::json;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    fn init_config() {
+        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
+    }
 
     struct MockStrategy {
         submitted: Vec<Message<KafkaPayload>>,
@@ -300,6 +326,8 @@ mod tests {
         This tests that the BLQRouter forwards business-as-usual fresh messages through it
         and crashes when it hits its first stale message
          */
+        init_config();
+        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
         let mut router = BLQRouter::new_with_strategy(
             MockStrategy::new(),
             MockStrategy::new(),
@@ -344,6 +372,8 @@ mod tests {
         This tests that the BLQRouter properly routes stale messages to the BLQ
         and then switches back to forwarding fresh messages once the backlog is burned
          */
+        init_config();
+        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
         let mut router = BLQRouter::new_with_strategy(
             MockStrategy::new(),
             MockStrategy::new(),
@@ -369,5 +399,57 @@ mod tests {
         assert!(router.producer.join_called);
         assert_eq!(router.producer.submitted.len(), 10);
         assert_eq!(router.next_step.submitted.len(), 5);
+    }
+
+    #[test]
+    fn test_passthrough_when_no_flag() {
+        // When the feature flag is not set, stale messages should pass through
+        // to next_step instead of being routed to BLQ
+        init_config();
+        let mut router = BLQRouter::new_with_strategy(
+            MockStrategy::new(),
+            MockStrategy::new(),
+            TimeDelta::seconds(10),
+            None,
+        )
+        .unwrap();
+
+        for _ in 0..5 {
+            router
+                .submit(make_message(Utc::now() - TimeDelta::minutes(1)))
+                .unwrap();
+            _ = router.poll();
+        }
+
+        // All stale messages went to next_step, none to producer
+        assert_eq!(router.next_step.submitted.len(), 5);
+        assert_eq!(router.producer.submitted.len(), 0);
+        assert_eq!(router.state, State::Idle);
+    }
+
+    #[test]
+    fn test_passthrough_when_flag_disabled() {
+        // When the feature flag is explicitly false, stale messages should pass through
+        init_config();
+        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(false))]).unwrap();
+        let mut router = BLQRouter::new_with_strategy(
+            MockStrategy::new(),
+            MockStrategy::new(),
+            TimeDelta::seconds(10),
+            None,
+        )
+        .unwrap();
+
+        for _ in 0..5 {
+            router
+                .submit(make_message(Utc::now() - TimeDelta::minutes(1)))
+                .unwrap();
+            _ = router.poll();
+        }
+
+        // All stale messages went to next_step, none to producer
+        assert_eq!(router.next_step.submitted.len(), 5);
+        assert_eq!(router.producer.submitted.len(), 0);
+        assert_eq!(router.state, State::Idle);
     }
 }

--- a/rust_snuba/src/strategies/blq_router.rs
+++ b/rust_snuba/src/strategies/blq_router.rs
@@ -162,10 +162,6 @@ where
     ProduceStrategy: ProcessingStrategy<KafkaPayload> + 'static,
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
-        if !self.is_enabled() {
-            return self.next_step.poll();
-        }
-
         let produce_result = self.producer.poll();
         let next_step_result = self.next_step.poll();
         match &mut self.state {


### PR DESCRIPTION
I moved the feature flag from factory_v2 into the BLQ. This will allow us to update the feature flag without restarting the consumer.