### PR TITLE
fix(eap): Include bool keys in attribute_keys_hash

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0055_fix_attribute_keys_hash_missing_bool.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0055_fix_attribute_keys_hash_missing_bool.py
@@ -1,0 +1,53 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import get_array_vals_hash
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import Array, Column, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    storage_set_key = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=self.storage_set_key,
+                table_name="eap_item_co_occurring_attrs_1_local",
+                column=Column(
+                    "attribute_keys_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=get_array_vals_hash(
+                                "arrayDistinct(arrayConcat(attributes_string, attributes_float, attributes_bool))"
+                            )
+                        ),
+                    ),
+                ),
+                target=OperationTarget.LOCAL,
+            )
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=self.storage_set_key,
+                table_name="eap_item_co_occurring_attrs_1_local",
+                column=Column(
+                    "attribute_keys_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=get_array_vals_hash(
+                                "arrayConcat(attributes_string, attributes_float)"
+                            )
+                        ),
+                    ),
+                ),
+                target=OperationTarget.LOCAL,
+            )
+        ]


### PR DESCRIPTION
Migration 0051 updated the Python `Column` definition for `attribute_keys_hash` on `eap_item_co_occurring_attrs_1` to include `attributes_bool`, but only in the column list passed to `CreateMaterializedView` — which (per Volo's #7848) does nothing to the destination table's actual column expression. The live MATERIALIZED expression on the table is still the 0030 form:

```sql
arrayMap(k -> cityHash64(k), arrayConcat(attributes_string, attributes_float))
```

That was harmless until #7689 removed the bool double-write into `attributes_float_*` on 2026-05-27 — at which point bool keys disappeared from `attribute_keys_hash` entirely, and bool-only `intersectingAttributesFilter` queries against `sentry._internal.cooccuring.*` started returning zero rows. awresports only started ingesting on 2026-05-27, so they see no metric attributes at all.

This is the `attribute_keys_hash` analogue of what migration 0054 did for `key_hash`: a single `ModifyColumn` that updates the materialized expression to include `attributes_bool`:

```sql
arrayMap(k -> cityHash64(k), arrayDistinct(arrayConcat(attributes_string, attributes_float, attributes_bool)))
```

## Design notes

- **Stays MATERIALIZED.** 0054 swapped `key_hash` to DEFAULT to let an MV provide it (Volo had hit `Cannot insert column key_hash, because it is MATERIALIZED column`). That rationale doesn't transfer — `attribute_keys_hash` is purely a bloom-filter index source, there's no scenario where an MV should provide its own value, and MATERIALIZED keeps the invariant that the column matches the source data.
- **No sort.** Each element is hashed independently so order doesn't affect the bloom filter or `hasAll`.
- **`arrayDistinct` to defend against cross-type duplicates.** Within a single attribute type, keys come from `mapKeys(...)` so they're already distinct. The only way to get duplicates is cross-type drift (the same name appearing as both, say, a string and a bool in the same merged row). Rare, but cheap to defend against.
- **No read-path changes needed.** `endpoint_trace_item_attribute_names.py` builds the predicate as `hasAll(attribute_keys_hash, [cityHash64(name)])` — bare untagged hash of the name, matching the per-element formula in the column.

## Caveats

- **Existing rows keep their old hash values.** New inserts get the corrected hash immediately, but historical rows need `ALTER TABLE eap_item_co_occurring_attrs_1_local MATERIALIZE COLUMN attribute_keys_hash` to be searchable under the new expression. Sequence that mutation separately.
- The 24h-vs-25h symptom Matt flagged on the Sentry org is a separate issue (cooccuring storage is per-week-bucket, so there's something funky in how the read path picks date buckets) — not addressed here.