### PR TITLE
feat(eap): Route select queries to read-only cluster

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -17,6 +17,7 @@ _HARDCODED_STORAGE_SET_KEYS = {
     "FUNCTIONS": "functions",
     "SEARCH_ISSUES": "search_issues",
     "EVENTS_ANALYTICS_PLATFORM": "events_analytics_platform",
+    "EVENTS_ANALYTICS_PLATFORM_RO": "events_analytics_platform_ro",
     "GROUP_ATTRIBUTES": "group_attributes",
     "PROFILE_CHUNKS": "profile_chunks",
 }

--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
@@ -55,6 +55,38 @@ storages:
             to_col_table: null
             to_col_name: _hash_map_float
             num_attribute_buckets: 40
+  - storage: eap_items_ro
+    is_writable: false
+    translation_mappers:
+      subscriptables:
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_string
+            to_col_table: null
+            to_col_name: attributes_string
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_float
+            to_col_table: null
+            to_col_name: attributes_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_string
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_float
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
   # listing all the materialized views so they get dropped with the entity
   - storage: eap_items_downsample_8
     is_writable: false
@@ -63,6 +95,14 @@ storages:
   - storage: eap_items_downsample_512
     is_writable: false
   - storage: eap_item_co_occurring_attrs
+    is_writable: false
+  - storage: eap_items_downsample_8_ro
+    is_writable: false
+  - storage: eap_items_downsample_64_ro
+    is_writable: false
+  - storage: eap_items_downsample_512_ro
+    is_writable: false
+  - storage: eap_item_co_occurring_attrs_ro
     is_writable: false
 
 storage_selector:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_item_co_occurring_attrs_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_item_co_occurring_attrs_ro.yaml
@@ -1,0 +1,29 @@
+version: v1
+kind: readable_storage
+name: eap_item_co_occurring_attrs_ro
+
+storage:
+  key: eap_item_co_occurring_attrs_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: date, type: Date},
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: attribute_keys_hash, type: Array, args: { inner_type: { type: UInt, args: { size: 64 } } } },
+      { name: attributes_string, type: Array, args: { inner_type: { type: String } } },
+      { name: attributes_float, type: Array, args: { inner_type: { type: String } } },
+      { name: attributes_bool, type: Array, args: { inner_type: { type: String } } }
+    ]
+  local_table_name: eap_item_co_occurring_attrs_1_local
+  dist_table_name: eap_item_co_occurring_attrs_1_dist
+  partition_format: [retention_days, date]
+allocation_policies: []

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512_ro.yaml
@@ -1,0 +1,137 @@
+version: v1
+kind: readable_storage
+name: eap_items_downsample_512_ro
+
+storage:
+  key: eap_items_downsample_512_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+    ]
+  local_table_name: eap_items_1_downsample_512_local
+  dist_table_name: eap_items_1_downsample_512_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64_ro.yaml
@@ -1,0 +1,138 @@
+version: v1
+kind: readable_storage
+name: eap_items_downsample_64_ro
+
+storage:
+  key: eap_items_downsample_64_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+    ]
+  local_table_name: eap_items_1_downsample_64_local
+  dist_table_name: eap_items_1_downsample_64_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8_ro.yaml
@@ -1,0 +1,137 @@
+version: v1
+kind: readable_storage
+name: eap_items_downsample_8_ro
+
+storage:
+  key: eap_items_downsample_8_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+    ]
+  local_table_name: eap_items_1_downsample_8_local
+  dist_table_name: eap_items_1_downsample_8_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_ro.yaml
@@ -1,0 +1,138 @@
+version: v1
+kind: readable_storage
+name: eap_items_ro
+
+storage:
+  key: eap_items_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+      { name: downsampled_retention_days, type: UInt, args: { size: 16 } },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+    ]
+  local_table_name: eap_items_1_local
+  dist_table_name: eap_items_1_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/entities/storage_selectors/eap_items.py
+++ b/snuba/datasets/entities/storage_selectors/eap_items.py
@@ -1,5 +1,6 @@
 from typing import Sequence
 
+from snuba import state
 from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.storage import EntityStorageConnection
 from snuba.datasets.storages.factory import get_storage
@@ -20,10 +21,16 @@ class EAPItemsStorageSelector(QueryStorageSelector):
 
         tier = query_settings.get_sampling_tier()
 
+        use_readonly_storage = (
+            state.get_config("enable_eap_readonly_table", False)
+            and not query_settings.get_consistent()
+        )
+
         if tier == Tier.TIER_1 or tier == Tier.TIER_NO_TIER:
-            storage_key = StorageKey.EAP_ITEMS
+            storage_key = StorageKey.EAP_ITEMS_RO if use_readonly_storage else StorageKey.EAP_ITEMS
         else:
