### PR TITLE
ref(eap): Add workflow attributes to attributes_array allowlist

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -180,6 +180,10 @@ ATTRIBUTES_ARRAY_ALLOWLIST: tuple[str, ...] = (
     "gen_ai.response.object",
     "gen_ai.tool.call.arguments",
     "gen_ai.tool.input",
+    "workflow_ids",
+    "triggered_workflow_ids",
+    "action_filter_group_ids",
+    "triggered_action_ids",
 )
 
 


### PR DESCRIPTION
Adds four workflow-related paths to `ATTRIBUTES_ARRAY_ALLOWLIST` so they get selected per-path from `attributes_array` on bulk-fetch endpoints (TraceItemDetails, GetTrace) without materializing the full dynamic JSON value.

New entries:

- `workflow_ids`
- `triggered_workflow_ids`
- `action_filter_group_ids`
- `triggered_action_ids`


Agent transcript: https://claudescope.sentry.dev/share/NOfanMmgoPOkAcX4072IS1pRxdViOnGGEOP1_cDQ2qo