### PR TITLE
perf(eap): drop attributes_array from trace_item_details SELECT

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -20,7 +20,6 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal
-from snuba.query.expressions import FunctionCall
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
@@ -31,7 +30,6 @@ from snuba.web.rpc.common.common import (
     add_existence_check_to_subscriptable_references,
     attribute_key_to_expression,
     base_conditions_and,
-    process_arrays,
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
 )
@@ -43,7 +41,6 @@ from snuba.web.rpc.common.exceptions import (
     BadSnubaRPCRequestException,
     RPCRequestException,
 )
-from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
@@ -85,14 +82,6 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             SelectedExpression("attributes_int", column("attributes_int", alias="attributes_int")),
             SelectedExpression(
                 "attributes_bool", column("attributes_bool", alias="attributes_bool")
-            ),
-            SelectedExpression(
-                "attributes_array",
-                FunctionCall(
-                    "attributes_array",
-                    "toJSONString",
-                    (column("attributes_array"),),
-                ),
             ),
         ],
         condition=base_conditions_and(
@@ -190,16 +179,6 @@ def _convert_results(
             # the original type, and ignore the float duplicate
             continue
         attrs.append(TraceItemDetailsAttribute(name=k, value=AttributeValue(val_double=v)))
-
-    raw_array = row.get("attributes_array")
-    if raw_array:
-        for k, values in process_arrays(raw_array).items():
-            attrs.append(
-                TraceItemDetailsAttribute(
-                    name=k,
-                    value=convert_to_attribute_value(values),
-                )
-            )
 
     return item_id, timestamp, attrs
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -14,7 +14,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
 from sentry_protos.snuba.v1.error_pb2 import Error as ErrorProto
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
-from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue
+from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -82,14 +82,6 @@ def setup_spans_in_db(eap: None, redis_db: None) -> None:
     ]
 
     write_raw_unprocessed_events(spans_storage, messages)  # type: ignore
-
-
-def _str_tags_array(*values: str) -> AnyValue:
-    return AnyValue(array_value=ArrayValue(values=[AnyValue(string_value=v) for v in values]))
-
-
-def _int_vals_array(*values: int) -> AnyValue:
-    return AnyValue(array_value=ArrayValue(values=[AnyValue(int_value=v) for v in values]))
 
 
 @pytest.mark.eap
@@ -257,160 +249,6 @@ class TestTraceItemDetails(BaseApiTest):
         }:
             assert k in attributes_returned, k
 
