### PR TITLE
feat(data-explore): Add support in EAP to filter Array by elements

### DIFF
--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -120,6 +120,52 @@ def _generate_subscriptable_reference(
     )
 
 
+def type_array_to_membership_array_expression(attr_key: AttributeKey) -> FunctionCall:
+    """To be used only in WHERE clause, not SELECT"""
+    if attr_key.type != AttributeKey.Type.TYPE_ARRAY:
+        raise MalformedAttributeException(
+            f"type_array_to_membership_array_expression expected TYPE_ARRAY, got "
+            f"{AttributeKey.Type.Name(attr_key.type)}"
+        )
+    # We need different label than attribute_key_to_expression(TYPE_ARRAY) [toJSONString]
+    alias = f"{_build_label_mapping_key(attr_key)}__array_members"
+    x = Argument(None, "x")
+    return FunctionCall(
+        alias=alias,
+        function_name="arrayMap",
+        parameters=(
+            Lambda(
+                alias=None,
+                parameters=("x",),
+                transformation=FunctionCall(
+                    alias=None,
+                    function_name="coalesce",
+                    parameters=(
+                        JsonPath(None, x, "String", "Nullable(String)"),
+                        FunctionCall(
+                            None,
+                            "toString",
+                            (JsonPath(None, x, "Int", "Nullable(Int64)"),),
+                        ),
+                        FunctionCall(
+                            None,
+                            "toString",
+                            (JsonPath(None, x, "Double", "Nullable(Float64)"),),
+                        ),
+                        JsonPath(None, x, "Bool", "Nullable(String)"),
+                    ),
+                ),
+            ),
+            JsonPath(
+                alias=None,
+                base=column("attributes_array"),
+                path=attr_key.name,
+                return_type="Array(JSON)",
+            ),
+        ),
+    )
+
+
 def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
@@ -178,38 +224,13 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
             )
 
     if attr_key.type == AttributeKey.Type.TYPE_ARRAY:
