### PR TITLE
ref(INC-2179): drop eap-items and accepted-outcomes messages with out-of-range timestamps

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -65,18 +65,21 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
     if let Some(event_ts) = event_timestamp {
         let now = Utc::now();
 
-        if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
-            if should_dlq_for_prior_partition(event_ts, now, grace_min) {
-                counter!("eap_items.messages.dlqed_prior_partition", 1);
-                anyhow::bail!(
-                    "eap-items message DLQed: event timestamp {event_ts} is before the prior weekly partition boundary; routed to DLQ"
-                );
-            }
-        }
-
+        // should_skip=true will drop messages that are too old or too far in the future
         if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
             counter!("eap_items.messages.dropped_out_of_range_timestamp", 1);
             should_skip = true;
+        }
+        // only DLQ messages that we don't want to drop (should_skip=false)
+        if !should_skip {
+            if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
+                if should_dlq_for_prior_partition(event_ts, now, grace_min) {
+                    counter!("eap_items.messages.dlqed_prior_partition", 1);
+                    anyhow::bail!(
+                        "eap-items message DLQed: event timestamp {event_ts} is before the prior weekly partition boundary; routed to DLQ"
+                    );
+                }
+            }
         }
     }
 

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -65,11 +65,6 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
     if let Some(event_ts) = event_timestamp {
         let now = Utc::now();
 
-        if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
-            counter!("eap_items.messages.dropped_out_of_range_timestamp", 1);
-            should_skip = true;
-        }
-
         if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
             if should_dlq_for_prior_partition(event_ts, now, grace_min) {
                 counter!("eap_items.messages.dlqed_prior_partition", 1);
@@ -77,6 +72,11 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
                     "eap-items message DLQed: event timestamp {event_ts} is before the prior weekly partition boundary; routed to DLQ"
                 );
             }
+        }
+
+        if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
+            counter!("eap_items.messages.dropped_out_of_range_timestamp", 1);
+            should_skip = true;
         }
     }
 

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -14,7 +14,9 @@ use sentry_protos::snuba::v1::any_value::Value;
 use sentry_protos::snuba::v1::{ArrayValue, TraceItem, TraceItemType};
 
 use crate::config::ProcessorConfig;
-use crate::processors::utils::enforce_retention;
+use crate::processors::utils::{
+    enforce_retention, get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs,
+};
 use crate::runtime_config::get_str_config;
 use crate::types::CogsData;
 use crate::types::{InsertBatch, ItemTypeMetrics, KafkaMessageMetadata, TypedInsertBatch};
@@ -44,6 +46,7 @@ struct ProcessedItem {
     origin_timestamp: Option<DateTime<Utc>>,
     item_type_metrics: ItemTypeMetrics,
     cogs_data: CogsData,
+    should_skip: bool,
 }
 
 fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Result<ProcessedItem> {
@@ -58,9 +61,16 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         .as_ref()
         .and_then(|ts| DateTime::from_timestamp(ts.seconds, 0));
 
+    let mut should_skip = false;
     if let Some(event_ts) = event_timestamp {
+        let now = Utc::now();
+
+        if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
+            counter!("eap_items.messages.dropped_out_of_range_timestamp", 1);
+            should_skip = true;
+        }
+
         if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
-            let now = Utc::now();
             if should_dlq_for_prior_partition(event_ts, now, grace_min) {
                 counter!("eap_items.messages.dlqed_prior_partition", 1);
                 anyhow::bail!(
@@ -128,6 +138,7 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         origin_timestamp,
         item_type_metrics,
         cogs_data,
+        should_skip,
     })
 }
 
