### PR TITLE
feat(eap): runtime kill switch for attributes_array on trace_item_table

### DIFF
--- a/snuba/admin/static/runtime_config/descriptions.tsx
+++ b/snuba/admin/static/runtime_config/descriptions.tsx
@@ -18,6 +18,7 @@ const DESCRIPTIONS: { [key: string]: string } = {
   "read_through_cache.short_circuit": "First stage of removing the readthrough cache entirely is disabling and monitoring - Rahul",
   "retry_duplicate_query_id": "Whether to retry clickhouse queries with a random query id (exactly once) if clickhouse rejected the query before due to the query id already being used. This can be useful in case of redis failover scenarios when we lose query cache.",
   "snuba_api_cogs_probability": "Sample rate for logging COGS in the API",
+  "trace_item_table_include_arrays": "If 1 (default), EndpointTraceItemTable SELECTs and decodes the attributes_array JSON column for TYPE_ARRAY columns in the request. If 0, those columns are returned as NULL (fast path, no array values in the response). Use as a kill switch when the JSON column read is causing latency on the trace-item-table hot path.",
 }
 
 function getDescription(key: string): [string, string] | undefined {

--- a/snuba/admin/static/runtime_config/descriptions.tsx
+++ b/snuba/admin/static/runtime_config/descriptions.tsx
@@ -18,7 +18,7 @@ const DESCRIPTIONS: { [key: string]: string } = {
   "read_through_cache.short_circuit": "First stage of removing the readthrough cache entirely is disabling and monitoring - Rahul",
   "retry_duplicate_query_id": "Whether to retry clickhouse queries with a random query id (exactly once) if clickhouse rejected the query before due to the query id already being used. This can be useful in case of redis failover scenarios when we lose query cache.",
   "snuba_api_cogs_probability": "Sample rate for logging COGS in the API",
-  "trace_item_table_include_arrays": "If 1 (default), EndpointTraceItemTable SELECTs and decodes the attributes_array JSON column for TYPE_ARRAY columns in the request. If 0, those columns are returned as NULL (fast path, no array values in the response). Use as a kill switch when the JSON column read is causing latency on the trace-item-table hot path.",
+  "trace_item_table_include_arrays": "If 0 (default), EndpointTraceItemTable returns NULL for TYPE_ARRAY columns in the request (fast path, no array values in the response). If 1, those columns are SELECTed and decoded from the attributes_array JSON column. The JSON column read can dominate latency on the trace-item-table hot path; flip to 1 only when you need array values and the cost is acceptable.",
 }
 
 function getDescription(key: string): [string, string] | undefined {

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -522,7 +522,7 @@ def build_query(
         sample=None,
     )
 
-    include_arrays = state.get_int_config("trace_item_table_include_arrays", 1)
+    include_arrays = state.get_int_config("trace_item_table_include_arrays", 0)
 
     selected_columns = []
     for column in request.columns:

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -522,12 +522,6 @@ def build_query(
         sample=None,
     )
 
-    # Reading the JSON attributes_array column forces ClickHouse to materialize
-    # every dynamic subcolumn per granule and re-serialize as a string, which
-    # dominates this endpoint's latency. Gate behind a runtime config so SRE
-    # can disable on the fly without a deploy. Default 1 preserves behavior.
-    # When 0, TYPE_ARRAY key columns return NULL instead of the JSON-decoded
-    # array so the response shape is preserved.
     include_arrays = state.get_int_config("trace_item_table_include_arrays", 1)
 
     selected_columns = []

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -522,15 +522,31 @@ def build_query(
         sample=None,
     )
 
+    # Reading the JSON attributes_array column forces ClickHouse to materialize
+    # every dynamic subcolumn per granule and re-serialize as a string, which
+    # dominates this endpoint's latency. Gate behind a runtime config so SRE
+    # can disable on the fly without a deploy. Default 1 preserves behavior.
+    # When 0, TYPE_ARRAY key columns return NULL instead of the JSON-decoded
+    # array so the response shape is preserved.
+    include_arrays = state.get_int_config("trace_item_table_include_arrays", 1)
+
     selected_columns = []
     for column in request.columns:
         # The key_col expression alias may differ from the column label. That is okay
         # the attribute key name is used in the groupby, the column label is just the name of
         # the returned attribute value
+        if (
+            not include_arrays
+            and column.HasField("key")
+            and column.key.type == AttributeKey.TYPE_ARRAY
+        ):
+            expression: Expression = f.cast(literal(None), "Nullable(String)", alias=column.label)
+        else:
+            expression = _column_to_expression(column, request.meta)
         selected_columns.append(
             SelectedExpression(
                 name=column.label,
-                expression=_column_to_expression(column, request.meta),
+                expression=expression,
             )
         )
         selected_columns.extend(_get_reliability_context_columns(column, request.meta))

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -3744,99 +3744,109 @@ class TestArrayWildcardSearch(BaseApiTest):
     @pytest.mark.redis_db
     def test_trace_item_table_array_op_equals_includes_string_ignore_case(self) -> None:
         """OP_EQUALS with ignore_case matches a string in a TYPE_ARRAY (element-wise)."""
-        span_ts = BASE_TIME - timedelta(minutes=1)
-        items_storage = get_storage(StorageKey("eap_items"))
-        write_raw_unprocessed_events(
-            items_storage,  # type: ignore
-            [
-                gen_item_message(span_ts, attributes={"tags": _str_array("ERROR", "other")}),
-                gen_item_message(
-                    span_ts, attributes={"tags": _str_array("success", "cached", "http-error")}
-                ),
-                gen_item_message(span_ts, attributes={"tags": _str_array("Error", "timeout")}),
-            ],
-        )
-        message = TraceItemTableRequest(
-            meta=RequestMeta(
-                project_ids=[1, 2, 3],
-                organization_id=1,
-                cogs_category="something",
-                referrer="something",
-                start_timestamp=START_TIMESTAMP,
-                end_timestamp=END_TIMESTAMP,
-                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-            ),
-            filter=TraceItemFilter(
-                comparison_filter=ComparisonFilter(
-                    key=AttributeKey(
-                        type=AttributeKey.TYPE_ARRAY,
-                        name="tags",
+        state.set_config("trace_item_table_include_arrays", 1)
+        try:
+            span_ts = BASE_TIME - timedelta(minutes=1)
+            items_storage = get_storage(StorageKey("eap_items"))
+            write_raw_unprocessed_events(
+                items_storage,  # type: ignore
+                [
+                    gen_item_message(span_ts, attributes={"tags": _str_array("ERROR", "other")}),
+                    gen_item_message(
+                        span_ts, attributes={"tags": _str_array("success", "cached", "http-error")}
                     ),
-                    op=ComparisonFilter.OP_EQUALS,
-                    value=AttributeValue(val_str="error"),
-                    ignore_case=True,
-                )
-            ),
-            columns=[
-                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
-                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags")),
-            ],
-        )
-        response = EndpointTraceItemTable().execute(message)
-        assert len(response.column_values[0].results) == 2
-        by_name = {cv.attribute_name: cv for cv in response.column_values}
-        for row in by_name["tags"].results:
-            vals = [e.val_str for e in row.val_array.values if e.WhichOneof("value") == "val_str"]
-            assert "error" in [val.lower() for val in vals]
+                    gen_item_message(span_ts, attributes={"tags": _str_array("Error", "timeout")}),
+                ],
+            )
+            message = TraceItemTableRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    start_timestamp=START_TIMESTAMP,
+                    end_timestamp=END_TIMESTAMP,
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                ),
+                filter=TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_ARRAY,
+                            name="tags",
+                        ),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=AttributeValue(val_str="error"),
+                        ignore_case=True,
+                    )
+                ),
+                columns=[
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags")),
+                ],
+            )
+            response = EndpointTraceItemTable().execute(message)
+            assert len(response.column_values[0].results) == 2
+            by_name = {cv.attribute_name: cv for cv in response.column_values}
+            for row in by_name["tags"].results:
+                vals = [
+                    e.val_str for e in row.val_array.values if e.WhichOneof("value") == "val_str"
+                ]
+                assert "error" in [val.lower() for val in vals]
+        finally:
+            state.delete_config("trace_item_table_include_arrays")
 
     @pytest.mark.clickhouse_db
     @pytest.mark.redis_db
     def test_trace_item_table_array_op_equals_includes_int(self) -> None:
         """OP_EQUALS on TYPE_ARRAY with val_int=45 returns rows where some element is 45."""
