### PR TITLE
ref(eap-outcomes): remove options

### DIFF
--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -13,12 +13,8 @@ use sentry_arroyo::types::{InnerMessage, Message, Partition};
 use sentry_arroyo::utils::timing::Deadline;
 use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 
-use sentry_options::options;
-
 use crate::processors::utils::{get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs};
 use crate::types::{item_type_name, AggregatedOutcomesBatch, BucketKey, ItemDedupKey};
-
-const OPTIONS_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Default)]
 struct TraceItemOutcome {
@@ -64,12 +60,6 @@ pub struct OutcomesAggregator<TNext> {
     message_carried_over: Option<Message<AggregatedOutcomesBatch>>,
     /// Commit request carried over from a poll where we had a message to retry.
     commit_request_carried_over: Option<CommitRequest>,
-    /// Cached value of the `consumer.use_item_timestamp` option, refreshed at most once per `OPTIONS_REFRESH_INTERVAL`.
-    use_item_timestamp: bool,
-    /// Cached value of the `consumer.log_duplicates` option, refreshed at most once per `OPTIONS_REFRESH_INTERVAL`.
-    log_duplicates: bool,
-    /// Last time cached options were refreshed; `None` means never refreshed yet.
-    last_options_refresh: Option<Instant>,
 }
 
 impl<TNext> OutcomesAggregator<TNext> {
@@ -89,31 +79,7 @@ impl<TNext> OutcomesAggregator<TNext> {
             latest_offsets: HashMap::new(),
             message_carried_over: None,
             commit_request_carried_over: None,
-            use_item_timestamp: false,
-            log_duplicates: false,
-            last_options_refresh: None,
         }
-    }
-
-    fn refresh_options_if_stale(&mut self) {
-        if self
-            .last_options_refresh
-            .is_some_and(|t| t.elapsed() < OPTIONS_REFRESH_INTERVAL)
-        {
-            return;
-        }
-        let snuba_opts = options("snuba").ok();
-        self.use_item_timestamp = snuba_opts
-            .as_ref()
-            .and_then(|o| o.get("consumer.use_item_timestamp").ok())
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        self.log_duplicates = snuba_opts
-            .as_ref()
-            .and_then(|o| o.get("consumer.log_duplicates").ok())
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        self.last_options_refresh = Some(Instant::now());
     }
 
     fn is_duplicate(&mut self, trace_item: &TraceItem) -> bool {
@@ -145,17 +111,6 @@ impl<TNext> OutcomesAggregator<TNext> {
                 item_id,
             };
             let is_dup = self.batch.record_if_duplicate(item_type, dedup_key);
-            if is_dup && self.log_duplicates {
-                let item_type_str = item_type_name(item_type);
-                let item_id_uuid = uuid::Uuid::from_bytes(item_id);
-                tracing::info!(
-                    "duplicate {} trace: org_id:{}, project_id:{}, item_id:{}",
-                    item_type_str,
-                    org_id,
-                    project_id,
-                    item_id_uuid
-                );
-            }
             return is_dup;
         }
         false
@@ -214,8 +169,6 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
     for OutcomesAggregator<TNext>
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
-        self.refresh_options_if_stale();
-
         let commit_request = self.next_step.poll()?;
         self.commit_request_carried_over =
             merge_commit_request(self.commit_request_carried_over.take(), commit_request);
@@ -297,20 +250,11 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
             }
         }
 
-        let ts_secs = if self.use_item_timestamp {
-            trace_item
-                .timestamp
-                .as_ref()
-                .or(trace_item.received.as_ref())
-                .map(|t| t.seconds as u64)
-                .unwrap_or(0)
-        } else {
-            trace_item
-                .received
-                .as_ref()
-                .map(|t| t.seconds as u64)
-                .unwrap_or(0)
-        };
+        let ts_secs = trace_item
+            .received
+            .as_ref()
+            .map(|t| t.seconds as u64)
+            .unwrap_or(0);
 
         let org_id = trace_item.organization_id;
         let project_id = trace_item.project_id;
