### PR TITLE
build: try ghcr.io/oioki/python-base-image for distroless targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,7 +163,7 @@ RUN ln -sf /opt/python/bin/python3 /.venv/bin/python3 && \
 RUN find /.venv -name "*.so" -exec ldd {} \; 2>&1 | grep "not found" && exit 1 || true
 
 # Distroless production image — minimal attack surface, no shell
-FROM ghcr.io/getsentry/dhi/python:3.13-debian13 AS application-distroless
+FROM ghcr.io/oioki/python-base-image/python:3.13-debian13 AS application-distroless
 
 COPY --from=distroless_prep /.venv /.venv
 COPY --from=distroless_prep /usr/src/snuba /usr/src/snuba
@@ -187,7 +187,7 @@ ENTRYPOINT ["python3", "/usr/src/snuba/docker_entrypoint.py"]
 CMD ["api"]
 
 # Debug distroless image — includes busybox (sh, ls, cat, wget, env, etc.)
-FROM ghcr.io/getsentry/dhi/python:3.13-debian13-dev AS application-distroless-debug
+FROM ghcr.io/oioki/python-base-image/python:3.13-debian13-dev AS application-distroless-debug
 
 COPY --from=distroless_prep /.venv /.venv
 COPY --from=distroless_prep /usr/src/snuba /usr/src/snuba


### PR DESCRIPTION
## Summary

Swap the `application-distroless` and `application-distroless-debug` base images from `ghcr.io/getsentry/dhi/python:3.13-debian13(-dev)` to `ghcr.io/oioki/python-base-image/python:3.13-debian13(-dev)`.

This is **draft / showcase only** — demonstrating that a community-built distroless Python image can be a drop-in for DHI here. Not intended to merge.

## What's the replacement image

[`oioki/python-base-image`](https://github.com/oioki/python-base-image) — a distroless Python 3.13 base built from scratch on Debian 13. Multi-arch (amd64+arm64), published to GHCR.

Same layout as DHI:
- Python at `/opt/python/bin/python3`
- `LD_LIBRARY_PATH=/opt/python/lib`
- CA bundle at `/etc/ssl/certs/ca-certificates.crt`
- ENTRYPOINT `python3`
- UID/GID 65532 `nonroot` (snuba's `distroless_prep` overwrites `/etc/passwd` anyway)

Difference vs DHI: build is a plain Dockerfile that walks CPython's shared-library closure (`ldd`-driven, transitive) rather than apko/melange-style exclusion lists. Resulting image is 73.7 MB (vs DHI's 83.6 MB measured locally).

## Test plan
- [x] `docker buildx build --target application-distroless .` — green locally
- [x] Resulting image: 842 MB (vs 864 MB with DHI baseline)
- [ ] CI on this branch builds both `application-distroless` and `application-distroless-debug`

## Known caveat (pre-existing, NOT caused by this change)
Running `snuba --help` against the resulting distroless image fails with `ModuleNotFoundError: No module named 'encodings'` — the venv's `pyvenv.cfg` still references `/usr/local/bin` from the build image. **The DHI-based image (current master) fails identically**, so this PR doesn't regress anything. A fix is a one-line `sed` in `distroless_prep` but is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)