-        span_ts = BASE_TIME - timedelta(minutes=1)
-        items_storage = get_storage(StorageKey("eap_items"))
-        write_raw_unprocessed_events(
-            items_storage,  # type: ignore
-            [
-                gen_item_message(span_ts, attributes={"frame_linenos": _int_array(1, 45, 200)}),
-                gen_item_message(span_ts, attributes={"frame_linenos": _int_array(10, 20)}),
-                gen_item_message(span_ts, attributes={"frame_linenos": _int_array(45, 99)}),
-            ],
-        )
-        message = TraceItemTableRequest(
-            meta=RequestMeta(
-                project_ids=[1, 2, 3],
-                organization_id=1,
-                cogs_category="something",
-                referrer="something",
-                start_timestamp=START_TIMESTAMP,
-                end_timestamp=END_TIMESTAMP,
-                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-            ),
-            filter=TraceItemFilter(
-                comparison_filter=ComparisonFilter(
-                    key=AttributeKey(
-                        type=AttributeKey.TYPE_ARRAY,
-                        name="frame_linenos",
-                    ),
-                    op=ComparisonFilter.OP_EQUALS,
-                    value=AttributeValue(val_int=45),
-                )
-            ),
-            columns=[
-                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
-                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="frame_linenos")),
-            ],
-        )
-        response = EndpointTraceItemTable().execute(message)
-        assert len(response.column_values[0].results) == 2
-        by_name = {cv.attribute_name: cv for cv in response.column_values}
-        assert by_name["frame_linenos"].results[0].WhichOneof("value") == "val_array"
-        for row in by_name["frame_linenos"].results:
-            int_vals = [
-                e.val_int for e in row.val_array.values if e.WhichOneof("value") == "val_int"
-            ]
-            assert 45 in int_vals
+        state.set_config("trace_item_table_include_arrays", 1)
+        try:
+            span_ts = BASE_TIME - timedelta(minutes=1)
+            items_storage = get_storage(StorageKey("eap_items"))
+            write_raw_unprocessed_events(
+                items_storage,  # type: ignore
+                [
+                    gen_item_message(span_ts, attributes={"frame_linenos": _int_array(1, 45, 200)}),
+                    gen_item_message(span_ts, attributes={"frame_linenos": _int_array(10, 20)}),
+                    gen_item_message(span_ts, attributes={"frame_linenos": _int_array(45, 99)}),
+                ],
+            )
+            message = TraceItemTableRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    start_timestamp=START_TIMESTAMP,
+                    end_timestamp=END_TIMESTAMP,
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                ),
+                filter=TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_ARRAY,
+                            name="frame_linenos",
+                        ),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=AttributeValue(val_int=45),
+                    )
+                ),
+                columns=[
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="frame_linenos")),
+                ],
+            )
+            response = EndpointTraceItemTable().execute(message)
+            assert len(response.column_values[0].results) == 2
+            by_name = {cv.attribute_name: cv for cv in response.column_values}
+            assert by_name["frame_linenos"].results[0].WhichOneof("value") == "val_array"
+            for row in by_name["frame_linenos"].results:
+                int_vals = [
+                    e.val_int for e in row.val_array.values if e.WhichOneof("value") == "val_int"
+                ]
+                assert 45 in int_vals
+        finally:
+            state.delete_config("trace_item_table_include_arrays")
 
     @pytest.mark.clickhouse_db
     @pytest.mark.redis_db