-        # Array values are stored as tagged variants (e.g. {"String": "alice"},
-        # {"Int": "123"}) in the JSON column. Cast to Array(JSON), then extract
-        # the value from whichever variant tag is present. We coalesce across
-        # all supported types, converting non-string types via toString so the
-        # result is always a string array.
-        x = Argument(None, "x")
+        # Tagged array under attributes_array.* as Array(JSON). Select toJSONString(...)
+        # so the result column is String; callers decode in application code. Raw
+        # Array(JSON) is not returned in the SELECT to avoid native client limits.
         return FunctionCall(
             alias=alias,
-            function_name="arrayMap",
+            function_name="toJSONString",
             parameters=(
-                Lambda(
-                    alias=None,
-                    parameters=("x",),
-                    transformation=FunctionCall(
-                        alias=None,
-                        function_name="coalesce",
-                        parameters=(
-                            JsonPath(None, x, "String", "Nullable(String)"),
-                            FunctionCall(
-                                None,
-                                "toString",
-                                (JsonPath(None, x, "Int", "Nullable(Int64)"),),
-                            ),
-                            FunctionCall(
-                                None,
-                                "toString",
-                                (JsonPath(None, x, "Double", "Nullable(Float64)"),),
-                            ),
-                            JsonPath(None, x, "Bool", "Nullable(String)"),
-                        ),
-                    ),
-                ),
                 JsonPath(
                     alias=None,
                     base=column("attributes_array"),

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -166,6 +166,15 @@ def type_array_to_membership_array_expression(attr_key: AttributeKey) -> Functio
     )
 
 
+def type_array_to_stored_array_json_path(attr_key: AttributeKey) -> JsonPath:
+    return JsonPath(
+        alias=None,
+        base=column("attributes_array"),
+        path=attr_key.name,
+        return_type="Array(JSON)",
+    )
+
+
 def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
@@ -230,14 +239,7 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
         return FunctionCall(
             alias=alias,
             function_name="toJSONString",
-            parameters=(
-                JsonPath(
-                    alias=None,
-                    base=column("attributes_array"),
-                    path=attr_key.name,
-                    return_type="Array(JSON)",
-                ),
-            ),
+            parameters=(type_array_to_stored_array_json_path(attr_key),),
         )
 
     raise MalformedAttributeException(

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -524,7 +524,8 @@ def trace_item_filters_to_expression(
         if value_type is None and not v.is_null:
             raise BadSnubaRPCRequestException("comparison does not have a right hand side")
 
-        if v.is_null:
+        # is_null and val_null both mean a null RHS;
+        if v.is_null or value_type == "val_null":
             v_expression: Expression = literal(None)
         else:
             v_expression = _attribute_value_to_expression(v)

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -265,6 +265,76 @@ _ARRAY_VALUE_TYPES = {
 }
 
 
+def _validate_comparison_filter_type_array(
+    op: ComparisonFilter.Op.ValueType, v: AttributeValue
+) -> None:
+    if op in (ComparisonFilter.OP_LIKE, ComparisonFilter.OP_NOT_LIKE):
+        if v.WhichOneof("value") != "val_str":
+            raise BadSnubaRPCRequestException(
+                "LIKE/NOT_LIKE on array keys requires a string pattern"
+            )
+        return
+    if op in (ComparisonFilter.OP_EQUALS, ComparisonFilter.OP_NOT_EQUALS):
+        if v.is_null or v.WhichOneof("value") == "val_null":
+            return
+        vt = v.WhichOneof("value")
+        if vt in (
+            None,
+            "val_array",
+            "val_str_array",
+            "val_int_array",
+            "val_float_array",
+            "val_double_array",
+        ):
+            raise BadSnubaRPCRequestException(
+                "OP_EQUALS/OP_NOT_EQUALS on array keys require a scalar value "
+                "(e.g. val_str, val_int) or null (is_null / val_null) to match null elements"
+            )
+        return
+    raise BadSnubaRPCRequestException(
+        f"{ComparisonFilter.Op.Name(op)} is not supported on array keys "
+        "(supported: LIKE, NOT_LIKE, OP_EQUALS, OP_NOT_EQUALS)"
+    )
+
+
+def _type_array_membership_rhs_expression(v: AttributeValue) -> Expression:
+    """RHS as String, comparable to TYPE_ARRAY arrayMap output (Array(String) in CH)."""
+    value_type = v.WhichOneof("value")
+    match value_type:
+        case "val_str":
+            return literal(v.val_str)
+        case "val_int":
+            return f.toString(literal(v.val_int))
+        case "val_double":
+            return f.toString(literal(v.val_double))
+        case "val_float":
+            return f.toString(literal(v.val_float))
+        case "val_bool":
+            return literal(str(v.val_bool).lower())
+        case _:
+            raise BadSnubaRPCRequestException(
+                f"unsupported AttributeValue for array membership: {value_type}"
+            )
+
+
+def _type_array_includes_scalar_expression(
+    array_expr: Expression,
+    v: AttributeValue,
+    ignore_case: bool,
+) -> Expression:
+    """Any element equals scalar (includes / [*]); null means any element is null."""
+    x = Argument(None, "x")
+    if v.is_null or v.WhichOneof("value") == "val_null":
+        return f.arrayExists(Lambda(None, ("x",), f.isNull(x)), array_expr)
+    rhs = _type_array_membership_rhs_expression(v)
+    if ignore_case and v.WhichOneof("value") == "val_str":
+        return f.arrayExists(
+            Lambda(None, ("x",), f.equals(f.lower(x), f.lower(rhs))),
+            array_expr,
+        )
+    return f.arrayExists(Lambda(None, ("x",), f.equals(x, rhs)), array_expr)
+
+
 def _any_attribute_filter_to_expression(
     filt: AnyAttributeFilter,
 ) -> Expression:
@@ -425,24 +495,13 @@ def trace_item_filters_to_expression(
         op = item_filter.comparison_filter.op
         v = item_filter.comparison_filter.value
 
-        # TYPE_ARRAY only supports LIKE/NOT_LIKE with string patterns — validate early.
         if k.type == AttributeKey.Type.TYPE_ARRAY:
-            if op not in (
-                ComparisonFilter.OP_LIKE,
-                ComparisonFilter.OP_NOT_LIKE,
-            ):
-                raise BadSnubaRPCRequestException(
-                    "only LIKE and NOT_LIKE comparisons are supported on array keys"
-                )
-            if v.WhichOneof("value") != "val_str":
-                raise BadSnubaRPCRequestException(
-                    "LIKE/NOT_LIKE on array keys requires a string pattern"
-                )
+            _validate_comparison_filter_type_array(op, v)
 
         k_expression = attribute_key_to_expression(k)
 
         value_type = v.WhichOneof("value")
-        if value_type is None:
+        if value_type is None and not v.is_null:
             raise BadSnubaRPCRequestException("comparison does not have a right hand side")
 
         if v.is_null:
@@ -452,26 +511,43 @@ def trace_item_filters_to_expression(
 
         if op == ComparisonFilter.OP_EQUALS:
             _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
-            expr = (
-                f.equals(f.lower(k_expression), f.lower(v_expression))
-                if item_filter.comparison_filter.ignore_case
-                else f.equals(k_expression, v_expression)
-            )
-            # we redefine the way equals works for nulls
-            # now null=null is true
-            expr_with_null = or_cond(expr, and_cond(f.isNull(k_expression), f.isNull(v_expression)))
-            return expr_with_null
+
+            if k.type == AttributeKey.Type.TYPE_ARRAY:
+                return _type_array_includes_scalar_expression(
+                    k_expression, v, item_filter.comparison_filter.ignore_case
+                )
+            else:
+                expr = (
+                    f.equals(f.lower(k_expression), f.lower(v_expression))
+                    if item_filter.comparison_filter.ignore_case
+                    else f.equals(k_expression, v_expression)
+                )
+                # we redefine the way equals works for nulls
+                # now null=null is true
+                expr_with_null = or_cond(
+                    expr, and_cond(f.isNull(k_expression), f.isNull(v_expression))
+                )
+                return expr_with_null
         if op == ComparisonFilter.OP_NOT_EQUALS:
             _check_non_string_values_cannot_ignore_case(item_filter.comparison_filter)
-            expr = (
-                f.notEquals(f.lower(k_expression), f.lower(v_expression))
-                if item_filter.comparison_filter.ignore_case
-                else f.notEquals(k_expression, v_expression)
-            )
-            # we redefine the way not equals works for nulls
-            # now null!=null is true
-            expr_with_null = or_cond(expr, f.xor(f.isNull(k_expression), f.isNull(v_expression)))
-            return expr_with_null
+            if k.type == AttributeKey.Type.TYPE_ARRAY:
+                return not_cond(
+                    _type_array_includes_scalar_expression(
+                        k_expression, v, item_filter.comparison_filter.ignore_case
+                    )
+                )
+            else:
+                expr = (
+                    f.notEquals(f.lower(k_expression), f.lower(v_expression))
+                    if item_filter.comparison_filter.ignore_case
+                    else f.notEquals(k_expression, v_expression)
+                )
+                # we redefine the way not equals works for nulls
+                # now null!=null is true
+                expr_with_null = or_cond(
+                    expr, f.xor(f.isNull(k_expression), f.isNull(v_expression))
+                )
+                return expr_with_null
         if op == ComparisonFilter.OP_LIKE:
             if k.type == AttributeKey.Type.TYPE_ARRAY:
                 like_fn = f.ilike if item_filter.comparison_filter.ignore_case else f.like

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -293,11 +293,11 @@ def _validate_comparison_filter_type_array(
             )
         return
     if op in (ComparisonFilter.OP_EQUALS, ComparisonFilter.OP_NOT_EQUALS):
-        if v.is_null or v.WhichOneof("value") == "val_null":
-            return
+        # Array can be empty or non-empty. It can never be null, or can never have null elements.
         vt = v.WhichOneof("value")
         if vt in (
             None,
+            "val_null",
             "val_array",
             "val_str_array",
             "val_int_array",
@@ -340,7 +340,9 @@ def _type_array_includes_scalar_expression(
     v: AttributeValue,
     ignore_case: bool,
 ) -> Expression:
-    """Any element equals scalar (includes / [*]); null means any element is null."""
+    """Any element equals scalar (includes / [*])"""
+    if v.WhichOneof("value") == "val_null" or v.is_null:
+        raise BadSnubaRPCRequestException("Arrays can't be NULL or cannot have NULL elements")
     x = Argument(None, "x")
     if v.is_null or v.WhichOneof("value") == "val_null":
         return f.arrayExists(Lambda(None, ("x",), f.isNull(x)), array_expr)
@@ -521,10 +523,9 @@ def trace_item_filters_to_expression(
         )
 
         value_type = v.WhichOneof("value")
-        if value_type is None and not v.is_null:
+        if value_type is None or not v.is_null:
             raise BadSnubaRPCRequestException("comparison does not have a right hand side")
 
-        # is_null and val_null both mean a null RHS;
         if v.is_null or value_type == "val_null":
             v_expression: Expression = literal(None)
         else:

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -523,7 +523,7 @@ def trace_item_filters_to_expression(
         )
 
         value_type = v.WhichOneof("value")
-        if value_type is None or not v.is_null:
+        if value_type is None:
             raise BadSnubaRPCRequestException("comparison does not have a right hand side")
 
         if v.is_null or value_type == "val_null":

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -12,7 +12,10 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from snuba import settings, state
-from snuba.protos.common import MalformedAttributeException
+from snuba.protos.common import (
+    MalformedAttributeException,
+    type_array_to_membership_array_expression,
+)
 from snuba.protos.common import (
     attribute_key_to_expression as _attribute_key_to_expression,
 )
@@ -52,6 +55,21 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
         return _attribute_key_to_expression(attr_key)
     except MalformedAttributeException as e:
         raise BadSnubaRPCRequestException(str(e)) from e
+
+
+def _trace_item_filter_key_expression(
+    attr_to_key_expression_callable: Callable[[AttributeKey], Expression], key: AttributeKey
+) -> Expression:
+    """predicates must use the normalized
+    ``arrayMap`` (``type_array_to_membership_array_expression``) so
+    ``arrayExists`` compares per element. It is different from SELECT predicate.
+    """
+    if key.type == AttributeKey.Type.TYPE_ARRAY:
+        try:
+            return type_array_to_membership_array_expression(key)
+        except MalformedAttributeException as e:
+            raise BadSnubaRPCRequestException(str(e)) from e
+    return attr_to_key_expression_callable(key)
 
 
 Tin = TypeVar("Tin", bound=ProtobufMessage)
@@ -498,7 +516,9 @@ def trace_item_filters_to_expression(
         if k.type == AttributeKey.Type.TYPE_ARRAY:
             _validate_comparison_filter_type_array(op, v)
 
-        k_expression = attribute_key_to_expression(k)
+        k_expression = _trace_item_filter_key_expression(
+            attr_to_key_expression_callable=attribute_key_to_expression, key=k
+        )
 
         value_type = v.WhichOneof("value")
         if value_type is None and not v.is_null:
@@ -654,7 +674,10 @@ def trace_item_filters_to_expression(
 
     if item_filter.HasField("exists_filter"):
         return get_field_existence_expression(
-            attribute_key_to_expression(item_filter.exists_filter.key)
+            _trace_item_filter_key_expression(
+                attr_to_key_expression_callable=attribute_key_to_expression,
+                key=item_filter.exists_filter.key,
+            )
         )
 
     if item_filter.HasField("any_attribute_filter"):

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -344,8 +344,6 @@ def _type_array_includes_scalar_expression(
     if v.WhichOneof("value") == "val_null" or v.is_null:
         raise BadSnubaRPCRequestException("Arrays can't be NULL or cannot have NULL elements")
     x = Argument(None, "x")
-    if v.is_null or v.WhichOneof("value") == "val_null":
-        return f.arrayExists(Lambda(None, ("x",), f.isNull(x)), array_expr)
     rhs = _type_array_membership_rhs_expression(v)
     if ignore_case and v.WhichOneof("value") == "val_str":
         return f.arrayExists(

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -19,6 +19,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     Reliability,
 )
 
+from snuba.protos.common import type_array_to_stored_array_json_path
 from snuba.query.dsl import CurriedFunctions as cf
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import and_cond, column, literal
@@ -129,6 +130,9 @@ def _resolve_field_and_existence(
         else:
             raise RuntimeError("expected existence_checks to never be empty, but it is")
         return field, existence
+    elif aggregation.key.type == AttributeKey.Type.TYPE_ARRAY:
+        field = type_array_to_stored_array_json_path(aggregation.key)
+        return field, f.notEmpty(field)
     else:
         field = attribute_key_to_expression(aggregation.key)
         return field, get_field_existence_expression(field)

--- a/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/common/trace_item_table.py
@@ -1,3 +1,4 @@
+import json
 import re
 from collections import defaultdict
 from typing import Any, Callable, Dict, Iterable
@@ -8,6 +9,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     TraceItemTableRequest,
 )
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    Array,
     AttributeKey,
     AttributeValue,
     Function,
@@ -19,7 +21,48 @@ from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 from snuba.web.rpc.v1.resolvers.common.aggregation import ExtrapolationContext
 
 
+def _json_array_element_to_scalar(obj: Any) -> Any:
+    if not isinstance(obj, dict) or len(obj) != 1:
+        return obj
+    (tag, val) = next(iter(obj.items()))
+    if tag == "String":
+        return str(val)
+    if tag == "Int":
+        return int(val)
+    if tag in ("Double", "Float"):
+        return float(val)
+    if tag == "Bool":
+        if isinstance(val, bool):
+            return val
+        return str(val).lower() == "true"
+    return obj
+
+
 def _array_raw_to_attribute_value(raw: Any) -> AttributeValue:
+    """
+    Array values will be JSON String
+    """
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise BadSnubaRPCRequestException(
+                f"TYPE_ARRAY column value is not valid JSON: {e}"
+            ) from e
+        if not isinstance(parsed, list):
+            raise BadSnubaRPCRequestException(
+                f"TYPE_ARRAY column JSON must decode to a list, got {type(parsed)}"
+            )
+        return AttributeValue(
+            val_array=Array(
+                values=[
+                    convert_to_attribute_value(_json_array_element_to_scalar(elem))
+                    for elem in parsed
+                ]
+            )
+        )
+    if isinstance(raw, (list, tuple)):
+        return convert_to_attribute_value(list(raw))
     return convert_to_attribute_value(raw)
 
 

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     Reliability,
 )
 
-from snuba.query.expressions import Column, FunctionCall, Literal, SubscriptableReference
+from snuba.query.expressions import Column, FunctionCall, JsonPath, Literal, SubscriptableReference
 from snuba.web.rpc.common.common import (
     attribute_key_to_expression,
     get_field_existence_expression,
@@ -312,6 +312,11 @@ def test_aggregation_to_expression_uniq_type_array() -> None:
     inner = expr.parameters[0]
     assert isinstance(inner, FunctionCall)
     assert inner.function_name == "uniqArrayIfOrNull"
+    # Must be the stored Array(JSON) path, not toJSONString (String) from attribute_key_to_expression
+    first = inner.parameters[0]
+    assert isinstance(first, JsonPath)
+    assert first.path == "user_ids"
+    assert first.return_type == "Array(JSON)"
 
 
 def test_aggregation_to_expression_sum_type_array_raises() -> None:

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -254,14 +254,11 @@ def test_attribute_key_to_expression_type_array() -> None:
     attr_key = AttributeKey(type=AttributeKey.TYPE_ARRAY, name="user_ids")
     expr = attribute_key_to_expression(attr_key)
     assert isinstance(expr, FunctionCall)
-    assert expr.function_name == "arrayMap"
+    assert expr.function_name == "toJSONString"
     assert expr.alias == "user_ids_TYPE_ARRAY"
     fmt = ClickhouseExpressionFormatter()
     sql = expr.accept(fmt)
-    assert (
-        sql
-        == "(arrayMap(x -> coalesce(x.`String`::Nullable(String), toString(x.`Int`::Nullable(Int64)), toString(x.`Double`::Nullable(Float64)), x.`Bool`::Nullable(String)), attributes_array.`user_ids`::Array(JSON)) AS user_ids_TYPE_ARRAY)"
-    )
+    assert sql == "(toJSONString(attributes_array.`user_ids`::Array(JSON)) AS user_ids_TYPE_ARRAY)"
 
 
 def test_get_field_existence_expression_array_map() -> None:

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -17,6 +17,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     Array,
     AttributeKey,
     AttributeValue,
+    StrArray,
 )
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     AnyAttributeFilter,
@@ -176,17 +177,17 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
 
-    def test_equals_on_array_key_raises(self) -> None:
+    def test_equals_on_array_key_with_str_array_value_raises(self) -> None:
         item_filter = TraceItemFilter(
             comparison_filter=ComparisonFilter(
                 key=AttributeKey(type=AttributeKey.Type.TYPE_ARRAY, name="my_tags"),
                 op=ComparisonFilter.OP_EQUALS,
-                value=AttributeValue(val_str="something"),
+                value=AttributeValue(val_str_array=StrArray(values=["a", "b"])),
             )
         )
         with pytest.raises(
             BadSnubaRPCRequestException,
-            match="only LIKE and NOT_LIKE comparisons are supported on array keys",
+            match="OP_EQUALS/OP_NOT_EQUALS on array keys require a scalar value",
         ):
             trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3640,6 +3640,14 @@ def _int_array(*values: int) -> AnyValue:
     return AnyValue(array_value=ArrayValue(values=[AnyValue(int_value=v) for v in values]))
 
 
+def _double_array(*values: float) -> AnyValue:
+    return AnyValue(array_value=ArrayValue(values=[AnyValue(double_value=v) for v in values]))
+
+
+def _bool_array(*values: bool) -> AnyValue:
+    return AnyValue(array_value=ArrayValue(values=[AnyValue(bool_value=v) for v in values]))
+
+
 class TestArrayWildcardSearch(BaseApiTest):
     @pytest.mark.clickhouse_db
     @pytest.mark.redis_db
@@ -3828,6 +3836,100 @@ class TestArrayWildcardSearch(BaseApiTest):
                 e.val_int for e in row.val_array.values if e.WhichOneof("value") == "val_int"
             ]
             assert 45 in int_vals
+
+    @pytest.mark.clickhouse_db
+    @pytest.mark.redis_db
+    @pytest.mark.parametrize(
+        "attr_name,match_attrs,no_match_attrs,filter_value,check_row",
+        [
+            pytest.param(
+                "arr_eq_flt",
+                {"arr_eq_flt": _double_array(0.0, 1.5, 2.0)},
+                {"arr_eq_flt": _double_array(0.1, 0.2)},
+                AttributeValue(val_float=1.5),
+                lambda row: any(
+                    isclose(e.val_double, 1.5)
+                    for e in row.val_array.values
+                    if e.WhichOneof("value") == "val_double"
+                )
+                or any(
+                    isclose(e.val_float, 1.5)
+                    for e in row.val_array.values
+                    if e.WhichOneof("value") == "val_float"
+                ),
+                id="val_float",
+            ),
+            pytest.param(
+                "arr_eq_dbl",
+                {"arr_eq_dbl": _double_array(9.9, 1.0)},
+                {"arr_eq_dbl": _double_array(0.0, 0.0)},
+                AttributeValue(val_double=9.9),
+                lambda row: any(
+                    e.WhichOneof("value") == "val_double" and e.val_double == 9.9
+                    for e in row.val_array.values
+                ),
+                id="val_double",
+            ),
+            pytest.param(
+                "arr_eq_bool",
+                {"arr_eq_bool": _bool_array(False, True)},
+                {"arr_eq_bool": _bool_array(False, False)},
+                AttributeValue(val_bool=True),
+                lambda row: any(
+                    e.WhichOneof("value") == "val_bool" and e.val_bool is True
+                    for e in row.val_array.values
+                ),
+                id="val_bool",
+            ),
+        ],
+    )
+    def test_trace_item_table_array_op_equals_all_scalar_rhs_types(
+        self,
+        attr_name: str,
+        match_attrs: dict[str, AnyValue],
+        no_match_attrs: dict[str, AnyValue],
+        filter_value: AttributeValue,
+        check_row: Any,
+    ) -> None:
+        """OP_EQUALS on TYPE_ARRAY: each scalar AttributeValue type matches a stored element"""
+        span_ts = BASE_TIME - timedelta(minutes=1)
+        items_storage = get_storage(StorageKey("eap_items"))
+        write_raw_unprocessed_events(
+            items_storage,  # type: ignore
+            [
+                gen_item_message(span_ts, attributes=match_attrs),
+                gen_item_message(span_ts, attributes=no_match_attrs),
+            ],
+        )
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            filter=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_ARRAY,
+                        name=attr_name,
+                    ),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=filter_value,
+                )
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name=attr_name)),
+            ],
+        )
+        response = EndpointTraceItemTable().execute(message)
+        by_name = {cv.attribute_name: cv for cv in response.column_values}
+        assert len(by_name[attr_name].results) == 1
+        assert check_row(by_name[attr_name].results[0])
 
 
 class TestTraceItemTableArrayColumn(BaseApiTest):

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3636,6 +3636,10 @@ def _str_array(*values: str) -> AnyValue:
     return AnyValue(array_value=ArrayValue(values=[AnyValue(string_value=v) for v in values]))
 
 
+def _int_array(*values: int) -> AnyValue:
+    return AnyValue(array_value=ArrayValue(values=[AnyValue(int_value=v) for v in values]))
+
+
 class TestArrayWildcardSearch(BaseApiTest):
     @pytest.mark.clickhouse_db
     @pytest.mark.redis_db
@@ -3726,6 +3730,101 @@ class TestArrayWildcardSearch(BaseApiTest):
         response = EndpointTraceItemTable().execute(message)
         # Only the item with ["success", "cached"] should match (no "error" elements)
         assert len(response.column_values[0].results) == 1
+
+    @pytest.mark.clickhouse_db
+    @pytest.mark.redis_db
+    def test_trace_item_table_array_op_equals_includes_string_ignore_case(self) -> None:
+        """OP_EQUALS with ignore_case matches a string in a TYPE_ARRAY (element-wise)."""
+        span_ts = BASE_TIME - timedelta(minutes=1)
+        items_storage = get_storage(StorageKey("eap_items"))
+        write_raw_unprocessed_events(
+            items_storage,  # type: ignore
+            [
+                gen_item_message(span_ts, attributes={"tags": _str_array("ERROR", "other")}),
+                gen_item_message(
+                    span_ts, attributes={"tags": _str_array("success", "cached", "http-error")}
+                ),
+                gen_item_message(span_ts, attributes={"tags": _str_array("Error", "timeout")}),
+            ],
+        )
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            filter=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_ARRAY,
+                        name="tags",
+                    ),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str="error"),
+                    ignore_case=True,
+                )
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags")),
+            ],
+        )
+        response = EndpointTraceItemTable().execute(message)
+        assert len(response.column_values[0].results) == 2
+        by_name = {cv.attribute_name: cv for cv in response.column_values}
+        for row in by_name["tags"].results:
+            vals = [e.val_str for e in row.val_array.values if e.WhichOneof("value") == "val_str"]
+            assert "error" in [val.lower() for val in vals]
+
+    @pytest.mark.clickhouse_db
+    @pytest.mark.redis_db
+    def test_trace_item_table_array_op_equals_includes_int(self) -> None:
+        """OP_EQUALS on TYPE_ARRAY with val_int matches an array element; SELECT preserves val_int."""
+        span_ts = BASE_TIME - timedelta(minutes=1)
+        items_storage = get_storage(StorageKey("eap_items"))
+        write_raw_unprocessed_events(
+            items_storage,  # type: ignore
+            [
+                gen_item_message(span_ts, attributes={"group_ids": _int_array(1, 2, 3)}),
+                gen_item_message(span_ts, attributes={"group_ids": _int_array(10, 20)}),
+                gen_item_message(span_ts, attributes={"group_ids": _int_array(3, 99)}),
+            ],
+        )
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            filter=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_ARRAY,
+                        name="group_ids",
+                    ),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_int=3),
+                )
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="group_ids")),
+            ],
+        )
+        response = EndpointTraceItemTable().execute(message)
+        assert len(response.column_values[0].results) == 2
+        by_name = {cv.attribute_name: cv for cv in response.column_values}
+        for row in by_name["group_ids"].results:
+            vals = [e.val_str for e in row.val_array.values if e.WhichOneof("value") == "val_str"]
+            assert "3" in vals
 
 
 class TestTraceItemTableArrayColumn(BaseApiTest):

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3783,15 +3783,15 @@ class TestArrayWildcardSearch(BaseApiTest):
     @pytest.mark.clickhouse_db
     @pytest.mark.redis_db
     def test_trace_item_table_array_op_equals_includes_int(self) -> None:
