### PR TITLE
ref(referrer): register supergroups_backfill_lightweight.get_latest_events

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -304,6 +304,9 @@ allocation_policies:
         getsentry.tasks.backfill_grouping_records:
           max_threads: 2
           concurrent_limit: 4
+        supergroups_backfill_lightweight.get_latest_events:
+          max_threads: 2
+          concurrent_limit: 4
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -299,6 +299,9 @@ allocation_policies:
         getsentry.tasks.backfill_grouping_records:
           max_threads: 7
           concurrent_limit: 60
+        supergroups_backfill_lightweight.get_latest_events:
+          max_threads: 7
+          concurrent_limit: 60
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser


### PR DESCRIPTION
## Summary
- Registers the new Sentry-side referrer `supergroups_backfill_lightweight.get_latest_events` in the `CrossOrgQueryAllocationPolicy` for both `errors` and `errors_ro` storages.
- Without this, unregistered referrers are throttled to `max_threads=1`/`concurrent_limit=1` by the policy, which would serialize (and loudly reject) the supergroups lightweight backfill's concurrent queries.
- Mirrors the limits already in place for `getsentry.tasks.backfill_grouping_records`: `2`/`4` on `errors`, `7`/`60` on `errors_ro`. No strict sizing requirements on the Sentry side — these can be tuned later if the backfill's fan-out warrants more headroom.

## Test plan
- [x] `validate-configs-syntax` pre-commit hook passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)