### PR TITLE
ref(inc-2150): handle future TimeoutError

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -370,10 +370,8 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
             message, result_future = self.__queue.popleft()
 
-            result = result_future.future.result()
-
             transformed_message = self.__result_encoder.encode(
-                SubscriptionTaskResult(result_future.task, result)
+                SubscriptionTaskResult(result_future.task, result_future.future.result())
             )
 
             self.__next_step.submit(message.replace(transformed_message))

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -5,6 +5,7 @@ import math
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import datetime
 from typing import Deque, Mapping, Optional, Sequence, Tuple
 
@@ -370,8 +371,16 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
             message, result_future = self.__queue.popleft()
 
+            try:
+                result = result_future.future.result(remaining)
+            except FutureTimeoutError:
+                logger.warning(
+                    f"Timed out waiting for future, {len(self.__queue)} futures remaining in queue"
+                )
+                continue
+
             transformed_message = self.__result_encoder.encode(
-                SubscriptionTaskResult(result_future.task, result_future.future.result())
+                SubscriptionTaskResult(result_future.task, result)
             )
 
             self.__next_step.submit(message.replace(transformed_message))

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -5,7 +5,6 @@ import math
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import datetime
 from typing import Deque, Mapping, Optional, Sequence, Tuple
 
@@ -371,13 +370,7 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
             message, result_future = self.__queue.popleft()
 
-            try:
-                result = result_future.future.result(remaining)
-            except FutureTimeoutError:
-                logger.warning(
-                    f"Timed out waiting for future, {len(self.__queue)} futures remaining in queue"
-                )
-                break
+            result = result_future.future.result()
 
             transformed_message = self.__result_encoder.encode(
                 SubscriptionTaskResult(result_future.task, result)
@@ -386,7 +379,7 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
             self.__next_step.submit(message.replace(transformed_message))
 
         remaining = timeout - (time.time() - start) if timeout is not None else None
-        self.__executor.shutdown()
+        self.__executor.shutdown(cancel_futures=True)
 
         self.__next_step.close()
         self.__next_step.join(remaining)

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -5,6 +5,7 @@ import math
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import datetime
 from typing import Deque, Mapping, Optional, Sequence, Tuple
 
@@ -370,8 +371,16 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
             message, result_future = self.__queue.popleft()
 
+            try:
+                result = result_future.future.result(remaining)
+            except FutureTimeoutError:
+                logger.warning(
+                    f"Timed out waiting for future, {len(self.__queue)} futures remaining in queue"
+                )
+                break
+
             transformed_message = self.__result_encoder.encode(
-                SubscriptionTaskResult(result_future.task, result_future.future.result(remaining))
+                SubscriptionTaskResult(result_future.task, result)
             )
 
             self.__next_step.submit(message.replace(transformed_message))


### PR DESCRIPTION
When closing a strategy we call `strategy.join` https://github.com/getsentry/arroyo/blob/3cb0b65d110eb9aa5efb6db88820792e6b3542ab/arroyo/processing/processor.py#L296 which for the subscriptions tries to finishes the subscriptions tasks. We have `join` timeout which handles dropping tasks left in the queue, but if an individual task timeout the consumer crashes. 

This PR avoids crashing the consumer on shutdown when a future raises a `TimeoutError`.