@@ -372,10 +316,8 @@ mod tests {
     use prost_types::Timestamp;
     use sentry_arroyo::types::{Partition, Topic};
     use sentry_options::init_with_schemas;
-    use sentry_options::testing::override_options;
     use sentry_protos::snuba::v1::TraceItemType;
     use sentry_protos::snuba::v1::{CategoryCount, Outcomes};
-    use serde_json::json;
 
     struct Noop {
         last_message: Option<Message<AggregatedOutcomesBatch>>,
@@ -699,150 +641,6 @@ mod tests {
         assert!(aggregator.message_carried_over.is_some());
     }
 
-    #[test]
-    fn submit_uses_item_timestamp_when_enabled() {
-        init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap();
-        let _guard =
-            override_options(&[("snuba", "consumer.use_item_timestamp", json!(true))]).unwrap();
-        let mut aggregator = OutcomesAggregator::new(
-            Noop { last_message: None },
-            500,
-            Duration::from_millis(2_000),
-            60,
-        );
-
-        let topic = Topic::new("snuba-items");
-        let partition = Partition::new(topic, 0);
-
-        let trace_item = TraceItem {
-            organization_id: 1,
-            project_id: 2,
-            received: Some(Timestamp {
-                seconds: 1_700_000_000,
-                nanos: 0,
-            }),
-            timestamp: Some(Timestamp {
-                seconds: 1_700_000_060,
-                nanos: 0,
-            }),
-            outcomes: Some(Outcomes {
-                key_id: 3,
-                category_count: vec![CategoryCount {
-                    data_category: 4,
-                    quantity: 1,
-                }],
-            }),
-            ..Default::default()
-        };
-        let mut buf = Vec::new();
-        trace_item.encode(&mut buf).unwrap();
-        let payload = KafkaPayload::new(None, None, Some(buf));
-
-        // we need to poll first in order to get the new value (true)
-        aggregator.poll().unwrap();
-
-        aggregator
-            .submit(Message::new_broker_message(
-                payload,
-                partition,
-                0,
-                Utc::now(),
-            ))
-            .unwrap();
-
-        let key = BucketKey {
-            time_offset: 28_333_334, // 1_700_000_060 / 60
-            org_id: 1,
-            project_id: 2,
-            key_id: 3,
-            category: 4,
-        };
-        assert_eq!(
-            aggregator.batch.buckets.get(&key).map(|s| s.quantity),
-            Some(1)
-        );
-    }
-
-    #[test]
-    fn poll_updates_use_item_timestamp_dynamically() {
-        init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap();
-        let mut aggregator = OutcomesAggregator::new(
-            Noop { last_message: None },
-            500,
-            Duration::from_millis(30_000),
-            60,
-        );
-
-        let partition = Partition::new(Topic::new("snuba-items"), 0);
-
-        let mut buf = Vec::new();
-        TraceItem {
-            organization_id: 1,
-            project_id: 2,
-            received: Some(Timestamp {
-                seconds: 1_700_000_000,
-                nanos: 0,
-            }),
-            timestamp: Some(Timestamp {
-                seconds: 1_700_000_060,
-                nanos: 0,
-            }),
-            outcomes: Some(Outcomes {
-                key_id: 3,
-                category_count: vec![CategoryCount {
-                    data_category: 4,
-                    quantity: 1,
-                }],
-            }),
-            ..Default::default()
-        }
-        .encode(&mut buf)
-        .unwrap();
-        let payload = KafkaPayload::new(None, None, Some(buf));
-
-        let bucket_quantity = |aggregator: &OutcomesAggregator<Noop>, offset: u64| {
-            let key = BucketKey {
-                time_offset: offset,
-                org_id: 1,
-                project_id: 2,
-                key_id: 3,
-                category: 4,
-            };
-            aggregator.batch.buckets.get(&key).map(|s| s.quantity)
-        };
-
-        let mut offset = 0;
-        let mut do_submit = |aggregator: &mut OutcomesAggregator<Noop>| {
-            // Bypass the refresh throttle so the test sees option changes immediately.
-            aggregator.last_options_refresh = None;
-            aggregator.poll().unwrap();
-            aggregator
-                .submit(Message::new_broker_message(
-                    payload.clone(),
-                    partition,
-                    offset,
-                    Utc::now(),
-                ))
-                .unwrap();
-            offset += 1;
-        };
-
-        // Enable item timestamp
-        let guard =
-            override_options(&[("snuba", "consumer.use_item_timestamp", json!(true))]).unwrap();
-        do_submit(&mut aggregator);
-        assert_eq!(bucket_quantity(&aggregator, 28_333_334), Some(1));
-        assert_eq!(bucket_quantity(&aggregator, 28_333_333), None);
-
-        // Disable item timestamp
-        drop(guard);
-        let _guard =
-            override_options(&[("snuba", "consumer.use_item_timestamp", json!(false))]).unwrap();
-        do_submit(&mut aggregator);
-        assert_eq!(bucket_quantity(&aggregator, 28_333_333), Some(1));
-        assert_eq!(bucket_quantity(&aggregator, 28_333_334), Some(1)); // still present from first submit
-    }
-
     fn make_payload_with_item_id(
         ts_secs: i64,
         org_id: u64,
@@ -993,77 +791,6 @@ mod tests {
         // First time: not a duplicate
         assert!(!aggregator.is_duplicate(&span_item));
         // Second time: duplicate, count incremented for this item type
-        assert!(aggregator.is_duplicate(&span_item));
-        assert_eq!(
-            aggregator
-                .batch
-                .duplicate_item_count
-                .get(&TraceItemType::Span),
-            Some(&1)
-        );
-    }
-
-    #[test]
-    fn poll_throttles_option_refresh() {
-        init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap();
-        let mut aggregator = OutcomesAggregator::new(
-            Noop { last_message: None },
-            500,
-            Duration::from_millis(30_000),
-            60,
-        );
-
-        // First poll: option is true; cached value should pick it up.
-        let guard =
-            override_options(&[("snuba", "consumer.use_item_timestamp", json!(true))]).unwrap();
-        aggregator.poll().unwrap();
-        assert!(aggregator.use_item_timestamp);
-        assert!(aggregator.last_options_refresh.is_some());
-
-        // Flip the option and poll again immediately; throttle should keep cached value.
-        drop(guard);
-        let _guard =
-            override_options(&[("snuba", "consumer.use_item_timestamp", json!(false))]).unwrap();
-        aggregator.poll().unwrap();
-        assert!(
-            aggregator.use_item_timestamp,
-            "throttle should keep stale cached value within OPTIONS_REFRESH_INTERVAL"
-        );
-
-        // Force the refresh window to be elapsed and poll again; cached value updates.
-        aggregator.last_options_refresh = None;
-        aggregator.poll().unwrap();
-        assert!(!aggregator.use_item_timestamp);
-    }
-
-    #[test]
-    fn is_duplicate_logs_when_option_enabled() {
-        init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap();
-        let _guard =
-            override_options(&[("snuba", "consumer.log_duplicates", json!(true))]).unwrap();
-
-        let mut aggregator = OutcomesAggregator::new(
-            Noop { last_message: None },
-            500,
-            Duration::from_millis(30_000),
-            60,
-        );
-
-        // Refresh options so log_duplicates picks up the override.
-        aggregator.poll().unwrap();
-        assert!(aggregator.log_duplicates);
-
-        let item_id: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-        let span_item = TraceItem {
-            organization_id: 1,
-            project_id: 2,
-            item_id: item_id.clone(),
-            item_type: TraceItemType::Span.into(),
-            ..Default::default()
-        };
-
-        // Counter behavior is unchanged regardless of log_duplicates.
-        assert!(!aggregator.is_duplicate(&span_item));
         assert!(aggregator.is_duplicate(&span_item));
         assert_eq!(
             aggregator

--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -111,6 +111,17 @@ impl<TNext> OutcomesAggregator<TNext> {
                 item_id,
             };
             let is_dup = self.batch.record_if_duplicate(item_type, dedup_key);
+            if is_dup {
+                let item_type_str = item_type_name(item_type);
+                let item_id_uuid = uuid::Uuid::from_bytes(item_id);
+                tracing::info!(
+                    "duplicate {} trace: org_id:{}, project_id:{}, item_id:{}",
+                    item_type_str,
+                    org_id,
+                    project_id,
+                    item_id_uuid
+                );
+            }
             return is_dup;
         }
         false


### PR DESCRIPTION
Removes the options that were used for accepted outcomes:
* `use_item_timestamp` - this was only used to easily compare timestamps when testing out the consumer. never was something that would be rolled out to production. additionally we now have `sentry._internal.received_at` (added in https://github.com/getsentry/snuba/pull/7916) we can use for timestamp comparisons
* `log_duplicates` - this was to help when debugging what messages were actually the duplicates, and since we previously were seeing high number of duplicates we put this behind a flag. Now we should almost never see duplicates, and if we do we should probably log them so we can figure out why. 