### PR TITLE
ci: bump ddl-changes job timeout to 10 minutes

### DIFF
--- a/.github/workflows/ddl-changes.yml
+++ b/.github/workflows/ddl-changes.yml
@@ -11,7 +11,7 @@ jobs:
   post_changes:
     name: Post new DDL changes from migrations
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         name: Checkout master for diffing


### PR DESCRIPTION
Bump the `timeout-minutes` for the "Post new DDL changes from migrations" job in `.github/workflows/ddl-changes.yml` from 5 to 10.

The job has recently been hitting the 5-minute ceiling (e.g. [run 25386264272](https://github.com/getsentry/snuba/actions/runs/25386264272/job/74448122651?pr=7920)) and getting cancelled before it can post the diff. Doubling the budget gives it headroom without making slow runs invisible.