-        """OP_EQUALS on TYPE_ARRAY with val_int matches an array element; SELECT preserves val_int."""
+        """OP_EQUALS on TYPE_ARRAY with val_int=45 returns rows where some element is 45."""
         span_ts = BASE_TIME - timedelta(minutes=1)
         items_storage = get_storage(StorageKey("eap_items"))
         write_raw_unprocessed_events(
             items_storage,  # type: ignore
             [
-                gen_item_message(span_ts, attributes={"group_ids": _int_array(1, 2, 3)}),
-                gen_item_message(span_ts, attributes={"group_ids": _int_array(10, 20)}),
-                gen_item_message(span_ts, attributes={"group_ids": _int_array(3, 99)}),
+                gen_item_message(span_ts, attributes={"frame_linenos": _int_array(1, 45, 200)}),
+                gen_item_message(span_ts, attributes={"frame_linenos": _int_array(10, 20)}),
+                gen_item_message(span_ts, attributes={"frame_linenos": _int_array(45, 99)}),
             ],
         )
         message = TraceItemTableRequest(
@@ -3808,23 +3808,26 @@ class TestArrayWildcardSearch(BaseApiTest):
                 comparison_filter=ComparisonFilter(
                     key=AttributeKey(
                         type=AttributeKey.TYPE_ARRAY,
-                        name="group_ids",
+                        name="frame_linenos",
                     ),
                     op=ComparisonFilter.OP_EQUALS,
-                    value=AttributeValue(val_int=3),
+                    value=AttributeValue(val_int=45),
                 )
             ),
             columns=[
                 Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
-                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="group_ids")),
+                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="frame_linenos")),
             ],
         )
         response = EndpointTraceItemTable().execute(message)
         assert len(response.column_values[0].results) == 2
         by_name = {cv.attribute_name: cv for cv in response.column_values}