@@ -169,6 +180,9 @@ pub fn process_message(
     config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let processed = process_eap_item(msg, config)?;
+    if processed.should_skip {
+        return Ok(InsertBatch::skip());
+    }
     let mut batch = InsertBatch::from_rows([processed.eap_item], processed.origin_timestamp)?;
     batch.item_type_metrics = Some(processed.item_type_metrics);
     batch.cogs_data = Some(processed.cogs_data);
@@ -181,6 +195,9 @@ pub fn process_message_row_binary(
     config: &ProcessorConfig,
 ) -> anyhow::Result<TypedInsertBatch<EAPItemRow>> {
     let processed = process_eap_item(msg, config)?;
+    if processed.should_skip {
+        return Ok(TypedInsertBatch::from_rows(vec![], None));
+    }
     let mut batch = TypedInsertBatch::from_rows(
         vec![EAPItemRow::try_from(processed.eap_item)?],
         processed.origin_timestamp,

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -10,7 +10,7 @@ mod profiles;
 mod querylog;
 mod release_health_metrics;
 mod replays;
-mod utils;
+pub mod utils;
 
 use crate::config::ProcessorConfig;
 use crate::types::{InsertBatch, InsertOrReplacement, KafkaMessageMetadata};

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -1,11 +1,37 @@
 use crate::config::EnvConfig;
+use crate::runtime_config::get_str_config;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 
+/// One week in seconds. The eap_items table is partitioned by
+/// `(retention_days, toMonday(timestamp))`, so any event more than a week
+/// off will add more parts
+pub const INVALID_TIMESTAMP_INTERVAL_SECONDS: i64 = 7 * 24 * 60 * 60;
+
+/// Runtime config key. When set to `"1"`, the eap-items consumer skips messages
+/// whose event `timestamp` is more than one week from now (see
+/// `out_of_valid_interval_secs`).
+pub const DROP_INVALID_TIMESTAMPS_KEY: &str = "eap_items_drop_invalid_timestamps";
+
 // Equivalent to "%Y-%m-%dT%H:%M:%S.%fZ" in python
 // Notice the differennce of .%fZ vs %.fZ, this comes from a difference in how rust's chrono handles the format
 const PAYLOAD_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.fZ";
+
+/// Returns true if `ts` is more than `INVALID_TIMESTAMP_INTERVAL_SECONDS` off from
+/// `now` in either direction (past or future).
+pub fn out_of_valid_interval_secs(ts: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    let offset_sec = now.signed_duration_since(ts).num_seconds();
+    offset_sec.abs() > INVALID_TIMESTAMP_INTERVAL_SECONDS
+}
+
+pub fn get_drop_invalid_timestamps_enabled() -> bool {
+    get_str_config(DROP_INVALID_TIMESTAMPS_KEY)
+        .ok()
+        .flatten()
+        .map(|s| s == "1")
+        .unwrap_or(false)
+}
 
 pub fn enforce_retention(value: Option<u16>, config: &EnvConfig) -> u16 {
     let mut retention_days = value.unwrap_or(config.default_retention_days);
@@ -66,3 +92,41 @@ pub struct StringToIntDatetime64(
     #[schemars(with = "String")]
     pub u64,
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_out_of_valid_interval_secs_drops_messages_more_than_a_week_old() {
+        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
+        let ts = DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_INTERVAL_SECONDS - 1, 0)
+            .unwrap();
+        assert!(out_of_valid_interval_secs(ts, now));
+    }
+
+    #[test]
+    fn test_out_of_valid_interval_secs_drops_messages_more_than_a_week_in_the_future() {
+        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
+        let ts = DateTime::from_timestamp(2_000_000 + INVALID_TIMESTAMP_INTERVAL_SECONDS + 1, 0)
+            .unwrap();
+        assert!(out_of_valid_interval_secs(ts, now));
+    }
+
+    #[test]
+    fn test_out_of_valid_interval_secs_keeps_messages_at_exactly_one_week_old() {
+        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
+        let ts =
+            DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_INTERVAL_SECONDS, 0).unwrap();
+        assert!(!out_of_valid_interval_secs(ts, now));
+    }
+
+    #[test]
+    fn test_out_of_valid_interval_secs_keeps_messages_within_a_week() {
+        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
+        let past = DateTime::from_timestamp(2_000_000 - 86_400, 0).unwrap();
+        assert!(!out_of_valid_interval_secs(past, now));
+        let future = DateTime::from_timestamp(2_000_000 + 86_400, 0).unwrap();
+        assert!(!out_of_valid_interval_secs(future, now));
+    }
+}

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -94,6 +94,7 @@ pub struct StringToIntDatetime64(
 );
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
 use prost::Message as ProstMessage;
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
 use sentry_arroyo::counter;
@@ -14,6 +15,7 @@ use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 
 use sentry_options::options;
 
+use crate::processors::utils::{get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs};
 use crate::types::{item_type_name, AggregatedOutcomesBatch, BucketKey, ItemDedupKey};
 
 const OPTIONS_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
@@ -278,6 +280,18 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
                 )));
             }
         };
+
+        let event_timestamp = trace_item
+            .timestamp
+            .as_ref()
+            .and_then(|ts| DateTime::from_timestamp(ts.seconds, 0));
+        if let Some(event_ts) = event_timestamp {
+            let now = Utc::now();
+            if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
+                counter!("accepted_outcomes.dropped_out_of_range_timestamp", 1);
+                return Ok(());
+            }
+        }
 
         let ts_secs = if self.use_item_timestamp {
             trace_item


### PR DESCRIPTION
We get bad data upstream that is either very far in the future, or very far in the past. As a result we want to drop that data when processing EAP Items. This means we also have to drop this in the outcomes aggregator as well so those counts remain accurate. 

- Adds runtime config (`eap_items_drop_invalid_timestamps`) that, when set to `"1"`, drops messages whose event `timestamp` is more than one week in the past or future. Only added the runtime config to test in region by region first, then can remove and have this be the default. 

- Wires the check into both the `eap_items` processor (returns a skip batch) and the `accepted_outcomes` aggregator strategy (drops before bucketing), each with its own dropped-message counter.
- Adds `out_of_valid_interval_secs` helper + unit tests in `processors/utils.rs`.

Opted to **not** to a separate `FilterStep` because I didn't want to have to decode the whole message twice in the eap items consumer. 

**Rollout plan**
- [ ] Roll out runtime config in S4S2 first, then DE, then US
- [ ] Validate no new data is written to clickhouse that is outside of the bounds set (older than a week, newer than one week in the future)
- [ ] Validate metrics for eap_items and accepted_outcomes align


🤖 Generated with [Claude Code](https://claude.com/claude-code)