### PR TITLE
feat(logs) : Update export items endpoint to respect sampling & routing decision 

### DIFF
--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -324,10 +324,17 @@ def _build_query(
         else []
     )
     meta = query_meta if query_meta is not None else in_msg.meta
+    item_type_filter = []
+    if meta.trace_item_type != TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
+        item_type_filter.append(
+            f.equals(
+                column("item_type"),
+                literal(meta.trace_item_type)
+            ))
     query = Query(
         from_clause=entity,
         selected_columns=selected_columns,
-        condition=base_conditions_and(meta, *page_token_filter),
+        condition=base_conditions_and(meta, *page_token_filter, *item_type_filter),
         order_by=[
             # we add organization_id and project_id to the order by to optimize data reading
             # https://clickhouse.com/docs/sql-reference/statements/select/order-by#optimization-of-data-reading

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -140,8 +140,8 @@ def _parse_last_seen_tuple(
 class ExportTraceItemsPageToken:
     """Page token: always encodes the active [start,end) in unix seconds, shared with flex routing.
 
-    2 filters: that window only — move to the next time slice (flex) with no keyset cursor.
-    7 filters: same 2 time-window fields plus 5 equality fields — continue after the
+    2 filters: window only; move to the next time slice (flex) with no keyset cursor.
+    7 filters: same 2 time-window fields plus 5 equality fields; continue after the
       last row within that window (keyset / tuple seek).
     """
 
@@ -155,7 +155,6 @@ class ExportTraceItemsPageToken:
         last_seen_timestamp: float = 0.0,
         last_seen_trace_id: str = "",
         last_seen_item_id: str = "",
-        include_last_seen: bool = False,
     ):
         self.window_start_sec = window_start_sec
         self.window_end_sec = window_end_sec
@@ -164,11 +163,10 @@ class ExportTraceItemsPageToken:
         self.last_seen_timestamp = last_seen_timestamp
         self.last_seen_trace_id = last_seen_trace_id
         self.last_seen_item_id = last_seen_item_id
-        self.include_last_seen = include_last_seen
 
     @property
     def has_last_seen(self) -> bool:
-        return self.include_last_seen
+        return self.last_seen_item_id != ""
 
     @classmethod
     def from_protobuf(cls, page_token: PageToken) -> Optional["ExportTraceItemsPageToken"]:
@@ -186,7 +184,6 @@ class ExportTraceItemsPageToken:
             return cls(
                 window_start_sec=w0,
                 window_end_sec=w1,
-                include_last_seen=False,
             )
         if n == 7:
             win = _parse_flex_window_from_filters(filters[:2])
@@ -202,7 +199,6 @@ class ExportTraceItemsPageToken:
                 last_seen_timestamp=lsts,
                 last_seen_trace_id=ltr,
                 last_seen_item_id=lid,
-                include_last_seen=True,
             )
         raise ValueError("Invalid page token: expected 2 or 7 filter clauses")
 
@@ -584,7 +580,6 @@ class EndpointExportTraceItems(RPCEndpoint[ExportTraceItemsRequest, ExportTraceI
             next_token = ExportTraceItemsPageToken(
                 window_start_sec=w_start,
                 window_end_sec=w_end,
-                include_last_seen=True,
                 last_seen_project_id=processed_results.last_seen_project_id,
                 last_seen_item_type=processed_results.last_seen_item_type,
                 last_seen_trace_id=processed_results.last_seen_trace_id,
@@ -595,7 +590,6 @@ class EndpointExportTraceItems(RPCEndpoint[ExportTraceItemsRequest, ExportTraceI
             next_token = ExportTraceItemsPageToken(
                 window_start_sec=orig_start,
                 window_end_sec=routed.start_timestamp.seconds,
-                include_last_seen=False,
             ).to_protobuf()
         else:
             next_token = PageToken(end_pagination=True)

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -140,13 +140,9 @@ def _parse_last_seen_tuple(
 class ExportTraceItemsPageToken:
     """Page token: always encodes the active [start,end) in unix seconds, shared with flex routing.
 
-    * **2 filters:** that window only — move to the next time slice (flex) with no keyset cursor.
-    * **7 filters:** same 2 time-window fields plus 5 equality fields — continue after the
+    2 filters: that window only — move to the next time slice (flex) with no keyset cursor.
+    7 filters: same 2 time-window fields plus 5 equality fields — continue after the
       last row within that window (keyset / tuple seek).
-
-    The first request has an empty `page_token`. Every continuation request must resend
-    `RequestMeta` (user range) and send a token so routing can read
-    `sentry__time_window.*` and align with the slice being scanned.
     """
 
     def __init__(

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -56,7 +56,7 @@ FLEX_WIN_END = "sentry__time_window.end_timestamp"
 _KEYSET_CURSOR_SCHEMA = [
     ("last_seen_project_id", AttributeKey.Type.TYPE_INT, "val_int"),
     ("last_seen_item_type", AttributeKey.Type.TYPE_INT, "val_int"),
-    ("last_seen_timestamp", AttributeKey.Type.TYPE_DOUBLE, "val_double"),
+    ("last_seen_timestamp", AttributeKey.Type.TYPE_INT, "val_int"),
     ("last_seen_trace_id", AttributeKey.Type.TYPE_STRING, "val_str"),
     ("last_seen_item_id", AttributeKey.Type.TYPE_STRING, "val_str"),
 ]
@@ -109,7 +109,7 @@ class FlexWindow(NamedTuple):
 class KeysetCursor(NamedTuple):
     last_seen_project_id: int
     last_seen_item_type: TraceItemType.ValueType
-    last_seen_timestamp: float
+    last_seen_timestamp: int
     last_seen_trace_id: str
     last_seen_item_id: str
 
@@ -409,7 +409,7 @@ def _convert_rows(rows: Iterable[Dict[str, Any]]) -> ProcessedResults:
     items: list[TraceItem] = []
     last_seen_project_id = 0
     last_seen_item_type = TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED
-    last_seen_timestamp = 0.0
+    last_seen_timestamp = 0
     last_seen_trace_id = ""
     last_seen_item_id = ""
 
@@ -460,7 +460,7 @@ def _convert_rows(rows: Iterable[Dict[str, Any]]) -> ProcessedResults:
 
         last_seen_project_id = int(proj_id)
         last_seen_item_type = item_type
-        last_seen_timestamp = float(ts)
+        last_seen_timestamp = int(ts)
         last_seen_trace_id = trace_id
         last_seen_item_id = item_id
 

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -326,11 +326,7 @@ def _build_query(
     meta = query_meta if query_meta is not None else in_msg.meta
     item_type_filter = []
     if meta.trace_item_type != TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
-        item_type_filter.append(
-            f.equals(
-                column("item_type"),
-                literal(meta.trace_item_type)
-            ))
+        item_type_filter.append(f.equals(column("item_type"), literal(meta.trace_item_type)))
     query = Query(
         from_clause=entity,
         selected_columns=selected_columns,

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -2,13 +2,15 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, Iterable, NamedTuple, Type, cast
 
+import sentry_sdk
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
     ExportTraceItemsRequest,
     ExportTraceItemsResponse,
 )
-from sentry_protos.snuba.v1.request_common_pb2 import PageToken, TraceItemType
+from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue, TraceItem
 
 from snuba import state
@@ -36,6 +38,7 @@ from snuba.web.rpc.common.common import (
 )
 from snuba.web.rpc.common.debug_info import setup_trace_query_settings
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+from snuba.web.rpc.storage_routing.routing_strategies.storage_routing import RoutingDecision
 
 _DEFAULT_PAGE_SIZE = 10_000
 
@@ -48,76 +51,172 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
+FLEX_WIN_START = "sentry__time_window.start_timestamp"
+FLEX_WIN_END = "sentry__time_window.end_timestamp"
+
+
+def _flex_time_window_filters(start_sec: int, end_sec: int) -> list[TraceItemFilter]:
+    return [
+        TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name=FLEX_WIN_START),
+                op=ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+                value=AttributeValue(val_int=start_sec),
+            )
+        ),
+        TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name=FLEX_WIN_END),
+                op=ComparisonFilter.OP_LESS_THAN,
+                value=AttributeValue(val_int=end_sec),
+            )
+        ),
+    ]
+
+
+def _parse_flex_window_from_filters(filters: list[TraceItemFilter]) -> tuple[int, int] | None:
+    start_sec: int | None = None
+    end_sec: int | None = None
+    for filt in filters:
+        if not filt.HasField("comparison_filter"):
+            continue
+        k = filt.comparison_filter.key.name
+        if k == FLEX_WIN_START and filt.comparison_filter.value.HasField("val_int"):
+            start_sec = filt.comparison_filter.value.val_int
+        elif k == FLEX_WIN_END and filt.comparison_filter.value.HasField("val_int"):
+            end_sec = filt.comparison_filter.value.val_int
+    if start_sec is not None and end_sec is not None:
+        return (start_sec, end_sec)
+    if start_sec is not None or end_sec is not None:
+        raise ValueError("Invalid flex time window in page token")
+    return None
+
+
+def _parse_last_seen_tuple(
+    filters: list[TraceItemFilter],
+) -> tuple[int, TraceItemType.ValueType, float, str, str]:
+    """Parse the 5 'last seen' key equality filters"""
+    if len(filters) != 5:
+        raise ValueError("Invalid last_seen in page token")
+    if not (
+        filters[0].comparison_filter.key.name == "last_seen_project_id"
+        and filters[0].comparison_filter.key.type == AttributeKey.Type.TYPE_INT
+    ):
+        raise ValueError("Invalid project id")
+    last_seen_project_id = filters[0].comparison_filter.value.val_int
+    if not (
+        filters[1].comparison_filter.key.name == "last_seen_item_type"
+        and filters[1].comparison_filter.key.type == AttributeKey.Type.TYPE_INT
+    ):
+        raise ValueError("Invalid item type")
+    last_seen_item_type = filters[1].comparison_filter.value.val_int
+    if not (
+        filters[2].comparison_filter.key.name == "last_seen_timestamp"
+        and filters[2].comparison_filter.key.type == AttributeKey.Type.TYPE_DOUBLE
+    ):
+        raise ValueError("Invalid timestamp")
+    last_seen_timestamp = filters[2].comparison_filter.value.val_double
+    if not (
+        filters[3].comparison_filter.key.name == "last_seen_trace_id"
+        and filters[3].comparison_filter.key.type == AttributeKey.Type.TYPE_STRING
+    ):
+        raise ValueError("Invalid trace id")
+    last_seen_trace_id = filters[3].comparison_filter.value.val_str
+    if not (
+        filters[4].comparison_filter.key.name == "last_seen_item_id"
+        and filters[4].comparison_filter.key.type == AttributeKey.Type.TYPE_STRING
+    ):
+        raise ValueError("Invalid item id")
+    last_seen_item_id = filters[4].comparison_filter.value.val_str
+    return (
+        last_seen_project_id,
+        cast(TraceItemType.ValueType, last_seen_item_type),
+        last_seen_timestamp,
+        last_seen_trace_id,
+        last_seen_item_id,
+    )
+
 
 class ExportTraceItemsPageToken:
+    """Page token: always encodes the active [start,end) in unix seconds, shared with flex routing.
+
+    * **2 filters:** that window only — move to the next time slice (flex) with no keyset cursor.
+    * **7 filters:** same 2 time-window fields plus 5 equality fields — continue after the
+      last row within that window (keyset / tuple seek).
+
+    The first request has an empty `page_token`. Every continuation request must resend
+    `RequestMeta` (user range) and send a token so routing can read
+    `sentry__time_window.*` and align with the slice being scanned.
+    """
+
     def __init__(
         self,
-        last_seen_project_id: int,
-        last_seen_item_type: TraceItemType.ValueType,
-        last_seen_timestamp: float,
-        last_seen_trace_id: str,
-        last_seen_item_id: str,
+        *,
+        window_start_sec: int,
+        window_end_sec: int,
+        last_seen_project_id: int = 0,
+        last_seen_item_type: TraceItemType.ValueType = TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED,
+        last_seen_timestamp: float = 0.0,
+        last_seen_trace_id: str = "",
+        last_seen_item_id: str = "",
+        include_last_seen: bool = False,
     ):
+        self.window_start_sec = window_start_sec
+        self.window_end_sec = window_end_sec
         self.last_seen_project_id = last_seen_project_id
         self.last_seen_item_type = last_seen_item_type
         self.last_seen_timestamp = last_seen_timestamp
         self.last_seen_trace_id = last_seen_trace_id
         self.last_seen_item_id = last_seen_item_id
+        self.include_last_seen = include_last_seen
+
+    @property
+    def has_last_seen(self) -> bool:
+        return self.include_last_seen
 
     @classmethod
     def from_protobuf(cls, page_token: PageToken) -> Optional["ExportTraceItemsPageToken"]:
         if page_token == PageToken():
             return None
-        filters = page_token.filter_offset.and_filter.filters
-        if len(filters) != 5:
+        if not page_token.filter_offset.HasField("and_filter"):
             raise ValueError("Invalid page token")
-
-        if not (
-            filters[0].comparison_filter.key.name == "last_seen_project_id"
-            and filters[0].comparison_filter.key.type == AttributeKey.Type.TYPE_INT
-        ):
-            raise ValueError("Invalid project id")
-        last_seen_project_id = filters[0].comparison_filter.value.val_int
-        if not (
-            filters[1].comparison_filter.key.name == "last_seen_item_type"
-            and filters[1].comparison_filter.key.type == AttributeKey.Type.TYPE_INT
-        ):
-            raise ValueError("Invalid item type")
-        last_seen_item_type = filters[1].comparison_filter.value.val_int
-
-        if not (
-            filters[2].comparison_filter.key.name == "last_seen_timestamp"
-            and filters[2].comparison_filter.key.type == AttributeKey.Type.TYPE_DOUBLE
-        ):
-            raise ValueError("Invalid timestamp")
-        last_seen_timestamp = filters[2].comparison_filter.value.val_double
-
-        if not (
-            filters[3].comparison_filter.key.name == "last_seen_trace_id"
-            and filters[3].comparison_filter.key.type == AttributeKey.Type.TYPE_STRING
-        ):
-            raise ValueError("Invalid trace id")
-        last_seen_trace_id = filters[3].comparison_filter.value.val_str
-
-        if not (
-            filters[4].comparison_filter.key.name == "last_seen_item_id"
-            and filters[4].comparison_filter.key.type == AttributeKey.Type.TYPE_STRING
-        ):
-            raise ValueError("Invalid item id")
-        last_seen_item_id = filters[4].comparison_filter.value.val_str
-
-        return cls(
-            last_seen_project_id,
-            cast(TraceItemType.ValueType, last_seen_item_type),
-            last_seen_timestamp,
-            last_seen_trace_id,
-            last_seen_item_id,
-        )
+        filters = list(page_token.filter_offset.and_filter.filters)
+        n = len(filters)
+        if n == 2:
+            win = _parse_flex_window_from_filters(filters)
+            if win is None:
+                raise ValueError("Invalid page token")
+            w0, w1 = win
+            return cls(
+                window_start_sec=w0,
+                window_end_sec=w1,
+                include_last_seen=False,
+            )
+        if n == 7:
+            win = _parse_flex_window_from_filters(filters[:2])
+            if win is None:
+                raise ValueError("Invalid page token")
+            w0, w1 = win
+            pid, ity, lsts, ltr, lid = _parse_last_seen_tuple(filters[2:])
+            return cls(
+                window_start_sec=w0,
+                window_end_sec=w1,
+                last_seen_project_id=pid,
+                last_seen_item_type=ity,
+                last_seen_timestamp=lsts,
+                last_seen_trace_id=ltr,
+                last_seen_item_id=lid,
+                include_last_seen=True,
+            )
+        raise ValueError("Invalid page token: expected 2 or 7 filter clauses")
 
     def to_protobuf(self) -> PageToken:
-        filters = TraceItemFilter(
-            and_filter=AndFilter(
-                filters=[
+        and_filters: list[TraceItemFilter] = list(
+            _flex_time_window_filters(self.window_start_sec, self.window_end_sec)
+        )
+        if self.has_last_seen:
+            and_filters.extend(
+                [
                     TraceItemFilter(
                         comparison_filter=ComparisonFilter(
                             key=AttributeKey(
@@ -165,12 +264,41 @@ class ExportTraceItemsPageToken:
                     ),
                 ]
             )
+        if not and_filters:
+            raise ValueError("empty export page token")
+        return PageToken(
+            filter_offset=TraceItemFilter(
+                and_filter=AndFilter(filters=and_filters),
+            )
         )
-        return PageToken(filter_offset=filters)
+
+
+def _is_flextime_export(in_msg: ExportTraceItemsRequest) -> bool:
+    if not in_msg.meta.HasField("downsampled_storage_config"):
+        return False
+    return (
+        in_msg.meta.downsampled_storage_config.mode
+        == DownsampledStorageConfig.Mode.MODE_HIGHEST_ACCURACY_FLEXTIME
+    )
+
+
+def _export_query_meta(
+    in_msg: ExportTraceItemsRequest, routing_decision: RoutingDecision
+) -> RequestMeta:
+    if routing_decision.time_window is None:
+        return in_msg.meta
+    meta = RequestMeta()
+    meta.CopyFrom(in_msg.meta)
+    meta.start_timestamp.CopyFrom(routing_decision.time_window.start_timestamp)
+    meta.end_timestamp.CopyFrom(routing_decision.time_window.end_timestamp)
+    return meta
 
 
 def _build_query(
-    in_msg: ExportTraceItemsRequest, limit: int, page_token: ExportTraceItemsPageToken | None = None
+    in_msg: ExportTraceItemsRequest,
+    limit: int,
+    page_token: ExportTraceItemsPageToken | None = None,
+    query_meta: RequestMeta | None = None,
 ) -> Query:
     selected_columns = [
         SelectedExpression("timestamp", f.toUnixTimestamp(column("timestamp"), alias="timestamp")),
@@ -244,13 +372,14 @@ def _build_query(
                 ),
             )
         ]
-        if page_token is not None
+        if page_token is not None and page_token.has_last_seen
         else []
     )
+    meta = query_meta if query_meta is not None else in_msg.meta
     query = Query(
         from_clause=entity,
         selected_columns=selected_columns,
-        condition=base_conditions_and(in_msg.meta, *(page_token_filter)),
+        condition=base_conditions_and(meta, *(page_token_filter)),
         order_by=[
             # we add organization_id and project_id to the order by to optimize data reading
             # https://clickhouse.com/docs/sql-reference/statements/select/order-by#optimization-of-data-reading
@@ -269,14 +398,28 @@ def _build_query(
 
 
 def _build_snuba_request(
-    in_msg: ExportTraceItemsRequest, limit: int, page_token: ExportTraceItemsPageToken | None = None
+    in_msg: ExportTraceItemsRequest,
+    routing_decision: RoutingDecision,
+    limit: int,
+    page_token: ExportTraceItemsPageToken | None = None,
 ) -> SnubaRequest:
     query_settings = setup_trace_query_settings() if in_msg.meta.debug else HTTPQuerySettings()
+    try:
+        routing_decision.strategy.merge_clickhouse_settings(routing_decision, query_settings)
+        query_settings.set_sampling_tier(routing_decision.tier)
+    except Exception as e:
+        sentry_sdk.capture_message(f"Error merging clickhouse settings: {e}")
+
     query_settings.set_skip_transform_order_by(True)
     return SnubaRequest(
         id=uuid.UUID(in_msg.meta.request_id),
         original_body=MessageToDict(in_msg),
-        query=_build_query(in_msg, limit, page_token),
+        query=_build_query(
+            in_msg,
+            limit,
+            page_token,
+            query_meta=_export_query_meta(in_msg, routing_decision),
+        ),
         query_settings=query_settings,
         attribution_info=AttributionInfo(
             referrer=in_msg.meta.referrer,
@@ -425,21 +568,38 @@ class EndpointExportTraceItems(RPCEndpoint[ExportTraceItemsRequest, ExportTraceI
         page_token = ExportTraceItemsPageToken.from_protobuf(in_msg.page_token)
         results = run_query(
             dataset=PluggableDataset(name="eap", all_entities=[]),
-            request=_build_snuba_request(in_msg, limit, page_token),
+            request=_build_snuba_request(in_msg, self.routing_decision, limit, page_token),
             timer=self._timer,
         )
 
         rows = results.result.get("data", [])
         processed_results = _convert_rows(rows)
+        is_flex = _is_flextime_export(in_msg)
+        orig_start = in_msg.meta.start_timestamp.seconds
+        routed = self.routing_decision.time_window
+
+        w_start = in_msg.meta.start_timestamp.seconds
+        w_end = in_msg.meta.end_timestamp.seconds
+        if routed is not None:
+            w_start, w_end = routed.start_timestamp.seconds, routed.end_timestamp.seconds
 
         next_token: PageToken | None = None
         if len(processed_results.items) >= limit:
             next_token = ExportTraceItemsPageToken(
+                window_start_sec=w_start,
+                window_end_sec=w_end,
+                include_last_seen=True,
                 last_seen_project_id=processed_results.last_seen_project_id,
                 last_seen_item_type=processed_results.last_seen_item_type,
                 last_seen_trace_id=processed_results.last_seen_trace_id,
                 last_seen_timestamp=processed_results.last_seen_timestamp,
                 last_seen_item_id=processed_results.last_seen_item_id,
+            ).to_protobuf()
+        elif is_flex and routed is not None and routed.start_timestamp.seconds > orig_start:
+            next_token = ExportTraceItemsPageToken(
+                window_start_sec=orig_start,
+                window_end_sec=routed.start_timestamp.seconds,
+                include_last_seen=False,
             ).to_protobuf()
         else:
             next_token = PageToken(end_pagination=True)

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -11,6 +11,12 @@ from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
     ExportTraceItemsResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
+    ComparisonFilter,
+    TraceItemFilter,
+)
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue, TraceItem
 
 from snuba import state
@@ -38,231 +44,181 @@ from snuba.web.rpc.common.common import (
 )
 from snuba.web.rpc.common.debug_info import setup_trace_query_settings
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
-from snuba.web.rpc.storage_routing.routing_strategies.storage_routing import RoutingDecision
-
-_DEFAULT_PAGE_SIZE = 10_000
-
-from typing import Optional
-
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
-    AndFilter,
-    ComparisonFilter,
-    TraceItemFilter,
+from snuba.web.rpc.storage_routing.routing_strategies.storage_routing import (
+    RoutingDecision,
+    TimeWindow,
 )
 
+_DEFAULT_PAGE_SIZE = 10_000
 FLEX_WIN_START = "sentry__time_window.start_timestamp"
 FLEX_WIN_END = "sentry__time_window.end_timestamp"
 
+_KEYSET_CURSOR_SCHEMA = [
+    ("last_seen_project_id", AttributeKey.Type.TYPE_INT, "val_int"),
+    ("last_seen_item_type", AttributeKey.Type.TYPE_INT, "val_int"),
+    ("last_seen_timestamp", AttributeKey.Type.TYPE_DOUBLE, "val_double"),
+    ("last_seen_trace_id", AttributeKey.Type.TYPE_STRING, "val_str"),
+    ("last_seen_item_id", AttributeKey.Type.TYPE_STRING, "val_str"),
+]
 
-def _flex_time_window_filters(start_sec: int, end_sec: int) -> list[TraceItemFilter]:
-    return [
-        TraceItemFilter(
-            comparison_filter=ComparisonFilter(
-                key=AttributeKey(name=FLEX_WIN_START),
-                op=ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
-                value=AttributeValue(val_int=start_sec),
+
+class FlexWindow(NamedTuple):
+    """Flex window start and end timestamps"""
+
+    start_sec: int
+    end_sec: int
+
+    @classmethod
+    def from_filters(cls, filters: list[TraceItemFilter]) -> "FlexWindow":
+        _SCHEMA = [
+            (FLEX_WIN_START, "val_int"),
+            (FLEX_WIN_END, "val_int"),
+        ]
+        values = []
+        for expected_filter, timestamp_filter in zip(_SCHEMA, filters):
+            filter_name, filter_value_type = expected_filter
+            if (
+                not timestamp_filter.HasField("comparison_filter")
+                or timestamp_filter.comparison_filter.key.name != filter_name
+                or not timestamp_filter.comparison_filter.value.HasField(filter_value_type)  # type: ignore[arg-type]
+            ):
+                raise ValueError("Invalid timestamp filter in page token")
+            values.append(timestamp_filter.comparison_filter.value.val_int)
+        start_sec, end_sec = values
+        return cls(start_sec=start_sec, end_sec=end_sec)
+
+    def to_filters(self) -> list[TraceItemFilter]:
+        return [
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name=FLEX_WIN_START),
+                    op=ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+                    value=AttributeValue(val_int=self.start_sec),
+                )
+            ),
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name=FLEX_WIN_END),
+                    op=ComparisonFilter.OP_LESS_THAN,
+                    value=AttributeValue(val_int=self.end_sec),
+                )
+            ),
+        ]
+
+
+class KeysetCursor(NamedTuple):
+    last_seen_project_id: int
+    last_seen_item_type: TraceItemType.ValueType
+    last_seen_timestamp: float
+    last_seen_trace_id: str
+    last_seen_item_id: str
+
+    @classmethod
+    def from_filters(cls, filters: list[TraceItemFilter]) -> "KeysetCursor":
+        if len(filters) != len(_KEYSET_CURSOR_SCHEMA):
+            raise ValueError("Invalid keyset cursor in page token")
+
+        values = []
+        for i, (expected_name, expected_type, val_field) in enumerate(_KEYSET_CURSOR_SCHEMA):
+            cf = filters[i].comparison_filter
+            if cf.key.name != expected_name or cf.key.type != expected_type:
+                raise ValueError(f"Invalid {expected_name} in page token")
+            values.append(getattr(cf.value, val_field))
+
+        project_id, item_type, timestamp, trace_id, item_id = values
+        return cls(
+            last_seen_project_id=project_id,
+            last_seen_item_type=cast(TraceItemType.ValueType, item_type),
+            last_seen_timestamp=timestamp,
+            last_seen_trace_id=trace_id,
+            last_seen_item_id=item_id,
+        )
+
+    def to_filters(self) -> list[TraceItemFilter]:
+        return [
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(name=name, type=attr_type),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(**{val_field: value}),  # type: ignore[arg-type]
+                )
             )
-        ),
-        TraceItemFilter(
-            comparison_filter=ComparisonFilter(
-                key=AttributeKey(name=FLEX_WIN_END),
-                op=ComparisonFilter.OP_LESS_THAN,
-                value=AttributeValue(val_int=end_sec),
-            )
-        ),
-    ]
-
-
-def _parse_flex_window_from_filters(filters: list[TraceItemFilter]) -> tuple[int, int] | None:
-    start_sec: int | None = None
-    end_sec: int | None = None
-    for filt in filters:
-        if not filt.HasField("comparison_filter"):
-            continue
-        k = filt.comparison_filter.key.name
-        if k == FLEX_WIN_START and filt.comparison_filter.value.HasField("val_int"):
-            start_sec = filt.comparison_filter.value.val_int
-        elif k == FLEX_WIN_END and filt.comparison_filter.value.HasField("val_int"):
-            end_sec = filt.comparison_filter.value.val_int
-    if start_sec is not None and end_sec is not None:
-        return (start_sec, end_sec)
-    if start_sec is not None or end_sec is not None:
-        raise ValueError("Invalid flex time window in page token")
-    return None
-
-
-def _parse_last_seen_tuple(
-    filters: list[TraceItemFilter],
-) -> tuple[int, TraceItemType.ValueType, float, str, str]:
-    """Parse the 5 'last seen' key equality filters"""
-    if len(filters) != 5:
-        raise ValueError("Invalid last_seen in page token")
-    if not (
-        filters[0].comparison_filter.key.name == "last_seen_project_id"
-        and filters[0].comparison_filter.key.type == AttributeKey.Type.TYPE_INT
-    ):
-        raise ValueError("Invalid project id")
-    last_seen_project_id = filters[0].comparison_filter.value.val_int
-    if not (
-        filters[1].comparison_filter.key.name == "last_seen_item_type"
-        and filters[1].comparison_filter.key.type == AttributeKey.Type.TYPE_INT
-    ):
-        raise ValueError("Invalid item type")
-    last_seen_item_type = filters[1].comparison_filter.value.val_int
-    if not (
-        filters[2].comparison_filter.key.name == "last_seen_timestamp"
-        and filters[2].comparison_filter.key.type == AttributeKey.Type.TYPE_DOUBLE
-    ):
-        raise ValueError("Invalid timestamp")
-    last_seen_timestamp = filters[2].comparison_filter.value.val_double
-    if not (
-        filters[3].comparison_filter.key.name == "last_seen_trace_id"
-        and filters[3].comparison_filter.key.type == AttributeKey.Type.TYPE_STRING
-    ):
-        raise ValueError("Invalid trace id")
-    last_seen_trace_id = filters[3].comparison_filter.value.val_str
-    if not (
-        filters[4].comparison_filter.key.name == "last_seen_item_id"
-        and filters[4].comparison_filter.key.type == AttributeKey.Type.TYPE_STRING
-    ):
-        raise ValueError("Invalid item id")
-    last_seen_item_id = filters[4].comparison_filter.value.val_str
-    return (
-        last_seen_project_id,
-        cast(TraceItemType.ValueType, last_seen_item_type),
-        last_seen_timestamp,
-        last_seen_trace_id,
-        last_seen_item_id,
-    )
+            for (name, attr_type, val_field), value in zip(_KEYSET_CURSOR_SCHEMA, self)
+        ]
 
 
 class ExportTraceItemsPageToken:
-    """Page token: always encodes the active [start,end) in unix seconds, shared with flex routing.
-
-    2 filters: window only; move to the next time slice (flex) with no keyset cursor.
-    7 filters: same 2 time-window fields plus 5 equality fields; continue after the
-      last row within that window (keyset / tuple seek).
-    """
+    """Pagination cursor: FlexWindow plus optional KeysetCursor."""
 
     def __init__(
         self,
         *,
-        window_start_sec: int,
-        window_end_sec: int,
-        last_seen_project_id: int = 0,
-        last_seen_item_type: TraceItemType.ValueType = TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED,
-        last_seen_timestamp: float = 0.0,
-        last_seen_trace_id: str = "",
-        last_seen_item_id: str = "",
+        flex_window: FlexWindow,
+        cursor: KeysetCursor | None = None,
     ):
-        self.window_start_sec = window_start_sec
-        self.window_end_sec = window_end_sec
-        self.last_seen_project_id = last_seen_project_id
-        self.last_seen_item_type = last_seen_item_type
-        self.last_seen_timestamp = last_seen_timestamp
-        self.last_seen_trace_id = last_seen_trace_id
-        self.last_seen_item_id = last_seen_item_id
-
-    @property
-    def has_last_seen(self) -> bool:
-        return self.last_seen_item_id != ""
+        self.keyset_cursor = cursor
+        self.flex_window = flex_window
 
     @classmethod
-    def from_protobuf(cls, page_token: PageToken) -> Optional["ExportTraceItemsPageToken"]:
+    def from_protobuf(cls, page_token: PageToken) -> "ExportTraceItemsPageToken | None":
         if page_token == PageToken():
             return None
         if not page_token.filter_offset.HasField("and_filter"):
             raise ValueError("Invalid page token")
         filters = list(page_token.filter_offset.and_filter.filters)
-        n = len(filters)
-        if n == 2:
-            win = _parse_flex_window_from_filters(filters)
-            if win is None:
-                raise ValueError("Invalid page token")
-            w0, w1 = win
-            return cls(
-                window_start_sec=w0,
-                window_end_sec=w1,
+
+        flex_field_count = len(FlexWindow._fields)
+        cursor_field_count = len(KeysetCursor._fields)
+        if len(filters) not in (flex_field_count, flex_field_count + cursor_field_count):
+            raise ValueError(
+                f"Invalid page token: expected {flex_field_count} or {flex_field_count + cursor_field_count} "
+                f"filter clauses, got {len(filters)}"
             )
-        if n == 7:
-            win = _parse_flex_window_from_filters(filters[:2])
-            if win is None:
-                raise ValueError("Invalid page token")
-            w0, w1 = win
-            pid, ity, lsts, ltr, lid = _parse_last_seen_tuple(filters[2:])
-            return cls(
-                window_start_sec=w0,
-                window_end_sec=w1,
-                last_seen_project_id=pid,
-                last_seen_item_type=ity,
-                last_seen_timestamp=lsts,
-                last_seen_trace_id=ltr,
-                last_seen_item_id=lid,
-            )
-        raise ValueError("Invalid page token: expected 2 or 7 filter clauses")
+        flex_filters = filters[:flex_field_count]
+        cursor_filters = filters[flex_field_count:]
+        flex_window = FlexWindow.from_filters(flex_filters)
+        keyset_cursor = KeysetCursor.from_filters(cursor_filters) if cursor_filters else None
+        return cls(
+            flex_window=flex_window,
+            cursor=keyset_cursor,
+        )
 
     def to_protobuf(self) -> PageToken:
-        and_filters: list[TraceItemFilter] = list(
-            _flex_time_window_filters(self.window_start_sec, self.window_end_sec)
-        )
-        if self.has_last_seen:
-            and_filters.extend(
-                [
-                    TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                name="last_seen_project_id", type=AttributeKey.Type.TYPE_INT
-                            ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_int=self.last_seen_project_id),
-                        )
-                    ),
-                    TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                name="last_seen_item_type", type=AttributeKey.Type.TYPE_INT
-                            ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_int=self.last_seen_item_type),
-                        )
-                    ),
-                    TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                name="last_seen_timestamp", type=AttributeKey.Type.TYPE_DOUBLE
-                            ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_double=self.last_seen_timestamp),
-                        )
-                    ),
-                    TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                name="last_seen_trace_id", type=AttributeKey.Type.TYPE_STRING
-                            ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str=self.last_seen_trace_id),
-                        )
-                    ),
-                    TraceItemFilter(
-                        comparison_filter=ComparisonFilter(
-                            key=AttributeKey(
-                                name="last_seen_item_id", type=AttributeKey.Type.TYPE_STRING
-                            ),
-                            op=ComparisonFilter.OP_EQUALS,
-                            value=AttributeValue(val_str=self.last_seen_item_id),
-                        )
-                    ),
-                ]
-            )
-        if not and_filters:
-            raise ValueError("empty export page token")
+        and_filters: list[TraceItemFilter] = self.flex_window.to_filters()
+        if self.keyset_cursor is not None:
+            and_filters.extend(self.keyset_cursor.to_filters())
+
         return PageToken(
             filter_offset=TraceItemFilter(
                 and_filter=AndFilter(filters=and_filters),
             )
         )
