### PR TITLE
feat(eap-outcomes): record broker latency metrics

### DIFF
--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -178,6 +178,7 @@ impl<TNext> OutcomesAggregator<TNext> {
 
         let category_metrics = batch.category_metrics.clone();
         let duplicate_item_counts = batch.duplicate_item_count.clone();
+        batch.record_message_latency("flush_broker_latency");
         let message = Message::new_any_message(batch, committable);
         match self.next_step.submit(message) {
             Ok(()) => {
@@ -253,6 +254,9 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
 
         let partition = broker_msg.partition;
         let broker_offset = broker_msg.offset;
+        let broker_timestamp = broker_msg.timestamp;
+
+        self.batch.add_broker_timestamp(broker_timestamp);
 
         self.latest_offsets
             .entry(partition)

--- a/rust_snuba/src/strategies/accepted_outcomes/produce_outcome.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/produce_outcome.rs
@@ -88,6 +88,9 @@ impl TaskRunner<AggregatedOutcomesBatch, AggregatedOutcomesBatch, anyhow::Error>
             if let Ok(elapsed) = produce_finish.duration_since(produce_start) {
                 timer!("accepted_outcomes.batch_produce_ms", elapsed);
             }
+            message
+                .payload()
+                .record_message_latency("produce_broker_latency");
             Ok(message)
         })
     }

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -153,18 +153,18 @@ impl LatencyRecorder {
         (write_time as f64 - (self.sum_timestamps / self.num_values as f64)) as u64
     }
 
-    fn send_metric(&self, write_time: DateTime<Utc>, metric_name: &str) {
+    fn send_metric(&self, write_time: DateTime<Utc>, metric_name: &str, metric_prefix: &str) {
         if self.num_values == 0 {
             return;
         }
 
         timer!(
-            format_args!("insertions.max_{}_ms", metric_name),
+            format_args!("{}.max_{}_ms", metric_prefix, metric_name),
             self.max_value_ms(write_time)
         );
 
         timer!(
-            format_args!("insertions.{}_ms", metric_name),
+            format_args!("{}.{}_ms", metric_prefix, metric_name),
             self.avg_value_ms(write_time),
         );
     }
@@ -404,11 +404,15 @@ impl<R> BytesInsertBatch<R> {
     pub fn record_message_latency(&self) {
         let write_time = Utc::now();
 
-        self.message_timestamp.send_metric(write_time, "latency");
+        self.message_timestamp
+            .send_metric(write_time, "latency", "insertions");
         self.origin_timestamp
-            .send_metric(write_time, "end_to_end_latency");
-        self.sentry_received_timestamp
-            .send_metric(write_time, "sentry_received_latency");
+            .send_metric(write_time, "end_to_end_latency", "insertions");
+        self.sentry_received_timestamp.send_metric(
+            write_time,
+            "sentry_received_latency",
+            "insertions",
+        );
     }
 
     pub fn emit_item_type_metrics(&self) {
@@ -677,6 +681,8 @@ pub struct AggregatedOutcomesBatch {
     pub seen_items: HashMap<TraceItemType, HashSet<ItemDedupKey>>,
     /// Count of items skipped due to deduplication within this batch, keyed by item type
     pub duplicate_item_count: HashMap<TraceItemType, u64>,
+    /// Uses the timestamp the message was added to snuba-items topic
+    broker_timestamp: LatencyRecorder,
 }
 
 impl Default for AggregatedOutcomesBatch {
@@ -687,6 +693,7 @@ impl Default for AggregatedOutcomesBatch {
             category_metrics: BTreeMap::new(),
             seen_items: HashMap::new(),
             duplicate_item_count: HashMap::new(),
+            broker_timestamp: LatencyRecorder::default(),
         }
     }
 }
@@ -728,5 +735,18 @@ impl AggregatedOutcomesBatch {
     /// Get the total number of buckets
     pub fn num_buckets(&self) -> usize {
         self.buckets.len()
+    }
+
+    /// Merge a single broker timestamp into the batch's running latency recorder.
+    pub fn add_broker_timestamp(&mut self, timestamp: DateTime<Utc>) {
+        self.broker_timestamp
+            .merge(LatencyRecorder::from(timestamp));
+    }
+
+    /// Emit broker-latency timers (avg + max) under `accepted_outcomes.{metric_name}_ms` and
+    /// `accepted_outcomes.max_{metric_name}_ms`. Mirrors `BytesInsertBatch::record_message_latency`.
+    pub fn record_message_latency(&self, metric_name: &str) {
+        self.broker_timestamp
+            .send_metric(Utc::now(), metric_name, "accepted_outcomes");
     }
 }


### PR DESCRIPTION
## Summary
Adds broker-latency observability to the accepted outcomes consumer so we can see how long messages sit in each stage of the pipeline.

The aggregator batches outcomes over a bucket interval before flushing them downstream, which means an individual outcome can wait in memory for the full batch window before being produced. Until now we had no visibility into either half of that wait, so spikes in end-to-end outcomes latency were hard to attribute.

This change threads the Kafka broker timestamp through `AggregatedOutcomesBatch`:
- On `submit`, the broker timestamp of each incoming message is merged into a `LatencyRecorder` on the batch (preserving the running sum and earliest timestamp across all messages in the bucket).
- At flush time, the aggregator emits `accepted_outcomes.flush_broker_latency_ms` (avg) and `accepted_outcomes.max_flush_broker_latency_ms` (max), measuring how long messages waited between hitting the broker and being flushed out of the aggregator.
- After the produce step completes, `produce_outcome` emits the same pair under `produce_broker_latency`, measuring the additional time taken to actually produce to the outcomes-billing topic.

To avoid duplicating the metric-emit logic, `LatencyRecorder::send_metric` now takes a `metric_prefix` argument. The existing `BytesInsertBatch` call sites continue to emit under `insertions.*` while the new outcomes call sites emit under `accepted_outcomes.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)