### PR TITLE
feat(replacer): expose --max-poll-interval-ms and --health-check-file into the CLI

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -57,6 +57,17 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option("--log-level", help="Logging level to use.")
+@click.option(
+    "--health-check-file",
+    default=None,
+    type=str,
+    help="Arroyo will touch this file at intervals to indicate health. If not provided, no health check is performed.",
+)
+@click.option(
+    "--max-poll-interval-ms",
+    type=int,
+    default=30000,
+)
 def replacer(
     *,
     replacements_topic: Optional[str],
@@ -68,6 +79,8 @@ def replacer(
     queued_max_messages_kbytes: int,
     queued_min_messages: int,
     log_level: Optional[str] = None,
+    health_check_file: Optional[str] = None,
+    max_poll_interval_ms: int = 30000,
 ) -> None:
     from arroyo import Topic, configure_metrics
     from arroyo.backends.kafka import KafkaConsumer
@@ -97,6 +110,12 @@ def replacer(
 
     configure_metrics(StreamMetricsAdapter(metrics))
 
+    consumer_config = {
+        "max.poll.interval.ms": max_poll_interval_ms,
+    }
+    if max_poll_interval_ms < 45000:
+        consumer_config["session.timeout.ms"] = max_poll_interval_ms
+
     replacer = StreamProcessor(
         KafkaConsumer(
             build_kafka_consumer_configuration(
@@ -107,11 +126,13 @@ def replacer(
                 strict_offset_reset=not no_strict_offset_reset,
                 queued_max_messages_kbytes=queued_max_messages_kbytes,
                 queued_min_messages=queued_min_messages,
+                override_params=consumer_config,
             ),
         ),
         Topic(replacements_topic),
         ReplacerStrategyFactory(
             worker=ReplacerWorker(storage, consumer_group, metrics=metrics),
+            health_check_file=health_check_file,
         ),
         ONCE_PER_SECOND,
     )

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -26,6 +26,7 @@ from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
+from arroyo.processing.strategies.healthcheck import Healthcheck
 from arroyo.types import BrokerValue, Commit, Message, Partition
 
 from snuba import settings
@@ -288,8 +289,10 @@ class ReplacerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     def __init__(
         self,
         worker: ReplacerWorker,
+        health_check_file: Optional[str] = None,
     ) -> None:
         self.__worker = worker
+        self.__health_check_file = health_check_file
 
     def create_with_partitions(
         self,
@@ -303,7 +306,12 @@ class ReplacerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
         commit_offsets: ProcessingStrategy[Any] = CommitOffsets(commit)
 
-        return RunTask(processing_func, commit_offsets)
+        strategy: ProcessingStrategy[KafkaPayload] = RunTask(processing_func, commit_offsets)
+
+        if self.__health_check_file is not None:
+            strategy = Healthcheck(self.__health_check_file, strategy)
+
+        return strategy
 
 
 class ReplacerWorker:

--- a/tests/cli/test_replacer.py
+++ b/tests/cli/test_replacer.py
@@ -1,0 +1,63 @@
+from typing import Sequence
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+import snuba.cli.replacer
+import snuba.replacer
+import snuba.utils.streams.configuration_builder
+from snuba.cli.replacer import replacer
+
+
+@patch("arroyo.processing.StreamProcessor")
+@patch("arroyo.backends.kafka.KafkaConsumer")
+@patch(
+    "snuba.utils.streams.configuration_builder.build_kafka_consumer_configuration",
+    return_value={"bootstrap.servers": "localhost"},
+)
+@patch.object(snuba.replacer, "ReplacerStrategyFactory")
+@patch.object(snuba.replacer, "ReplacerWorker")
+@patch.object(snuba.cli.replacer, "get_writable_storage")
+@patch.object(snuba.cli.replacer, "setup_logging")
+@patch.object(snuba.cli.replacer, "setup_sentry")
+@patch.object(snuba.cli.replacer, "configure_metrics")
+@patch.object(snuba.cli.replacer, "signal")
+def test_replacer_cli(
+    *_mocks: Sequence[Mock],
+) -> None:
+    storage = Mock()
+    topic_spec = Mock()
+    topic_spec.topic_name = "replacements-topic"
+    topic_spec.topic = Mock()
+    storage.get_table_writer.return_value.get_stream_loader.return_value.get_replacement_topic_spec.return_value = (
+        topic_spec
+    )
+    snuba.cli.replacer.get_writable_storage.return_value = storage
+
+    worker = Mock()
+    snuba.replacer.ReplacerWorker.return_value = worker
+
+    runner = CliRunner()
+    result = runner.invoke(
+        replacer,
+        [
+            "--storage",
+            "errors",
+            "--health-check-file",
+            "/tmp/health.txt",
+            "--max-poll-interval-ms",
+            "12345",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert snuba.replacer.ReplacerStrategyFactory.call_args.kwargs == {
+        "worker": worker,
+        "health_check_file": "/tmp/health.txt",
+    }
+    assert snuba.utils.streams.configuration_builder.build_kafka_consumer_configuration.call_args.kwargs[
+        "override_params"
+    ] == {
+        "max.poll.interval.ms": 12345,
+        "session.timeout.ms": 12345,
+    }

--- a/tests/cli/test_replacer.py
+++ b/tests/cli/test_replacer.py
@@ -37,9 +37,7 @@ def test_replacer_cli(
     topic_spec = Mock()
     topic_spec.topic_name = "replacements-topic"
     topic_spec.topic = Mock()
-    storage.get_table_writer.return_value.get_stream_loader.return_value.get_replacement_topic_spec.return_value = (
-        topic_spec
-    )
+    storage.get_table_writer.return_value.get_stream_loader.return_value.get_replacement_topic_spec.return_value = topic_spec
     get_writable_storage.return_value = storage
 
     worker = Mock()
@@ -63,9 +61,7 @@ def test_replacer_cli(
         "worker": worker,
         "health_check_file": "/tmp/health.txt",
     }
-    assert build_kafka_consumer_configuration.call_args.kwargs[
-        "override_params"
-    ] == {
+    assert build_kafka_consumer_configuration.call_args.kwargs["override_params"] == {
         "max.poll.interval.ms": 12345,
         "session.timeout.ms": 12345,
     }

--- a/tests/cli/test_replacer.py
+++ b/tests/cli/test_replacer.py
@@ -1,4 +1,3 @@
-from typing import Sequence
 from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
@@ -20,10 +19,19 @@ from snuba.cli.replacer import replacer
 @patch.object(snuba.cli.replacer, "get_writable_storage")
 @patch.object(snuba.cli.replacer, "setup_logging")
 @patch.object(snuba.cli.replacer, "setup_sentry")
-@patch.object(snuba.cli.replacer, "configure_metrics")
+@patch("arroyo.configure_metrics")
 @patch.object(snuba.cli.replacer, "signal")
 def test_replacer_cli(
-    *_mocks: Sequence[Mock],
+    _signal: Mock,
+    _configure_metrics: Mock,
+    _setup_sentry: Mock,
+    _setup_logging: Mock,
+    get_writable_storage: Mock,
+    replacer_worker: Mock,
+    replacer_strategy_factory: Mock,
+    build_kafka_consumer_configuration: Mock,
+    _kafka_consumer: Mock,
+    _stream_processor: Mock,
 ) -> None:
     storage = Mock()
     topic_spec = Mock()
@@ -32,10 +40,10 @@ def test_replacer_cli(
     storage.get_table_writer.return_value.get_stream_loader.return_value.get_replacement_topic_spec.return_value = (
         topic_spec
     )
-    snuba.cli.replacer.get_writable_storage.return_value = storage
+    get_writable_storage.return_value = storage
 
     worker = Mock()
-    snuba.replacer.ReplacerWorker.return_value = worker
+    replacer_worker.return_value = worker
 
     runner = CliRunner()
     result = runner.invoke(
@@ -51,11 +59,11 @@ def test_replacer_cli(
     )
 
     assert result.exit_code == 0, result.output
-    assert snuba.replacer.ReplacerStrategyFactory.call_args.kwargs == {
+    assert replacer_strategy_factory.call_args.kwargs == {
         "worker": worker,
         "health_check_file": "/tmp/health.txt",
     }
-    assert snuba.utils.streams.configuration_builder.build_kafka_consumer_configuration.call_args.kwargs[
+    assert build_kafka_consumer_configuration.call_args.kwargs[
         "override_params"
     ] == {
         "max.poll.interval.ms": 12345,

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -9,6 +9,7 @@ from unittest import mock
 import pytest
 import simplejson as json
 from arroyo.backends.kafka import KafkaPayload
+from arroyo.processing.strategies.healthcheck import Healthcheck
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
 from snuba import replacer, settings
@@ -423,3 +424,14 @@ class TestReplacer:
             # exclude_groups from project setter, start_merge from group setter
             {ReplacementType.EXCLUDE_GROUPS, ReplacementType.START_MERGE},
         )
+
+    def test_replacer_strategy_factory_wraps_healthcheck(self) -> None:
+        worker = mock.Mock()
+        factory = replacer.ReplacerStrategyFactory(
+            worker=worker,
+            health_check_file="/tmp/health.txt",
+        )
+
+        strategy = factory.create_with_partitions(mock.Mock(), {})
+
+        assert isinstance(strategy, Healthcheck)


### PR DESCRIPTION
Currently there are no way in self-hosted to be able to configure many things on `snuba replacer`. This PR adds `--max-poll-interval-ms` and `--health-check-file`.