+
+
+def _next_page_token(
+    *,
+    items_returned: int,
+    limit: int,
+    flex_window: FlexWindow,
+    keyset_cursor: KeysetCursor,
+    is_flex: bool,
+    orig_start: int,
+    routed_window: TimeWindow | None,
+) -> PageToken:
+    if items_returned >= limit:
+        return ExportTraceItemsPageToken(
+            flex_window=flex_window, cursor=keyset_cursor
+        ).to_protobuf()
+
+    if is_flex and routed_window is not None:
+        routed_start = routed_window.start_timestamp.seconds
+        routed_end = routed_window.end_timestamp.seconds
+        if orig_start < routed_start < routed_end:
+            return ExportTraceItemsPageToken(
+                flex_window=FlexWindow(start_sec=orig_start, end_sec=routed_start),
+            ).to_protobuf()
+
+    return PageToken(end_pagination=True)
 
 
 def _is_flextime_export(in_msg: ExportTraceItemsRequest) -> bool:
@@ -356,22 +312,22 @@ def _build_query(
                     column("item_id"),
                 ),
                 f.tuple(
-                    literal(page_token.last_seen_project_id),
-                    literal(page_token.last_seen_item_type),
-                    literal(page_token.last_seen_timestamp),
-                    literal(page_token.last_seen_trace_id),
-                    literal(page_token.last_seen_item_id),
+                    literal(page_token.keyset_cursor.last_seen_project_id),
+                    literal(page_token.keyset_cursor.last_seen_item_type),
+                    literal(page_token.keyset_cursor.last_seen_timestamp),
+                    literal(page_token.keyset_cursor.last_seen_trace_id),
+                    literal(page_token.keyset_cursor.last_seen_item_id),
                 ),
             )
         ]
