### PR TITLE
Reapply "ref: drop dead down-file shutdown signaling path (#7924)"

### DIFF
--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Set, Union, cast
+from typing import Any, Dict, List, Mapping, MutableMapping, Set, Union, cast
 
 import sentry_sdk
 import simplejson as json
@@ -31,46 +30,6 @@ setup_logging(None)
 logger = logging.getLogger("snuba.health")
 
 
-def shutdown_time() -> Optional[float]:
-    try:
-        return os.stat("/tmp/snuba.down").st_mtime
-    except OSError:
-        return None
-
-
-_IS_SHUTTING_DOWN = False
-
-try:
-    import uwsgi
-except ImportError:
-
-    def check_down_file_exists() -> bool:
-        return False
-
-else:
-
-    def check_down_file_exists() -> bool:
-        try:
-            m_time = shutdown_time()
-            if m_time is None:
-                return False
-
-            start_time: float = uwsgi.started_on
-            _set_shutdown(m_time > start_time)
-            return get_shutdown()
-        except OSError:
-            return False
-
-
-def _set_shutdown(is_shutting_down: bool) -> None:
-    global _IS_SHUTTING_DOWN
-    _IS_SHUTTING_DOWN = is_shutting_down
-
-
-def get_shutdown() -> bool:
-    return _IS_SHUTTING_DOWN
-
-
 def _execute_show_tables(cluster: ClickhouseCluster) -> bool:
     clickhouse = cluster.get_query_connection(ClickhouseClientSettings.QUERY)
     clickhouse.execute("show tables").results
@@ -85,14 +44,8 @@ class HealthInfo:
 
 
 def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
-
     start = time.time()
-    down_file_exists = check_down_file_exists()
-
-    metric_tags = {
-        "down_file_exists": str(down_file_exists),
-        "thorough": str(thorough),
-    }
+    metric_tags = {"thorough": str(thorough)}
 
     if get_int_config("health_check_ignore_clickhouse", 0) == 1:
         clickhouse_health = True
@@ -108,12 +61,10 @@ def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
 
     body: Mapping[str, Union[str, bool]]
     if clickhouse_health:
-        body = {"status": "ok", "down_file_exists": down_file_exists}
+        body = {"status": "ok"}
         status = 200
     else:
-        body = {
-            "down_file_exists": down_file_exists,
-        }
+        body = {}
         if thorough:
             body["clickhouse_ok"] = clickhouse_health
         status = 502
@@ -121,15 +72,12 @@ def get_health_info(thorough: Union[bool, str]) -> HealthInfo:
     payload = json.dumps(body)
     if status != 200:
         metrics.increment("healthcheck_failed", tags=metric_tags)
