### PR TITLE
fix(eap): fix coalesced attribute handling for deprecated keys

### DIFF
--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Final, Mapping, Sequence, cast
+from typing import Final, Mapping, Sequence
 
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
@@ -65,8 +65,8 @@ PROTO_TYPE_TO_ATTRIBUTE_COLUMN: Final[Mapping[AttributeKey.Type.ValueType, str]]
 def _build_deprecated_attributes() -> dict[str, set[str]]:
     current_to_deprecated: dict[str, set[str]] = defaultdict(set)
     for name, metadata in ATTRIBUTE_METADATA.items():
-        if metadata.deprecation:
-            replacement = cast(str, metadata.deprecation.replacement)
+        if metadata.deprecation and metadata.deprecation.replacement:
+            replacement = metadata.deprecation.replacement
             deprecated = {name}
             if metadata.aliases:
                 deprecated.update(metadata.aliases)

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -670,6 +670,11 @@ def get_field_existence_expression(field: Expression) -> Expression:
 
         return None
 
+    if isinstance(field, FunctionCall) and field.function_name == "coalesce":
+        return combine_or_conditions(
+            [get_field_existence_expression(param) for param in field.parameters]
+        )
+
     subscriptable_field = get_subscriptable_field(field)
     if subscriptable_field is not None:
         return f.mapContains(subscriptable_field.column, subscriptable_field.key)

--- a/tests/protos/test_protos_common.py
+++ b/tests/protos/test_protos_common.py
@@ -96,6 +96,9 @@ class TestAttributeKeyToExpression:
             alias=f"{new_attribute}_TYPE_STRING",
         )
 
+    def test_coalesce_map_does_not_include_none_key(self) -> None:
+        assert None not in ATTRIBUTES_TO_COALESCE
+
     def test_unspecified_type_raises_exception(self) -> None:
         with pytest.raises(MalformedAttributeException) as exc_info:
             attribute_key_to_expression(

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     Reliability,
 )
 
-from snuba.query.expressions import FunctionCall
+from snuba.query.expressions import Column, FunctionCall, Literal, SubscriptableReference
 from snuba.web.rpc.common.common import (
     attribute_key_to_expression,
     get_field_existence_expression,
@@ -270,6 +270,35 @@ def test_get_field_existence_expression_array_map() -> None:
     expr = get_field_existence_expression(field)
     assert isinstance(expr, FunctionCall)
     assert expr.function_name == "notEmpty"
+
+
+def test_get_field_existence_expression_coalesce() -> None:
+    """Coalesced attributes should check existence for all underlying keys with OR."""
+    attr_col = Column(alias=None, table_name=None, column_name="attributes_string")
+    canonical_ref = SubscriptableReference(
+        column=attr_col,
+        key=Literal(alias=None, value="http.response.body.size"),
+        alias=None,
+    )
+    deprecated_ref = SubscriptableReference(
+        column=attr_col,
+        key=Literal(alias=None, value="http.response_content_length"),
+        alias=None,
+    )
+    coalesce_field = FunctionCall(
+        alias="test",
+        function_name="coalesce",
+        parameters=(canonical_ref, deprecated_ref),
+    )
+    expr = get_field_existence_expression(coalesce_field)
+    assert isinstance(expr, FunctionCall)
+    assert expr.function_name == "or"
+    assert len(expr.parameters) == 2
+    lhs, rhs = expr.parameters
+    assert isinstance(lhs, FunctionCall) and lhs.function_name == "mapContains"
+    assert isinstance(rhs, FunctionCall) and rhs.function_name == "mapContains"
+    assert lhs.parameters[1] == Literal(alias=None, value="http.response.body.size")
+    assert rhs.parameters[1] == Literal(alias=None, value="http.response_content_length")
 
 
 def test_aggregation_to_expression_uniq_type_array() -> None:

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -246,8 +246,8 @@ class TestExistsFilterCoalesced:
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == "or"
         checked_keys = self._collect_map_contains_keys(expr)
-        assert canonical in checked_keys
-        assert deprecated_keys <= checked_keys
+        expected_keys = {canonical, *deprecated_keys}
+        assert checked_keys == expected_keys
 
     def test_exists_filter_on_non_coalesced_attribute_unchanged(self) -> None:
         """Non-coalesced attributes should still produce a single mapContains."""

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -21,6 +21,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     AnyAttributeFilter,
     ComparisonFilter,
+    ExistsFilter,
     TraceItemFilter,
 )
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
@@ -28,7 +29,8 @@ from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 from snuba import settings
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.query.expressions import FunctionCall, Lambda
+from snuba.protos.common import ATTRIBUTES_TO_COALESCE
+from snuba.query.expressions import FunctionCall, Lambda, Literal
 from snuba.web.rpc.common.common import (
     _any_attribute_filter_to_expression,
     attribute_key_to_expression,
@@ -208,6 +210,55 @@ class TestTraceItemFiltersArrayLike:
             match="NOT LIKE comparison is only supported on string and array keys",
         ):
             trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+
