### PR TITLE
ref(gocd): bump gocd-jsonnet to v3.0.0 (grouped pipedream)

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.19.0"
+      "version": "v3.0.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "56cc4d91cbaac4569b37b4911998b48c2f9c2ac4",
-      "sum": "J0D//go/146qfReWFTTL5xWWCVlkTjqhnALYPH4Z9rE="
+      "version": "3465d94bb68e41c24d93a80d0b3f0ab8168d26c6",
+      "sum": "SbALpMwOdnmqi5w6cJKPOWDp3gcuafqk7JCninnrrLA="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/pipelines/snuba-py.libsonnet
+++ b/gocd/templates/pipelines/snuba-py.libsonnet
@@ -195,7 +195,7 @@ function(region) {
                   checks: {
                     elastic_profile_id: 'snuba',
                     environment_variables: {
-                      PIPELINE_FIRST_STEP: 'deploy-snuba-py-s4s',
+                      PIPELINE_FIRST_STEP: 'deploy-snuba-py-s4s2',
                     },
                     tasks: [
                       gocdtasks.script(importstr '../bash/check-github.sh'),

--- a/gocd/templates/pipelines/snuba-rs.libsonnet
+++ b/gocd/templates/pipelines/snuba-rs.libsonnet
@@ -177,7 +177,7 @@ function(region) {
           checks: {
             elastic_profile_id: 'snuba',
             environment_variables: {
-              PIPELINE_FIRST_STEP: 'deploy-snuba-rs-s4s',
+              PIPELINE_FIRST_STEP: 'deploy-snuba-rs-s4s2',
             },
             tasks: [
               gocdtasks.script(importstr '../bash/check-github.sh'),


### PR DESCRIPTION
Bump to gocd-jsonnet v3.0.0 for snuba-py and snuba-rs. This is a change to support cellularization, and when we eventually will have multiple cells per region. Currently, the pipelines should be unchanged apart from collapsing the 4 per-customer-region pipelines into a single `deploy-snuba-{py,rs}-st` grouped pipeline with parallel jobs. All other pipeline names (`s4s2`, `de`, `us`) are unchanged.

Also fixed the `PIPELINE_FIRST_STEP:` `deploy-snuba-{py,rs}-s4s` → `deploy-snuba-{py,rs}-s4s2`.
