### PR TITLE
ref(metrics): Tag dropped_out_of_range_timestamp with item_type and is_future

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -20,7 +20,9 @@ use crate::processors::utils::{
 };
 use crate::runtime_config::get_str_config;
 use crate::types::CogsData;
-use crate::types::{InsertBatch, ItemTypeMetrics, KafkaMessageMetadata, TypedInsertBatch};
+use crate::types::{
+    item_type_name, InsertBatch, ItemTypeMetrics, KafkaMessageMetadata, TypedInsertBatch,
+};
 
 /// Runtime config key prefix. Per-storage key
 /// `eap_items_dlq_grace_period_min:<storage_name>`: a non-negative integer
@@ -79,7 +81,8 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         if !should_skip {
             if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
                 if should_dlq_for_prior_partition(event_ts, now, grace_min) {
-                    counter!("eap_items.messages.dlqed_prior_partition", 1);
+                    let item_type_str = item_type_name(item_type);
+                    counter!("eap_items.messages.dlqed_prior_partition", 1, "item_type" => item_type_str);
                     anyhow::bail!(
                         "eap-items message DLQed: event timestamp {event_ts} is before the prior weekly partition boundary; routed to DLQ"
                     );

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -16,6 +16,7 @@ use sentry_protos::snuba::v1::{ArrayValue, TraceItem, TraceItemType};
 use crate::config::ProcessorConfig;
 use crate::processors::utils::{
     enforce_retention, get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs,
+    record_invalid_timestamp_metric,
 };
 use crate::runtime_config::get_str_config;
 use crate::types::CogsData;
@@ -61,13 +62,17 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         .as_ref()
         .and_then(|ts| DateTime::from_timestamp(ts.seconds, 0));
 
+    let item_type =
+        TraceItemType::try_from(trace_item.item_type).unwrap_or(TraceItemType::Unspecified);
+
     let mut should_skip = false;
     if let Some(event_ts) = event_timestamp {
         let now = Utc::now();
 
         // should_skip=true will drop messages that are too old or too far in the future
         if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
-            counter!("eap_items.messages.dropped_out_of_range_timestamp", 1);
+            let is_future = event_ts > now;
+            record_invalid_timestamp_metric("eap_items.messages", is_future, item_type);
             should_skip = true;
         }
         // only DLQ messages that we don't want to drop (when should_skip=false)
@@ -93,8 +98,6 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         retention_days
     };
 
-    let item_type =
-        TraceItemType::try_from(trace_item.item_type).unwrap_or(TraceItemType::Unspecified);
     let mut eap_item = EAPItem::try_from(trace_item)?;
 
     eap_item.retention_days = retention_days;

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -1,7 +1,10 @@
 use crate::config::EnvConfig;
 use crate::runtime_config::get_str_config;
+use crate::types::item_type_name;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use schemars::JsonSchema;
+use sentry_arroyo::counter;
+use sentry_protos::snuba::v1::TraceItemType;
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// One week in seconds. The eap_items table is partitioned by
@@ -36,6 +39,12 @@ pub fn get_drop_invalid_timestamps_enabled() -> bool {
         .flatten()
         .map(|s| s == "1")
         .unwrap_or(false)
+}
+
+pub fn record_invalid_timestamp_metric(prefix: &str, is_future: bool, item_type: TraceItemType) {
+    let metric_name = format!("{}.dropped_out_of_range_timestamp", prefix);
+    let item_type_str = item_type_name(item_type);
+    counter!(metric_name, 1, "is_future" => is_future.to_string(), "item_type" => item_type_str);
 }
 
 pub fn enforce_retention(value: Option<u16>, config: &EnvConfig) -> u16 {

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -42,7 +42,7 @@ pub fn get_drop_invalid_timestamps_enabled() -> bool {
 }
 
 pub fn record_invalid_timestamp_metric(prefix: &str, is_future: bool, item_type: TraceItemType) {
-    let metric_name = format!("{}.dropped_out_of_range_timestamp", prefix);
+    let metric_name = format!("{prefix}.dropped_out_of_range_timestamp");
     let item_type_str = item_type_name(item_type);
     counter!(metric_name, 1, "is_future" => is_future.to_string(), "item_type" => item_type_str);
 }

--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -13,7 +13,10 @@ use sentry_arroyo::types::{InnerMessage, Message, Partition};
 use sentry_arroyo::utils::timing::Deadline;
 use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 
-use crate::processors::utils::{get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs};
+use crate::processors::utils::{
+    get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs,
+    record_invalid_timestamp_metric,
+};
 use crate::types::{item_type_name, AggregatedOutcomesBatch, BucketKey, ItemDedupKey};
 
 #[derive(Debug, Default)]
@@ -256,7 +259,10 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
         if let Some(event_ts) = event_timestamp {
             let now = Utc::now();
             if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
-                counter!("accepted_outcomes.dropped_out_of_range_timestamp", 1);
+                let item_type = TraceItemType::try_from(trace_item.item_type)
+                    .unwrap_or(TraceItemType::Unspecified);
+                let is_future = event_ts > now;
+                record_invalid_timestamp_metric("accepted_outcomes", is_future, item_type);
                 return Ok(());
             }
         }


### PR DESCRIPTION
## Summary
- Adds `item_type` and `is_future` tags to the `dropped_out_of_range_timestamp` counter in the eap-items processor and the accepted-outcomes aggregator, so drops can be attributed to a producer surface and clock-skew-future drops can be told apart from old-data drops.
- Adds the `item_type` to the DLQ `eap_items.messages.dlqed_prior_partition` metric as well
- Extracts the emission into `record_invalid_timestamp_metric` in `processors::utils` so both call sites share one metric shape.

## Test plan
- [ ] `cargo check -p rust_snuba` passes locally (verified).
- [ ] After deploy, confirm the `eap_items.messages.dropped_out_of_range_timestamp` and `accepted_outcomes.dropped_out_of_range_timestamp` series in DataDog now break down by `item_type` and `is_future`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)