### PR TITLE
OutcomesBasedRoutingStrategy: allow org-specific downsampling

### DIFF
--- a/snuba/web/rpc/storage_routing/routing_strategies/outcomes_based.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/outcomes_based.py
@@ -60,10 +60,15 @@ class OutcomesBasedRoutingStrategy(BaseRoutingStrategy):
     def _additional_config_definitions(self) -> list[Configuration]:
         return [
             Configuration(
-                name="some_additional_config",
-                description="Placeholder for now",
+                name="max_items_before_downsampling",
+                description=(
+                    "Per-org override for the max ingested items threshold above which a query is "
+                    "downsampled. When set to a positive value, takes precedence over the global "
+                    "OutcomesBasedRoutingStrategy.max_items_before_downsampling runtime config. "
+                    "Default 0 means no override (use global)."
+                ),
                 value_type=int,
-                default=50,
+                default=0,
                 param_types={"organization_id": int},
             ),
         ]
@@ -189,7 +194,14 @@ class OutcomesBasedRoutingStrategy(BaseRoutingStrategy):
         routing_context.extra_info["estimation_sql"] = res.extra.get("sql", "")
         return cast(int, res.result.get("data", [{}])[0].get("num_items", 0))
 
-    def _get_max_items_before_downsampling(self) -> int:
+    def _get_max_items_before_downsampling(self, organization_id: int) -> int:
+        per_org_override = self.get_config_value(
+            "max_items_before_downsampling",
+            params={"organization_id": organization_id},
+        )
+        if per_org_override > 0:
+            return cast(int, per_org_override)
+
         default = 1_000_000_000
         return (
             state.get_int_config(
@@ -260,7 +272,9 @@ class OutcomesBasedRoutingStrategy(BaseRoutingStrategy):
         # downsample if it's too many
         ingested_items = self.get_ingested_items_for_timerange(routing_decision.routing_context)
         routing_decision.routing_context.extra_info["ingested_items"] = ingested_items
-        max_items_before_downsampling = self._get_max_items_before_downsampling()
+        max_items_before_downsampling = self._get_max_items_before_downsampling(
+            in_msg_meta.organization_id
+        )
         routing_decision.routing_context.extra_info["max_items_before_downsampling"] = (
             max_items_before_downsampling
         )

--- a/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
+++ b/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
@@ -301,6 +301,46 @@ def test_outcomes_based_routing_downsample(store_outcomes_fixture: Any) -> None:
 
 @pytest.mark.eap
 @pytest.mark.redis_db
+def test_outcomes_based_routing_per_org_override(store_outcomes_fixture: Any) -> None:
+    # global says no downsampling; per-org override forces TIER_64
+    state.set_config("OutcomesBasedRoutingStrategy.max_items_before_downsampling", 1_000_000_000)
+    strategy = OutcomesBasedRoutingStrategy()
+    strategy.set_config_value(
+        "max_items_before_downsampling",
+        500_000,
+        params={"organization_id": _ORG_ID},
+    )
+
+    request = TraceItemTableRequest(meta=_get_request_meta())
+    request.meta.downsampled_storage_config.mode = DownsampledStorageConfig.MODE_NORMAL
+
+    routing_decision = strategy.get_routing_decision(
+        RoutingContext(
+            in_msg=request,
+            timer=Timer("test"),
+            query_id=uuid.uuid4().hex,
+        )
+    )
+    assert routing_decision.tier == Tier.TIER_64
+    assert routing_decision.can_run
+
+    # different org with no override falls back to the global config
+    other_org_request = TraceItemTableRequest(meta=_get_request_meta())
+    other_org_request.meta.organization_id = _ORG_ID + 1
+    other_org_request.meta.downsampled_storage_config.mode = DownsampledStorageConfig.MODE_NORMAL
+
+    other_routing_decision = strategy.get_routing_decision(
+        RoutingContext(
+            in_msg=other_org_request,
+            timer=Timer("test"),
+            query_id=uuid.uuid4().hex,
+        )
+    )
+    assert other_routing_decision.tier == Tier.TIER_1
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
 def test_outcomes_based_routing_highest_accuracy_mode(store_outcomes_fixture: Any) -> None:
     strategy = OutcomesBasedRoutingStrategy()
 


### PR DESCRIPTION
EAP-509               
                                                                                
  ## Summary                                                                    
                                                                                
  Adds a per-org runtime override for                                           
  `OutcomesBasedRoutingStrategy.max_items_before_downsampling` so we can force a
   single org onto a more aggressive downsampling tier without changing the     
  global threshold.                                         

  - New parameterized `Configuration` `max_items_before_downsampling` with      
  `param_types={"organization_id": int}` on `OutcomesBasedRoutingStrategy`.
  - `_get_max_items_before_downsampling(organization_id)` checks the per-org    
  override first; if it's `> 0` it wins, otherwise it falls back to the existing
   global `state.get_int_config("OutcomesBasedRoutingStrategy.max_items_before_d
  ownsampling", …)`. Default `0` = "no override".                               
  - Caller in `_update_routing_decision` passes `in_msg_meta.organization_id`.
                                                                                
  This replaces the `some_additional_config` placeholder that was already wired 
  up for `organization_id` parameterization.                                    
                                                                                
                                                            
  ```python
  strategy.set_config_value(
      "max_items_before_downsampling",
      <new_threshold>,                                                          
      params={"organization_id": <some_org_id>},
  )       