@@ -3893,44 +3903,48 @@ class TestArrayWildcardSearch(BaseApiTest):
         check_row: Any,
     ) -> None:
         """OP_EQUALS on TYPE_ARRAY: each scalar AttributeValue type matches a stored element"""
-        span_ts = BASE_TIME - timedelta(minutes=1)
-        items_storage = get_storage(StorageKey("eap_items"))
-        write_raw_unprocessed_events(
-            items_storage,  # type: ignore
-            [
-                gen_item_message(span_ts, attributes=match_attrs),
-                gen_item_message(span_ts, attributes=no_match_attrs),
-            ],
-        )
-        message = TraceItemTableRequest(
-            meta=RequestMeta(
-                project_ids=[1, 2, 3],
-                organization_id=1,
-                cogs_category="something",
-                referrer="something",
-                start_timestamp=START_TIMESTAMP,
-                end_timestamp=END_TIMESTAMP,
-                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-            ),
-            filter=TraceItemFilter(
-                comparison_filter=ComparisonFilter(
-                    key=AttributeKey(
-                        type=AttributeKey.TYPE_ARRAY,
-                        name=attr_name,
-                    ),
-                    op=ComparisonFilter.OP_EQUALS,
-                    value=filter_value,
-                )
-            ),
-            columns=[
-                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
-                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name=attr_name)),
-            ],
-        )
-        response = EndpointTraceItemTable().execute(message)
-        by_name = {cv.attribute_name: cv for cv in response.column_values}
-        assert len(by_name[attr_name].results) == 1
-        assert check_row(by_name[attr_name].results[0])
+        state.set_config("trace_item_table_include_arrays", 1)
+        try:
+            span_ts = BASE_TIME - timedelta(minutes=1)
+            items_storage = get_storage(StorageKey("eap_items"))
+            write_raw_unprocessed_events(
+                items_storage,  # type: ignore
+                [
+                    gen_item_message(span_ts, attributes=match_attrs),
+                    gen_item_message(span_ts, attributes=no_match_attrs),
+                ],
+            )
+            message = TraceItemTableRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    start_timestamp=START_TIMESTAMP,
+                    end_timestamp=END_TIMESTAMP,
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                ),
+                filter=TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_ARRAY,
+                            name=attr_name,
+                        ),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=filter_value,
+                    )
+                ),
+                columns=[
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name=attr_name)),
+                ],
+            )
+            response = EndpointTraceItemTable().execute(message)
+            by_name = {cv.attribute_name: cv for cv in response.column_values}
+            assert len(by_name[attr_name].results) == 1
+            assert check_row(by_name[attr_name].results[0])
+        finally:
+            state.delete_config("trace_item_table_include_arrays")
 
 
 class TestTraceItemTableArrayColumn(BaseApiTest):
