### PR TITLE
ref(gocd): bump gocd-jsonnet to v3.0.3

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.0"
+      "version": "v3.0.3"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "3465d94bb68e41c24d93a80d0b3f0ab8168d26c6",
-      "sum": "SbALpMwOdnmqi5w6cJKPOWDp3gcuafqk7JCninnrrLA="
+      "version": "11c0c766fc66ef7d1b100f8c83b0ba56612bab2e",
+      "sum": "DwMwLzsG4k4fqJWibFgTk71p93ivdFupCpftwDbK5xU="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Bump to v3.0.3 to mitigate issues with the pipeline/job name changes introduced in v3.0.0 (grouped pipedream's cell-name auto-suffix), in particular interactions with the auto-rollback script.