### PR TITLE
feat: make BLQ stale threshold and static friction runtime-configurable

### DIFF
--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::TimeDelta;
 use sentry::{Hub, SentryFutureExt};
 use sentry_arroyo::backends::kafka::config::KafkaConfig;
 use sentry_arroyo::backends::kafka::producer::KafkaProducer;
@@ -39,10 +38,6 @@ use crate::strategies::processor::{
 use crate::strategies::python::PythonTransformStep;
 use crate::strategies::replacements::ProduceReplacements;
 use crate::types::{BytesInsertBatch, CogsData, RowData, TypedInsertBatch};
-
-// BLQ configuration
-const BLQ_STALE_THRESHOLD: TimeDelta = TimeDelta::minutes(30);
-const BLQ_STATIC_FRICTION: Option<TimeDelta> = Some(TimeDelta::minutes(2));
 
 pub struct ConsumerStrategyFactoryV2 {
     pub storage_config: config::StorageConfig,
@@ -279,21 +274,15 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                 (&self.blq_producer_config, self.blq_topic)
             {
                 tracing::info!(
-                "Routing all messages older than {:?} to the topic {:?} with static_friction {:?}",
-                BLQ_STALE_THRESHOLD,
-                self.blq_topic,
-                BLQ_STATIC_FRICTION
-            );
-                Box::new(
-                    BLQRouter::new(
-                        next_step,
-                        blq_producer_config.clone(),
-                        blq_topic,
-                        BLQ_STALE_THRESHOLD,
-                        BLQ_STATIC_FRICTION,
-                    )
-                    .expect("invalid BLQRouter config"),
-                )
+                    "Routing stale messages to the backlog-queue topic {:?} \
+                     (thresholds configured via sentry-options)",
+                    self.blq_topic,
+                );
+                Box::new(BLQRouter::new(
+                    next_step,
+                    blq_producer_config.clone(),
+                    blq_topic,
+                ))
             } else {
                 tracing::info!("Not using a backlog-queue",);
                 Box::new(next_step)
@@ -431,21 +420,15 @@ impl ConsumerStrategyFactoryV2 {
                 (&self.blq_producer_config, self.blq_topic)
             {
                 tracing::info!(
-                "Routing all messages older than {:?} to the topic {:?} with static_friction {:?}",
-                BLQ_STALE_THRESHOLD,
-                self.blq_topic,
-                BLQ_STATIC_FRICTION,
+                    "Routing stale messages to the backlog-queue topic {:?} \
+                     (thresholds configured via sentry-options)",
+                    self.blq_topic,
                 );
-                Box::new(
-                    BLQRouter::new(
-                        next_step,
-                        blq_producer_config.clone(),
-                        blq_topic,
-                        BLQ_STALE_THRESHOLD,
-                        BLQ_STATIC_FRICTION,
-                    )
-                    .expect("invalid BLQRouter config"),
-                )
+                Box::new(BLQRouter::new(
+                    next_step,
+                    blq_producer_config.clone(),
+                    blq_topic,
+                ))
             } else {
                 tracing::info!("Not using a backlog-queue",);
                 Box::new(next_step)

--- a/rust_snuba/src/strategies/blq_router.rs
+++ b/rust_snuba/src/strategies/blq_router.rs
@@ -57,10 +57,8 @@ enum State {
 
 pub struct BLQRouter<Next, ProduceStrategy> {
     next_step: Next,
-    stale_threshold: TimeDelta,
     state: State,
     producer: ProduceStrategy,
-    static_friction: Option<TimeDelta>,
 
     // We have to keep this around ourself bc strategies::produce::Produce didn't define their lifetimes well
     _concurrency: Option<ConcurrencyConfig>,
@@ -71,24 +69,12 @@ where
     Next: ProcessingStrategy<KafkaPayload> + 'static,
 {
     /// next_step,
-    ///     is where fresh messages get forwarded to
-    /// stale_threshold,
-    ///     messages older than the stale_threshold will get sent to the producer
-    /// static_friction,
-    ///     Once we enter stale routing mode (at STALE_THRESHOLD),
-    ///     we keep routing messages that are at least (STALE_THRESHOLD - STATIC_FRICTION_SECS) seconds old.
-    ///     This is because we want a higher threshold to enter the stale routing state
-    ///     but a lower threshold to stay in it, so we don't flip-flop at the boundary.
-    ///     Best practice would be no greater than a small percent of stable_threshold like 10%
-    ///     ex: stale_threshold=10m, static_friction=1m
-    ///     and the implication is 9m old messages will now be sent to the BLQ in some cases
-    pub fn new(
-        next_step: Next,
-        blq_producer_config: KafkaConfig,
-        blq_topic: Topic,
-        stale_threshold: TimeDelta,
-        static_friction: Option<TimeDelta>,
-    ) -> Result<Self, &'static str> {
+    ///     is where fresh messages get forwarded to.
+    ///
+    /// The stale threshold and static friction are read at runtime from sentry-options
+    /// (`consumer.blq_stale_threshold_seconds`, `consumer.blq_static_friction_seconds`)
+    /// so they can be tuned without a restart.
+    pub fn new(next_step: Next, blq_producer_config: KafkaConfig, blq_topic: Topic) -> Self {
         let concurrency = ConcurrencyConfig::new(10);
         let blq_producer = Produce::new(
             CommitOffsets::new(Duration::from_millis(250)),
@@ -96,10 +82,9 @@ where
             &concurrency,
             TopicOrPartition::Topic(blq_topic),
         );
-        let mut router =
-            Self::new_with_strategy(next_step, blq_producer, stale_threshold, static_friction)?;
+        let mut router = Self::new_with_strategy(next_step, blq_producer);
         router._concurrency = Some(concurrency);
-        Ok(router)
+        router
     }
 }
 
@@ -108,21 +93,6 @@ where
     Next: ProcessingStrategy<KafkaPayload> + 'static,
     ProduceStrategy: ProcessingStrategy<KafkaPayload> + 'static,
 {
-    /// next_step,
-    ///     is where fresh messages get forwarded to
-    /// producer,
-    ///     ProcessingStrategy that submits messages to the BLQ,
-    ///     stale messages will get submitted to it.
-    /// stale_threshold,
-    ///     messages older than the stale_threshold will get sent to the producer
-    /// static_friction,
-    ///     Once we enter stale routing mode (at STALE_THRESHOLD),
-    ///     we keep routing messages that are at least (STALE_THRESHOLD - STATIC_FRICTION_SECS) seconds old.
-    ///     This is because we want a higher threshold to enter the stale routing state
-    ///     but a lower threshold to stay in it, so we don't flip-flop at the boundary.
-    ///     Best practice would be no greater than a small percent of stable_threshold like 10%
-    ///     ex: stale_threshold=10m, static_friction=1m
-    ///     and the implication is 9m old messages will now be sent to the BLQ in some cases
     fn is_enabled(&self) -> bool {
         options("snuba")
             .ok()
@@ -131,28 +101,42 @@ where
             .unwrap_or(false)
     }
 
-    fn new_with_strategy(
-        next_step: Next,
-        blq_producer: ProduceStrategy,
-        stale_threshold: TimeDelta,
-        static_friction: Option<TimeDelta>,
-    ) -> Result<Self, &'static str> {
-        if stale_threshold <= TimeDelta::zero() {
-            return Err("stale_threshold must be positive");
+    /// Messages older than this are routed to the backlog queue.
+    /// Read per-message from sentry-options to allow runtime tuning.
+    /// Falls back to 30 minutes if the option is missing or non-positive.
+    fn stale_threshold(&self) -> TimeDelta {
+        options("snuba")
+            .ok()
+            .and_then(|o| o.get("consumer.blq_stale_threshold_seconds").ok())
+            .and_then(|v| v.as_i64())
+            .filter(|s| *s > 0)
+            .map(TimeDelta::seconds)
+            .unwrap_or(TimeDelta::minutes(30))
+    }
+
+    /// Hysteresis applied while in RoutingStale: we keep routing messages at
+    /// least (stale_threshold - static_friction) old so we don't flip-flop at
+    /// the boundary. A value <= 0 disables friction. Defaults to 2 minutes.
+    fn static_friction(&self) -> Option<TimeDelta> {
+        let secs = options("snuba")
+            .ok()
+            .and_then(|o| o.get("consumer.blq_static_friction_seconds").ok())
+            .and_then(|v| v.as_i64())
+            .unwrap_or(120);
+        if secs > 0 {
+            Some(TimeDelta::seconds(secs))
+        } else {
+            None
         }
-        if let Some(friction) = static_friction {
-            if friction >= stale_threshold {
-                return Err("static_friction must be less than stale_threshold");
-            }
-        }
-        Ok(Self {
+    }
+
+    fn new_with_strategy(next_step: Next, blq_producer: ProduceStrategy) -> Self {
+        Self {
             next_step,
-            stale_threshold,
             state: State::Idle,
             producer: blq_producer,
-            static_friction,
             _concurrency: None,
-        })
+        }
     }
 }
 
@@ -185,9 +169,11 @@ where
             .expect("Expected kafka message to always have a timestamp, but there wasn't one");
         let elapsed = Utc::now() - msg_ts;
 
-        let threshold = match (&self.state, self.static_friction) {
-            (State::RoutingStale, Some(friction)) => self.stale_threshold - friction,
-            _ => self.stale_threshold,
+        let stale_threshold = self.stale_threshold();
+        let friction = self.static_friction().filter(|f| *f < stale_threshold);
+        let threshold = match (&self.state, friction) {
+            (State::RoutingStale, Some(f)) => stale_threshold - f,
+            _ => stale_threshold,
         };
         let is_stale = elapsed > threshold;
         match (is_stale, &self.state) {
@@ -323,14 +309,13 @@ mod tests {
         and crashes when it hits its first stale message
          */
         init_config();
-        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
-        let mut router = BLQRouter::new_with_strategy(
-            MockStrategy::new(),
-            MockStrategy::new(),
-            TimeDelta::seconds(10),
-            None,
-        )
+        let _guard = override_options(&[
+            ("snuba", "consumer.blq_enabled", json!(true)),
+            ("snuba", "consumer.blq_stale_threshold_seconds", json!(1200)),
+            ("snuba", "consumer.blq_static_friction_seconds", json!(120)),
+        ])
         .unwrap();
+        let mut router = BLQRouter::new_with_strategy(MockStrategy::new(), MockStrategy::new());
         // consuming messages as normal
         for _ in 0..10 {
             router.submit(make_message(Utc::now())).unwrap();
@@ -370,13 +355,7 @@ mod tests {
          */
         init_config();
         let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
-        let mut router = BLQRouter::new_with_strategy(
-            MockStrategy::new(),
-            MockStrategy::new(),
-            TimeDelta::seconds(10),
-            Some(TimeDelta::seconds(1)),
-        )
-        .unwrap();
+        let mut router = BLQRouter::new_with_strategy(MockStrategy::new(), MockStrategy::new());
         // backlog of 10 stale messages
         for _ in 0..10 {
             router
@@ -402,13 +381,7 @@ mod tests {
         // When the feature flag is not set, stale messages should pass through
         // to next_step instead of being routed to BLQ
         init_config();
-        let mut router = BLQRouter::new_with_strategy(
-            MockStrategy::new(),
-            MockStrategy::new(),
-            TimeDelta::seconds(10),
-            None,
-        )
-        .unwrap();
+        let mut router = BLQRouter::new_with_strategy(MockStrategy::new(), MockStrategy::new());
 
         for _ in 0..5 {
             router
@@ -428,13 +401,7 @@ mod tests {
         // When the feature flag is explicitly false, stale messages should pass through
         init_config();
         let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(false))]).unwrap();
-        let mut router = BLQRouter::new_with_strategy(
-            MockStrategy::new(),
-            MockStrategy::new(),
-            TimeDelta::seconds(10),
-            None,
-        )
-        .unwrap();
+        let mut router = BLQRouter::new_with_strategy(MockStrategy::new(), MockStrategy::new());
 
         for _ in 0..5 {
             router

--- a/rust_snuba/src/strategies/blq_router.rs
+++ b/rust_snuba/src/strategies/blq_router.rs
@@ -311,8 +311,8 @@ mod tests {
         init_config();
         let _guard = override_options(&[
             ("snuba", "consumer.blq_enabled", json!(true)),
-            ("snuba", "consumer.blq_stale_threshold_seconds", json!(1200)),
-            ("snuba", "consumer.blq_static_friction_seconds", json!(120)),
+            ("snuba", "consumer.blq_stale_threshold_seconds", json!(10)),
+            ("snuba", "consumer.blq_static_friction_seconds", json!(0)),
         ])
         .unwrap();
         let mut router = BLQRouter::new_with_strategy(MockStrategy::new(), MockStrategy::new());
@@ -354,7 +354,12 @@ mod tests {
         and then switches back to forwarding fresh messages once the backlog is burned
          */
         init_config();
-        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(true))]).unwrap();
+        let _guard = override_options(&[
+            ("snuba", "consumer.blq_enabled", json!(true)),
+            ("snuba", "consumer.blq_stale_threshold_seconds", json!(10)),
+            ("snuba", "consumer.blq_static_friction_seconds", json!(0)),
+        ])
+        .unwrap();
         let mut router = BLQRouter::new_with_strategy(MockStrategy::new(), MockStrategy::new());
         // backlog of 10 stale messages
         for _ in 0..10 {
@@ -400,7 +405,12 @@ mod tests {
     fn test_passthrough_when_flag_disabled() {
         // When the feature flag is explicitly false, stale messages should pass through
         init_config();
-        let _guard = override_options(&[("snuba", "consumer.blq_enabled", json!(false))]).unwrap();
+        let _guard = override_options(&[
+            ("snuba", "consumer.blq_enabled", json!(false)),
+            ("snuba", "consumer.blq_stale_threshold_seconds", json!(10)),
+            ("snuba", "consumer.blq_static_friction_seconds", json!(0)),
+        ])
+        .unwrap();
         let mut router = BLQRouter::new_with_strategy(MockStrategy::new(), MockStrategy::new());
 
         for _ in 0..5 {

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -12,6 +12,16 @@
       "default": false,
       "description": "enable backlog queue in snuba consumers"
     },
+    "consumer.blq_stale_threshold_seconds": {
+      "type": "integer",
+      "default": 1800,
+      "description": "BLQ stale threshold in seconds. Messages older than this are routed to the backlog queue."
+    },
+    "consumer.blq_static_friction_seconds": {
+      "type": "integer",
+      "default": 120,
+      "description": "BLQ hysteresis in seconds. Once routing stale, keep routing messages at least (stale_threshold - static_friction) old. Set to 0 to disable friction."
+    },
     "consumer.commit_log_use_next_offset": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
This PR is just replacing hardcoded constants with options so I can change the value at runtime. This is necessary for testing in s4s, I dont want to create an actual backlog of 30 minutes, so I will reduce stale threshold to say 4 minutes and test that.

## Summary
- Replaces hardcoded `BLQ_STALE_THRESHOLD` (30m) and `BLQ_STATIC_FRICTION` (2m) with two sentry-options keys: `consumer.blq_stale_threshold_seconds` (default 1800) and `consumer.blq_static_friction_seconds` (default 120).
- `BLQRouter` now reads both values per-`submit()` the same way `consumer.blq_enabled` is read, so they hot-reload without a consumer restart. Friction <= 0 disables friction; friction >= threshold is ignored at runtime.
- Drops the two constants and the corresponding `BLQRouter::new` arguments from `factory_v2.rs`.

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo test --lib blq_router` — 4/4 pass, tests now set thresholds via `override_options`
- [ ] Runtime smoke: with `blq_enabled=true` and `blq_stale_threshold_seconds=5`, confirm a 10s-old message routes to BLQ; flip the threshold to 3600 and confirm the next fresh message passes through without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)