### PR TITLE
fix(admin): Allow ClickHouse replace* functions in read-only query validation

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import MutableMapping
 
 from sql_metadata import Parser, QueryType  # type: ignore
@@ -241,7 +242,10 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
     ]
 
     for kw in disallowed_keywords:
-        if kw in lowered:
+        if kw == "replace":
+            if re.search(r"\breplace\b", lowered):
+                raise InvalidCustomQuery(f"{kw} is not allowed in the query")
+        elif kw in lowered:
             raise InvalidCustomQuery(f"{kw} is not allowed in the query")
 
     parsed = Parser(lowered)

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -48,3 +48,19 @@ def test_allowed_tables_with_left_array_join() -> None:
             "SELECT * FROM my_table, other_table LEFT ARRAY JOIN tags.key AS tag_key, tags.raw_value AS tag_value",
             allowed_tables={"my_table"},
         )
+
+
+def test_replace_functions_allowed() -> None:
+    # ClickHouse replace* functions should be allowed in read-only queries
+    validate_ro_query("SELECT replaceAll(message, 'foo', 'bar') FROM my_table")
+    validate_ro_query("SELECT replaceRegexpAll(message, '[0-9]+', 'N') FROM my_table")
+    validate_ro_query("SELECT replaceOne(message, 'x', 'y') FROM my_table")
+    validate_ro_query("SELECT replaceRegexpOne(message, 'x', 'y') FROM my_table")
+
+
+def test_replace_dml_rejected() -> None:
+    # DML forms of REPLACE must still be blocked
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query("REPLACE INTO my_table VALUES (1, 2, 3)")
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query("REPLACE TABLE my_table SELECT * FROM other_table")


### PR DESCRIPTION
The snuba-admin query validator blocked any query containing the substring `replace`, which caused ClickHouse functions like `replaceAll()`, `replaceRegexpAll()`, etc. to be rejected with a validation error.

The intent of the `replace` entry in the blocklist is to prevent SQL DML statements like `REPLACE TABLE` or `REPLACE INTO`, not to block legitimate ClickHouse string functions. Switching to a word-boundary regex match (`\breplace\b`) for this keyword preserves the DML protection while allowing function names that begin with `replace`.