### PR TITLE
feat(explore): Add support for array in TraceItemDetail and TraceItemTable Endpoints

### DIFF
--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -178,7 +178,6 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
             )
 
     if attr_key.type == AttributeKey.Type.TYPE_ARRAY:
-        alias = _build_label_mapping_key(attr_key)
         # Array values are stored as tagged variants (e.g. {"String": "alice"},
         # {"Int": "123"}) in the JSON column. Cast to Array(JSON), then extract
         # the value from whichever variant tag is present. We coalesce across

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -3,7 +3,7 @@ import os
 import random
 import uuid
 from bisect import bisect_left
-from typing import Any, Generic, List, Optional, Tuple, Type, cast, final
+from typing import Generic, List, Tuple, Type, cast, final
 
 import sentry_sdk
 from clickhouse_driver.errors import ErrorCodes as clickhouse_errors
@@ -12,7 +12,6 @@ from google.protobuf.message import Message as ProtobufMessage
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeValue
 
 from snuba import environment, state
 from snuba.query.allocation_policies import AllocationPolicyViolations
@@ -99,24 +98,6 @@ def _set_rpc_error_tags(in_msg: ProtobufMessage) -> None:
             sentry_sdk.set_tag("organization_id", str(meta.organization_id))
         if hasattr(meta, "request_id") and meta.request_id:
             sentry_sdk.set_tag("request_id", str(meta.request_id))
-
-
-def _scalar_to_attribute_value(elem: Any) -> Optional[AttributeValue]:
-    if elem is None:
-        return AttributeValue(is_null=True)
-    if isinstance(elem, bool):
-        return AttributeValue(val_bool=elem)
-    if isinstance(elem, int):
-        return AttributeValue(val_int=elem)
-    if isinstance(elem, float):
-        return AttributeValue(val_double=elem)
-    if isinstance(elem, str):
-        return AttributeValue(val_str=elem)
-    return None
-
-
-def convert_array_elements(values: List[Any]) -> list[AttributeValue]:
-    return [av for e in values if (av := _scalar_to_attribute_value(e)) is not None]
 
 
 class TraceItemDataResolver(Generic[Tin, Tout], metaclass=RegisteredClass):

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -3,7 +3,7 @@ import os
 import random
 import uuid
 from bisect import bisect_left
-from typing import Generic, List, Tuple, Type, cast, final
+from typing import Generic, List, Tuple, Type, cast, final, Optional, Any
 
 import sentry_sdk
 from clickhouse_driver.errors import ErrorCodes as clickhouse_errors
@@ -12,6 +12,7 @@ from google.protobuf.message import Message as ProtobufMessage
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeValue
 
 from snuba import environment, state
 from snuba.query.allocation_policies import AllocationPolicyViolations
@@ -99,6 +100,25 @@ def _set_rpc_error_tags(in_msg: ProtobufMessage) -> None:
         if hasattr(meta, "request_id") and meta.request_id:
             sentry_sdk.set_tag("request_id", str(meta.request_id))
 
