### PR TITLE
ref(eap-outcomes): add min_partition tag

### DIFF
--- a/rust_snuba/src/accepted_outcomes_consumer.rs
+++ b/rust_snuba/src/accepted_outcomes_consumer.rs
@@ -38,8 +38,11 @@ pub struct AcceptedOutcomesStrategyFactory {
 }
 
 impl ProcessingStrategyFactory<KafkaPayload> for AcceptedOutcomesStrategyFactory {
-    fn update_partitions(&self, _partitions: &HashMap<Partition, u64>) {
-        // No-op for now
+    fn update_partitions(&self, partitions: &HashMap<Partition, u64>) {
+        match partitions.keys().map(|partition| partition.index).min() {
+            Some(min) => set_global_tag("min_partition".to_owned(), min.to_string()),
+            None => set_global_tag("min_partition".to_owned(), "none".to_owned()),
+        }
     }
 
     fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {


### PR DESCRIPTION
Adding the `min_partition` tag for the accepted outcomes consumer like we do in our other consumers https://github.com/getsentry/snuba/blob/2fda7c868714b193e322771fba6ce15d5eada8aa/rust_snuba/src/factory_v2.rs#L86-L88