### PR TITLE
ref(inc-2150): hard limit of MAX_BUFFERED_MESSAGES for batched deletes

### DIFF
--- a/snuba/lw_deletions/batching.py
+++ b/snuba/lw_deletions/batching.py
@@ -15,6 +15,9 @@ TResult = TypeVar("TResult")
 
 
 Accumulator = Callable[[TResult, BaseValue[TPayload]], TResult]
+# https://clickhouse.com/docs/operations/settings/settings#max_ast_elements
+# max_ast_elements defaults to 50000
+MAX_BUFFERED_MESSAGES = 10000
 
 
 class ReduceRowsBuffer(Generic[TPayload, TResult]):
@@ -35,6 +38,8 @@ class ReduceRowsBuffer(Generic[TPayload, TResult]):
         self._buffer = initial_value()
         self._buffer_size = 0
         self._buffer_until = time.time() + max_batch_time
+        # used to set a max value on the delete AST
+        self._buffered_messages = 0
 
     @property
     def buffer(self) -> TResult:
@@ -46,7 +51,11 @@ class ReduceRowsBuffer(Generic[TPayload, TResult]):
 
     @property
     def is_ready(self) -> bool:
-        return self._buffer_size >= self.max_batch_size or time.time() >= self._buffer_until
+        return (
+            self._buffer_size >= self.max_batch_size
+            or time.time() >= self._buffer_until
+            or self._buffered_messages > MAX_BUFFERED_MESSAGES
+        )
 
     def append(self, message: BaseValue[TPayload]) -> None:
         """
@@ -61,6 +70,7 @@ class ReduceRowsBuffer(Generic[TPayload, TResult]):
         else:
             buffer_increment = 1
         self._buffer_size += buffer_increment
+        self._buffered_messages += 1
 
     def new(self) -> "ReduceRowsBuffer[TPayload, TResult]":
         return ReduceRowsBuffer(

--- a/snuba/lw_deletions/batching.py
+++ b/snuba/lw_deletions/batching.py
@@ -17,7 +17,7 @@ TResult = TypeVar("TResult")
 Accumulator = Callable[[TResult, BaseValue[TPayload]], TResult]
 # https://clickhouse.com/docs/operations/settings/settings#max_ast_elements
 # max_ast_elements defaults to 50000
-MAX_BUFFERED_MESSAGES = 10000
+MAX_BUFFERED_MESSAGES = 2000
 
 
 class ReduceRowsBuffer(Generic[TPayload, TResult]):

--- a/snuba/lw_deletions/batching.py
+++ b/snuba/lw_deletions/batching.py
@@ -54,7 +54,7 @@ class ReduceRowsBuffer(Generic[TPayload, TResult]):
         return (
             self._buffer_size >= self.max_batch_size
             or time.time() >= self._buffer_until
-            or self._buffered_messages > MAX_BUFFERED_MESSAGES
+            or self._buffered_messages >= MAX_BUFFERED_MESSAGES
         )
 
     def append(self, message: BaseValue[TPayload]) -> None:

--- a/tests/lw_deletions/test_batching.py
+++ b/tests/lw_deletions/test_batching.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import Mock, patch
+
+import rapidjson
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import BrokerValue, Message, Partition, Topic
+
+from snuba.lw_deletions.batching import BatchStepCustom, ReduceRowsBuffer
+from snuba.lw_deletions.strategy import increment_by
+from snuba.utils.streams.topics import Topic as SnubaTopic
+
+
+def _lw_deletion_kafka_message(offset: int) -> Message[KafkaPayload]:
+    payload = {
+        "rows_to_delete": 5,
+        "storage_name": "search_issues",
+        "conditions": {"project_id": [1]},
+        "tenant_ids": {"project_id": 1, "organization_id": 1},
+    }
+    return Message(
+        BrokerValue(
+            KafkaPayload(None, rapidjson.dumps(payload).encode("utf-8"), []),
+            Partition(Topic(SnubaTopic.LW_DELETIONS_GENERIC_EVENTS.value), 0),
+            offset,
+            datetime(1970, 1, 1),
+        )
+    )
+
+
+@patch("snuba.lw_deletions.batching.MAX_BUFFERED_MESSAGES", 2)
+def test_reduce_rows_buffer_is_ready_after_buffered_messages_exceeds_max() -> None:
+    def accumulator(acc: list[object], msg: object) -> list[object]:
+        acc.append(msg)
+        return acc
+
+    buf: ReduceRowsBuffer[Any, list[Any]] = ReduceRowsBuffer(
+        accumulator,
+        lambda: [],
+        max_batch_size=10**9,
+        max_batch_time=10**9,
+    )
+    assert buf.is_empty
+    buf.append(Mock())
+    assert not buf.is_ready
+    buf.append(Mock())
+    assert not buf.is_ready
+    buf.append(Mock())
+    assert buf.is_ready
+
+    # sudo flush the batch, test that state is reset
+    buf = buf.new()
+    assert not buf.is_ready
+    buf.append(Mock())
+    assert not buf.is_ready
+
+
+@patch("snuba.lw_deletions.batching.MAX_BUFFERED_MESSAGES", 5)
+def test_rows_to_delete_and_max_buffered_messages() -> None:
+    """
+    Buffer.submit flushes when is_ready before accepting the next message.
+    with rows_to_delete as 5 for each message it will batch 3 messages and
+    the next batch will be the last message.
+    Test that max_batch_size unaffected by MAX_BUFFERED_MESSAGES.
+    """
+    next_step = Mock()
+    strategy: BatchStepCustom[KafkaPayload] = BatchStepCustom(
+        max_batch_size=15,
+        max_batch_time=10**9,
+        next_step=next_step,
+        increment_by=increment_by,
+    )
+    for i in range(3):
+        strategy.submit(_lw_deletion_kafka_message(i))
+    assert next_step.submit.call_count == 0
+
+    # new batch created after submitting
+    strategy.submit(_lw_deletion_kafka_message(4))
+    assert next_step.submit.call_count == 1
+    flushed = next_step.submit.call_args[0][0]
+    assert len(flushed.payload) == 3
+
+    strategy.close()
+    strategy.join()
+    assert next_step.submit.call_count == 2
+    final = next_step.submit.call_args[0][0]
+    assert len(final.payload) == 1

--- a/tests/lw_deletions/test_batching.py
+++ b/tests/lw_deletions/test_batching.py
@@ -30,7 +30,7 @@ def _lw_deletion_kafka_message(offset: int) -> Message[KafkaPayload]:
     )
 
 
-@patch("snuba.lw_deletions.batching.MAX_BUFFERED_MESSAGES", 2)
+@patch("snuba.lw_deletions.batching.MAX_BUFFERED_MESSAGES", 3)
 def test_reduce_rows_buffer_is_ready_after_buffered_messages_exceeds_max() -> None:
     def accumulator(acc: list[object], msg: object) -> list[object]:
         acc.append(msg)


### PR DESCRIPTION
We had issues with some of the mutations being too large and saw exceptions like the following

```Code: 168. DB::Exception: AST is too big. Maximum: 500000: (after expansion of aliases). (TOO_BIG_AST) (version 25.3.6.10034.altinitystable (altinity build))```

I added a `MAX_BUFFERED_MESSAGES` of `10000` so that we hopefully don't hit this again. I think this number should be high enough that we wouldn't be trying to submit mutations too often and also I don't think the backlog normally gets this high (at least in de)