### PR TITLE
ref(INC-2179): drop past data older than 30 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,6 @@ jobs:
               tests/sentry/uptime/endpoints/test_organization_uptime_stats.py \
               tests/sentry/api/endpoints/test_organization_traces.py \
               tests/sentry/api/endpoints/test_organization_spans_fields.py \
-              tests/sentry/api/endpoints/test_organization_spans_fields_stats.py \
               tests/sentry/sentry_metrics/querying \
               -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -70,7 +70,7 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
             counter!("eap_items.messages.dropped_out_of_range_timestamp", 1);
             should_skip = true;
         }
-        // only DLQ messages that we don't want to drop (should_skip=false)
+        // only DLQ messages that we don't want to drop (when should_skip=false)
         if !should_skip {
             if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
                 if should_dlq_for_prior_partition(event_ts, now, grace_min) {

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -6,23 +6,30 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 /// One week in seconds. The eap_items table is partitioned by
 /// `(retention_days, toMonday(timestamp))`, so any event more than a week
-/// off will add more parts
-pub const INVALID_TIMESTAMP_INTERVAL_SECONDS: i64 = 7 * 24 * 60 * 60;
+/// in the future will add more parts.
+pub const INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS: i64 = 7 * 24 * 60 * 60;
+
+/// Thirty days in seconds. Events older than this are dropped when invalid
+/// timestamp dropping is enabled.
+pub const INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
 
 /// Runtime config key. When set to `"1"`, the eap-items consumer skips messages
-/// whose event `timestamp` is more than one week from now (see
-/// `out_of_valid_interval_secs`).
+/// whose event `timestamp` is more than one week in the future or more than
+/// thirty days in the past (see `out_of_valid_interval_secs`).
 pub const DROP_INVALID_TIMESTAMPS_KEY: &str = "eap_items_drop_invalid_timestamps";
 
 // Equivalent to "%Y-%m-%dT%H:%M:%S.%fZ" in python
 // Notice the differennce of .%fZ vs %.fZ, this comes from a difference in how rust's chrono handles the format
 const PAYLOAD_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.fZ";
 
-/// Returns true if `ts` is more than `INVALID_TIMESTAMP_INTERVAL_SECONDS` off from
-/// `now` in either direction (past or future).
+/// Returns true if `ts` is more than one week after `now` or more than thirty
+/// days before `now`.
 pub fn out_of_valid_interval_secs(ts: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-    let offset_sec = now.signed_duration_since(ts).num_seconds();
-    offset_sec.abs() > INVALID_TIMESTAMP_INTERVAL_SECONDS
+    if ts > now {
+        ts.signed_duration_since(now).num_seconds() > INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS
+    } else {
+        now.signed_duration_since(ts).num_seconds() > INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS
+    }
 }
 
 pub fn get_drop_invalid_timestamps_enabled() -> bool {
@@ -99,26 +106,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_out_of_valid_interval_secs_drops_messages_more_than_a_week_old() {
+    fn test_out_of_valid_interval_secs_drops_messages_more_than_thirty_days_old() {
         let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let ts = DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_INTERVAL_SECONDS - 1, 0)
-            .unwrap();
+        let ts =
+            DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS - 1, 0)
+                .unwrap();
         assert!(out_of_valid_interval_secs(ts, now));
     }
 
     #[test]
     fn test_out_of_valid_interval_secs_drops_messages_more_than_a_week_in_the_future() {
         let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let ts = DateTime::from_timestamp(2_000_000 + INVALID_TIMESTAMP_INTERVAL_SECONDS + 1, 0)
-            .unwrap();
+        let ts =
+            DateTime::from_timestamp(2_000_000 + INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS + 1, 0)
+                .unwrap();
         assert!(out_of_valid_interval_secs(ts, now));
     }
 
     #[test]
-    fn test_out_of_valid_interval_secs_keeps_messages_at_exactly_one_week_old() {
+    fn test_out_of_valid_interval_secs_keeps_messages_at_exactly_thirty_days_old() {
+        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
+        let ts = DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS, 0)
+            .unwrap();
+        assert!(!out_of_valid_interval_secs(ts, now));
+    }
+
+    #[test]
+    fn test_out_of_valid_interval_secs_keeps_messages_more_than_a_week_old_but_within_thirty_days()
+    {
         let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
         let ts =
-            DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_INTERVAL_SECONDS, 0).unwrap();
+            DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS - 1, 0)
+                .unwrap();
         assert!(!out_of_valid_interval_secs(ts, now));
     }
 

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -25,11 +25,9 @@ const PAYLOAD_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.fZ";
 /// Returns true if `ts` is more than one week after `now` or more than thirty
 /// days before `now`.
 pub fn out_of_valid_interval_secs(ts: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-    if ts > now {
-        ts.signed_duration_since(now).num_seconds() > INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS
-    } else {
-        now.signed_duration_since(ts).num_seconds() > INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS
-    }
+    let offset_sec = ts.signed_duration_since(now).num_seconds();
+    offset_sec > INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS
+        || offset_sec < -INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS
 }
 
 pub fn get_drop_invalid_timestamps_enabled() -> bool {
@@ -128,16 +126,6 @@ mod tests {
         let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
         let ts = DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS, 0)
             .unwrap();
-        assert!(!out_of_valid_interval_secs(ts, now));
-    }
-
-    #[test]
-    fn test_out_of_valid_interval_secs_keeps_messages_more_than_a_week_old_but_within_thirty_days()
-    {
-        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let ts =
-            DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS - 1, 0)
-                .unwrap();
         assert!(!out_of_valid_interval_secs(ts, now));
     }
 

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -26,8 +26,8 @@ const PAYLOAD_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.fZ";
 /// days before `now`.
 pub fn out_of_valid_interval_secs(ts: DateTime<Utc>, now: DateTime<Utc>) -> bool {
     let offset_sec = ts.signed_duration_since(now).num_seconds();
-    offset_sec > INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS
-        || offset_sec < -INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS
+    !(-INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS..=INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS)
+        .contains(&offset_sec)
 }
 
 pub fn get_drop_invalid_timestamps_enabled() -> bool {


### PR DESCRIPTION
Changes https://github.com/getsentry/snuba/pull/7945 to only drop items that are older than 30 days instead of 1 week. The past data that is within the 30 threshold will be DLQ'd but it will be processed eventually. 