@@ -3938,66 +3952,74 @@ class TestTraceItemTableArrayColumn(BaseApiTest):
     @pytest.mark.redis_db
     def test_select_array_column_returns_val_array(self) -> None:
         """TYPE_ARRAY columns are returned as val_array on TraceItemTable."""
-        span_ts = BASE_TIME - timedelta(minutes=1)
-        items_storage = get_storage(StorageKey("eap_items"))
-        write_raw_unprocessed_events(
-            items_storage,  # type: ignore
-            [
-                gen_item_message(
-                    span_ts,
-                    attributes={
-                        "tags": _str_array("alpha", "beta"),
-                        "cols": AnyValue(
-                            array_value=ArrayValue(values=[AnyValue(int_value=v) for v in [1, 3]])
-                        ),
-                        "resource.process.command_args": AnyValue(
-                            array_value=ArrayValue(
-                                values=[
-                                    AnyValue(string_value="node"),
-                                    AnyValue(string_value="--enable-source-maps"),
-                                ]
-                            )
-                        ),
-                    },
+        state.set_config("trace_item_table_include_arrays", 1)
+        try:
+            span_ts = BASE_TIME - timedelta(minutes=1)
+            items_storage = get_storage(StorageKey("eap_items"))
+            write_raw_unprocessed_events(
+                items_storage,  # type: ignore
+                [
+                    gen_item_message(
+                        span_ts,
+                        attributes={
+                            "tags": _str_array("alpha", "beta"),
+                            "cols": AnyValue(
+                                array_value=ArrayValue(
+                                    values=[AnyValue(int_value=v) for v in [1, 3]]
+                                )
+                            ),
+                            "resource.process.command_args": AnyValue(
+                                array_value=ArrayValue(
+                                    values=[
+                                        AnyValue(string_value="node"),
+                                        AnyValue(string_value="--enable-source-maps"),
+                                    ]
+                                )
+                            ),
+                        },
+                    ),
+                ],
+            )
+            message = TraceItemTableRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    start_timestamp=START_TIMESTAMP,
+                    end_timestamp=END_TIMESTAMP,
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
                 ),
-            ],
-        )
-        message = TraceItemTableRequest(
-            meta=RequestMeta(
-                project_ids=[1, 2, 3],
-                organization_id=1,
-                cogs_category="something",
-                referrer="something",
-                start_timestamp=START_TIMESTAMP,
-                end_timestamp=END_TIMESTAMP,
-                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
-            ),
-            columns=[
-                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
-                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags")),
-                Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="cols")),
-                Column(
-                    key=AttributeKey(
-                        type=AttributeKey.TYPE_ARRAY, name="resource.process.command_args"
-                    )
-                ),
-            ],
-        )
-        response = EndpointTraceItemTable().execute(message)
-        by_name = {cv.attribute_name: cv for cv in response.column_values}
-        assert by_name["tags"].results[0].WhichOneof("value") == "val_array"
-        assert [e.val_str for e in by_name["tags"].results[0].val_array.values] == [
-            "alpha",
-            "beta",
-        ]
-        assert by_name["cols"].results[0].WhichOneof("value") == "val_array"
-        assert [e.val_int for e in by_name["cols"].results[0].val_array.values] == [1, 3]
-        assert (
-            by_name["resource.process.command_args"].results[0].WhichOneof("value") == "val_array"
-        )
-        assert [
-            e.val_str for e in by_name["resource.process.command_args"].results[0].val_array.values
-        ] == ["node", "--enable-source-maps"]
+                columns=[
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags")),
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="cols")),
+                    Column(
+                        key=AttributeKey(
+                            type=AttributeKey.TYPE_ARRAY, name="resource.process.command_args"
+                        )
+                    ),
+                ],
+            )
+            response = EndpointTraceItemTable().execute(message)
+            by_name = {cv.attribute_name: cv for cv in response.column_values}
+            assert by_name["tags"].results[0].WhichOneof("value") == "val_array"
+            assert [e.val_str for e in by_name["tags"].results[0].val_array.values] == [
+                "alpha",
+                "beta",
+            ]
+            assert by_name["cols"].results[0].WhichOneof("value") == "val_array"
+            assert [e.val_int for e in by_name["cols"].results[0].val_array.values] == [1, 3]
+            assert (
+                by_name["resource.process.command_args"].results[0].WhichOneof("value")
+                == "val_array"
+            )
+            assert [
+                e.val_str
+                for e in by_name["resource.process.command_args"].results[0].val_array.values
+            ] == ["node", "--enable-source-maps"]
+        finally:
+            state.delete_config("trace_item_table_include_arrays")
 
     @pytest.mark.clickhouse_db
     @pytest.mark.redis_db

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -4062,12 +4062,13 @@ class TestTraceItemTableArrayColumn(BaseApiTest):
             by_name = {cv.attribute_name: cv for cv in response.column_values}
             # Non-array column still resolves normally.
             assert by_name["sentry.item_id"].results[0].WhichOneof("value") == "val_str"