-        if page_token is not None and page_token.has_last_seen
+        if page_token is not None and page_token.keyset_cursor is not None
         else []
     )
     meta = query_meta if query_meta is not None else in_msg.meta
     query = Query(
         from_clause=entity,
         selected_columns=selected_columns,
-        condition=base_conditions_and(meta, *(page_token_filter)),
+        condition=base_conditions_and(meta, *page_token_filter),
         order_by=[
             # we add organization_id and project_id to the order by to optimize data reading
             # https://clickhouse.com/docs/sql-reference/statements/select/order-by#optimization-of-data-reading
@@ -444,17 +400,9 @@ def _to_any_value(value: Any) -> AnyValue:
         raise BadSnubaRPCRequestException(f"data type unknown: {type(value)}")
 
 
-ProcessedResults = NamedTuple(
-    "ProcessedResults",
-    [
-        ("items", list[TraceItem]),
-        ("last_seen_project_id", int),
-        ("last_seen_item_type", TraceItemType.ValueType),
-        ("last_seen_timestamp", float),
-        ("last_seen_trace_id", str),
-        ("last_seen_item_id", str),
-    ],
-)
+class ProcessedResults(NamedTuple):
+    items: list[TraceItem]
+    keyset_cursor: KeysetCursor
 
 
 def _convert_rows(rows: Iterable[Dict[str, Any]]) -> ProcessedResults:
@@ -474,8 +422,8 @@ def _convert_rows(rows: Iterable[Dict[str, Any]]) -> ProcessedResults:
         ts = row.pop("timestamp")
         client_sample_rate = row.pop("client_sample_rate", 1.0)
         server_sample_rate = row.pop("server_sample_rate", 1.0)
-        sampling_factor = row.pop("sampling_factor", 1.0)  # noqa: F841
-        sampling_weight = row.pop("sampling_weight", 1.0)  # noqa: F841
+        row.pop("sampling_factor", 1.0)
+        row.pop("sampling_weight", 1.0)
         arrays = row.pop("attributes_array", "{}") or "{}"
         booleans = row.pop("attributes_bool", {}) or {}
         integers = row.pop("attributes_int", {}) or {}
@@ -490,18 +438,9 @@ def _convert_rows(rows: Iterable[Dict[str, Any]]) -> ProcessedResults:
             else:
                 attributes_map[row_key] = _to_any_value(row_value)
 
-        attributes_array = process_arrays(arrays)
-        for array_key, array_value in attributes_array.items():
-            attributes_map[array_key] = _to_any_value(array_value)
-
-        for bool_key, bool_value in booleans.items():
-            attributes_map[bool_key] = _to_any_value(bool_value)
-
-        for int_key, int_value in integers.items():
-            attributes_map[int_key] = _to_any_value(int_value)
-
-        for float_key, float_value in floats.items():
-            attributes_map[float_key] = _to_any_value(float_value)
+        for source in (process_arrays(arrays), booleans, integers, floats):
+            for key, value in source.items():
+                attributes_map[key] = _to_any_value(value)
 
         timestamp = Timestamp()
         timestamp.FromNanoseconds(int(ts * 1e6) * 1000)
@@ -527,11 +466,13 @@ def _convert_rows(rows: Iterable[Dict[str, Any]]) -> ProcessedResults:
 
     return ProcessedResults(
         items=items,
-        last_seen_project_id=last_seen_project_id,
-        last_seen_item_type=last_seen_item_type,
-        last_seen_timestamp=last_seen_timestamp,
-        last_seen_trace_id=last_seen_trace_id,
-        last_seen_item_id=last_seen_item_id,
+        keyset_cursor=KeysetCursor(
+            last_seen_project_id=last_seen_project_id,
+            last_seen_item_type=last_seen_item_type,
+            last_seen_timestamp=last_seen_timestamp,
+            last_seen_trace_id=last_seen_trace_id,
+            last_seen_item_id=last_seen_item_id,
+        ),
     )
 
 
@@ -570,29 +511,22 @@ class EndpointExportTraceItems(RPCEndpoint[ExportTraceItemsRequest, ExportTraceI
         orig_start = in_msg.meta.start_timestamp.seconds
         routed = self.routing_decision.time_window
 
-        w_start = in_msg.meta.start_timestamp.seconds
-        w_end = in_msg.meta.end_timestamp.seconds
         if routed is not None:
             w_start, w_end = routed.start_timestamp.seconds, routed.end_timestamp.seconds
-
-        next_token: PageToken | None = None
-        if len(processed_results.items) >= limit:
-            next_token = ExportTraceItemsPageToken(
-                window_start_sec=w_start,
-                window_end_sec=w_end,
-                last_seen_project_id=processed_results.last_seen_project_id,
-                last_seen_item_type=processed_results.last_seen_item_type,
-                last_seen_trace_id=processed_results.last_seen_trace_id,
-                last_seen_timestamp=processed_results.last_seen_timestamp,
-                last_seen_item_id=processed_results.last_seen_item_id,
-            ).to_protobuf()
-        elif is_flex and routed is not None and routed.start_timestamp.seconds > orig_start:
-            next_token = ExportTraceItemsPageToken(
-                window_start_sec=orig_start,
-                window_end_sec=routed.start_timestamp.seconds,
-            ).to_protobuf()
         else:
-            next_token = PageToken(end_pagination=True)
+            w_start, w_end = in_msg.meta.start_timestamp.seconds, in_msg.meta.end_timestamp.seconds
+        flex_window = FlexWindow(start_sec=w_start, end_sec=w_end)
+
+        keyset_cursor = processed_results.keyset_cursor
+        next_token = _next_page_token(
+            items_returned=len(processed_results.items),
+            limit=limit,
+            flex_window=flex_window,
+            keyset_cursor=keyset_cursor,
+            is_flex=is_flex,
+            orig_start=orig_start,
+            routed_window=routed,
+        )
 
         return ExportTraceItemsResponse(
             trace_items=processed_results.items,

--- a/tests/web/rpc/v1/test_endpoint_export_trace_items.py
+++ b/tests/web/rpc/v1/test_endpoint_export_trace_items.py
@@ -1,20 +1,32 @@
+import re
 import uuid
-from datetime import timedelta
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import ExportTraceItemsRequest
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
+from sentry_relay.consts import DataCategory
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.web import QueryResult
 from snuba.web.query import run_query
-from snuba.web.rpc.v1.endpoint_export_trace_items import EndpointExportTraceItems
+from snuba.web.rpc.storage_routing.routing_strategies.outcomes_flex_time import (
+    OutcomesFlexTimeRoutingStrategy,
+)
+from snuba.web.rpc.v1.endpoint_export_trace_items import (
+    EndpointExportTraceItems,
+    FlexWindow,
+    KeysetCursor,
+)
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
+from tests.web.rpc.v1.routing_strategies.common import store_outcomes_data
 from tests.web.rpc.v1.test_utils import _DEFAULT_ATTRIBUTES, BASE_TIME, gen_item_message
 
 _SPAN_COUNT = 120
@@ -100,7 +112,6 @@ class TestExportTraceItems(BaseApiTest):
         assert response.trace_items == []
 
     def test_with_pagination(self, setup_teardown: Any) -> None:
-        response = None
         message = ExportTraceItemsRequest(
             meta=RequestMeta(
                 project_ids=[1, 2, 3],
@@ -128,6 +139,58 @@ class TestExportTraceItems(BaseApiTest):
         _assert_attributes_keys(items)
 
         assert len(items) == _SPAN_COUNT + _LOG_COUNT
+
+    def test_with_pagination_flex_storage_mode(self, eap: Any, redis_db: Any) -> None:
+        """Like ``test_with_pagination`` but ``MODE_HIGHEST_ACCURACY_FLEXTIME``; outcomes volume is low enough the routed window is not narrowed."""
+        total = _SPAN_COUNT + _LOG_COUNT
+        OutcomesFlexTimeRoutingStrategy().set_config_value("max_items_to_query", 500_000_000)
+        payloads = [
+            gen_item_message(
+                start_timestamp=BASE_TIME + timedelta(seconds=i),
+                item_id=int(uuid.uuid4().hex[:16], 16).to_bytes(16, byteorder="little"),
+                type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                project_id=1,
+            )
+            for i in range(total)
+        ]
+        write_raw_unprocessed_events(get_storage(StorageKey("eap_items")), payloads)  # type: ignore
+        store_outcomes_data(
+            [(BASE_TIME + timedelta(hours=h), 5_000) for h in range(6)],
+            DataCategory.LOG_ITEM,
+            org_id=1,
+            project_id=1,
+        )
+
+        message = ExportTraceItemsRequest(
+            meta=RequestMeta(
+                project_ids=[1],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int((BASE_TIME + timedelta(seconds=total)).timestamp())
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.Mode.MODE_HIGHEST_ACCURACY_FLEXTIME
+                ),
+                request_id=uuid.uuid4().hex,
+            ),
+            limit=20,
+        )
+        items: list[TraceItem] = []
+        for _ in range(1, 100):
+            response = EndpointExportTraceItems().execute(message)
+            items.extend(response.trace_items)
+            if len(response.trace_items) == 20:
+                assert response.page_token.end_pagination is False
+                assert len(response.page_token.filter_offset.and_filter.filters) == 7
+            else:
+                assert response.page_token.end_pagination
+                break
+            message.page_token.CopyFrom(response.page_token)
+        assert len(items) == total
 
     def test_pagination_with_128_bit_item_id(self, eap: Any, redis_db: Any) -> None:
         num_items = 120
@@ -211,4 +274,152 @@ class TestExportTraceItems(BaseApiTest):
         assert (
             "ORDER BY organization_id ASC, project_id ASC, item_type ASC, timestamp ASC, trace_id ASC, item_id ASC"
             in qr.extra["sql"]
+        )
+
+    def test_pagination_with_real_flex_window(
+        self, eap: Any, redis_db: Any, monkeypatch: Any
+    ) -> None:
+        """
+        Verify end-to-end flex-window pagination by capturing the full sequence of
+        queries.
+
+        Setup: 20 items [T0, T0+20s), limit=4, routing mock returns 20 outcomes for
+        any window crossing T0+5s → narrows to [T0+5, T0+20). After that window is
+        exhausted a window-only token advances to the earlier slice [T0, T0+5).
+        """
+        total = 20
+        max_items = 15
+        start_sec = int(BASE_TIME.timestamp())
+        end_sec = start_sec + total
+        # 20 outcomes / max 15 → factor 4/3 → routed window = last 15s = [T0+5, T0+20)
+        routed_start_sec = start_sec + 5
+
+        write_raw_unprocessed_events(
+            get_storage(StorageKey("eap_items")),  # type: ignore[arg-type]
+            [
+                gen_item_message(
+                    start_timestamp=BASE_TIME + timedelta(seconds=i),
+                    item_id=int(uuid.uuid4().hex[:16], 16).to_bytes(16, byteorder="little"),
+                    type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                    project_id=1,
+                )
+                for i in range(total)
+            ],
+        )
+        OutcomesFlexTimeRoutingStrategy().set_config_value("max_items_to_query", max_items)
+
+        # outcomes_hourly buckets by hour, so second-level splits are invisible to routing.
+        # Mock the count directly so each sub-range sees the logically correct volume.
+        def _mock_outcomes(self: Any, routing_context: Any, time_window: Any) -> int:
+            tw_start = time_window.start_timestamp.seconds
+            tw_end = time_window.end_timestamp.seconds
+            if tw_start < routed_start_sec < tw_end:
+                return 20  # crosses the T0+5 boundary: triggers narrowing
+            if tw_start >= routed_start_sec:
+                return 14  # entirely in [T0+5, T0+20): below max, no narrowing
+            return 6  # entirely in [T0, T0+5): below max, no narrowing
+
+        monkeypatch.setattr(
+            OutcomesFlexTimeRoutingStrategy,
+            "get_ingested_items_for_timerange",
+            _mock_outcomes,
+        )
+
+        # Capture the actual time window each query ran against by parsing the SQL.
+        sql_queried_windows: list[tuple[int, int]] = []
+
+        def _capture_query(
+            dataset: Any,
+            request: Any,
+            timer: Any,
+            robust: bool = False,
+            concurrent_queries_gauge: Any = None,
+        ) -> QueryResult:
+            qr = run_query(dataset, request, timer, robust, concurrent_queries_gauge)
+            sql = qr.extra.get("sql", "")
+            start_m = re.search(r"greaterOrEquals\(timestamp, toDateTime\('([^']+)'\)\)", sql)
+            end_m = re.search(r"less\(timestamp, toDateTime\('([^']+)'\)\)", sql)
+            if start_m and end_m:
+
+                def _to_sec(s: str) -> int:
+                    return int(
+                        datetime.strptime(s, "%Y-%m-%d %H:%M:%S")
+                        .replace(tzinfo=timezone.utc)
+                        .timestamp()
+                    )
+
+                sql_queried_windows.append((_to_sec(start_m.group(1)), _to_sec(end_m.group(1))))
+            return qr
+
+        monkeypatch.setattr(
+            "snuba.web.rpc.v1.endpoint_export_trace_items.run_query", _capture_query
+        )
+
+        message = ExportTraceItemsRequest(
+            meta=RequestMeta(
+                project_ids=[1],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=start_sec),
+                end_timestamp=Timestamp(seconds=end_sec),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+                downsampled_storage_config=DownsampledStorageConfig(
+                    mode=DownsampledStorageConfig.Mode.MODE_HIGHEST_ACCURACY_FLEXTIME
+                ),
+                request_id=uuid.uuid4().hex,
+            ),
+            limit=4,
+        )
+
+        PageRecord = namedtuple(
+            "PageRecord",
+            ["window_start", "window_end", "items_count", "has_cursor", "end_pagination"],
+        )
+        records: list[Any] = []
+
+        while True:
+            response = EndpointExportTraceItems().execute(message)
+            token = response.page_token
+            filter_count = len(token.filter_offset.and_filter.filters)
+            records.append(
+                PageRecord(
+                    window_start=sql_queried_windows[-1][0],
+                    window_end=sql_queried_windows[-1][1],
+                    items_count=len(response.trace_items),
+                    has_cursor=filter_count == len(FlexWindow._fields) + len(KeysetCursor._fields),
+                    end_pagination=token.end_pagination,
+                )
+            )
+            if token.end_pagination:
+                break
+            message.page_token.CopyFrom(token)
+
+        routed_pages = [r for r in records if r.window_start == routed_start_sec]
+        earlier_pages = [r for r in records if r.window_start == start_sec]
+
+        assert sum(r.items_count for r in records) == total, "not all items were returned"
+        assert records.index(routed_pages[-1]) < records.index(earlier_pages[0]), (
+            "routed window [T0+5, T0+20) must be fully exhausted before the earlier slice [T0, T0+5) begins"
+        )
+        assert sum(r.items_count for r in routed_pages) == 15, (
+            "routed window [T0+5, T0+20) should contain exactly 15 items"
+        )
+        assert all(r.has_cursor for r in routed_pages[:-1]), (
+            "every full page in the routed window carries a keyset cursor to continue within that window"
+        )
+        assert not routed_pages[-1].has_cursor, (
+            "once the routed window is exhausted the token switches to window-only (no cursor) to advance to the earlier slice"
+        )
+        assert not routed_pages[-1].end_pagination, (
+            "exhausting the routed window is not the end — the earlier slice [T0, T0+5) still needs to be fetched"
+        )
+        assert sum(r.items_count for r in earlier_pages) == 5, (
+            "earlier slice [T0, T0+5) should contain the remaining 5 items"
+        )
+        assert all(r.has_cursor for r in earlier_pages[:-1]), (
+            "every full page in the earlier slice carries a keyset cursor"
+        )
+        assert records[-1].end_pagination, (
+            "pagination ends only after the earlier slice is fully consumed"
         )

--- a/tests/web/rpc/v1/test_endpoint_export_trace_items.py
+++ b/tests/web/rpc/v1/test_endpoint_export_trace_items.py
@@ -10,7 +10,6 @@ from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageCon
 from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import ExportTraceItemsRequest
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
-from sentry_relay.consts import DataCategory
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -26,7 +25,6 @@ from snuba.web.rpc.v1.endpoint_export_trace_items import (
 )
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
-from tests.web.rpc.v1.routing_strategies.common import store_outcomes_data
 from tests.web.rpc.v1.test_utils import _DEFAULT_ATTRIBUTES, BASE_TIME, gen_item_message
 
 _SPAN_COUNT = 120
@@ -139,58 +137,6 @@ class TestExportTraceItems(BaseApiTest):
         _assert_attributes_keys(items)
 
         assert len(items) == _SPAN_COUNT + _LOG_COUNT
-
-    def test_with_pagination_flex_storage_mode(self, eap: Any, redis_db: Any) -> None:
-        """Like ``test_with_pagination`` but ``MODE_HIGHEST_ACCURACY_FLEXTIME``; outcomes volume is low enough the routed window is not narrowed."""
-        total = _SPAN_COUNT + _LOG_COUNT
-        OutcomesFlexTimeRoutingStrategy().set_config_value("max_items_to_query", 500_000_000)
-        payloads = [
-            gen_item_message(
-                start_timestamp=BASE_TIME + timedelta(seconds=i),
-                item_id=int(uuid.uuid4().hex[:16], 16).to_bytes(16, byteorder="little"),
-                type=TraceItemType.TRACE_ITEM_TYPE_LOG,
-                project_id=1,
-            )
-            for i in range(total)
-        ]
-        write_raw_unprocessed_events(get_storage(StorageKey("eap_items")), payloads)  # type: ignore
-        store_outcomes_data(
-            [(BASE_TIME + timedelta(hours=h), 5_000) for h in range(6)],
-            DataCategory.LOG_ITEM,
-            org_id=1,
-            project_id=1,
-        )
-
-        message = ExportTraceItemsRequest(
-            meta=RequestMeta(
-                project_ids=[1],
-                organization_id=1,
-                cogs_category="something",
-                referrer="something",
-                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
-                end_timestamp=Timestamp(
-                    seconds=int((BASE_TIME + timedelta(seconds=total)).timestamp())
-                ),
-                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
-                downsampled_storage_config=DownsampledStorageConfig(
-                    mode=DownsampledStorageConfig.Mode.MODE_HIGHEST_ACCURACY_FLEXTIME
-                ),
-                request_id=uuid.uuid4().hex,
-            ),
-            limit=20,
-        )
-        items: list[TraceItem] = []
-        for _ in range(1, 100):
-            response = EndpointExportTraceItems().execute(message)
-            items.extend(response.trace_items)
-            if len(response.trace_items) == 20:
-                assert response.page_token.end_pagination is False
-                assert len(response.page_token.filter_offset.and_filter.filters) == 7
-            else:
-                assert response.page_token.end_pagination
-                break
-            message.page_token.CopyFrom(response.page_token)
-        assert len(items) == total
 
     def test_pagination_with_128_bit_item_id(self, eap: Any, redis_db: Any) -> None:
         num_items = 120


### PR DESCRIPTION
Update ExportTraceItems endpoint to respect the routing decision so that we can reduce the time window for scanned items based on sampling config. This will help with Timing out of sentry requests. 

### Pagination logic:
Pagination uses a keyset cursor encoded as a protobuf `PageToken.filter_offset (AndFilter)`. 
Every token carries the active [`window_start`, `window_end`) time range. Presence of a cursor is inferred from `last_seen_item_id` being non-empty.


Two shapes:
- 2 filters:  time window only. Used when advancing to the next flex-time slice (no rows seen yet in that window).
- 7 filters:  time window + 5 last-seen fields `(project_id, item_type, timestamp, trace_id, item_id)`. Used when the page was full and the next request should continue after the last returned row.

The keyset condition injected into the query is a tuple comparison:
    ```
    WHERE (project_id, item_type, timestamp, trace_id, item_id) > (last_seen_project_id, last_seen_item_type, ...)
    ```
This matches the ORDER BY column order, so ClickHouse can seek directly without scanning already-returned rows.
Next-token decision at end of each request:
- Results filled the page =>  7-filter token (same window, last row as cursor)
- Results exhausted the window AND flex routing narrowed the original range → 2-filter token (advance to the remaining earlier slice)
- Otherwise, end_pagination = True

                                                                                                                                                     