-    def test_endpoint_returns_array_attribute(self, eap: None, redis_db: None) -> None:
-        """attributes_array from storage is exposed as val_array on TraceItemDetails."""
-        span_ts = BASE_TIME - timedelta(minutes=1)
-        storage = get_storage(StorageKey("eap_items"))
-        write_raw_unprocessed_events(
-            storage,  # type: ignore
-            [
-                gen_item_message(
-                    span_ts,
-                    attributes={
-                        "tags": _str_tags_array("gamma", "delta"),
-                        "cols": _int_vals_array(1, 3),
-                    },
-                ),
-            ],
-        )
-        start = Timestamp()
-        end = Timestamp()
-        start.FromDatetime(BASE_TIME - timedelta(hours=4))
-        end.GetCurrentTime()
-
-        spans = (
-            EndpointTraceItemTable()
-            .execute(
-                TraceItemTableRequest(
-                    meta=RequestMeta(
-                        project_ids=[1],
-                        organization_id=1,
-                        cogs_category="something",
-                        referrer="something",
-                        start_timestamp=start,
-                        end_timestamp=end,
-                        request_id=_REQUEST_ID,
-                        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-                    ),
-                    columns=[
-                        Column(
-                            key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")
-                        ),
-                        Column(
-                            key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.trace_id")
-                        ),
-                    ],
-                )
-            )
-            .column_values
-        )
-        item_id = spans[0].results[0].val_str
-        trace_id = spans[1].results[0].val_str
-
-        res = EndpointTraceItemDetails().execute(
-            TraceItemDetailsRequest(
-                meta=RequestMeta(
-                    project_ids=[1],
-                    organization_id=1,
-                    cogs_category="something",
-                    referrer="something",
-                    start_timestamp=start,
-                    end_timestamp=end,
-                    request_id=_REQUEST_ID,
-                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-                ),
-                item_id=item_id,
-                trace_id=trace_id,
-            )
-        )
-        tags_attr = next((a for a in res.attributes if a.name == "tags"), None)
-        assert tags_attr is not None
-        assert tags_attr.value.WhichOneof("value") == "val_array"
-        assert [e.val_str for e in tags_attr.value.val_array.values] == ["gamma", "delta"]
-        cols_attr = next((a for a in res.attributes if a.name == "cols"), None)
-        assert cols_attr is not None
-        assert cols_attr.value.WhichOneof("value") == "val_array"
-        assert [e.val_int for e in cols_attr.value.val_array.values] == [1, 3]
-
-    def test_dotted_key_array_attribute_parsed_properly(self, eap: None, redis_db: None) -> None:
-        trace_id = uuid.uuid4().hex
-        span_ts = BASE_TIME - timedelta(minutes=1)
-        storage = get_storage(StorageKey("eap_items"))
-        write_raw_unprocessed_events(
-            storage,  # type: ignore
-            [
-                gen_item_message(
-                    span_ts,
-                    trace_id=trace_id,
-                    remove_default_attributes=True,
-                    attributes={
-                        "resource.process.command_args": _str_tags_array(
-                            "node", "--enable-source-maps"
-                        ),
-                    },
-                ),
-            ],
-        )
-        start = Timestamp()
-        end = Timestamp()
-        start.FromDatetime(BASE_TIME - timedelta(hours=4))
-        end.GetCurrentTime()
-
-        spans = (
-            EndpointTraceItemTable()
-            .execute(
-                TraceItemTableRequest(
-                    meta=RequestMeta(
-                        project_ids=[1],
-                        organization_id=1,
-                        cogs_category="something",
-                        referrer="something",
-                        start_timestamp=start,
-                        end_timestamp=end,
-                        request_id=_REQUEST_ID,
-                        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-                    ),
-                    columns=[
-                        Column(
-                            key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")
-                        ),
-                        Column(
-                            key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.trace_id")
-                        ),
-                    ],
-                )
-            )
-            .column_values
-        )
-        idx = next(
-            i
-            for i, tr in enumerate(spans[1].results)
-            if tr.val_str.replace("-", "").lower() == trace_id.replace("-", "").lower()
-        )
-        item_id = spans[0].results[idx].val_str
-        trace_id_for_details = spans[1].results[idx].val_str
-
-        res = EndpointTraceItemDetails().execute(
-            TraceItemDetailsRequest(
-                meta=RequestMeta(
-                    project_ids=[1],
-                    organization_id=1,
-                    cogs_category="something",
-                    referrer="something",
-                    start_timestamp=start,
-                    end_timestamp=end,
-                    request_id=_REQUEST_ID,
-                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-                ),
-                item_id=item_id,
-                trace_id=trace_id_for_details,
-            )
-        )
-        attr = next((a for a in res.attributes if a.name == "resource.process.command_args"), None)
-        assert attr is not None
-        assert attr.value.WhichOneof("value") == "val_array"
-        assert [e.val_str for e in attr.value.val_array.values] == ["node", "--enable-source-maps"]
-
     def test_endpoint_on_spans(self, setup_spans_in_db: Any) -> None:
         end = Timestamp()
         start = Timestamp()
@@ -515,30 +353,3 @@ def test_convert_results_dedupes() -> None:
     _, _, attrs = _convert_results(data)
     is_segment_attrs = list(filter(lambda x: x.name == "sentry.is_segment", attrs))
     assert len(is_segment_attrs) == 1
