### PR TITLE
feat(eap-items): runtime killswitch to DLQ messages with old event timestamps

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -8,13 +8,21 @@ use std::collections::{BTreeMap, HashMap};
 use uuid::Uuid;
 
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
+use sentry_arroyo::counter;
 use sentry_protos::snuba::v1::any_value::Value;
 use sentry_protos::snuba::v1::{ArrayValue, TraceItem, TraceItemType};
 
 use crate::config::ProcessorConfig;
 use crate::processors::utils::enforce_retention;
+use crate::runtime_config::get_str_config;
 use crate::types::CogsData;
 use crate::types::{InsertBatch, ItemTypeMetrics, KafkaMessageMetadata, TypedInsertBatch};
+
+/// Runtime config key. When set to a positive integer N, the eap-items
+/// consumer drops any message whose `received` timestamp is older than N
+/// seconds relative to now (e.g. N=3600 drops anything more than an hour
+/// stale). Unset / non-positive disables the killswitch.
+const DROP_STALE_THRESHOLD_KEY: &str = "eap_items_drop_stale_threshold_sec";
 
 /// Precision factor for sampling_factor calculations to compensate for floating point errors
 const SAMPLING_FACTOR_PRECISION: f64 = 1e9;
@@ -35,6 +43,18 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         .received
         .as_ref()
         .and_then(|received| DateTime::from_timestamp(received.seconds, 0));
+
+    if let Some(received_at) = origin_timestamp {
+        if let Some(threshold_sec) = get_drop_stale_threshold_sec() {
+            if let Some(age_sec) = stale_age_secs(received_at, Utc::now(), threshold_sec) {
+                counter!("eap_items.messages.dropped_stale", 1);
+                anyhow::bail!(
+                    "eap-items message dropped as stale (age {age_sec}s > threshold {threshold_sec}s); routed to DLQ"
+                );
+            }
+        }
+    }
+
     let retention_days = Some(enforce_retention(
         Some(trace_item.retention_days as u16),
         &config.env_config,
@@ -94,6 +114,23 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         item_type_metrics,
         cogs_data,
     })