-        for row in by_name["group_ids"].results:
-            vals = [e.val_str for e in row.val_array.values if e.WhichOneof("value") == "val_str"]
-            assert "3" in vals
+        assert by_name["frame_linenos"].results[0].WhichOneof("value") == "val_array"
+        for row in by_name["frame_linenos"].results:
+            int_vals = [
+                e.val_int for e in row.val_array.values if e.WhichOneof("value") == "val_int"
+            ]
+            assert 45 in int_vals
 
 
 class TestTraceItemTableArrayColumn(BaseApiTest):
@@ -3872,10 +3875,7 @@ class TestTraceItemTableArrayColumn(BaseApiTest):
             "beta",
         ]
         assert by_name["cols"].results[0].WhichOneof("value") == "val_array"
-        assert [e.val_str for e in by_name["cols"].results[0].val_array.values] == [
-            "1",
-            "3",
-        ]
+        assert [e.val_int for e in by_name["cols"].results[0].val_array.values] == [1, 3]
 
 
 class TestUtils:


### PR DESCRIPTION
Current implementation of arrays in TraceItemTable endpoint transforms arrays as array of strings, and then only allows `LIKE/NOT_LIKE` filter on them. 

With this change, arrays will preserve their original type, and client can filter EAP items by element of an array attribute. 
To preserve the type, array is converted to JSON string, (clickhouse-driver doesn't support Array(JSON) type, as discussed in this [PR](https://github.com/getsentry/snuba/pull/7551)), and post processing of results recovers the original array by decoding JSON string. 

To filter, predicate maps arrays to corresponding type and use array exists with element filter. 

Example Clickhouse query is:
```

SELECT (
    cast(lower(leftPad(hex(item_id), if(
        greater(length(hex(item_id)), 16), 32, 16), '0')), 'String'
    ) AS `sentry.item_id_TYPE_STRING`
), (toJSONString(attributes_array.`tags`::Array(
    JSON)) AS tags_TYPE_ARRAY
)
FROM eap_items_1_local
WHERE in(
    project_id, [1, 2, 3]
)
AND equals(organization_id, 1)
AND less(
    timestamp, toDateTime('2026-04-24 14:00:00')
)
AND greaterOrEquals(timestamp, toDateTime('2026-04-24 08:00:00'))
AND arrayExists(x -> equals(lower(x), lower('error')), (arrayMap(x -> coalesce(
    x.`String`::Nullable(String), toString(x.`Int`::Nullable(Int64)), toString(x.`Double`::Nullable(Float64)), x.`Bool`::Nullable(String)), attributes_array.`tags`::Array(
        JSON)) AS tags_TYPE_ARRAY__array_members
    )
)
AND lessOrEquals(sampling_factor, 1)
AND greater(sampling_factor, 0)
AND equals(item_type, 1)
LIMIT 10001 OFFSET 0

```