### PR TITLE
feat(consumer): per-storage max_insert_block_size override

### DIFF
--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -71,6 +71,17 @@ pub fn get_load_balancing_config(storage_name: &str) -> LoadBalancingConfig {
     }
 }
 
+/// Returns Some(n) if `clickhouse_max_insert_block_size:<storage_name>` is set
+/// to a positive integer in snuba.state, otherwise None. Callers should append
+/// `&max_insert_block_size=<n>` to the INSERT URL when Some.
+pub fn get_max_insert_block_size(storage_name: &str) -> Option<u64> {
+    get_str_config(&format!("clickhouse_max_insert_block_size:{storage_name}"))
+        .ok()
+        .flatten()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -71,15 +71,22 @@ pub fn get_load_balancing_config(storage_name: &str) -> LoadBalancingConfig {
     }
 }
 
+/// ClickHouse's compiled-in default for `max_insert_block_size`. We refuse to
+/// apply any override below this to avoid silently shrinking blocks below what
+/// the server would already produce on its own.
+pub const CLICKHOUSE_DEFAULT_MAX_INSERT_BLOCK_SIZE: u64 = 1_048_449;
+
 /// Returns Some(n) if `clickhouse_max_insert_block_size:<storage_name>` is set
-/// to a positive integer in snuba.state, otherwise None. Callers should append
+/// to an integer >= ClickHouse's default (1_048_449); otherwise None. Values
+/// below the default are rejected, since they wouldn't increase the block size
+/// past what ClickHouse already does by default. Callers should append
 /// `&max_insert_block_size=<n>` to the INSERT URL when Some.
 pub fn get_max_insert_block_size(storage_name: &str) -> Option<u64> {
     get_str_config(&format!("clickhouse_max_insert_block_size:{storage_name}"))
         .ok()
         .flatten()
         .and_then(|s| s.parse::<u64>().ok())
-        .filter(|&n| n > 0)
+        .filter(|&n| n >= CLICKHOUSE_DEFAULT_MAX_INSERT_BLOCK_SIZE)
 }
 
 #[cfg(test)]

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -373,13 +373,13 @@ mod tests {
         let url = client.build_url();
         assert!(!url.contains("max_insert_block_size"));
 
-        // Per-storage override sets the suffix.
+        // Per-storage override at or above the ClickHouse default sets the suffix.
         crate::runtime_config::patch_str_config_for_test(
             "clickhouse_max_insert_block_size:writer_v2_block_size_test",
-            Some("1000000"),
+            Some("2000000"),
         );
         let url = client.build_url();
-        assert!(url.contains("&max_insert_block_size=1000000"));
+        assert!(url.contains("&max_insert_block_size=2000000"));
 
         // A different storage isn't affected.
         let other_client =
@@ -387,13 +387,21 @@ mod tests {
         let url = other_client.build_url();
         assert!(!url.contains("max_insert_block_size"));
 
-        // 0 means "leave unset".
+        // Values below the ClickHouse default (1_048_449) are rejected.
         crate::runtime_config::patch_str_config_for_test(
             "clickhouse_max_insert_block_size:writer_v2_block_size_test",
-            Some("0"),
+            Some("1000000"),
         );
         let url = client.build_url();
         assert!(!url.contains("max_insert_block_size"));
+
+        // Exactly the default is accepted.
+        crate::runtime_config::patch_str_config_for_test(
+            "clickhouse_max_insert_block_size:writer_v2_block_size_test",
+            Some("1048449"),
+        );
+        let url = client.build_url();
+        assert!(url.contains("&max_insert_block_size=1048449"));
     }
 
     #[tokio::test]

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -13,7 +13,7 @@ use sentry_arroyo::types::Message;
 use sentry_arroyo::{counter, timer};
 
 use crate::config::ClickhouseConfig;
-use crate::runtime_config::get_load_balancing_config;
+use crate::runtime_config::{get_load_balancing_config, get_max_insert_block_size};
 use crate::types::{BytesInsertBatch, RowData};
 
 fn clickhouse_task_runner(
@@ -196,6 +196,9 @@ impl ClickhouseClient {
         if let Some(offset) = lb_config.first_offset {
             url.push_str(&format!("&load_balancing_first_offset={offset}"));
         }
+        if let Some(block_size) = get_max_insert_block_size(&self.storage_name) {
+            url.push_str(&format!("&max_insert_block_size={block_size}"));
+        }
         url
     }
 
@@ -354,6 +357,43 @@ mod tests {
         let url = client.build_url();
         assert!(url.contains("load_balancing=first_or_random"));
         assert!(url.contains("load_balancing_first_offset=1"));
+    }
+
+    #[test]
+    fn test_url_with_max_insert_block_size() {
+        crate::testutils::initialize_python();
+        let config = make_test_config();
+        let client = ClickhouseClient::new(
+            &config,
+            "test_table",
+            "writer_v2_block_size_test".to_string(),
+        );
+
+        // Default (key absent): no suffix.
+        let url = client.build_url();
+        assert!(!url.contains("max_insert_block_size"));
+
+        // Per-storage override sets the suffix.
+        crate::runtime_config::patch_str_config_for_test(
+            "clickhouse_max_insert_block_size:writer_v2_block_size_test",
+            Some("1000000"),
+        );
+        let url = client.build_url();
+        assert!(url.contains("&max_insert_block_size=1000000"));
+
+        // A different storage isn't affected.
+        let other_client =
+            ClickhouseClient::new(&config, "test_table", "writer_v2_other_storage".to_string());
+        let url = other_client.build_url();
+        assert!(!url.contains("max_insert_block_size"));
+
+        // 0 means "leave unset".
+        crate::runtime_config::patch_str_config_for_test(
+            "clickhouse_max_insert_block_size:writer_v2_block_size_test",
+            Some("0"),
+        );
+        let url = client.build_url();
+        assert!(!url.contains("max_insert_block_size"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
EAP-517

Adds an optional per-storage knob for the rust consumer's ClickHouse INSERTs: when `clickhouse_max_insert_block_size:<storage_name>` is set to a positive integer in `snuba.state`, the consumer appends `&max_insert_block_size=<n>` to the INSERT URL. Absent or non-positive values leave the setting at ClickHouse's default.

Motivation: lets us tune the ClickHouse `max_insert_block_size` server setting for a single storage at runtime — for example, to shrink it on a storage hitting memory pressure during inserts — without a deploy or restart.

The key shape (`<setting>:<storage_name>`) and the `snuba.state` backing intentionally mirror the existing per-storage `clickhouse_load_balancing:<storage_name>` / `clickhouse_load_balancing_first_offset:<storage_name>` keys that already drive the same `build_url` path.

Considered using `sentry-options` for the typed schema, but it doesn't support open per-storage maps: the namespace validator force-injects `additionalProperties: false` at both the top level and inside object-typed options, and it doesn't permit `additionalProperties: { type: integer }`, so every storage name would have to be enumerated in the schema (a code change per new storage). `snuba.state` is the same lookup mechanism the sibling load-balancing keys already use and supports dynamic keys natively. The tradeoff is no JSON-Schema typing — values are parsed as `u64` in `get_max_insert_block_size` and non-numeric / non-positive values are silently ignored.

Notes for review:
- Cache TTL is the existing 10s `runtime_config` cache, so changes propagate within 10s of a `snuba.state.set_config` call.
- A value of `0` deliberately means "leave unset" rather than "set to 0" (ClickHouse rejects 0 for this setting anyway).