+
+def _scalar_to_attribute_value(elem: Any) -> Optional[AttributeValue]:
+    if elem is None:
+        return AttributeValue(is_null=True)
+    if isinstance(elem, bool):
+        return AttributeValue(val_bool=elem)
+    if isinstance(elem, int):
+        return AttributeValue(val_int=elem)
+    if isinstance(elem, float):
+        return AttributeValue(val_double=elem)
+    if isinstance(elem, str):
+        return AttributeValue(val_str=elem)
+    return None
+
+
+def convert_array_elements(values: List[Any]) -> list[AttributeValue]:
+    return [
+        av for e in values if (av := _scalar_to_attribute_value(e)) is not None
+    ]
 
 class TraceItemDataResolver(Generic[Tin, Tout], metaclass=RegisteredClass):
     def __init__(

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -3,7 +3,7 @@ import os
 import random
 import uuid
 from bisect import bisect_left
-from typing import Generic, List, Tuple, Type, cast, final, Optional, Any
+from typing import Any, Generic, List, Optional, Tuple, Type, cast, final
 
 import sentry_sdk
 from clickhouse_driver.errors import ErrorCodes as clickhouse_errors
@@ -116,9 +116,8 @@ def _scalar_to_attribute_value(elem: Any) -> Optional[AttributeValue]:
 
 
 def convert_array_elements(values: List[Any]) -> list[AttributeValue]:
-    return [
-        av for e in values if (av := _scalar_to_attribute_value(e)) is not None
-    ]
+    return [av for e in values if (av := _scalar_to_attribute_value(e)) is not None]
+
 
 class TraceItemDataResolver(Generic[Tin, Tout], metaclass=RegisteredClass):
     def __init__(

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -397,7 +397,7 @@ def convert_to_attribute_value(value: Any) -> AttributeValue:
         return AttributeValue(
             val_str=value,
         )
-    elif isinstance(value, list):
+    elif isinstance(value, (list, tuple)):
         return AttributeValue(
             val_array=Array(values=[convert_to_attribute_value(v) for v in value])
         )

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, Iterable, Tuple, Type
+from typing import Any, Dict, Iterable, Tuple, Type, List
 
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -9,7 +9,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import (
     TraceItemDetailsResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeValue
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeValue, Array
 
 from snuba.attribution.appid import AppID
 from snuba.attribution.attribution_info import AttributionInfo
@@ -31,7 +31,7 @@ from snuba.web.rpc.common.common import (
     attribute_key_to_expression,
     base_conditions_and,
     trace_item_filters_to_expression,
-    treeify_or_and_conditions,
+    treeify_or_and_conditions, process_arrays,
 )
 from snuba.web.rpc.common.debug_info import (
     extract_response_meta,
@@ -83,6 +83,9 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             SelectedExpression(
                 "attributes_bool", column("attributes_bool", alias="attributes_bool")
             ),
+            SelectedExpression(
+                "attributes_array", column("attributes_array", alias="attributes_array")
+            )
         ],
         condition=base_conditions_and(
             request.meta,
@@ -124,6 +127,23 @@ def _build_snuba_request(request: TraceItemDetailsRequest) -> SnubaRequest:
             parent_api="eap_trace_item_table",
         ),
     )
+
+def _convert_array_elements(values: List[Any]) -> List[Any]:
+    elements = []
+    for elem in values:
+        if elem is None:
+            elements.append(AttributeValue(is_null=True))
+        elif isinstance(elem, bool):
+            elements.append(AttributeValue(val_bool=elem))
+        elif isinstance(elem, int):
+            elements.append(AttributeValue(val_int=elem))
+        elif isinstance(elem, float):
+            elements.append(AttributeValue(val_double=elem))
+        elif isinstance(elem, str):
+            elements.append(AttributeValue(val_str=elem))
+        else:
+            continue
+    return elements
 
 
 def _convert_results(
@@ -179,6 +199,18 @@ def _convert_results(
             # the original type, and ignore the float duplicate
             continue
         attrs.append(TraceItemDetailsAttribute(name=k, value=AttributeValue(val_double=v)))
+
+
+    raw_array = row.get("attributes_array")
+    if raw_array:
+        for k, values in process_arrays(raw_array).items():
+            attrs.append(
+                TraceItemDetailsAttribute(
+                    name=k,
+                    value=AttributeValue(val_array=Array(values=_convert_array_elements(values))),
+                )
+            )
+
     return item_id, timestamp, attrs
 
 

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -20,6 +20,7 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal
+from snuba.query.expressions import FunctionCall
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
@@ -84,7 +85,12 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
                 "attributes_bool", column("attributes_bool", alias="attributes_bool")
             ),
             SelectedExpression(
-                "attributes_array", column("attributes_array", alias="attributes_array")
+                "attributes_array",
+                FunctionCall(
+                    "attributes_array",
+                    "toJSONString",
+                    (column("attributes_array"),),
+                ),
             )
         ],
         condition=base_conditions_and(

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, Iterable, Tuple, Type, List
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -24,7 +24,7 @@ from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
 from snuba.web.query import run_query
-from snuba.web.rpc import RPCEndpoint
+from snuba.web.rpc import RPCEndpoint, convert_array_elements
 from snuba.web.rpc.common.common import (
     BUCKET_COUNT,
     add_existence_check_to_subscriptable_references,
@@ -128,24 +128,6 @@ def _build_snuba_request(request: TraceItemDetailsRequest) -> SnubaRequest:
         ),
     )
 
-def _convert_array_elements(values: List[Any]) -> List[Any]:
-    elements = []
-    for elem in values:
-        if elem is None:
-            elements.append(AttributeValue(is_null=True))
-        elif isinstance(elem, bool):
-            elements.append(AttributeValue(val_bool=elem))
-        elif isinstance(elem, int):
-            elements.append(AttributeValue(val_int=elem))
-        elif isinstance(elem, float):
-            elements.append(AttributeValue(val_double=elem))
-        elif isinstance(elem, str):
-            elements.append(AttributeValue(val_str=elem))
-        else:
-            continue
-    return elements
-
-
 def _convert_results(
     data: Iterable[Dict[str, Any]],
 ) -> Tuple[str, Timestamp, list[TraceItemDetailsAttribute]]:
@@ -207,7 +189,7 @@ def _convert_results(
             attrs.append(
                 TraceItemDetailsAttribute(
                     name=k,
-                    value=AttributeValue(val_array=Array(values=_convert_array_elements(values))),
+                    value=AttributeValue(val_array=Array(values=convert_array_elements(values))),
                 )
             )
 

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -9,7 +9,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import (
     TraceItemDetailsResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Array, AttributeValue
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeValue
 
 from snuba.attribution.appid import AppID
 from snuba.attribution.attribution_info import AttributionInfo
@@ -25,7 +25,7 @@ from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
 from snuba.web.query import run_query
-from snuba.web.rpc import RPCEndpoint, convert_array_elements
+from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.common import (
     BUCKET_COUNT,
     add_existence_check_to_subscriptable_references,
@@ -43,6 +43,7 @@ from snuba.web.rpc.common.exceptions import (
     BadSnubaRPCRequestException,
     RPCRequestException,
 )
+from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
@@ -196,7 +197,7 @@ def _convert_results(
             attrs.append(
                 TraceItemDetailsAttribute(
                     name=k,
-                    value=AttributeValue(val_array=Array(values=convert_array_elements(values))),
+                    value=convert_to_attribute_value(values),
                 )
             )
 

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
+from typing import Any, Dict, Iterable, Tuple, Type
 
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -9,7 +9,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import (
     TraceItemDetailsResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeValue, Array
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import Array, AttributeValue
 
 from snuba.attribution.appid import AppID
 from snuba.attribution.attribution_info import AttributionInfo
@@ -31,8 +31,9 @@ from snuba.web.rpc.common.common import (
     add_existence_check_to_subscriptable_references,
     attribute_key_to_expression,
     base_conditions_and,
+    process_arrays,
     trace_item_filters_to_expression,
-    treeify_or_and_conditions, process_arrays,
+    treeify_or_and_conditions,
 )
 from snuba.web.rpc.common.debug_info import (
     extract_response_meta,
@@ -91,7 +92,7 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
                     "toJSONString",
                     (column("attributes_array"),),
                 ),
-            )
+            ),
         ],
         condition=base_conditions_and(
             request.meta,
@@ -133,6 +134,7 @@ def _build_snuba_request(request: TraceItemDetailsRequest) -> SnubaRequest:
             parent_api="eap_trace_item_table",
         ),
     )
+
 
 def _convert_results(
     data: Iterable[Dict[str, Any]],
@@ -187,7 +189,6 @@ def _convert_results(
             # the original type, and ignore the float duplicate
             continue
         attrs.append(TraceItemDetailsAttribute(name=k, value=AttributeValue(val_double=v)))
-
 
     raw_array = row.get("attributes_array")
     if raw_array:

--- a/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
@@ -11,11 +11,22 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeKey,
     AttributeValue,
     Function,
-    Reliability,
+    Reliability, Array,
 )
 
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.resolvers.common.aggregation import ExtrapolationContext
+
+
+def _array_raw_to_attribute_value(raw: Any) -> AttributeValue:
+    if raw is None:
+        return AttributeValue(is_null=True)
+    elements = [
+        AttributeValue(val_str=str(elem)) if elem is not None else AttributeValue(is_null=True)
+        for elem in raw
+    ]
+    return AttributeValue(val_array=Array(values=elements))
+
 
 
 def _get_converter_for_type(
@@ -32,6 +43,8 @@ def _get_converter_for_type(
         return lambda x: AttributeValue(val_float=float(x))
     elif key_type == AttributeKey.TYPE_DOUBLE:
         return lambda x: AttributeValue(val_double=float(x))
+    elif key_type == AttributeKey.TYPE_ARRAY:
+        return _array_raw_to_attribute_value
     else:
         raise BadSnubaRPCRequestException(
             f"unknown attribute type: {AttributeKey.Type.Name(key_type)}"

--- a/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
@@ -8,20 +8,19 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableRequest,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
-    Array,
     AttributeKey,
     AttributeValue,
     Function,
     Reliability,
 )
 
-from snuba.web.rpc import convert_array_elements
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 from snuba.web.rpc.v1.resolvers.common.aggregation import ExtrapolationContext
 
 
 def _array_raw_to_attribute_value(raw: Any) -> AttributeValue:
-    return AttributeValue(val_array=Array(values=convert_array_elements(raw)))
+    return convert_to_attribute_value(raw)
 
 
 def _get_converter_for_type(

--- a/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
@@ -14,20 +14,13 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     Reliability, Array,
 )
 
+from snuba.web.rpc import convert_array_elements
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.resolvers.common.aggregation import ExtrapolationContext
 
 
 def _array_raw_to_attribute_value(raw: Any) -> AttributeValue:
-    if raw is None:
-        return AttributeValue(is_null=True)
-    elements = [
-        AttributeValue(val_str=str(elem)) if elem is not None else AttributeValue(is_null=True)
-        for elem in raw
-    ]
-    return AttributeValue(val_array=Array(values=elements))
-
-
+    return AttributeValue(val_array=Array(values=convert_array_elements(raw)))
 
 def _get_converter_for_type(
     key_type: "AttributeKey.Type.ValueType",

--- a/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
@@ -8,10 +8,11 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableRequest,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    Array,
     AttributeKey,
     AttributeValue,
     Function,
-    Reliability, Array,
+    Reliability,
 )
 
 from snuba.web.rpc import convert_array_elements
@@ -21,6 +22,7 @@ from snuba.web.rpc.v1.resolvers.common.aggregation import ExtrapolationContext
 
 def _array_raw_to_attribute_value(raw: Any) -> AttributeValue:
     return AttributeValue(val_array=Array(values=convert_array_elements(raw)))
+
 
 def _get_converter_for_type(
     key_type: "AttributeKey.Type.ValueType",

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -14,7 +14,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
-from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
+from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -82,6 +82,17 @@ def setup_spans_in_db(eap: None, redis_db: None) -> None:
     ]
 
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
+
+
+def _str_tags_array(*values: str) -> AnyValue:
+    return AnyValue(
+        array_value=ArrayValue(values=[AnyValue(string_value=v) for v in values])
+    )
+
+def _int_vals_array(*values: int) -> AnyValue:
+    return AnyValue(
+        array_value=ArrayValue(values=[AnyValue(int_value=v) for v in values])
+    )
 
 
 @pytest.mark.eap
@@ -249,6 +260,82 @@ class TestTraceItemDetails(BaseApiTest):
         }:
             assert k in attributes_returned, k
 
+    def test_endpoint_returns_array_attribute(self, eap: None, redis_db: None) -> None:
+        """attributes_array from storage is exposed as val_array on TraceItemDetails."""
+        span_ts = BASE_TIME - timedelta(minutes=1)
+        storage = get_storage(StorageKey("eap_items"))
+        write_raw_unprocessed_events(
+            storage,  # type: ignore
+            [
+                gen_item_message(
+                    span_ts,
+                    attributes={
+                        "tags": _str_tags_array("gamma", "delta"),
+                        "cols": _int_vals_array(1, 3)
+
+                    },
+                ),
+            ],
+        )
+        start = Timestamp()
+        end = Timestamp()
+        start.FromDatetime(BASE_TIME - timedelta(hours=4))
+        end.GetCurrentTime()
+
+        spans = (
+            EndpointTraceItemTable()
+            .execute(
+                TraceItemTableRequest(
+                    meta=RequestMeta(
+                        project_ids=[1],
+                        organization_id=1,
+                        cogs_category="something",
+                        referrer="something",
+                        start_timestamp=start,
+                        end_timestamp=end,
+                        request_id=_REQUEST_ID,
+                        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                    ),
+                    columns=[
+                        Column(
+                            key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")
+                        ),
+                        Column(
+                            key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.trace_id")
+                        ),
+                    ],
+                )
+            )
+            .column_values
+        )
+        item_id = spans[0].results[0].val_str
+        trace_id = spans[1].results[0].val_str
+
+        res = EndpointTraceItemDetails().execute(
+            TraceItemDetailsRequest(
+                meta=RequestMeta(
+                    project_ids=[1],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    start_timestamp=start,
+                    end_timestamp=end,
+                    request_id=_REQUEST_ID,
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                ),
+                item_id=item_id,
+                trace_id=trace_id,
+            )
+        )
+        tags_attr = next((a for a in res.attributes if a.name == "tags"), None)
+        assert tags_attr is not None
+        assert tags_attr.value.WhichOneof("value") == "val_array"
+        assert [e.val_str for e in tags_attr.value.val_array.values] == ["gamma", "delta"]
+        cols_attr = next((a for a in res.attributes if a.name == "cols"), None)
+        assert cols_attr is not None
+        assert cols_attr.value.WhichOneof("value") == "val_array"
+        assert [e.val_int for e in cols_attr.value.val_array.values] == [1, 3]
+
     def test_endpoint_on_spans(self, setup_spans_in_db: Any) -> None:
         end = Timestamp()
         start = Timestamp()
@@ -353,3 +440,30 @@ def test_convert_results_dedupes() -> None:
     _, _, attrs = _convert_results(data)
     is_segment_attrs = list(filter(lambda x: x.name == "sentry.is_segment", attrs))
     assert len(is_segment_attrs) == 1
+
+
+def test_convert_results_includes_attributes_array() -> None:
+    """
+    TraceItemDetails maps the ClickHouse attributes_array JSON payload into val_array
+    attributes (same path EndpointTraceItemDetails uses after the query).
+    """
+    data = [
+        {
+            "timestamp": 1750964400,
+            "hex_item_id": "e70ef5b1b5bc4611840eff9964b7a767",
+            "trace_id": "cb190d6e7d5743d5bc1494c650592cd2",
+            "organization_id": 1,
+            "project_id": 1,
+            "item_type": 1,
+            "attributes_string": {},
+            "attributes_int": {},
+            "attributes_float": {},
+            "attributes_bool": {},
+            "attributes_array": '{"tags":[{"String":"gamma"},{"String":"delta"}]}',
+        }
+    ]
+    _, _, attrs = _convert_results(data)
+    tags = [a for a in attrs if a.name == "tags"]
+    assert len(tags) == 1
+    assert tags[0].value.WhichOneof("value") == "val_array"
+    assert [e.val_str for e in tags[0].value.val_array.values] == ["gamma", "delta"]

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -85,14 +85,11 @@ def setup_spans_in_db(eap: None, redis_db: None) -> None:
 
 
 def _str_tags_array(*values: str) -> AnyValue:
-    return AnyValue(
-        array_value=ArrayValue(values=[AnyValue(string_value=v) for v in values])
-    )
+    return AnyValue(array_value=ArrayValue(values=[AnyValue(string_value=v) for v in values]))
+
 
 def _int_vals_array(*values: int) -> AnyValue:
-    return AnyValue(
-        array_value=ArrayValue(values=[AnyValue(int_value=v) for v in values])
-    )
+    return AnyValue(array_value=ArrayValue(values=[AnyValue(int_value=v) for v in values]))
 
 
 @pytest.mark.eap
@@ -271,8 +268,7 @@ class TestTraceItemDetails(BaseApiTest):
                     span_ts,
                     attributes={
                         "tags": _str_tags_array("gamma", "delta"),
-                        "cols": _int_vals_array(1, 3)
-
+                        "cols": _int_vals_array(1, 3),
                     },
                 ),
             ],

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3582,7 +3582,10 @@ class TestTraceItemTableArrayColumn(BaseApiTest):
                     span_ts,
                     attributes={
                         "tags": _str_array("alpha", "beta"),
-                        "cols": AnyValue(array_value=ArrayValue(values=[AnyValue(int_value=v) for v in [1, 3]]))},
+                        "cols": AnyValue(
+                            array_value=ArrayValue(values=[AnyValue(int_value=v) for v in [1, 3]])
+                        ),
+                    },
                 ),
             ],
         )
