### PR TITLE
ref(ci): add cancel-in-progress to pull_request prs

### DIFF
--- a/.github/workflows/admin-sourcemaps.yml
+++ b/.github/workflows/admin-sourcemaps.yml
@@ -2,6 +2,11 @@ on:
   pull_request:
   push:
     branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "build sourcemaps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   files-changed:
     name: detect what files changed

--- a/.github/workflows/ddl-changes.yml
+++ b/.github/workflows/ddl-changes.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   post_changes:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches: ["master"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -3,6 +3,10 @@ name: Snuba Docs on PR's
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     name: Sphinx

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -5,6 +5,10 @@ on:
       - master
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-multiplatform:
     strategy:


### PR DESCRIPTION
this adds concurrency cancellation to pull_request workflows so that pushing a new commit to a PR automatically cancels any still-running workflow from the previous commit

99% of the time if you push a new commit you don't care about the previous workflow if its still running

**we already do this for all sentry+getsentry pull_request workflows**

we (devinfra) can't measure this yet but this would greatly help decrease org-wide runner queue pressure!