-            # TYPE_ARRAY columns come back as is_null instead of val_array.
+            # TYPE_ARRAY columns come back as is_null with no oneof value set,
+            # not as val_array (or any other typed payload).
             for name in ("tags", "cols"):
                 assert len(by_name[name].results) == len(by_name["sentry.item_id"].results)
                 for result in by_name[name].results:
                     assert result.is_null is True
-                    assert result.WhichOneof("value") != "val_array"
+                    assert result.WhichOneof("value") is None
         finally:
             state.delete_config("trace_item_table_include_arrays")
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -57,6 +57,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue
 
+from snuba import state
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query import OrderBy, OrderByDirection
@@ -3997,6 +3998,56 @@ class TestTraceItemTableArrayColumn(BaseApiTest):
         assert [
             e.val_str for e in by_name["resource.process.command_args"].results[0].val_array.values
         ] == ["node", "--enable-source-maps"]
+
+    @pytest.mark.clickhouse_db
+    @pytest.mark.redis_db
+    def test_kill_switch_returns_null_for_array_columns(self) -> None:
+        """Setting trace_item_table_include_arrays=0 returns NULL for TYPE_ARRAY columns
+        instead of decoding the attributes_array JSON column."""
+        state.set_config("trace_item_table_include_arrays", 0)
+        try:
+            span_ts = BASE_TIME - timedelta(minutes=1)
+            items_storage = get_storage(StorageKey("eap_items"))
+            write_raw_unprocessed_events(
+                items_storage,  # type: ignore
+                [
+                    gen_item_message(
+                        span_ts,
+                        attributes={
+                            "tags": _str_array("alpha", "beta"),
+                            "cols": _int_array(1, 3),
+                        },
+                    ),
+                ],
+            )
+            message = TraceItemTableRequest(
+                meta=RequestMeta(
+                    project_ids=[1, 2, 3],
+                    organization_id=1,
+                    cogs_category="something",
+                    referrer="something",
+                    start_timestamp=START_TIMESTAMP,
+                    end_timestamp=END_TIMESTAMP,
+                    trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                ),
+                columns=[
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.item_id")),
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags")),
+                    Column(key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="cols")),
+                ],
+            )
+            response = EndpointTraceItemTable().execute(message)
+            by_name = {cv.attribute_name: cv for cv in response.column_values}
+            # Non-array column still resolves normally.
+            assert by_name["sentry.item_id"].results[0].WhichOneof("value") == "val_str"
+            # TYPE_ARRAY columns come back as is_null instead of val_array.
+            for name in ("tags", "cols"):
+                assert len(by_name[name].results) == len(by_name["sentry.item_id"].results)
+                for result in by_name[name].results:
+                    assert result.is_null is True
+                    assert result.WhichOneof("value") != "val_array"
+        finally:
+            state.delete_config("trace_item_table_include_arrays")
 
 
 class TestUtils:


### PR DESCRIPTION
## Summary

- Gates the `toJSONString(attributes_array.<path>)` SELECT for `TYPE_ARRAY` key columns on `EndpointTraceItemTable` behind `state.get_int_config("trace_item_table_include_arrays", 0)`. **Default `0` — `TYPE_ARRAY` columns come back as NULL on deploy.**
- Mirrors the [trace_item_details kill switch](https://github.com/getsentry/snuba/pull/7942) (`trace_item_details_include_arrays`) under a separate config key so SRE can roll out the table-endpoint switch independently of the details one. Both default to `0`.
- When the switch is off (the default), the requested `TYPE_ARRAY` columns come back as `is_null=True` via `cast(NULL, 'Nullable(String)')` so the response shape is preserved and callers don't crash. WHERE filters on `TYPE_ARRAY` keys go through `type_array_to_membership_array_expression` and are unaffected. Flip to `1` via snuba-admin to re-enable the JSON column read when array values are needed.

Context: the JSON `attributes_array` column (`JSON(max_dynamic_paths=128)`) forces ClickHouse to materialize every dynamic subcolumn per granule and re-serialize as a string. That dominates these endpoints' latency, so the safe default is off; callers that need array values opt back in via the runtime config.

## Test plan

- [ ] CI green
- [ ] `test_kill_switch_returns_null_for_array_columns` exercises the off path (default): requests two `TYPE_ARRAY` columns, asserts each comes back with `is_null=True` and no `val_array` payload, while a sibling non-array column still resolves normally.
- [ ] Existing array-column tests opt in explicitly via `state.set_config("trace_item_table_include_arrays", 1)` and continue to assert `val_array` payloads — covers the include path under the new default.
- [ ] Sanity-check in snuba-admin that `trace_item_table_include_arrays` shows up with the new description and that toggling it to `1` adds the `toJSONString` SELECT back to the query plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/4ioeXC1RZsjPHacEDKBYDd5wWejqK6XZsaxlFJFfYQc