-        if down_file_exists:
-            logger.error("Snuba health check failed! Tags: %s", metric_tags)
-        else:
-            logger.info("Snuba health check failed! Tags: %s", metric_tags)
+        logger.info("Snuba health check failed! Tags: %s", metric_tags)
 
     metrics.timing(
         "healthcheck.latency",
         time.time() - start,
-        tags={"thorough": str(thorough), "down_file_exists": str(down_file_exists)},
+        tags={"thorough": str(thorough)},
     )
 
     return HealthInfo(

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import atexit
 import functools
 import logging
-import random
 import time
 from datetime import datetime
 from typing import (
@@ -63,11 +62,8 @@ from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import PartitionId
 from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionDeleter
 from snuba.utils.health_info import (
-    check_down_file_exists,
     get_health_info,
-    get_shutdown,
     metrics,
-    shutdown_time,
 )
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.util import with_span
@@ -202,25 +198,13 @@ def handle_internal_server_error(exception: InternalServerError) -> Response:
 
 @application.route("/health_envoy")
 def health_envoy() -> Response:
-    """K8s can decide to shut down the pod, at which point it will write the down file.
-    This down file signals that we have to drain the pod, and not accept any new traffic.
-    In SaaS, envoy is the thing that will decided to route traffic to this node or not. It
-    uses this endpoint to make that decision.
-
-    This differs from the generic health endpoint because the pod can still be healthy
-    but just not accepting traffic. That way k8s will not restart it until it is drained
+    """Always returns 200. The historical down-file drain mechanism (consulted
+    here via uwsgi worker introspection) was retired with the granian migration
+    in PR #7566 and is no longer used by ops infra. The endpoint is kept as a
+    no-op so existing envoy callers don't 404 — remove once the envoy config no
+    longer references it.
     """
-
-    down_file_exists = check_down_file_exists()
-
-    if not down_file_exists:
-        status = 200
-    else:
-        status = 503
-
-    if status != 200:
-        metrics.increment("healthcheck_envoy_failed")
-    return Response(json.dumps({}), status, {"Content-Type": "application/json"})
+    return Response(json.dumps({}), 200, {"Content-Type": "application/json"})
 
 
 @application.route("/health")
@@ -346,7 +330,6 @@ def mql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response,
 @util.time_request("delete_query")
 def storage_delete(*, storage: WritableTableStorage, timer: Timer) -> Union[Response, str]:
     if http_request.method == "DELETE":
-        check_shutdown({"storage": storage.get_storage_key()})
         body = parse_request_body(http_request)
 
         try:
@@ -435,27 +418,12 @@ def dump_payload(payload: MutableMapping[str, Any]) -> str:
         return json.dumps(sanitized_payload, default=str)
 
 
-def check_shutdown(tags: Dict[str, Any]) -> None:
-    # Try to detect if new requests are being sent to the api
-    # after the shutdown command has been issued, and if so
-    # how long after. I don't want to do a disk check for
-    # every query, so randomly sample until the shutdown file
-    # is detected, and then log everything
-    if get_shutdown() or random.random() < 0.05:
-        if get_shutdown() or check_down_file_exists():
-            metrics.increment("post.shutdown.query", tags=tags)
-            diff = time.time() - (shutdown_time() or 0.0)  # this should never be None
-            metrics.timing("post.shutdown.query.delay", diff, tags=tags)
-
-
 @with_span()
 def dataset_query(
     dataset_name: str, body: Dict[str, Any], timer: Timer, is_mql: bool = False
 ) -> Response:
     assert http_request.method == "POST"
     referrer = http_request.referrer or "<unknown>"  # mypy
-
-    check_shutdown({"dataset": dataset_name})
 
     try:
         request, result = parse_and_run_query(body, timer, is_mql, dataset_name, referrer)

--- a/tests/cli/test_health.py
+++ b/tests/cli/test_health.py
@@ -5,18 +5,6 @@ from click.testing import CliRunner
 from snuba.cli.health import health
 
 
-def test_down_file_exists_pod_healthy() -> None:
-    runner = CliRunner()
-    # down file existing does not mean the pod is unhealthy
-    with mock.patch("snuba.utils.health_info.check_down_file_exists", return_value=True):
-        with mock.patch(
-            "snuba.utils.health_info.sanity_check_clickhouse_connections",
-            return_value=True,
-        ):
-            result = runner.invoke(health)
-            assert result.exit_code == 0
-
-
 def test_bad_clickhouse_connection_healthcheck_fails() -> None:
     runner = CliRunner()
     # sanity check clickhouse connections when not running in thorough mode

--- a/tests/utils/test_check_clickhouse.py
+++ b/tests/utils/test_check_clickhouse.py
@@ -12,10 +12,8 @@ from snuba.datasets.readiness_state import ReadinessState
 from snuba.datasets.storage import ReadableTableStorage, Storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.utils.health_info import (
-    _set_shutdown,
     check_all_tables_present,
     filter_checked_storages,
-    get_shutdown,
     sanity_check_clickhouse_connections,
 )
 
@@ -189,12 +187,3 @@ def test_filter_checked_storages(mock1: mock.MagicMock, temp_settings: Any) -> N
 
     # check that the storage with a non-supported readiness state is excluded in list
     assert MockStorage() not in storages
-
-
-def test_get_shutdown() -> None:
-    assert not get_shutdown()
-    _set_shutdown(True)
-    assert get_shutdown()
-
-    _set_shutdown(False)
-    assert not get_shutdown()

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -77,26 +77,6 @@ def test_handle_invalid_query(
 def test_check_envoy_health(snuba_api: FlaskClient) -> None:
     response = snuba_api.get("/health_envoy")
     assert response.status_code == 200
-    with mock.patch("snuba.web.views.check_down_file_exists", return_value=True):
-        response = snuba_api.get("/health_envoy")
-        assert response.status_code == 503
-
-
-def test_down_file_exists_pod_healthy(snuba_api: FlaskClient) -> None:
-    with mock.patch(
-        "snuba.utils.health_info.sanity_check_clickhouse_connections",
-        return_value=True,
-    ):
-        response = snuba_api.get("/health")
-        assert response.status_code == 200
-    # down file existing does not mean the pod is unhealthy
-    with mock.patch(
-        "snuba.utils.health_info.sanity_check_clickhouse_connections",
-        return_value=True,
-    ):
-        with mock.patch("snuba.utils.health_info.check_down_file_exists", return_value=True):
-            response = snuba_api.get("/health")
-            assert response.status_code == 200
 
 
 def test_do_not_check_clickhouse_tables_if_not_thorough(snuba_api: FlaskClient) -> None:


### PR DESCRIPTION
This reverts commit 342d0cbb2be62ef5b6f076932c078f8b5b08d0c3.

This was reverted quickly during an incident but this change probably had nothing to do with it, revert helps unblock https://github.com/getsentry/snuba/pull/7925