### PR TITLE
ref(gocd): gocd-jsonnet 3.0.4

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.0"
+      "version": "v3.0.4"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
## Summary
- Bumps the `gocd-jsonnet` library from v3.0.0 to v3.0.4 in `gocd/templates/jsonnetfile.json`

## Test plan
- [ ] GoCD pipeline templates render correctly after the version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)