### PR TITLE
Ensure SENTRY_OPTIONS_DIR/values exists in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,6 +182,7 @@ ENV PATH="/.venv/bin:/opt/python/bin:$PATH" \
     SENTRY_OPTIONS_DIR=/etc/sentry-options
 
 USER 1000
+RUN mkdir -p "${SENTRY_OPTIONS_DIR}"
 EXPOSE 1218 1219
 ENTRYPOINT ["python3", "/usr/src/snuba/docker_entrypoint.py"]
 CMD ["api"]
@@ -206,6 +207,7 @@ ENV PATH="/.venv/bin:/opt/python/bin:$PATH" \
     SENTRY_OPTIONS_DIR=/etc/sentry-options
 
 USER 1000
+RUN mkdir -p "${SENTRY_OPTIONS_DIR}"
 EXPOSE 1218 1219
 ENTRYPOINT ["python3", "/usr/src/snuba/docker_entrypoint.py"]
 CMD ["api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,8 +181,8 @@ ENV PATH="/.venv/bin:/opt/python/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     SENTRY_OPTIONS_DIR=/etc/sentry-options
 
+RUN install -d -o 1000 -g 1000 "${SENTRY_OPTIONS_DIR}"
 USER 1000
-RUN mkdir -p "${SENTRY_OPTIONS_DIR}"
 EXPOSE 1218 1219
 ENTRYPOINT ["python3", "/usr/src/snuba/docker_entrypoint.py"]
 CMD ["api"]
@@ -206,8 +206,8 @@ ENV PATH="/.venv/bin:/opt/python/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     SENTRY_OPTIONS_DIR=/etc/sentry-options
 
+RUN install -d -o 1000 -g 1000 "${SENTRY_OPTIONS_DIR}"
 USER 1000
-RUN mkdir -p "${SENTRY_OPTIONS_DIR}"
 EXPOSE 1218 1219
 ENTRYPOINT ["python3", "/usr/src/snuba/docker_entrypoint.py"]
 CMD ["api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,7 @@ ENV LD_PRELOAD=/usr/src/snuba/libjemalloc.so.2 \
 
 # set default path for sentry options values
 ENV SENTRY_OPTIONS_DIR=/etc/sentry-options
+RUN install -d -o snuba -g snuba "${SENTRY_OPTIONS_DIR}/values"
 
 USER snuba
 EXPOSE 1218 1219
@@ -167,6 +168,7 @@ FROM ghcr.io/getsentry/dhi/python:3.13-debian13 AS application-distroless
 
 COPY --from=distroless_prep /.venv /.venv
 COPY --from=distroless_prep /usr/src/snuba /usr/src/snuba
+COPY --from=distroless_prep /etc/sentry-options /etc/sentry-options
 COPY --from=distroless_prep /usr/lib/*/libjemalloc.so.2 /usr/lib/libjemalloc.so.2
 COPY --from=distroless_prep /etc/passwd /etc/passwd
 COPY --from=distroless_prep /etc/group /etc/group
@@ -181,7 +183,6 @@ ENV PATH="/.venv/bin:/opt/python/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     SENTRY_OPTIONS_DIR=/etc/sentry-options
 
-RUN install -d -o 1000 -g 1000 "${SENTRY_OPTIONS_DIR}"
 USER 1000
 EXPOSE 1218 1219
 ENTRYPOINT ["python3", "/usr/src/snuba/docker_entrypoint.py"]
@@ -192,6 +193,7 @@ FROM ghcr.io/getsentry/dhi/python:3.13-debian13-dev AS application-distroless-de
 
 COPY --from=distroless_prep /.venv /.venv
 COPY --from=distroless_prep /usr/src/snuba /usr/src/snuba
+COPY --from=distroless_prep /etc/sentry-options /etc/sentry-options
 COPY --from=distroless_prep /usr/lib/*/libjemalloc.so.2 /usr/lib/libjemalloc.so.2
 COPY --from=distroless_prep /etc/passwd /etc/passwd
 COPY --from=distroless_prep /etc/group /etc/group
@@ -206,7 +208,6 @@ ENV PATH="/.venv/bin:/opt/python/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     SENTRY_OPTIONS_DIR=/etc/sentry-options
 
-RUN install -d -o 1000 -g 1000 "${SENTRY_OPTIONS_DIR}"
 USER 1000
 EXPOSE 1218 1219
 ENTRYPOINT ["python3", "/usr/src/snuba/docker_entrypoint.py"]


### PR DESCRIPTION
Fixes https://github.com/getsentry/self-hosted/issues/4306

Since https://github.com/getsentry/snuba/commit/5b6307384be46a8f4c6affcb0cd3c647464c803d final image does not contain `/etc/sentry-options` anymore, and so it floods logs with `Failed to read directory /etc/sentry-options/values: No such file or directory (os error 2)` because of that.

This PR ensures the env exists.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
