### PR TITLE
feat(eap): Route EAP RO storages through their _dist_ro tables

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_item_co_occurring_attrs_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_item_co_occurring_attrs_ro.yaml
@@ -24,6 +24,6 @@ schema:
       { name: attributes_bool, type: Array, args: { inner_type: { type: String } } }
     ]
   local_table_name: eap_item_co_occurring_attrs_1_local
-  dist_table_name: eap_item_co_occurring_attrs_1_dist
+  dist_table_name: eap_item_co_occurring_attrs_1_dist_ro
   partition_format: [retention_days, date]
 allocation_policies: []

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_512_ro.yaml
@@ -106,7 +106,7 @@ schema:
       { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
     ]
   local_table_name: eap_items_1_downsample_512_local
-  dist_table_name: eap_items_1_downsample_512_dist
+  dist_table_name: eap_items_1_downsample_512_dist_ro
   partition_format: [retention_days, date]
 
 query_processors:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64_ro.yaml
@@ -107,7 +107,7 @@ schema:
 
     ]
   local_table_name: eap_items_1_downsample_64_local
-  dist_table_name: eap_items_1_downsample_64_dist
+  dist_table_name: eap_items_1_downsample_64_dist_ro
   partition_format: [retention_days, date]
 
 query_processors:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_8_ro.yaml
@@ -106,7 +106,7 @@ schema:
       { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
     ]
   local_table_name: eap_items_1_downsample_8_local
-  dist_table_name: eap_items_1_downsample_8_dist
+  dist_table_name: eap_items_1_downsample_8_dist_ro
   partition_format: [retention_days, date]
 
 query_processors:

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_ro.yaml
@@ -107,7 +107,7 @@ schema:
       { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
     ]
   local_table_name: eap_items_1_local
-  dist_table_name: eap_items_1_dist
+  dist_table_name: eap_items_1_dist_ro
   partition_format: [retention_days, date]
 
 query_processors:


### PR DESCRIPTION
## Summary
- Switch every `events_analytics_platform_ro` storage YAML to point at the new `_dist_ro` Distributed tables introduced in #7995.
- This is what actually makes `enable_eap_readonly_table` route reads to the `-ro` cluster (which excludes the write-dedicated replica on each shard) — without it, the new `_dist_ro` tables exist but are never queried.

## Why
The migration in #7995 creates `eap_items_1_dist_ro` and friends with a `Distributed(...)` engine bound to the RO cluster name. Until the storage YAMLs route to them, reads through `eap_items_ro` still hit the shared writable `eap_items_1_dist` (bound to the full cluster).

## Storages updated
- `eap_items_ro.yaml` → `eap_items_1_dist_ro`
- `eap_items_downsample_8_ro.yaml` → `eap_items_1_downsample_8_dist_ro`
- `eap_items_downsample_64_ro.yaml` → `eap_items_1_downsample_64_dist_ro`
- `eap_items_downsample_512_ro.yaml` → `eap_items_1_downsample_512_dist_ro`
- `eap_item_co_occurring_attrs_ro.yaml` → `eap_item_co_occurring_attrs_1_dist_ro`

## Ordering
Do not merge until #7995 has shipped AND its migration has run in every region. Otherwise the RO storages will reference tables that don't exist yet, which would break queries the moment `enable_eap_readonly_table` is flipped on.

## Test plan
- [ ] CI green (YAML schema validation, storage loading).
- [ ] After both PRs are deployed and the migration has run, flip `enable_eap_readonly_table` on in a low-traffic region and confirm via ClickHouse `query_log` that EAP read queries no longer hit the write-dedicated replica `-1` on any shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/FjeKiOMwwi2TCFDpsJeIg1ckqK7BWlBp2IQwOrERLUE