### PR TITLE
snuba/cli: fix 'occured' -> 'occurred' typo in querylog_to_csv help text

### DIFF
--- a/snuba/cli/querylog_to_csv.py
+++ b/snuba/cli/querylog_to_csv.py
@@ -113,7 +113,7 @@ def get_credentials() -> Tuple[str, str]:
 )
 @click.option(
     "--event-type",
-    help="Type of event that occured while executing query.",
+    help="Type of event that occurred while executing query.",
     type=click.Choice(["QueryFinish", "ExceptionBeforeStart", "ExceptionWhileProcessing"]),
     required=True,
     default="QueryFinish",


### PR DESCRIPTION
Fixes a spelling typo (`occured` -> `occurred`) in the CLI help string for `querylog_to_csv`.