### PR TITLE
fix(ci): set build_target to 'application' to reduce Docker image size

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -31,6 +31,7 @@ jobs:
         image_name: 'snuba'
         platforms: linux/${{ matrix.platform }}
         dockerfile_path: 'Dockerfile'
+        build_target: 'application'
         tag_suffix: -${{ matrix.platform }}
         ghcr: true
         tag_nightly: false


### PR DESCRIPTION
Should be done after https://github.com/getsentry/snuba/pull/7909 is merged
