### PR TITLE
fix(docker): Detect snuba subcommands via listdir instead of --help probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,17 @@ jobs:
       - name: Verify --help works
         run: docker run --rm snuba-distroless:test --help
 
+      - name: Verify subcommand resolution (api)
+        # Exercises the docker_entrypoint.py path where args[0] does NOT
+        # start with "-". This is the default self-hosted snuba-api
+        # invocation and the path that previously fell through to a
+        # FileNotFoundError when the snuba --help probe timed out.
+        run: docker run --rm snuba-distroless:test api --help
+
+      - name: Verify subcommand resolution (rust-consumer)
+        # rust-consumer is what every self-hosted consumer service runs.
+        run: docker run --rm snuba-distroless:test rust-consumer --help
+
       - name: Verify Python imports
         run: |
           docker run --rm --entrypoint python3 snuba-distroless:test \

--- a/docker_entrypoint.py
+++ b/docker_entrypoint.py
@@ -1,8 +1,27 @@
 #!/usr/bin/env python3
 import os
-import subprocess
 import sys
 from datetime import datetime
+
+CLI_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "snuba", "cli")
+
+
+def _is_snuba_subcommand(name: str) -> bool:
+    # Snuba's CLI auto-discovers commands from files in snuba/cli/, with
+    # underscores in filenames replaced by dashes in the command name
+    # (see SnubaCLI in snuba/cli/__init__.py). Mirror that lookup here so
+    # we can detect subcommands without spawning a `snuba <cmd> --help`
+    # probe — that probe runs initialize_snuba() inside get_command and
+    # routinely takes 7s+, with a hard 30s timeout that occasionally
+    # fires under load. When the timeout fired, the previous code swallowed
+    # the exception and execvp'd args[0] directly, which then failed with
+    # FileNotFoundError because subcommand names like "api" or
+    # "rust-consumer" aren't binaries.
+    filename = name.replace("-", "_") + ".py"
+    try:
+        return filename in os.listdir(CLI_DIR)
+    except OSError:
+        return False
 
 
 def main() -> None:
@@ -10,26 +29,8 @@ def main() -> None:
     if not args:
         args = ["api"]
 
-    if args[0].startswith("-"):
+    if args[0].startswith("-") or _is_snuba_subcommand(args[0]):
         args = ["snuba"] + args
-    else:
-        try:
-            result = subprocess.run(
-                ["snuba", args[0], "--help"],
-                capture_output=True,
-                timeout=30,
-            )
-            if result.returncode == 0:
-                args = ["snuba"] + args
-            else:
-                print(
-                    f"Error running snuba {args[0]} --help, passing command to exec directly.",
-                    file=sys.stderr,
-                )
-                print(result.stdout.decode(errors="replace"), file=sys.stderr)
-                print(result.stderr.decode(errors="replace"), file=sys.stderr)
-        except Exception:
-            pass
 
     if os.environ.get("ENABLE_HEAPTRACK"):
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")


### PR DESCRIPTION
Self-hosted users running on the distroless `:nightly-distroless` image have been hitting `FileNotFoundError: [Errno 2] No such file or directory` from `os.execvp(args[0], args)` in `docker_entrypoint.py` for the api and consumer services. The api logs also sometimes show snuba starting once before crashing into the same traceback on container restart, which made it look intermittent.

## Root cause

`docker_entrypoint.py` decides whether to prepend `snuba` to argv by probing:

```python
result = subprocess.run(["snuba", args[0], "--help"], capture_output=True, timeout=30)
```

That subprocess is expensive — `snuba <cmd> --help` runs `initialize_snuba()` inside `SnubaCLI.get_command` (`snuba/cli/__init__.py:56`) before emitting help text. Snuba init takes ~7s in production, the subprocess has `capture_output=True` (buffering all of structlog's stderr), and the `timeout=30` window occasionally fires under load. When it does, the surrounding `except Exception: pass` swallows it silently and argv stays as `["api"]` / `["rust-consumer", …]`, which then dies in `execvp` because those aren't binaries.

## Fix

Detect snuba subcommands by listing `snuba/cli/` — the same mechanism `SnubaCLI` itself uses to enumerate commands (`os.listdir(plugin_folder)`, with underscores→dashes). No subprocess, no timeout window, no silent failure path. Container startup drops by ~7s as a side effect since we no longer initialize snuba twice.

## Why the existing CI smoke test didn't catch this

`ci.yml` had one `docker run --rm snuba-distroless:test --help` step. `--help` starts with `-`, which skips the broken probe path entirely (the `if args[0].startswith("-"):` branch). Two new steps exercise the actual subcommand path: `api --help` (self-hosted snuba-api default) and `rust-consumer --help` (every self-hosted consumer service).

## Why "listdir" specifically

Considered alternatives:

- **Keep the probe, just stop swallowing the exception.** Smaller diff, but doesn't fix the root cause — slow + flaky probe stays, and we still pay the ~7s startup tax on every container start.
- **Hardcode the subcommand list.** Drift risk every time someone adds a CLI command.
- **Always prepend `snuba` unconditionally.** Works for our distroless image (only python3/snuba on PATH) but breaks the distroless-debug variant where you might want `docker run image sh` or another busybox command.

Mirroring snuba's own discovery mechanism keeps it self-consistent with `SnubaCLI` and has zero maintenance overhead.