### PR TITLE
chore(snuba commit log): Remove commit log next offset option from `sentry-options` schema

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -21,11 +21,6 @@
       "type": "integer",
       "default": 120,
       "description": "BLQ hysteresis in seconds. Once routing stale, keep routing messages at least (stale_threshold - static_friction) old. Set to 0 to disable friction."
-    },
-    "consumer.commit_log_use_next_offset": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, the Rust consumer writes offset+1 (next-to-consume) to the commit log instead of the raw offset."
     }
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry-options-automator/pull/7428.

Removing this option as it is no longer needed/used.