### PR TITLE
perf(eap): Read only allowlisted attributes_array sub-paths

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, Iterator, TypeVar, cast
 
 from google.protobuf.message import Message as ProtobufMessage
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
@@ -19,7 +19,7 @@ from snuba.protos.common import (
 from snuba.protos.common import (
     attribute_key_to_expression as _attribute_key_to_expression,
 )
-from snuba.query import Query
+from snuba.query import Query, SelectedExpression
 from snuba.query.conditions import combine_and_conditions, combine_or_conditions
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import (
@@ -35,6 +35,7 @@ from snuba.query.expressions import (
     Argument,
     Expression,
     FunctionCall,
+    JsonPath,
     Lambda,
     SubscriptableReference,
 )
@@ -163,6 +164,70 @@ def process_arrays(raw: str) -> dict[str, list[Any]]:
                 ) from e
         arrays[key] = parsed_elements
     return arrays
+
+
+# Allowlist of `attributes_array` JSON sub-paths exposed by endpoints that
+# return all attributes (TraceItemDetails, GetTrace bulk-fetch). Each path is
+# read as its own JSON sub-column so we don't materialize the full dynamic
+# JSON value on every request.
+ATTRIBUTES_ARRAY_ALLOWLIST: tuple[str, ...] = (
+    "gen_ai.input.messages",
+    "gen_ai.output.messages",
+    "gen_ai.request.messages",
+    "gen_ai.response.text",
+    "gen_ai.system_instructions",
+    "gen_ai.tool.definitions",
+    "gen_ai.response.object",
+    "gen_ai.tool.call.arguments",
+    "gen_ai.tool.input",
+)
+
+
+def attributes_array_selected_expressions() -> list[SelectedExpression]:
+    """Per-path `toJSONString(attributes_array.<path>.:Array(JSON))` selects for the allowlist."""
+    return [
+        SelectedExpression(
+            path,
+            FunctionCall(
+                alias=path,
+                function_name="toJSONString",
+                parameters=(
+                    JsonPath(
+                        alias=None,
+                        base=column("attributes_array"),
+                        path=path,
+                        return_type="Array(JSON)",
+                    ),
+                ),
+            ),
+        )
+        for path in ATTRIBUTES_ARRAY_ALLOWLIST
+    ]
+
+
+def pop_attributes_array_paths(row: dict[str, Any]) -> Iterator[tuple[str, list[Any]]]:
+    """Yield (path, decoded_values) for each allowlisted attributes_array path.
+
+    Consumed keys are popped from `row` so callers can iterate the rest safely.
+    Empty arrays (the default for missing JSON paths) are skipped.
+    """
+    for path in ATTRIBUTES_ARRAY_ALLOWLIST:
+        raw = row.pop(path, None)
+        if not raw:
+            continue
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise BadSnubaRPCRequestException(
+                f"attributes_array path {path!r} is not valid JSON: {e}"
+            ) from e
+        if not isinstance(parsed, list):
+            raise BadSnubaRPCRequestException(
+                f"attributes_array path {path!r} must decode to a list, got {type(parsed).__name__}"
+            )
+        if not parsed:
+            continue
+        yield path, [transform_array_value(elem) for elem in parsed]
 
 
 def _check_non_string_values_cannot_ignore_case(

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -46,7 +46,8 @@ from snuba.web.query import run_query
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.common import (
     attribute_key_to_expression,
-    process_arrays,
+    attributes_array_selected_expressions,
+    pop_attributes_array_paths,
     project_id_and_org_conditions,
     timestamp_in_range_condition,
     treeify_or_and_conditions,
@@ -226,14 +227,7 @@ def _build_query(
                     tuple(column(f"attributes_float_{i}") for i in range(40)),
                 ),
             ),
-            SelectedExpression(
-                name="attributes_array",
-                expression=FunctionCall(
-                    "attributes_array",
-                    "toJSONString",
-                    (column("attributes_array"),),
-                ),
-            ),
+            *attributes_array_selected_expressions(),
         ]
         selected_columns.extend(
             map(
@@ -488,7 +482,6 @@ def _process_results(
         for row in data:
             id = row.pop("id")
             ts = row.pop("timestamp")
-            arrays = row.pop("attributes_array", "{}") or "{}"
             # We want to merge these values after to overwrite potential floats
             # with the same name.
             booleans = row.pop("attributes_bool", {}) or {}
@@ -510,16 +503,15 @@ def _process_results(
                     value=attribute_value,
                 )
 
+            for array_key, array_value in pop_attributes_array_paths(row):
+                add_attribute(array_key, array_value)
+
             for row_key, row_value in row.items():
                 if isinstance(row_value, dict):
                     for column_key, column_value in row_value.items():
                         add_attribute(column_key, column_value)
                 else:
                     add_attribute(row_key, row_value)
-
-            attributes_array = process_arrays(arrays)
-            for array_key, array_value in attributes_array.items():
-                add_attribute(array_key, array_value)
 
             for bool_key, bool_value in booleans.items():
                 add_attribute(bool_key, bool_value)

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from typing import Any, Dict, Iterable, Tuple, Type
 
@@ -20,7 +21,7 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal
-from snuba.query.expressions import FunctionCall
+from snuba.query.expressions import FunctionCall, JsonPath
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
@@ -31,8 +32,8 @@ from snuba.web.rpc.common.common import (
     add_existence_check_to_subscriptable_references,
     attribute_key_to_expression,
     base_conditions_and,
-    process_arrays,
     trace_item_filters_to_expression,
+    transform_array_value,
     treeify_or_and_conditions,
 )
 from snuba.web.rpc.common.debug_info import (
@@ -44,6 +45,20 @@ from snuba.web.rpc.common.exceptions import (
     RPCRequestException,
 )
 from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
+
+# Each path is read as its own JSON sub-column so we don't materialize the full
+# dynamic `attributes_array` value on every request.
+ATTRIBUTES_ARRAY_ALLOWLIST: Tuple[str, ...] = (
+    "gen_ai.input.messages",
+    "gen_ai.output.messages",
+    "gen_ai.request.messages",
+    "gen_ai.response.text",
+    "gen_ai.system_instructions",
+    "gen_ai.tool.definitions",
+    "gen_ai.response.object",
+    "gen_ai.tool.call.arguments",
+    "gen_ai.tool.input",
+)
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
@@ -86,14 +101,24 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             SelectedExpression(
                 "attributes_bool", column("attributes_bool", alias="attributes_bool")
             ),
-            SelectedExpression(
-                "attributes_array",
-                FunctionCall(
-                    "attributes_array",
-                    "toJSONString",
-                    (column("attributes_array"),),
-                ),
-            ),
+            *[
+                SelectedExpression(
+                    path,
+                    FunctionCall(
+                        alias=path,
+                        function_name="toJSONString",
+                        parameters=(
+                            JsonPath(
+                                alias=None,
+                                base=column("attributes_array"),
+                                path=path,
+                                return_type="Array(JSON)",
+                            ),
+                        ),
+                    ),
+                )
+                for path in ATTRIBUTES_ARRAY_ALLOWLIST
+            ],
         ],
         condition=base_conditions_and(
             request.meta,
@@ -191,15 +216,28 @@ def _convert_results(
             continue
         attrs.append(TraceItemDetailsAttribute(name=k, value=AttributeValue(val_double=v)))
 
-    raw_array = row.get("attributes_array")
-    if raw_array:
-        for k, values in process_arrays(raw_array).items():
-            attrs.append(
-                TraceItemDetailsAttribute(
-                    name=k,
-                    value=convert_to_attribute_value(values),
-                )
+    for path in ATTRIBUTES_ARRAY_ALLOWLIST:
+        raw = row.get(path)
+        if not raw:
+            continue
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise BadSnubaRPCRequestException(
+                f"attributes_array path {path!r} is not valid JSON: {e}"
+            ) from e
+        if not isinstance(parsed, list):
+            raise BadSnubaRPCRequestException(
+                f"attributes_array path {path!r} must decode to a list, got {type(parsed).__name__}"
             )
+        if not parsed:
+            continue
+        attrs.append(
+            TraceItemDetailsAttribute(
+                name=path,
+                value=convert_to_attribute_value([transform_array_value(elem) for elem in parsed]),
+            )
+        )
 
     return item_id, timestamp, attrs
 

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,4 +1,3 @@
-import json
 import uuid
 from typing import Any, Dict, Iterable, Tuple, Type
 
@@ -21,7 +20,6 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import column, literal
-from snuba.query.expressions import FunctionCall, JsonPath
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
@@ -31,9 +29,10 @@ from snuba.web.rpc.common.common import (
     BUCKET_COUNT,
     add_existence_check_to_subscriptable_references,
     attribute_key_to_expression,
+    attributes_array_selected_expressions,
     base_conditions_and,
+    pop_attributes_array_paths,
     trace_item_filters_to_expression,
-    transform_array_value,
     treeify_or_and_conditions,
 )
 from snuba.web.rpc.common.debug_info import (
@@ -45,20 +44,6 @@ from snuba.web.rpc.common.exceptions import (
     RPCRequestException,
 )
 from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
-
-# Each path is read as its own JSON sub-column so we don't materialize the full
-# dynamic `attributes_array` value on every request.
-ATTRIBUTES_ARRAY_ALLOWLIST: Tuple[str, ...] = (
-    "gen_ai.input.messages",
-    "gen_ai.output.messages",
-    "gen_ai.request.messages",
-    "gen_ai.response.text",
-    "gen_ai.system_instructions",
-    "gen_ai.tool.definitions",
-    "gen_ai.response.object",
-    "gen_ai.tool.call.arguments",
-    "gen_ai.tool.input",
-)
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
@@ -101,24 +86,7 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             SelectedExpression(
                 "attributes_bool", column("attributes_bool", alias="attributes_bool")
             ),
-            *[
-                SelectedExpression(
-                    path,
-                    FunctionCall(
-                        alias=path,
-                        function_name="toJSONString",
-                        parameters=(
-                            JsonPath(
-                                alias=None,
-                                base=column("attributes_array"),
-                                path=path,
-                                return_type="Array(JSON)",
-                            ),
-                        ),
-                    ),
-                )
-                for path in ATTRIBUTES_ARRAY_ALLOWLIST
-            ],
+            *attributes_array_selected_expressions(),
         ],
         condition=base_conditions_and(
             request.meta,
@@ -216,28 +184,8 @@ def _convert_results(
             continue
         attrs.append(TraceItemDetailsAttribute(name=k, value=AttributeValue(val_double=v)))
 
-    for path in ATTRIBUTES_ARRAY_ALLOWLIST:
-        raw = row.get(path)
-        if not raw:
-            continue
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as e:
-            raise BadSnubaRPCRequestException(
-                f"attributes_array path {path!r} is not valid JSON: {e}"
-            ) from e
-        if not isinstance(parsed, list):
-            raise BadSnubaRPCRequestException(
-                f"attributes_array path {path!r} must decode to a list, got {type(parsed).__name__}"
-            )
-        if not parsed:
-            continue
-        attrs.append(
-            TraceItemDetailsAttribute(
-                name=path,
-                value=convert_to_attribute_value([transform_array_value(elem) for elem in parsed]),
-            )
-        )
+    for path, values in pop_attributes_array_paths(row):
+        attrs.append(TraceItemDetailsAttribute(name=path, value=convert_to_attribute_value(values)))
 
     return item_id, timestamp, attrs
 

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -32,6 +32,7 @@ from snuba import state
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.settings import ENABLE_TRACE_PAGINATION_DEFAULT
+from snuba.web.rpc.common.common import ATTRIBUTES_ARRAY_ALLOWLIST
 from snuba.web.rpc.v1.endpoint_get_trace import (
     APPLY_FINAL_ROLLOUT_PERCENTAGE_CONFIG_KEY,
     EndpointGetTrace,
@@ -128,6 +129,9 @@ def get_attributes(
     for key, value in span.attributes.items():
         value_type = value.WhichOneof("value")
         if not value_type:
+            continue
+        if value_type == "array_value" and key not in ATTRIBUTES_ARRAY_ALLOWLIST:
+            # bulk get_trace only surfaces allowlisted attributes_array paths
             continue
         attribute_key = AttributeKey(
             name=key,
@@ -366,7 +370,7 @@ class TestGetTrace(BaseApiTest):
 
         query = _build_query(message, item)
 
-        assert query.get_final() == True
+        assert query.get_final()
 
         state.set_config(
             APPLY_FINAL_ROLLOUT_PERCENTAGE_CONFIG_KEY,
@@ -375,7 +379,7 @@ class TestGetTrace(BaseApiTest):
 
         query = _build_query(message, item)
 
-        assert query.get_final() == False
+        assert not query.get_final()
 
     def test_with_logs(self, setup_teardown: Any) -> None:
         ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))
@@ -540,7 +544,7 @@ class TestGetTracePagination(BaseApiTest):
                     items_received.append(item.id)
             assert curr_response_len <= mylimit
             if curr_response_len < mylimit:
-                assert response.page_token.end_pagination == True
+                assert response.page_token.end_pagination
             if response.page_token.end_pagination:
                 break
             message.page_token.CopyFrom(response.page_token)
@@ -609,7 +613,7 @@ class TestGetTracePagination(BaseApiTest):
                         items_received.append(item.id)
                 assert curr_response_len <= configmax
                 if curr_response_len < configmax:
-                    assert response.page_token.end_pagination == True
+                    assert response.page_token.end_pagination
                 if response.page_token.end_pagination:
                     break
                 message.page_token.CopyFrom(response.page_token)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_details.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_details.py
@@ -258,7 +258,7 @@ class TestTraceItemDetails(BaseApiTest):
             assert k in attributes_returned, k
 
     def test_endpoint_returns_array_attribute(self, eap: None, redis_db: None) -> None:
-        """attributes_array from storage is exposed as val_array on TraceItemDetails."""
+        """Allowlisted attributes_array paths are exposed as val_array on TraceItemDetails."""
         span_ts = BASE_TIME - timedelta(minutes=1)
         storage = get_storage(StorageKey("eap_items"))
         write_raw_unprocessed_events(
@@ -267,8 +267,8 @@ class TestTraceItemDetails(BaseApiTest):
                 gen_item_message(
                     span_ts,
                     attributes={
-                        "tags": _str_tags_array("gamma", "delta"),
-                        "cols": _int_vals_array(1, 3),
+                        "gen_ai.response.text": _str_tags_array("gamma", "delta"),
+                        "gen_ai.tool.input": _int_vals_array(1, 3),
                     },
                 ),
             ],
@@ -323,11 +323,11 @@ class TestTraceItemDetails(BaseApiTest):
                 trace_id=trace_id,
             )
         )
-        tags_attr = next((a for a in res.attributes if a.name == "tags"), None)
+        tags_attr = next((a for a in res.attributes if a.name == "gen_ai.response.text"), None)
         assert tags_attr is not None
         assert tags_attr.value.WhichOneof("value") == "val_array"
         assert [e.val_str for e in tags_attr.value.val_array.values] == ["gamma", "delta"]
-        cols_attr = next((a for a in res.attributes if a.name == "cols"), None)
+        cols_attr = next((a for a in res.attributes if a.name == "gen_ai.tool.input"), None)
         assert cols_attr is not None
         assert cols_attr.value.WhichOneof("value") == "val_array"
         assert [e.val_int for e in cols_attr.value.val_array.values] == [1, 3]
@@ -344,9 +344,7 @@ class TestTraceItemDetails(BaseApiTest):
                     trace_id=trace_id,
                     remove_default_attributes=True,
                     attributes={
-                        "resource.process.command_args": _str_tags_array(
-                            "node", "--enable-source-maps"
-                        ),
+                        "gen_ai.input.messages": _str_tags_array("node", "--enable-source-maps"),
                     },
                 ),
             ],
@@ -406,7 +404,7 @@ class TestTraceItemDetails(BaseApiTest):
                 trace_id=trace_id_for_details,
             )
         )
-        attr = next((a for a in res.attributes if a.name == "resource.process.command_args"), None)
+        attr = next((a for a in res.attributes if a.name == "gen_ai.input.messages"), None)
         assert attr is not None
         assert attr.value.WhichOneof("value") == "val_array"
         assert [e.val_str for e in attr.value.val_array.values] == ["node", "--enable-source-maps"]
@@ -519,8 +517,8 @@ def test_convert_results_dedupes() -> None:
 
 def test_convert_results_includes_attributes_array() -> None:
     """
-    TraceItemDetails maps the ClickHouse attributes_array JSON payload into val_array
-    attributes (same path EndpointTraceItemDetails uses after the query).
+    TraceItemDetails maps per-path JSON sub-column payloads from `attributes_array`
+    into val_array attributes (only allowlisted paths are read).
     """
     data = [
         {
@@ -534,11 +532,32 @@ def test_convert_results_includes_attributes_array() -> None:
             "attributes_int": {},
             "attributes_float": {},
             "attributes_bool": {},
-            "attributes_array": '{"tags":[{"String":"gamma"},{"String":"delta"}]}',
+            "gen_ai.input.messages": '[{"String":"gamma"},{"String":"delta"}]',
         }
     ]
     _, _, attrs = _convert_results(data)
-    tags = [a for a in attrs if a.name == "tags"]
-    assert len(tags) == 1
-    assert tags[0].value.WhichOneof("value") == "val_array"
-    assert [e.val_str for e in tags[0].value.val_array.values] == ["gamma", "delta"]
+    msgs = [a for a in attrs if a.name == "gen_ai.input.messages"]
+    assert len(msgs) == 1
+    assert msgs[0].value.WhichOneof("value") == "val_array"
+    assert [e.val_str for e in msgs[0].value.val_array.values] == ["gamma", "delta"]
+
+
+def test_convert_results_skips_non_allowlisted_array_paths() -> None:
+    """Rows only contain keys we explicitly selected; anything else is ignored."""
+    data = [
+        {
+            "timestamp": 1750964400,
+            "hex_item_id": "e70ef5b1b5bc4611840eff9964b7a767",
+            "trace_id": "cb190d6e7d5743d5bc1494c650592cd2",
+            "organization_id": 1,
+            "project_id": 1,
+            "item_type": 1,
+            "attributes_string": {},
+            "attributes_int": {},
+            "attributes_float": {},
+            "attributes_bool": {},
+            "gen_ai.input.messages": "[]",
+        }
+    ]
+    _, _, attrs = _convert_results(data)
+    assert not any(a.name == "gen_ai.input.messages" for a in attrs)


### PR DESCRIPTION
Stop materializing the entire `attributes_array` JSON column on every `TraceItemDetails` and `GetTrace` request, and only read the gen_ai.* sub-paths the AI agents UI consumes.

#7890 added unconditional `SELECT toJSONString(attributes_array)` to the details query so that array attributes could be returned to the client. The same pattern already existed in `GetTrace`'s bulk-fetch branch. Because `attributes_array` is a New JSON column (`max_dynamic_paths=128`), `toJSONString` forces ClickHouse to reconstruct every dynamic path for the matching row and ship the full serialized payload back, where the Python side then `json.loads` + per-element variant-decodes it. Every request pays for this, and p99 on both endpoints regressed visibly after #7890 shipped.

This change replaces that single SELECT with one `JsonPath` SELECT per allowlisted path, e.g. ``toJSONString(attributes_array.`gen_ai.input.messages`.:`Array(JSON)`)``. Each path is its own sub-column on disk in the New JSON layout, so we only read the data we're going to return. Missing paths produce empty arrays and are skipped rather than emitted as empty `val_array` attributes.

`TraceItemTable` was already correct: it routes everything through `attribute_key_to_expression`, which for TYPE_ARRAY compiles to per-path sub-column access. `GetTrace`'s specific-attributes branch (when the caller lists attribute names) was also already correct for the same reason — only its bulk-fetch branch was the regression.

The shared bits live in `snuba/web/rpc/common/common.py`:
- `ATTRIBUTES_ARRAY_ALLOWLIST` — the 9 gen_ai.* paths.
- `attributes_array_selected_expressions()` — builds the per-path `SelectedExpression` list.
- `pop_attributes_array_paths(row)` — decodes each path and pops the consumed keys from the row dict so the rest of the row-processing loop stays clean.

Both endpoints call into the same helpers.

## Behavior change

Anything in `attributes_array` outside the 9 paths is no longer surfaced by either endpoint. The original PR exposed every array attribute on `TraceItemDetails`; `GetTrace`'s bulk path used to surface every array as well. If product wants more keys, add them to `ATTRIBUTES_ARRAY_ALLOWLIST`. The alternative I considered — a `requested_attributes` field on the request protos — requires caller cooperation and proto changes; given the immediate goal is fixing p99, the server-side allowlist is the smaller hammer.

## Caveats

- Paths beyond the dynamic 128 are stored in the shared-data bucket and don't get the full sub-column I/O win — they still avoid the whole-column `toJSONString` though.
- `endpoint_export_trace_items.py` also unconditionally `toJSONString`s the column. Leaving that for a separate change: export is a different access pattern (bulk dump, all attributes) where the same allowlist isn't obviously the right answer.

Refs #7890