### PR TITLE
ref(eap-outcomes): add duplicate_item_count metric

### DIFF
--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -103,6 +103,7 @@ impl<TNext> OutcomesAggregator<TNext> {
             .collect();
 
         let category_metrics = batch.category_metrics.clone();
+        let duplicate_item_count = batch.duplicate_item_count;
         let message = Message::new_any_message(batch, committable);
         match self.next_step.submit(message) {
             Ok(()) => {
@@ -111,6 +112,7 @@ impl<TNext> OutcomesAggregator<TNext> {
                 self.last_flush = now;
 
                 tracing::info!("flushed {} buckets after {} seconds", num_buckets, seconds);
+                counter!("accepted_outcomes.duplicate_items", duplicate_item_count);
                 for (category, m) in category_metrics {
                     let cat_str = category.to_string();
                     counter!("accepted_outcomes.messages_seen", m.messages_seen, "data_category" => cat_str.as_str());
@@ -229,6 +231,7 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
                 item_id,
             };
             if !self.batch.seen_items.insert(dedup_key) {
+                self.batch.duplicate_item_count += 1;
                 return Ok(());
             }
         }

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -671,6 +671,8 @@ pub struct AggregatedOutcomesBatch {
     pub category_metrics: BTreeMap<u32, CategoryMetrics>,
     /// Set of items already processed in this batch, used for deduplication
     pub seen_items: HashSet<ItemDedupKey>,
+    /// Count of items skipped due to deduplication within this batch
+    pub duplicate_item_count: u64,
 }
 
 impl Default for AggregatedOutcomesBatch {
@@ -680,6 +682,7 @@ impl Default for AggregatedOutcomesBatch {
             bucket_interval: 60,
             category_metrics: BTreeMap::new(),
             seen_items: HashSet::new(),
+            duplicate_item_count: 0,
         }
     }
 }


### PR DESCRIPTION
Added de-duping in https://github.com/getsentry/snuba/pull/7885 and wanted to add some metrics so we can see when these duplicates are happening more easily