### PR TITLE
feat(docker): Add granian_entrypoint.py

### DIFF
--- a/granian_entrypoint.py
+++ b/granian_entrypoint.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Python equivalent of granian_entrypoint.sh.
+
+Mirrors the behavior of the bash script currently shipped to SaaS:
+optionally waits for envoy admin to report LIVE, then execs granian
+with the WSGI app.
+
+Provides a shell-free entrypoint so deployment manifests can invoke
+`python3 ./granian_entrypoint.py` instead of `./granian_entrypoint.sh`.
+"""
+
+import os
+import time
+import urllib.error
+import urllib.request
+
+
+def wait_for_envoy() -> None:
+    port = os.environ.get("ENVOY_ADMIN_PORT")
+    if not port:
+        print("ENVOY_ADMIN_PORT env var is unset")
+        print("Fall through to snuba start without check")
+        return
+
+    url = f"http://localhost:{port}/ready"
+    print(f"Check envoy readiness on {url}")
+    while True:
+        time.sleep(1)
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.read().decode().strip() == "LIVE":
+                    print("Envoy is ready")
+                    return
+        except Exception:
+            pass
+        print("Envoy not ready, looping..")
+
+
+def main() -> None:
+    wait_for_envoy()
+
+    wsgi_target = os.environ.get("SNUBA_WSGI_TARGET", "snuba.web.wsgi:application")
+    args = ["granian", "--interface", "wsgi", "--host", "0.0.0.0", "--http", "auto", wsgi_target]
+    os.execvp(args[0], args)
+
+
+if __name__ == "__main__":
+    main()

--- a/granian_entrypoint.py
+++ b/granian_entrypoint.py
@@ -14,6 +14,7 @@ import os
 import time
 import urllib.error
 import urllib.request
+from datetime import datetime
 
 
 def wait_for_envoy() -> None:
@@ -42,6 +43,14 @@ def main() -> None:
 
     wsgi_target = os.environ.get("SNUBA_WSGI_TARGET", "snuba.web.wsgi:application")
     args = ["granian", "--interface", "wsgi", "--host", "0.0.0.0", "--http", "auto", wsgi_target]
+
+    if os.environ.get("ENABLE_HEAPTRACK"):
+        # The bash predecessor had a latent bug: it built a `heaptrack …` argv
+        # via `set --` but then `exec granian …` instead of `exec "$@"`, so the
+        # wrapping never took effect. Fix it here by actually prepending.
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        args = ["heaptrack", "-o", f"./profiler_data/profile_{timestamp}"] + args
+
     os.execvp(args[0], args)
 
 


### PR DESCRIPTION
Adds a Python equivalent of `granian_entrypoint.sh` — the script that
currently runs in SaaS api/admin pods via the snuba ConfigMap. Same
behavior: optionally wait for envoy admin to report `LIVE`, then exec
granian with the WSGI app.

The motivation is to remove the bash dependency from the entrypoint
path. Today's `granian_entrypoint.sh` invokes itself with `#!/bin/bash`
and uses `curl`, neither of which exist in the upcoming distroless
image variant. A pure-Python script with the same behavior lets us
land the entrypoint switch as a standalone, low-risk change first
(SaaS deployments can move to `python3 ./granian_entrypoint.py`
against the existing image) and then swap to the distroless image
without any further manifest change.

No existing call site changes here — this is just the new file.
The follow-ups will live in `getsentry/ops`.