-
-
-def test_convert_results_includes_attributes_array() -> None:
-    """
-    TraceItemDetails maps the ClickHouse attributes_array JSON payload into val_array
-    attributes (same path EndpointTraceItemDetails uses after the query).
-    """
-    data = [
-        {
-            "timestamp": 1750964400,
-            "hex_item_id": "e70ef5b1b5bc4611840eff9964b7a767",
-            "trace_id": "cb190d6e7d5743d5bc1494c650592cd2",
-            "organization_id": 1,
-            "project_id": 1,
-            "item_type": 1,
-            "attributes_string": {},
-            "attributes_int": {},
-            "attributes_float": {},
-            "attributes_bool": {},
-            "attributes_array": '{"tags":[{"String":"gamma"},{"String":"delta"}]}',
-        }
-    ]
-    _, _, attrs = _convert_results(data)
-    tags = [a for a in attrs if a.name == "tags"]
-    assert len(tags) == 1
-    assert tags[0].value.WhichOneof("value") == "val_array"
-    assert [e.val_str for e in tags[0].value.val_array.values] == ["gamma", "delta"]


### PR DESCRIPTION
## Summary

Partial revert of #7890 to mitigate the trace-item-details latency regression (p99 ~3s → ~22s since April 22, brushing the 25s `max_execution_time` ceiling). Removes the `toJSONString(attributes_array)` from the `EndpointTraceItemDetails` SELECT and the matching `process_arrays` post-processing — and the three tests that asserted on it.

## No customer impact

This functionality is **not in use by any customer org today**. The Sentry-side exposure is fully gated by `organizations:trace-item-details-array-fields`, and per `sentry-options-automator/options/default/flagpole.yaml` the flag is currently enrolled by `user_email` for exactly two internal Sentry engineers (`nicholas.deschenes@sentry.io`, `saraj.manes@sentry.io`) — i.e. only the developers working on the feature see array attributes in the trace-item-details panel. Reverting the SELECT drops the data only for those two internal users; every other code path either ignores arrays (default) or gracefully no-ops when they're absent (the "preserve string array" fallback added in sentry PR #114853).

## Why this is the right wedge

- `attributes_array` is a `JSON(max_dynamic_paths=128, ZSTD(1))` column. `toJSONString(attributes_array)` forces ClickHouse to read every dynamic subcolumn file in every granule that survives the `trace_id` PREWHERE and re-serialize the full JSON object per row. That cost lands on every trace-item-details request, on a hot path that fires on every span click, hover-prefetch, and logs row in the UI (see e.g. `static/app/views/explore/hooks/useTraceItemDetails.tsx`).
- Result-set inflation matters too: the returned JSON string can be many KB per row for spans with rich array attributes (AI/LLM workloads especially), which compounds ClickHouse→Snuba transport and Python parse cost in `process_arrays`.

## What is _not_ touched

- **`snuba/web/rpc/v1/resolvers/common/trace_item_table.py`** — keeps the `_array_raw_to_attribute_value` extension and TYPE_ARRAY converter, which #7898 (TraceItemTable array-element filtering) builds on.
- **`snuba/web/rpc/common/common.py`** — `process_arrays` and its #7911 nested-key flattening fix stay. `endpoint_get_trace.py` and `endpoint_export_trace_items.py` still call it.
- **`snuba/protos/common.py`**, **`endpoint_get_trace.py`** — left at master.

## Tests removed

Three tests asserted on `val_array` attributes being present on TraceItemDetails responses; they go with the SELECT:
- `test_endpoint_returns_array_attribute` (added by #7890)
- `test_convert_results_includes_attributes_array` (added by #7890)
- `test_dotted_key_array_attribute_parsed_properly` (added by #7911)

Helpers `_str_tags_array` / `_int_vals_array` and the now-unused `ArrayValue` import are removed with them.

## Followups (separate PRs)

- The proper fix is to plumb the existing `organizations:trace-item-details-array-fields` flag into the snuba RPC — likely an `include_arrays` field on `TraceItemDetailsRequest` — so the cost is per-org opt-in.
- Worth a heads-up to `data-browsing` (flag owner: `saraj.manes@sentry.io`) that the array-fields dev surface goes dark until that follow-up lands.

## Test plan

- [ ] CI passes (ruff, mypy, pytest)
- [ ] Verify trace-item-details p99 returns to ~3s baseline post-deploy in canary
- [ ] Spot-check that span click → drawer in trace UI still loads scalar/bool/int/float/string attributes correctly
- [ ] Spot-check logs detail row in Explore still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)