### PR TITLE
ref(eap-outcomes): remove skip_produce

### DIFF
--- a/rust_snuba/src/accepted_outcomes_consumer.rs
+++ b/rust_snuba/src/accepted_outcomes_consumer.rs
@@ -20,7 +20,6 @@ use crate::config;
 use crate::logging::{setup_logging, setup_sentry};
 use crate::metrics::global_tags::set_global_tag;
 use crate::metrics::statsd::StatsDBackend;
-use crate::runtime_config::get_str_config;
 use crate::strategies::accepted_outcomes::aggregator::OutcomesAggregator;
 use crate::strategies::accepted_outcomes::commit_outcomes::CommitOutcomes;
 use crate::strategies::accepted_outcomes::produce_outcome::ProduceAcceptedOutcome;
@@ -34,7 +33,6 @@ pub struct AcceptedOutcomesStrategyFactory {
     produce_topic: Topic,
     producer: Arc<KafkaProducer>,
     concurrency: ConcurrencyConfig,
-    skip_produce: bool,
 }
 
 impl ProcessingStrategyFactory<KafkaPayload> for AcceptedOutcomesStrategyFactory {
@@ -51,7 +49,6 @@ impl ProcessingStrategyFactory<KafkaPayload> for AcceptedOutcomesStrategyFactory
             self.producer.clone(),
             self.produce_topic,
             &self.concurrency,
-            self.skip_produce,
         );
         let commit = CommitOutcomes::new(produce, Some(self.commit_frequency));
         Box::new(OutcomesAggregator::new(
@@ -203,12 +200,6 @@ pub fn accepted_outcomes_consumer_impl(
         KafkaConfig::new_producer_config(vec![], Some(topic_config.broker_config));
     let producer = Arc::new(KafkaProducer::new(producer_config));
     let produce_topic = Topic::new(&topic_config.physical_topic_name);
-    // Default to skipping produce for now
-    let skip_produce = get_str_config("accepted_outcomes_skip_produce")
-        .ok()
-        .flatten()
-        .unwrap_or("1".to_string())
-        == "1";
 
     let factory = AcceptedOutcomesStrategyFactory {
         bucket_interval,
@@ -218,7 +209,6 @@ pub fn accepted_outcomes_consumer_impl(
         produce_topic,
         producer,
         concurrency: ConcurrencyConfig::new(concurrency),
-        skip_produce,
     };
     let processor = StreamProcessor::with_kafka(config, factory, topic, dlq_policy);
 

--- a/rust_snuba/src/strategies/accepted_outcomes/produce_outcome.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/produce_outcome.rs
@@ -16,19 +16,13 @@ use std::time::{Duration, SystemTime};
 struct ProduceOutcome {
     producer: Arc<dyn Producer<KafkaPayload>>,
     destination: Topic,
-    skip_produce: bool,
 }
 
 impl ProduceOutcome {
-    pub fn new(
-        producer: Arc<dyn Producer<KafkaPayload> + 'static>,
-        destination: Topic,
-        skip_produce: bool,
-    ) -> Self {
+    pub fn new(producer: Arc<dyn Producer<KafkaPayload> + 'static>, destination: Topic) -> Self {
         ProduceOutcome {
             producer,
             destination,
-            skip_produce,
         }
     }
 }
@@ -42,7 +36,6 @@ impl TaskRunner<AggregatedOutcomesBatch, AggregatedOutcomesBatch, anyhow::Error>
     ) -> RunTaskFunc<AggregatedOutcomesBatch, anyhow::Error> {
         let producer = self.producer.clone();
         let destination: TopicOrPartition = self.destination.into();
-        let skip_produce = self.skip_produce;
 
         Box::pin(async move {
             let produce_start = SystemTime::now();
@@ -67,10 +60,6 @@ impl TaskRunner<AggregatedOutcomesBatch, AggregatedOutcomesBatch, anyhow::Error>
                     category: key.category,
                     quantity: stats.quantity,
                 };
-
-                if skip_produce {
-                    continue;
-                }
 
                 let payload_bytes = serde_json::to_vec(&outcome).map_err(|e| {
                     RunTaskError::Other(anyhow::anyhow!("serialization error: {e}"))
@@ -109,11 +98,10 @@ where
         producer: Arc<dyn Producer<KafkaPayload> + 'static>,
         destination: Topic,
         concurrency: &ConcurrencyConfig,
-        skip_produce: bool,
     ) -> Self {
         let inner = RunTaskInThreads::new(
             next_step,
-            ProduceOutcome::new(producer, destination, skip_produce),
+            ProduceOutcome::new(producer, destination),
             concurrency,
             Some("produce_outcome"),
         );
@@ -208,7 +196,6 @@ mod tests {
             Arc::new(producer),
             Topic::new("test-outcomes"),
             &concurrency,
-            false,
         );
 
         strategy
@@ -219,60 +206,6 @@ mod tests {
 
         let produced = produced_payloads.lock().unwrap();
         assert_eq!(produced.len(), 2);
-    }
-
-    #[test]
-    fn skip_produce_does_not_produce() {
-        struct MockProducer {
-            pub payloads: Arc<Mutex<Vec<KafkaPayload>>>,
-        }
-
-        impl Producer<KafkaPayload> for MockProducer {
-            fn produce(
-                &self,
-                _topic: &TopicOrPartition,
-                payload: KafkaPayload,
-            ) -> Result<(), ProducerError> {
-                self.payloads.lock().unwrap().push(payload);
-                Ok(())
-            }
-        }
-
-        let produced_payloads = Arc::new(Mutex::new(Vec::new()));
-
-        let mut batch = AggregatedOutcomesBatch::new(60);
-        batch.buckets.insert(
-            BucketKey {
-                time_offset: 100,
-                org_id: 1,
-                project_id: 100,
-                key_id: 10,
-                category: 1,
-            },
-            BucketStats::new(5),
-        );
-
-        let producer = MockProducer {
-            payloads: produced_payloads.clone(),
-        };
-
-        let concurrency = ConcurrencyConfig::new(1);
-        let mut strategy = ProduceAcceptedOutcome::new(
-            Noop,
-            Arc::new(producer),
-            Topic::new("test-outcomes"),
-            &concurrency,
-            true, // skip_produce
-        );
-
-        strategy
-            .submit(Message::new_any_message(batch, BTreeMap::new()))
-            .unwrap();
-        strategy.poll().unwrap();
-        strategy.join(None).unwrap();
-
-        let produced = produced_payloads.lock().unwrap();
-        assert_eq!(produced.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
No reason to have `skip_produce` now  - should have been removed earlier