### PR TITLE
chore(admin): Replace team-sns with team-events-analytics-platform in IAM policy

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -14,14 +14,14 @@
     },
     {
       "members": [
-        "group:team-sns@sentry.io",
+        "group:team-events-analytics-platform@sentry.io",
         "group:access-snuba-admin@sentry.io"
       ],
       "role": "roles/MigrationsReader"
     },
     {
       "members": [
-        "group:team-sns@sentry.io",
+        "group:team-events-analytics-platform@sentry.io",
         "group:team-ops@sentry.io"
       ],
       "role": "roles/AllTools"
@@ -45,14 +45,14 @@
     {
       "members": [
         "group:team-ops@sentry.io",
-        "group:team-sns@sentry.io"
+        "group:team-events-analytics-platform@sentry.io"
       ],
       "role": "roles/AllMigrationsExecutor"
     },
     {
       "members": [
         "group:team-ops@sentry.io",
-        "group:team-sns@sentry.io"
+        "group:team-events-analytics-platform@sentry.io"
       ],
       "role": "roles/ClickhouseAdmin"
     }


### PR DESCRIPTION
## Summary

- Replaces all `group:team-sns@sentry.io` bindings in `snuba/admin/iam_policy/iam_policy.json` with `group:team-events-analytics-platform@sentry.io`.
- Affected roles: `MigrationsReader`, `AllTools`, `AllMigrationsExecutor`, `ClickhouseAdmin`.

## Why

The `team-sns` Google group is being deleted in getsentry/security-as-code#3061, with ownership of snuba (and related repos) reassigned to `team-events-analytics-platform`. Once that PR lands the old group will no longer exist, so this update keeps the snuba admin IAM policy in sync — without it, the current SNS members would lose admin access (migrations, ClickHouse admin, all tools) on the snuba admin tool.

## Test plan

- [ ] CI passes
- [ ] Land after (or alongside) getsentry/security-as-code#3061 so the new group exists before this policy references it

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/SWNuNGdMIx3NF5P70Vl0ZbbWCGuM-NfNVcfvFqVwxfQ