### PR TITLE
ref(ci): pull out migrations tests maybe lets see

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,7 @@ jobs:
           [
             "25.3.6.10034.altinitystable",
           ]
+        test_type: [snuba-test, snuba-test-migrations]
 
     steps:
       - name: Checkout code
@@ -520,7 +521,7 @@ jobs:
       - name: Docker Snuba Test other ClickHouse versions
         run: |
           export CLICKHOUSE_IMAGE=ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:${{matrix.version}}
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm ${{ matrix.test_type }}
 
       - name: Upload to codecov
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,8 @@ jobs:
             "test_rust",
             "test_distributed",
             "test_distributed_migrations",
+            "test_migrations",
+            "test_migrations_distributed"
           ]
     steps:
       - name: Checkout code
@@ -308,6 +310,16 @@ jobs:
         run: |
           SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}
+
+      - name: Docker Snuba Migrations tests
+        run: |
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} docker compose -f docker-compose.gcb.yml run --rm snuba-test-migrations
+        if: ${{ matrix.snuba_settings == 'test_migrations' }}
+
+      - name: Docker Snuba Migrations Distributed tests
+        run: |
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=test_distributed docker compose -f docker-compose.gcb.yml run --rm snuba-test-migrations
+        if: ${{ matrix.snuba_settings  == 'test_migrations_distributed' }}
 
       - name: Docker Snuba Multi-Node Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
 
       - name: Docker Snuba Migrations tests
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} docker compose -f docker-compose.gcb.yml run --rm snuba-test-migrations
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm snuba-test-migrations
         if: ${{ matrix.snuba_settings == 'test_migrations' }}
 
       - name: Docker Snuba Migrations Distributed tests

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -42,12 +42,25 @@ services:
       - "-m"
       - "pytest"
       - "-x"
+      - "--ignore"
+      - "tests/migrations"
       - "-vv"
       - "${TEST_LOCATION:-tests}"
       - "--cov"
       - "."
       - "--cov-report"
       - "xml:/.artifacts/${TEST_LOCATION:-tests}/${SNUBA_SETTINGS}/coverage.xml"
+      - "--junit-xml"
+      - "/.artifacts/${TEST_LOCATION:-tests}/${SNUBA_SETTINGS}/pytest.junit.xml"
+  snuba-test-migrations:
+    <<: *test-common
+    entrypoint: python
+    command:
+      - "-m"
+      - "pytest"
+      - "-x"
+      - "-vv"
+      - "tests/migrations"
       - "--junit-xml"
       - "/.artifacts/${TEST_LOCATION:-tests}/${SNUBA_SETTINGS}/pytest.junit.xml"
   zookeeper:


### PR DESCRIPTION
Migrations take up a big chunk of time in our CI, trying to see if we can pull them out to run in parallel easily

## Results

**Baseline (master) — `test_distributed` duration:**
| Run | Duration |
|-----|----------|
| Apr 16 (run 1) | 26 min 44 sec |
| Apr 16 (run 2) | 26 min 39 sec |
| Apr 15 | 27 min 3 sec |
| **Average** | **~26 min 49 sec** |

**After this change:**
| Job | Duration |
|-----|----------|
| `test_distributed` | 20 min 24 sec |
| `test_migrations_distributed` (new, parallel) | 10 min 21 sec |
| `test_migrations` (new, parallel) | 3 min 36 sec |

`test_distributed` went from ~27 min → ~20 min, saving **~6.5 minutes** on the critical path. Migrations tests now run in parallel and don't add to wall-clock time.