@@ -3614,8 +3617,6 @@ class TestTraceItemTableArrayColumn(BaseApiTest):
             "1",
             "3",
         ]
-
-
 
 
 class TestUtils:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3568,6 +3568,56 @@ class TestArrayWildcardSearch(BaseApiTest):
         assert len(response.column_values[0].results) == 1
 
 
+class TestTraceItemTableArrayColumn(BaseApiTest):
+    @pytest.mark.clickhouse_db
+    @pytest.mark.redis_db
+    def test_select_array_column_returns_val_array(self) -> None:
+        """TYPE_ARRAY columns are returned as val_array on TraceItemTable."""
+        span_ts = BASE_TIME - timedelta(minutes=1)
+        items_storage = get_storage(StorageKey("eap_items"))
+        write_raw_unprocessed_events(
+            items_storage,  # type: ignore
+            [
+                gen_item_message(
+                    span_ts,
+                    attributes={
+                        "tags": _str_array("alpha", "beta"),
+                        "cols": AnyValue(array_value=ArrayValue(values=[AnyValue(int_value=v) for v in [1, 3]]))},
+                ),
+            ],
+        )
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags")),
+                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="cols")),
+            ],
+        )
+        response = EndpointTraceItemTable().execute(message)
+        by_name = {cv.attribute_name: cv for cv in response.column_values}
+        assert by_name["tags"].results[0].WhichOneof("value") == "val_array"
+        assert [e.val_str for e in by_name["tags"].results[0].val_array.values] == [
+            "alpha",
+            "beta",
+        ]
+        assert by_name["cols"].results[0].WhichOneof("value") == "val_array"
+        assert [e.val_str for e in by_name["cols"].results[0].val_array.values] == [
+            "1",
+            "3",
+        ]
+
+
+
+
 class TestUtils:
     def test_apply_labels_to_columns_backward_compat(self) -> None:
         message = TraceItemTableRequest(


### PR DESCRIPTION
Expose Array attributes of EAP items in Trace item details endpoint and Trace Item Table endpoint. 

### Note
TraceItemTable endpoint converts all array types to string arrays while TraceItemDetail endpoint preserves the types.  