-            storage_key = getattr(StorageKey, f"EAP_ITEMS_DOWNSAMPLE_{tier.value}")
+            suffix = "_RO" if use_readonly_storage else ""
+            storage_key = getattr(StorageKey, f"EAP_ITEMS_DOWNSAMPLE_{tier.value}{suffix}")
 
         return EntityStorageConnection(
             storage=get_storage(storage_key),

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -164,7 +164,10 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     ),
     MigrationGroup.EVENTS_ANALYTICS_PLATFORM: _MigrationGroup(
         loader=EventsAnalyticsPlatformLoader(),
-        storage_sets_keys={StorageSetKey.EVENTS_ANALYTICS_PLATFORM},
+        storage_sets_keys={
+            StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+            StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO,
+        },
         readiness_state=ReadinessState.COMPLETE,
     ),
     MigrationGroup.GROUP_ATTRIBUTES: _MigrationGroup(

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -130,6 +130,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "search_issues",
             "generic_metrics_counters",
             "events_analytics_platform",
+            "events_analytics_platform_ro",
             "group_attributes",
             "generic_metrics_gauges",
             "profile_chunks",

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -31,6 +31,7 @@ CLUSTERS = [
             "search_issues",
             "generic_metrics_counters",
             "events_analytics_platform",
+            "events_analytics_platform_ro",
             "group_attributes",
             "generic_metrics_gauges",
             "profile_chunks",

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -54,6 +54,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "search_issues",
             "generic_metrics_counters",
             "events_analytics_platform",
+            "events_analytics_platform_ro",
             "group_attributes",
             "generic_metrics_gauges",
             "profile_chunks",

--- a/snuba/utils/health_info.py
+++ b/snuba/utils/health_info.py
@@ -39,6 +39,7 @@ ESSENTIAL_STORAGE_SET_KEYS = {
     StorageSetKey.EVENTS,  # errors storage
     StorageSetKey.EVENTS_RO,  # errors_ro storage
     StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+    StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO,
 }
 
 

--- a/tests/datasets/entities/storage_selectors/test_eap_items.py
+++ b/tests/datasets/entities/storage_selectors/test_eap_items.py
@@ -1,3 +1,6 @@
+import pytest
+
+from snuba import state
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.entities.storage_selectors.eap_items import EAPItemsStorageSelector
@@ -37,3 +40,51 @@ def test_selects_correct_eap_items_tier() -> None:
         unimportant_query, query_settings, EAP_ITEMS_STORAGE_CONNECTIONS
     )
     assert selected_storage.storage == get_storage(StorageKey.EAP_ITEMS_DOWNSAMPLE_512)
+
+
+@pytest.mark.redis_db
+def test_selects_eap_items_ro_when_enabled() -> None:
+    unimportant_query = Query(from_clause=EAP_ITEMS_ENTITY)
+    query_settings = HTTPQuerySettings()
+    query_settings.set_sampling_tier(Tier.TIER_1)
+
+    state.set_config("enable_eap_readonly_table", 1)
+    try:
+        selected_storage = EAPItemsStorageSelector().select_storage(
+            unimportant_query, query_settings, EAP_ITEMS_STORAGE_CONNECTIONS
+        )
+        assert selected_storage.storage == get_storage(StorageKey.EAP_ITEMS_RO)
+    finally:
+        state.delete_config("enable_eap_readonly_table")
+
+
+@pytest.mark.redis_db
+def test_selects_writable_when_consistent() -> None:
+    unimportant_query = Query(from_clause=EAP_ITEMS_ENTITY)
+    query_settings = HTTPQuerySettings(consistent=True)
+    query_settings.set_sampling_tier(Tier.TIER_1)
+
+    state.set_config("enable_eap_readonly_table", 1)
+    try:
+        selected_storage = EAPItemsStorageSelector().select_storage(
+            unimportant_query, query_settings, EAP_ITEMS_STORAGE_CONNECTIONS
+        )
+        assert selected_storage.storage == get_storage(StorageKey.EAP_ITEMS)
+    finally:
+        state.delete_config("enable_eap_readonly_table")
+
+
+@pytest.mark.redis_db
+def test_selects_downsample_ro_when_enabled() -> None:
+    unimportant_query = Query(from_clause=EAP_ITEMS_ENTITY)
+    query_settings = HTTPQuerySettings()
+    query_settings.set_sampling_tier(Tier.TIER_512)
+
+    state.set_config("enable_eap_readonly_table", 1)
+    try:
+        selected_storage = EAPItemsStorageSelector().select_storage(
+            unimportant_query, query_settings, EAP_ITEMS_STORAGE_CONNECTIONS
+        )
+        assert selected_storage.storage == get_storage(StorageKey.EAP_ITEMS_DOWNSAMPLE_512_RO)
+    finally:
+        state.delete_config("enable_eap_readonly_table")


### PR DESCRIPTION
Route EAP select queries through a separate `events_analytics_platform_ro` storage set so production can map reads to a read-only ClickHouse cluster while writes stay on the existing one. Mirrors the long-standing `errors`/`errors_ro` split. Behavior is unchanged until `enable_eap_readonly_table` is flipped on and the new storage set is mapped to its own cluster in `settings.CLUSTERS`.

**Storage selector gate**

`EAPItemsStorageSelector` picks the `_ro` variant when `enable_eap_readonly_table` is set and the query is not `consistent`. Sampling-tier branching is preserved, so downsampled tiers route to their matching `_ro` table.

**RO storage variants**

New readable-only storages cover every read path: `eap_items_ro`, `eap_items_downsample_{8,64,512}_ro`, and `eap_item_co_occurring_attrs_ro`. They reuse the same `local_table_name`/`dist_table_name` as their writable counterparts but reference `set_key: events_analytics_platform_ro`, so the underlying ClickHouse tables are unchanged — only the cluster connection used to query them differs.

**Migration group + health check**

`EVENTS_ANALYTICS_PLATFORM_RO` is added to the existing EAP migration group (so readiness-state validation accepts the `complete` storages) and to `ESSENTIAL_STORAGE_SET_KEYS` so the RO cluster gets health-checked alongside the writable one.


Agent transcript: https://claudescope.sentry.dev/share/v07YB8oWTKrAoPK3IupNmre81H-S1m-WLHmMopypz9M