+}
+
+fn get_drop_stale_threshold_sec() -> Option<i64> {
+    get_str_config(DROP_STALE_THRESHOLD_KEY)
+        .ok()
+        .flatten()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// Returns Some(age_in_seconds) if `received` is more than `threshold_sec`
+/// older than `now`. Returns None when the message is within the threshold
+/// (or arrived from the future, indicating clock skew on the producer side
+/// rather than staleness).
+fn stale_age_secs(received: DateTime<Utc>, now: DateTime<Utc>, threshold_sec: i64) -> Option<i64> {
+    let age_sec = now.signed_duration_since(received).num_seconds();
+    (age_sec > threshold_sec).then_some(age_sec)
 }
 
 pub fn process_message(
@@ -759,6 +796,35 @@ mod tests {
             .iter()
             .any(|(k, _)| k == "sentry._internal.received_at");
         assert!(!has_received_at);
+    }
+
+    #[test]
+    fn test_stale_age_secs_drops_old_messages() {
+        let now = DateTime::from_timestamp(1_000_000, 0).unwrap();
+        let received = DateTime::from_timestamp(1_000_000 - 3601, 0).unwrap();
+        assert_eq!(stale_age_secs(received, now, 3600), Some(3601));
+    }
+
+    #[test]
+    fn test_stale_age_secs_keeps_recent_messages() {
+        let now = DateTime::from_timestamp(1_000_000, 0).unwrap();
+        let received = DateTime::from_timestamp(1_000_000 - 1, 0).unwrap();
+        assert_eq!(stale_age_secs(received, now, 3600), None);
+    }
+
+    #[test]
+    fn test_stale_age_secs_exactly_at_threshold_is_not_stale() {
+        let now = DateTime::from_timestamp(1_000_000, 0).unwrap();
+        let received = DateTime::from_timestamp(1_000_000 - 3600, 0).unwrap();
+        assert_eq!(stale_age_secs(received, now, 3600), None);
+    }
+
+    #[test]
+    fn test_stale_age_secs_future_received_is_not_stale() {
+        // Clock skew on the producer can yield received > now; never treat as stale.
+        let now = DateTime::from_timestamp(1_000_000, 0).unwrap();
+        let received = DateTime::from_timestamp(1_000_500, 0).unwrap();
+        assert_eq!(stale_age_secs(received, now, 3600), None);
     }
 
     #[test]

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -19,10 +19,15 @@ use crate::types::CogsData;
 use crate::types::{InsertBatch, ItemTypeMetrics, KafkaMessageMetadata, TypedInsertBatch};
 
 /// Runtime config key. When set to a positive integer N, the eap-items
-/// consumer drops any message whose `received` timestamp is older than N
+/// consumer drops any message whose event `timestamp` is older than N
 /// seconds relative to now (e.g. N=3600 drops anything more than an hour
 /// stale). Unset / non-positive disables the killswitch.
-const DROP_STALE_THRESHOLD_KEY: &str = "eap_items_drop_stale_threshold_sec";
+///
+/// We key on `timestamp` (not `received`) because the eap_items table is
+/// partitioned by `(retention_days, toMonday(timestamp))`. Inserts that
+/// straddle the weekly partition boundary tax the system, and dropping by
+/// `timestamp` is what prevents writes into a prior partition.
+const DROP_OLD_TIMESTAMP_KEY: &str = "eap_items_drop_old_timestamp_threshold_sec";
 
 /// Precision factor for sampling_factor calculations to compensate for floating point errors
 const SAMPLING_FACTOR_PRECISION: f64 = 1e9;
@@ -43,13 +48,17 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         .received
         .as_ref()
         .and_then(|received| DateTime::from_timestamp(received.seconds, 0));
+    let event_timestamp = trace_item
+        .timestamp
+        .as_ref()
+        .and_then(|ts| DateTime::from_timestamp(ts.seconds, 0));
 
-    if let Some(received_at) = origin_timestamp {
-        if let Some(threshold_sec) = get_drop_stale_threshold_sec() {
-            if let Some(age_sec) = stale_age_secs(received_at, Utc::now(), threshold_sec) {
-                counter!("eap_items.messages.dropped_stale", 1);
+    if let Some(event_ts) = event_timestamp {
+        if let Some(threshold_sec) = get_drop_old_timestamp_threshold_sec() {
+            if let Some(age_sec) = stale_age_secs(event_ts, Utc::now(), threshold_sec) {
+                counter!("eap_items.messages.dropped_old_timestamp", 1);
                 anyhow::bail!(
-                    "eap-items message dropped as stale (age {age_sec}s > threshold {threshold_sec}s); routed to DLQ"
+                    "eap-items message dropped: event timestamp {age_sec}s old > threshold {threshold_sec}s; routed to DLQ"
                 );
             }
         }
@@ -116,20 +125,20 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
     })
 }
 
-fn get_drop_stale_threshold_sec() -> Option<i64> {
-    get_str_config(DROP_STALE_THRESHOLD_KEY)
+fn get_drop_old_timestamp_threshold_sec() -> Option<i64> {
+    get_str_config(DROP_OLD_TIMESTAMP_KEY)
         .ok()
         .flatten()
         .and_then(|s| s.parse::<i64>().ok())
         .filter(|&n| n > 0)
 }
 
-/// Returns Some(age_in_seconds) if `received` is more than `threshold_sec`
-/// older than `now`. Returns None when the message is within the threshold
-/// (or arrived from the future, indicating clock skew on the producer side
+/// Returns Some(age_in_seconds) if `ts` is more than `threshold_sec` older
+/// than `now`. Returns None when the message is within the threshold (or
+/// arrived from the future, indicating clock skew on the producer side
 /// rather than staleness).
-fn stale_age_secs(received: DateTime<Utc>, now: DateTime<Utc>, threshold_sec: i64) -> Option<i64> {
-    let age_sec = now.signed_duration_since(received).num_seconds();
+fn stale_age_secs(ts: DateTime<Utc>, now: DateTime<Utc>, threshold_sec: i64) -> Option<i64> {
+    let age_sec = now.signed_duration_since(ts).num_seconds();
     (age_sec > threshold_sec).then_some(age_sec)
 }
 


### PR DESCRIPTION
Adds a runtime config `eap_items_drop_old_timestamp_threshold_sec` to the
eap-items consumer. When set to a positive integer N, any message whose
event `timestamp` is more than N seconds older than now is rejected via
`anyhow::Err`, which the processor strategy converts to
`RunTaskError::InvalidMessage` (`rust_snuba/src/strategies/processor.rs:339`)
and routes the message to the DLQ for later reprocessing. Unset /
non-positive disables the killswitch, so default behavior is unchanged.

The motivation is operational: the `eap_items` table is partitioned by
`(retention_days, toMonday(timestamp))`
(`snuba/snuba_migrations/events_analytics_platform/0024_items.py:107`).
Around the weekly partition boundary, inserts that straddle two
partitions tax ClickHouse — so when that happens we want the ability to
drop the late events writing into the prior partition without losing
them. e.g. `snuba state set eap_items_drop_old_timestamp_threshold_sec 3600`
sends anything more than an hour stale (by event time) to the DLQ. The
Rust side caches runtime config for 10s
(`rust_snuba/src/runtime_config.rs:23`), so changes propagate quickly.

The check intentionally gates on `trace_item.timestamp` rather than
`trace_item.received`: it's `timestamp` that determines which ClickHouse
partition the row lands in, so it's the only field that addresses the
partition-boundary load problem. (An earlier revision of this branch
gated on `received`; that was the wrong column.)

Considered just returning `Ok(InsertBatch::skip())` (the pattern used by
the generic-metrics use-case killswitch), but routing through the DLQ is
strictly better here — operators can replay once load subsides, rather
than permanently losing data they didn't actually intend to drop.

Messages with no `timestamp` are not affected (won't happen in practice —
EAPItem construction requires it), and future-dated timestamps (producer
clock skew) are not treated as stale. A
`eap_items.messages.dropped_old_timestamp` counter is bumped on each
drop so we can alert / dashboard on volume when the switch is engaged.

Scoped to the eap-items consumer only. Easy to generalize to a
per-storage key later if we want the same lever for other consumers.