### PR TITLE
feat(clickhouse): Add timeout for ClickHouse pool connection acquisition

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -86,6 +86,7 @@ class ClickhousePool(object):
         connect_timeout: int = 1,
         send_receive_timeout: Optional[int] = 35,
         max_pool_size: int = settings.CLICKHOUSE_MAX_POOL_SIZE,
+        pool_get_timeout_seconds: float = settings.CLICKHOUSE_POOL_GET_TIMEOUT_SECONDS,
         client_settings: Mapping[str, Any] = {},
     ) -> None:
         self.host = host
@@ -98,6 +99,7 @@ class ClickhousePool(object):
         self.verify = verify
         self.connect_timeout = connect_timeout
         self.send_receive_timeout = send_receive_timeout
+        self.pool_get_timeout_seconds = pool_get_timeout_seconds
         self.client_settings = client_settings
 
         self.pool: queue.LifoQueue[Optional[Client]] = queue.LifoQueue(max_pool_size)
@@ -130,8 +132,15 @@ class ClickhousePool(object):
         failures.
         """
         try:
-            conn = self.pool.get(block=True)
+            conn = self.pool.get(block=True, timeout=self.pool_get_timeout_seconds)
+        except queue.Empty:
+            metrics.increment(
+                "pool_get_timeout",
+                tags={"host": self.host, "port": str(self.port)},
+            )
+            raise
 
+        try:
             if retryable:
                 attempts_remaining = 3
             else:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -94,6 +94,10 @@ DISABLED_DATASETS: Set[str] = set()
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
+# Maximum time (seconds) to wait for a connection from the ClickHouse pool
+# before failing fast. Prevents API workers from blocking indefinitely on
+# pool.get() when ClickHouse is hung but not dropping connections.
+CLICKHOUSE_POOL_GET_TIMEOUT_SECONDS = 5
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {


### PR DESCRIPTION
Adds a `CLICKHOUSE_POOL_GET_TIMEOUT_SECONDS` setting (default 5s) that bounds how long `ClickhousePool.execute` will block waiting for a connection from the pool, and emits a `clickhouse.native.pool_get_timeout` counter (tagged with host/port) when the timeout fires.

Today `ClickhousePool.execute` calls `self.pool.get(block=True)` with no timeout. If ClickHouse accepts TCP connections but stalls without dropping them, every pool slot fills with hung connections and every subsequent request blocks indefinitely on `pool.get`. The 35s socket-level `send_receive_timeout` does eventually unwedge each individual request, but while the pool is saturated, all API workers in the process are stuck — including workers serving endpoints that route to *other*, healthy ClickHouse clusters. One sick cluster takes down the whole process.

With this change, `pool.get` raises `queue.Empty` after 5s if no connection is available. The exception propagates out of `execute`/`execute_robust` (it's deliberately not in either retry list — pool exhaustion is a saturation signal, not a transient error, so retrying would only compound the problem) and the request fails fast as a 500. Workers free up every 5s under saturation instead of permanently blocking, which breaks the cross-cluster blast radius.

The new counter gives operators a leading indicator of pool saturation that is otherwise hard to derive from existing metrics; today you have to infer it from a delta between request-level and query-level timers.

This change was prompted by INC-2141