+
+class TestExistsFilterCoalesced:
+    """exists_filter on coalesced attributes must check all deprecated keys."""
+
+    @staticmethod
+    def _collect_map_contains_keys(expr: FunctionCall) -> set[str]:
+        """Recursively collect all keys from a (possibly nested) OR of mapContains calls."""
+        keys: set[str] = set()
+        if expr.function_name == "mapContains":
+            key_literal = expr.parameters[1]
+            assert isinstance(key_literal, Literal)
+            assert isinstance(key_literal.value, str)
+            keys.add(key_literal.value)
+        elif expr.function_name == "or":
+            for param in expr.parameters:
+                assert isinstance(param, FunctionCall)
+                keys.update(TestExistsFilterCoalesced._collect_map_contains_keys(param))
+        return keys
+
+    def test_exists_filter_on_coalesced_string_attribute(self) -> None:
+        """End-to-end: exists_filter through trace_item_filters_to_expression
+        for a canonical key that has deprecated aliases (string type)."""
+        canonical = "db.system.name"
+        assert canonical in ATTRIBUTES_TO_COALESCE, "test precondition: key must be coalesced"
+        deprecated_keys = ATTRIBUTES_TO_COALESCE[canonical]
+
+        item_filter = TraceItemFilter(
+            exists_filter=ExistsFilter(
+                key=AttributeKey(type=AttributeKey.Type.TYPE_STRING, name=canonical)
+            )
+        )
+        expr = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        assert isinstance(expr, FunctionCall)
+        assert expr.function_name == "or"
+        checked_keys = self._collect_map_contains_keys(expr)
+        assert canonical in checked_keys
+        assert deprecated_keys <= checked_keys
+
+    def test_exists_filter_on_non_coalesced_attribute_unchanged(self) -> None:
+        """Non-coalesced attributes should still produce a single mapContains."""
+        item_filter = TraceItemFilter(
+            exists_filter=ExistsFilter(
+                key=AttributeKey(type=AttributeKey.Type.TYPE_STRING, name="some.custom.tag")
+            )
+        )
+        expr = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        assert isinstance(expr, FunctionCall)
+        assert expr.function_name == "mapContains"
 
 
 @pytest.mark.redis_db

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3384,6 +3384,49 @@ class TestTraceItemTable(BaseApiTest):
             ),
         ]
 
+    def test_exists_filter_on_coalesced_deprecated_key(self) -> None:
+        """exists_filter on a canonical key must match spans that only have the deprecated key."""
+        span_ts = BASE_TIME + timedelta(minutes=1)
+        write_eap_item(span_ts, {"ai.model_id": "sentaur"})
+
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            filter=TraceItemFilter(
+                exists_filter=ExistsFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING,
+                        name="gen_ai.response.model",
+                    ),
+                )
+            ),
+            columns=[
+                Column(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING,
+                        name="gen_ai.response.model",
+                    )
+                ),
+            ],
+        )
+        response = EndpointTraceItemTable().execute(message)
+
+        assert response.column_values == [
+            TraceItemColumnValues(
+                attribute_name="gen_ai.response.model",
+                results=[
+                    AttributeValue(val_str="sentaur"),
+                ],
+            ),
+        ]
+
     def test_multiply_attribute_aggregation(self) -> None:
         """
         Tests avg(game_size * game_size_unit_mult) using AttributeKeyExpression formulas.


### PR DESCRIPTION
Two related fixes for coalesced attribute handling:

**1. Skip deprecations without a replacement when building coalesce map**

The `_build_deprecated_attributes` loop assumed every deprecation has a `replacement`, but `replacement` is optional. For deprecations without a successor, `replacement=None` created a `None` key in `ATTRIBUTES_TO_COALESCE` and grouped unrelated deprecated attributes together. Now only deprecated attributes that define a replacement are included.

Refs #7884

**2. Handle coalesced attributes in `exists_filter`**

`exists_filter` (`has:` syntax) on coalesced attributes only checked the canonical key, missing v1 spans stored under deprecated keys. In `get_field_existence_expression`, when `attribute_key_to_expression` returns a `coalesce(...)` for attributes with deprecated mappings, the helper `get_subscriptable_field` extracted only the first parameter (canonical key) and generated `mapContains` for just that key — all deprecated alternatives were silently ignored.

Added a handler that detects `coalesce` function calls and recursively generates per-parameter existence checks combined with OR.

Fixes #7879