### PR TITLE
ref(gocd): update jsonnetfile.lock.json for gocd-jsonnet 3.0.4

### DIFF
--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "3465d94bb68e41c24d93a80d0b3f0ab8168d26c6",
-      "sum": "SbALpMwOdnmqi5w6cJKPOWDp3gcuafqk7JCninnrrLA="
+      "version": "7a25c44956933a57b5ca03beb3b70c470724c2c8",
+      "sum": "0S+eGE0WHdxJxKS/Bdga+NB+cB+ZBwF4LoehKv0azXc="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
## Summary
- Follow-up to #7963, which bumped `gocd-jsonnet` to 3.0.4 in `jsonnetfile.json` but did not regenerate the lockfile.

## Test plan
- [ ] GoCD pipeline templates render correctly with the updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)