### PR TITLE
ref(consumer): set message.max.bytes for DLQ/BLQ producers

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -194,7 +194,9 @@ pub fn consumer_impl(
     // writing to the DLQ topics in prod.
 
     let dlq_producer_config = consumer_config.dlq_topic.as_ref().map(|dlq_topic_config| {
-        KafkaConfig::new_producer_config(vec![], Some(dlq_topic_config.broker_config.clone()))
+        let mut overrides = dlq_topic_config.broker_config.clone();
+        overrides.insert("message.max.bytes".to_string(), "10000000".to_string()); // 10 MB, broker max
+        KafkaConfig::new_producer_config(vec![], Some(overrides))
     });
 
     let dlq_topic = consumer_config

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -193,7 +193,7 @@ pub fn consumer_impl(
     // DLQ policy applies only if we are not skipping writes, otherwise we don't want to be
     // writing to the DLQ topics in prod.
 
-    let dlq_producer_config = consumer_config.dlq_topic.as_ref().map(|dlq_topic_config| {
+    let blq_producer_config = consumer_config.dlq_topic.as_ref().map(|dlq_topic_config| {
         let mut overrides = dlq_topic_config.broker_config.clone();
         overrides.insert("message.max.bytes".to_string(), "10000000".to_string()); // 10 MB, broker max
         KafkaConfig::new_producer_config(vec![], Some(overrides))
@@ -289,7 +289,7 @@ pub fn consumer_impl(
         join_timeout_ms,
         health_check: health_check.to_string(),
         use_row_binary,
-        blq_producer_config: dlq_producer_config.clone(),
+        blq_producer_config: blq_producer_config.clone(),
         blq_topic: dlq_topic,
     };
 


### PR DESCRIPTION
the dlq isnt actually used right now, so this should be fine. the value aligns with the topic https://github.com/getsentry/sentry-kafka-schemas/blob/main/topics/snuba-items.yaml#L18

## Summary
- Override \`message.max.bytes\` to 10MB on the DLQ producer \`KafkaConfig\` in \`consumer.rs\`. This config is also cloned for the BLQ producer, so both get the same broker-max limit.
- Mirrors the existing override already applied to the Python replacements producer in \`snuba/consumers/consumer_builder.py\`.

## Test plan
- [ ] \`cargo check -p rust_snuba\` passes locally
- [ ] Consumer starts cleanly and produces to DLQ/BLQ topics with large payloads that previously would have exceeded the 1MB default

🤖 Generated with [Claude Code](https://claude.com/claude-code)