### PR TITLE
snuba/admin: fix 'occured' -> 'occurred' typos in Google admin error messages

### DIFF
--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -37,7 +37,7 @@ class CloudIdentityAPI:
             response = request.execute()
             if "error" in response:
                 logger.exception(
-                    f"An HTTP error occured when fetching group id for email {group_email}.",
+                    f"An HTTP error occurred when fetching group id for email {group_email}.",
                     google_api_error=response["error"],
                 )
                 return None
@@ -63,7 +63,7 @@ class CloudIdentityAPI:
             response = request.execute()
             if "error" in response:
                 logger.exception(
-                    f"An HTTP error occured when checking if user {member} is a member of group {group_resource_name}",
+                    f"An HTTP error occurred when checking if user {member} is a member of group {group_resource_name}",
                     google_api_error=response["error"],
                 )
             return bool(response.get("hasMembership", False))


### PR DESCRIPTION
Fixes two misspellings of "occured" -> "occurred" in user-visible HTTP error messages raised by `snuba/admin/google.py`.