### PR TITLE
feat(eap): Add _dist_ro Distributed tables for EAP read-only routing

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0056_eap_items_dist_ro.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0056_eap_items_dist_ro.py
@@ -1,0 +1,95 @@
+from typing import Optional, Sequence
+
+from snuba.clusters.cluster import get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO
+
+# (new_dist_ro_table, source_dist_table, local_table, sharding_key)
+DIST_RO_TABLES: list[tuple[str, str, str, Optional[str]]] = [
+    (
+        "eap_items_1_dist_ro",
+        "eap_items_1_dist",
+        "eap_items_1_local",
+        "cityHash64(reinterpretAsUInt128(trace_id))",
+    ),
+    (
+        "eap_items_1_downsample_8_dist_ro",
+        "eap_items_1_downsample_8_dist",
+        "eap_items_1_downsample_8_local",
+        "cityHash64(reinterpretAsUInt128(trace_id))",
+    ),
+    (
+        "eap_items_1_downsample_64_dist_ro",
+        "eap_items_1_downsample_64_dist",
+        "eap_items_1_downsample_64_local",
+        "cityHash64(reinterpretAsUInt128(trace_id))",
+    ),
+    (
+        "eap_items_1_downsample_512_dist_ro",
+        "eap_items_1_downsample_512_dist",
+        "eap_items_1_downsample_512_local",
+        "cityHash64(reinterpretAsUInt128(trace_id))",
+    ),
+    (
+        "eap_item_co_occurring_attrs_1_dist_ro",
+        "eap_item_co_occurring_attrs_1_dist",
+        "eap_item_co_occurring_attrs_1_local",
+        None,
+    ),
+]
+
+
+def _on_cluster_clause() -> str:
+    cluster = get_cluster(storage_set)
+    if cluster.is_single_node():
+        return ""
+    name = cluster.get_clickhouse_distributed_cluster_name()
+    return f" ON CLUSTER `{name}`" if name else ""
+
+
+def _create_dist_ro_sql(
+    new_table: str,
+    source_table: str,
+    local_table: str,
+    sharding_key: Optional[str],
+) -> str:
+    cluster = get_cluster(storage_set)
+    cluster_name = cluster.get_clickhouse_cluster_name()
+    database = cluster.get_database()
+    sharding = f", {sharding_key}" if sharding_key else ""
+    return (
+        f"CREATE TABLE IF NOT EXISTS {new_table}{_on_cluster_clause()} "
+        f"AS {source_table} "
+        f"ENGINE = Distributed(`{cluster_name}`, {database}, {local_table}{sharding})"
+    )
+
+
+def _drop_dist_ro_sql(table: str) -> str:
+    return f"DROP TABLE IF EXISTS {table}{_on_cluster_clause()}"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.RunSql(
+                storage_set=storage_set,
+                statement=_create_dist_ro_sql(new, src, local, key),
+                target=OperationTarget.DISTRIBUTED,
+            )
+            for new, src, local, key in DIST_RO_TABLES
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.RunSql(
+                storage_set=storage_set,
+                statement=_drop_dist_ro_sql(new),
+                target=OperationTarget.DISTRIBUTED,
+            )
+            for new, *_ in DIST_RO_TABLES
+        ]


### PR DESCRIPTION
## Summary
- Add `0056_eap_items_dist_ro.py` migration creating `_dist_ro` Distributed tables under `events_analytics_platform_ro`, so EAP selects routed through the RO storage set use a Distributed engine bound to the RO cluster name (e.g. `snuba-events-analytics-platform-ro` in prod), which excludes the write-dedicated replica on each shard. Mirrors the long-standing `errors_dist` / `errors_dist_ro` split.
- New tables: `eap_items_1_dist_ro`, `eap_items_1_downsample_{8,64,512}_dist_ro`, `eap_item_co_occurring_attrs_1_dist_ro`. Each is created via `CREATE TABLE ... AS source_dist ENGINE = Distributed(...)` so the schema (including materialized hash-map columns) is copied from the existing `_dist` table, and the engine string carries the RO cluster name resolved at migration time from the storage-set's cluster configuration.

## Why
`enable_eap_readonly_table` flips the storage selector to `eap_items_ro` etc., but those storages currently point at the same `eap_items_1_dist` Distributed table as the writable storage. That table's `Distributed(...)` engine was created under `EVENTS_ANALYTICS_PLATFORM` and is permanently bound to the full `snuba-events-analytics-platform` cluster — so RO queries still fan out to replica `-1` of each shard. With a `_dist_ro` table whose engine is bound to the `-ro` cluster name, the fan-out excludes that replica.

## Follow-up
The storage YAMLs (`eap_items_ro.yaml`, `eap_items_downsample_{8,64,512}_ro.yaml`, `eap_item_co_occurring_attrs_ro.yaml`) need their `dist_table_name` updated to the new `_dist_ro` tables. That change is intentionally split into a separate PR so this one only adds the tables; once the migration has run in all regions we can flip the storage routing.

## Test plan
- [ ] CI green (migration validators, schema parsing, runner tests).
- [ ] Verify on a multi-node test/canary that the new `_dist_ro` tables are created with the expected `Distributed(<ro-cluster-name>, ...)` engine string.
- [ ] After the follow-up YAML PR ships and `enable_eap_readonly_table` is on, confirm via ClickHouse `query_log` that EAP read queries no longer hit the write-dedicated replica `-1` on any shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/zkowmgbWIGwHpAyisKfBNEouNgggB3Sxfhy0chpHSdY