### PR TITLE
fix(admin): Use readonly user for non-sudo clusterless system queries

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -206,6 +206,38 @@ def get_clusterless_node_connection(
     return connection
 
 
+def get_ro_clusterless_node_connection(
+    clickhouse_host: str,
+    clickhouse_port: int,
+    storage_name: str,
+    client_settings: ClickhouseClientSettings,
+) -> ClickhousePool:
+    storage = _get_storage(storage_name)
+    cluster = storage.get_cluster()
+    database = cluster.get_database()
+
+    key = f"{storage.get_storage_key()}-{clickhouse_host}-clusterless-ro-{database}"
+    if key in NODE_CONNECTIONS:
+        return NODE_CONNECTIONS[key]
+
+    assert client_settings in {
+        ClickhouseClientSettings.QUERY,
+        ClickhouseClientSettings.QUERYLOG,
+    }, "ro clusterless connections must use a read-only client settings profile"
+
+    connection = ClickhousePool(
+        clickhouse_host,
+        clickhouse_port,
+        settings.CLICKHOUSE_READONLY_USER,
+        settings.CLICKHOUSE_READONLY_PASSWORD,
+        database,
+        max_pool_size=2,
+        client_settings=client_settings.value.settings,
+    )
+    NODE_CONNECTIONS[key] = connection
+    return connection
+
+
 def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) -> None:
     """
     Validates that the query is a safe read-only query.

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -8,6 +8,7 @@ from snuba.admin.auth_roles import ExecuteSudoSystemQuery
 from snuba.admin.clickhouse.common import (
     InvalidCustomQuery,
     get_clusterless_node_connection,
+    get_ro_clusterless_node_connection,
     get_ro_node_connection,
     get_sudo_node_connection,
 )
@@ -45,10 +46,20 @@ def _run_sql_query_on_host(
         settings = ClickhouseClientSettings.QUERY
 
     if clusterless_mode:
-        connection = get_clusterless_node_connection(
-            clickhouse_host, clickhouse_port, storage_name, settings
+        # Sudo clusterless queries (SYSTEM, ALTER, DROP, etc.) require the full
+        # cluster credentials; read-only clusterless queries use the global
+        # readonly user so anonymous/low-privilege admin users cannot connect
+        # to ClickHouse with admin credentials via this path.
+        clusterless_connection = (
+            get_clusterless_node_connection(
+                clickhouse_host, clickhouse_port, storage_name, settings
+            )
+            if sudo
+            else get_ro_clusterless_node_connection(
+                clickhouse_host, clickhouse_port, storage_name, settings
+            )
         )
-        return connection.execute(query=sql, with_column_types=True)
+        return clusterless_connection.execute(query=sql, with_column_types=True)
 
     connection = (
         get_ro_node_connection(clickhouse_host, clickhouse_port, storage_name, settings)

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -224,6 +224,58 @@ def test_run_sudo_queries(
 
 
 @pytest.mark.parametrize(
+    "sudo_mode, expected_helper",
+    [
+        pytest.param(
+            False,
+            "get_ro_clusterless_node_connection",
+            id="Non-sudo clusterless uses readonly credentials",
+        ),
+        pytest.param(
+            True,
+            "get_clusterless_node_connection",
+            id="Sudo clusterless uses cluster admin credentials",
+        ),
+    ],
+)
+def test_clusterless_uses_readonly_for_non_sudo(sudo_mode: bool, expected_helper: str) -> None:
+    """
+    Non-sudo clusterless system queries must connect with the global readonly
+    user. Without this, the default NOOP auth provider would let anonymous
+    users run queries against ClickHouse with the full cluster admin
+    credentials, leaking sensitive data via system tables.
+    """
+    from unittest.mock import patch
+
+    from snuba.admin.clickhouse import system_queries
+
+    mock_result = type("MockResult", (), {"results": []})()
+    forbidden = (
+        "get_clusterless_node_connection"
+        if expected_helper == "get_ro_clusterless_node_connection"
+        else "get_ro_clusterless_node_connection"
+    )
+
+    with (
+        patch.object(system_queries, expected_helper) as mock_used,
+        patch.object(system_queries, forbidden) as mock_forbidden,
+    ):
+        mock_used.return_value.execute.return_value = mock_result
+
+        system_queries._run_sql_query_on_host(
+            "host",
+            9000,
+            "errors",
+            "SELECT * FROM system.clusters",
+            sudo_mode,
+            True,
+        )
+
+        assert mock_used.called, f"Expected {expected_helper} to be used"
+        assert not mock_forbidden.called, f"{forbidden} must not be used in this mode"
+
+
+@pytest.mark.parametrize(
     "sql_query, sudo_mode",
     [
         ("SELECT * FROM system.clusters;", True),


### PR DESCRIPTION
The `/run_clickhouse_system_query` endpoint accepts a `clusterless` flag that routed through `get_clusterless_node_connection`, which connects with the full ClickHouse cluster admin credentials. Combined with the default `ADMIN_AUTH_PROVIDER=NOOP` and the `ProductTools` role granted to every user by default, an anonymous caller could run system queries against ClickHouse with admin credentials and exfiltrate sensitive cluster state (`system.users`, `system.macros`, etc).

**Readonly clusterless helper**

Add `get_ro_clusterless_node_connection`, which mirrors the existing helper but connects with the global `CLICKHOUSE_READONLY_USER` / `CLICKHOUSE_READONLY_PASSWORD`. An assert restricts it to the read-only `QUERY` / `QUERYLOG` client-settings profiles so the helper can never be misused as an admin path.

**Routing in `_run_sql_query_on_host`**

Non-sudo clusterless queries now flow through the readonly helper; sudo clusterless queries keep using the admin helper because they are already gated by `ExecuteSudoSystemQuery` and need write capability for `SYSTEM` / `ALTER` / `DROP` commands. `copy_tables.py` still uses the admin helper since it creates tables.

Fixes EAP-488


Agent transcript: https://claudescope.sentry.dev/share/vYeXhE8szqoRMlXrOHkZ3cXlnUjRx7Jngh35E1JJF0A