### PR TITLE
perf(eap): Stream RowBinary INSERTs to ClickHouse instead of buffering

### DIFF
--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -26,7 +26,10 @@ use crate::processors::{self, get_cogs_label};
 use crate::strategies::accountant::RecordCogs;
 
 use crate::strategies::blq_router::BLQRouter;
-use crate::strategies::clickhouse::writer_v2::{ClickhouseWriterStep, InsertFormat};
+use crate::strategies::clickhouse::streaming_writer::StreamingClickhouseWriter;
+use crate::strategies::clickhouse::writer_v2::{
+    ClickhouseClient, ClickhouseWriterStep, InsertFormat,
+};
 use crate::strategies::commit_log::ProduceCommitLog;
 use crate::strategies::healthcheck::HealthCheck as SnubaHealthCheck;
 use crate::strategies::join_timeout::SetJoinTimeout;
@@ -151,49 +154,77 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
             Some(Duration::from_millis(self.join_timeout_ms.unwrap_or(0))),
         );
 
-        let next_step = ClickhouseWriterStep::new(
-            next_step,
-            self.storage_config.clickhouse_cluster.clone(),
-            self.storage_config.clickhouse_table_name.clone(),
-            false,
-            &self.clickhouse_concurrency,
-            self.storage_config.name.clone(),
-            insert_format,
-            insert_columns,
-        );
-
-        let accumulator = Arc::new(
-            |batch: BytesInsertBatch<RowData>, small_batch: Message<BytesInsertBatch<RowData>>| {
-                Ok(batch.merge(small_batch.into_payload()))
-            },
-        );
-
         let compute_batch_size: fn(&BytesInsertBatch<RowData>) -> usize =
             match self.max_batch_size_calculation {
                 config::BatchSizeCalculation::Bytes => |batch| batch.num_bytes(),
                 config::BatchSizeCalculation::Rows => |batch| batch.len(),
             };
 
-        let next_step = Reduce::new(
-            next_step,
-            accumulator,
-            Arc::new(move || {
-                BytesInsertBatch::<RowData>::new(
-                    RowData::default(),
-                    None,
-                    None,
-                    None,
-                    Default::default(),
-                    CogsData::default(),
+        // RowBinary gets the streaming writer (Reduce + ClickhouseWriterStep
+        // collapsed into one step that compresses + POSTs rows to ClickHouse
+        // as they arrive). JSON stays on the buffered writer — same pipeline
+        // we've shipped, no urgency to migrate it.
+        let next_step: Box<dyn ProcessingStrategy<BytesInsertBatch<RowData>>> =
+            if self.use_row_binary {
+                tracing::info!("Using streaming ClickHouse writer (RowBinary)");
+                let client = Arc::new(ClickhouseClient::new(
+                    &self.storage_config.clickhouse_cluster,
+                    &self.storage_config.clickhouse_table_name,
+                    self.storage_config.name.clone(),
+                    insert_format,
+                    insert_columns,
+                ));
+                Box::new(StreamingClickhouseWriter::new(
+                    next_step,
+                    client,
+                    false,
+                    self.clickhouse_concurrency.handle(),
+                    self.max_batch_size,
+                    self.max_batch_time,
+                    compute_batch_size,
+                ))
+            } else {
+                let writer = ClickhouseWriterStep::new(
+                    next_step,
+                    self.storage_config.clickhouse_cluster.clone(),
+                    self.storage_config.clickhouse_table_name.clone(),
+                    false,
+                    &self.clickhouse_concurrency,
+                    self.storage_config.name.clone(),
+                    insert_format,
+                    insert_columns,
+                );
+
+                let accumulator = Arc::new(
+                    |batch: BytesInsertBatch<RowData>,
+                     small_batch: Message<BytesInsertBatch<RowData>>| {
+                        Ok(batch.merge(small_batch.into_payload()))
+                    },
+                );
+
+                Box::new(
+                    Reduce::new(
+                        writer,
+                        accumulator,
+                        Arc::new(move || {
+                            BytesInsertBatch::<RowData>::new(
+                                RowData::default(),
+                                None,
+                                None,
+                                None,
+                                Default::default(),
+                                CogsData::default(),
+                            )
+                        }),
+                        self.max_batch_size,
+                        self.max_batch_time,
+                        compute_batch_size,
+                        // we need to enable this to deal with storages where we skip 100% of values,
+                        // such as gen-metrics-gauges in s4s. we still need to commit there
+                    )
+                    .flush_empty_batches(true),
                 )
-            }),
-            self.max_batch_size,
-            self.max_batch_time,
-            compute_batch_size,
-            // we need to enable this to deal with storages where we skip 100% of values, such as
-            // gen-metrics-gauges in s4s. we still need to commit there
-        )
-        .flush_empty_batches(true);
+            };
 
         // RowBinary can only be emitted by the Rust processor (the Python path
         // always returns JSONEachRow bytes). If the storage opted into

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -1,3 +1,4 @@
 pub mod rowbinary;
 pub mod streaming_lz4;
+pub mod streaming_writer;
 pub mod writer_v2;

--- a/rust_snuba/src/strategies/clickhouse/mod.rs
+++ b/rust_snuba/src/strategies/clickhouse/mod.rs
@@ -1,2 +1,3 @@
 pub mod rowbinary;
+pub mod streaming_lz4;
 pub mod writer_v2;

--- a/rust_snuba/src/strategies/clickhouse/streaming_lz4.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_lz4.rs
@@ -6,10 +6,9 @@
 //! a `Bytes` for each complete block as soon as it fills. Used by the
 //! streaming writer so we never buffer a full uncompressed batch.
 //!
-//! Scaffolded ahead of `StreamingClickhouseWriter` — items below are
-//! exercised by unit tests now and will be picked up by the strategy in
-//! a follow-up commit.
-#![allow(dead_code)]
+//! Consumed by `StreamingClickhouseWriter` (see `streaming_writer.rs`),
+//! which feeds rows incrementally and forwards each emitted block onto
+//! the HTTP body channel for an in-flight POST.
 
 use bytes::Bytes;
 

--- a/rust_snuba/src/strategies/clickhouse/streaming_lz4.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_lz4.rs
@@ -1,0 +1,194 @@
+//! Incremental ClickHouse-native LZ4 compressor.
+//!
+//! Sister to `writer_v2::lz4_compress`. Both emit the same wire format
+//! (concatenated CityHash128 + 9-byte header + LZ4 blocks chunked at
+//! `LZ4_BLOCK_SIZE`), but this one accepts bytes incrementally and emits
+//! a `Bytes` for each complete block as soon as it fills. Used by the
+//! streaming writer so we never buffer a full uncompressed batch.
+//!
+//! Scaffolded ahead of `StreamingClickhouseWriter` — items below are
+//! exercised by unit tests now and will be picked up by the strategy in
+//! a follow-up commit.
+#![allow(dead_code)]
+
+use bytes::Bytes;
+
+use super::writer_v2::{ch_compression_checksum, LZ4_BLOCK_SIZE, LZ4_METHOD_BYTE};
+
+pub struct StreamingLz4Compressor {
+    pending: Vec<u8>,
+}
+
+impl StreamingLz4Compressor {
+    pub fn new() -> Self {
+        Self {
+            pending: Vec::with_capacity(LZ4_BLOCK_SIZE),
+        }
+    }
+
+    /// Append `data` to the internal buffer. Returns one `Bytes` per
+    /// complete block that filled. Each returned chunk is a self-contained
+    /// ClickHouse native block ready to push onto an HTTP body stream.
+    pub fn push(&mut self, data: &[u8]) -> Vec<Bytes> {
+        self.pending.extend_from_slice(data);
+        let mut out = Vec::new();
+        while self.pending.len() >= LZ4_BLOCK_SIZE {
+            let block: Vec<u8> = self.pending.drain(..LZ4_BLOCK_SIZE).collect();
+            out.push(Bytes::from(encode_block(&block)));
+        }
+        out
+    }
+
+    /// Emit any buffered remainder as a final (partial) block. Returns
+    /// `None` if the compressor saw no data — important because ClickHouse
+    /// rejects an empty native body, so callers must not append `None`
+    /// to the wire.
+    pub fn finish(mut self) -> Option<Bytes> {
+        if self.pending.is_empty() {
+            None
+        } else {
+            let last = std::mem::take(&mut self.pending);
+            Some(Bytes::from(encode_block(&last)))
+        }
+    }
+}
+
+impl Default for StreamingLz4Compressor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Encode `chunk` as a single ClickHouse native compressed block:
+/// `[16 B CityHash128 || 0x82 || u32 LE compressed-with-header || u32 LE
+/// uncompressed || LZ4 raw bytes]`. The checksum spans the 9-byte header
+/// and the compressed payload.
+fn encode_block(chunk: &[u8]) -> Vec<u8> {
+    let compressed = lz4_flex::block::compress(chunk);
+    let compressed_with_header = 9u32 + compressed.len() as u32;
+    let uncompressed_size = chunk.len() as u32;
+
+    let mut out = Vec::with_capacity(25 + compressed.len());
+    out.extend_from_slice(&[0u8; 16]);
+    out.push(LZ4_METHOD_BYTE);
+    out.extend_from_slice(&compressed_with_header.to_le_bytes());
+    out.extend_from_slice(&uncompressed_size.to_le_bytes());
+    out.extend_from_slice(&compressed);
+
+    let checksum = ch_compression_checksum(&out[16..]);
+    out[..16].copy_from_slice(&checksum);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Walks a concatenation of ClickHouse-native compressed blocks and
+    /// returns the decoded payload. Mirrors the decoder in `writer_v2`'s
+    /// tests so the streaming output is verified against the same wire
+    /// expectations the buffered path is.
+    fn decode_native_blocks(buf: &[u8]) -> Vec<u8> {
+        let mut decoded = Vec::new();
+        let mut pos = 0;
+        while pos < buf.len() {
+            assert!(buf.len() - pos >= 25, "truncated block header");
+            let stored_checksum: [u8; 16] = buf[pos..pos + 16].try_into().unwrap();
+            assert_eq!(buf[pos + 16], LZ4_METHOD_BYTE, "wrong compression method");
+            let compressed_with_header =
+                u32::from_le_bytes(buf[pos + 17..pos + 21].try_into().unwrap()) as usize;
+            let uncompressed_size =
+                u32::from_le_bytes(buf[pos + 21..pos + 25].try_into().unwrap()) as usize;
+            let block_end = pos + 16 + compressed_with_header;
+            assert!(block_end <= buf.len(), "block size overruns buffer");
+
+            let computed = ch_compression_checksum(&buf[pos + 16..block_end]);
+            assert_eq!(computed, stored_checksum, "checksum mismatch");
+
+            let chunk = lz4_flex::block::decompress(&buf[pos + 25..block_end], uncompressed_size)
+                .expect("decompress");
+            assert_eq!(chunk.len(), uncompressed_size);
+            decoded.extend_from_slice(&chunk);
+            pos = block_end;
+        }
+        decoded
+    }
+
+    fn drain_to_bytes(chunks: Vec<Bytes>) -> Vec<u8> {
+        let mut out = Vec::new();
+        for c in chunks {
+            out.extend_from_slice(&c);
+        }
+        out
+    }
+
+    #[test]
+    fn push_under_block_size_buffers_until_finish() {
+        let mut c = StreamingLz4Compressor::new();
+        assert!(c.push(b"hello, world").is_empty());
+        let last = c.finish().expect("partial final block");
+        assert_eq!(decode_native_blocks(&last), b"hello, world");
+    }
+
+    #[test]
+    fn empty_compressor_finishes_to_none() {
+        assert!(StreamingLz4Compressor::new().finish().is_none());
+    }
+
+    #[test]
+    fn exactly_one_full_block_emits_immediately_no_remainder() {
+        let input = vec![0xABu8; LZ4_BLOCK_SIZE];
+        let mut c = StreamingLz4Compressor::new();
+        let emitted = c.push(&input);
+        assert_eq!(emitted.len(), 1);
+        assert!(c.finish().is_none(), "should not have a partial tail");
+        assert_eq!(decode_native_blocks(&drain_to_bytes(emitted)), input);
+    }
+
+    #[test]
+    fn cross_boundary_push_splits_into_full_block_plus_remainder() {
+        let input: Vec<u8> = (0..(LZ4_BLOCK_SIZE + LZ4_BLOCK_SIZE / 2))
+            .map(|i| (i % 251) as u8)
+            .collect();
+        let mut c = StreamingLz4Compressor::new();
+        let mut combined = drain_to_bytes(c.push(&input));
+        combined.extend_from_slice(&c.finish().expect("half-block remainder"));
+        assert_eq!(decode_native_blocks(&combined), input);
+    }
+
+    #[test]
+    fn many_small_pushes_recombine_at_block_boundary() {
+        // Stream 2.25 blocks worth of bytes one byte at a time. Two full
+        // blocks should emit during pushes (after byte LZ4_BLOCK_SIZE and
+        // byte 2*LZ4_BLOCK_SIZE), the rest comes out on finish.
+        let total = LZ4_BLOCK_SIZE * 2 + LZ4_BLOCK_SIZE / 4;
+        let mut c = StreamingLz4Compressor::new();
+        let mut expected = Vec::with_capacity(total);
+        let mut wire = Vec::new();
+        let mut full_blocks_seen = 0;
+        for i in 0..total {
+            let byte = (i % 251) as u8;
+            expected.push(byte);
+            let chunks = c.push(&[byte]);
+            full_blocks_seen += chunks.len();
+            wire.extend_from_slice(&drain_to_bytes(chunks));
+        }
+        assert_eq!(
+            full_blocks_seen, 2,
+            "should emit at each full-block boundary"
+        );
+        wire.extend_from_slice(&c.finish().expect("trailing partial block"));
+        assert_eq!(decode_native_blocks(&wire), expected);
+    }
+
+    #[test]
+    fn single_push_of_multiple_blocks_emits_all_at_once() {
+        // 3 full blocks in one push call — all three should emit; no remainder.
+        let input: Vec<u8> = (0..(LZ4_BLOCK_SIZE * 3)).map(|i| (i % 251) as u8).collect();
+        let mut c = StreamingLz4Compressor::new();
+        let emitted = c.push(&input);
+        assert_eq!(emitted.len(), 3);
+        assert!(c.finish().is_none());
+        assert_eq!(decode_native_blocks(&drain_to_bytes(emitted)), input);
+    }
+}

--- a/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
@@ -469,25 +469,46 @@ where
     fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
         let deadline = timeout.map(Deadline::new);
 
-        // Force-flush any in-progress batch so the request closes and
-        // begins finishing. After this, `in_flight` is set (or there
-        // was nothing pending), and we just need to wait for the HTTP
-        // response and drain into next_step.
-        if self.in_flight.is_none() && self.message_carried_over.is_none() {
+        // Only flush the pending batch if we have time to wait for the
+        // HTTP response. Spawning a POST and then bailing on the
+        // deadline before we can drain it would let the request land
+        // in ClickHouse without the matching offset commit — duplicate
+        // data on the next consumer instance picking up from the last
+        // committed offset. `SetJoinTimeout(0)` (used by arroyo to
+        // drop in-flight work during rebalance) exercises this path.
+        if deadline.is_some_and(|d| d.has_elapsed()) {
+            if let Some(pending) = self.pending.take() {
+                tracing::warn!(
+                    "Streaming writer join called with already-elapsed deadline; abandoning pending batch ({} rows, {} uncompressed bytes)",
+                    pending.num_rows,
+                    pending.num_bytes
+                );
+            }
+        } else if self.in_flight.is_none() && self.message_carried_over.is_none() {
             self.flush_pending();
         }
 
         // Drain until we either finish everything in flight or hit the
         // deadline. Pass the remaining deadline into the drain so
-        // block_on inside it is bounded — otherwise a hung HTTP
+        // `block_on` inside it is bounded — otherwise a hung HTTP
         // response would keep `join` running indefinitely regardless
-        // of the timeout we were given.
+        // of the timeout we were given. On a deadline-driven break,
+        // abort any still-running in-flight task: leaving it detached
+        // would let the POST complete after we've already returned,
+        // landing data in ClickHouse for offsets we never committed.
         while self.in_flight.is_some() || self.message_carried_over.is_some() {
             if deadline.is_some_and(|d| d.has_elapsed()) {
-                tracing::warn!(
-                    "Timeout {:?} reached while waiting for streaming writer to finish",
-                    timeout
-                );
+                if let Some(in_flight) = self.in_flight.take() {
+                    if let Some(handle) = in_flight.handle {
+                        handle.abort();
+                    }
+                    tracing::warn!(
+                        "Timeout {:?} reached during streaming-writer join; aborted in-flight batch ({} rows)",
+                        timeout,
+                        in_flight.num_rows
+                    );
+                }
+                self.message_carried_over = None;
                 break;
             }
 
@@ -751,6 +772,57 @@ mod tests {
         // The stuck batch was aborted, not flushed downstream — the
         // recording step must not have seen anything.
         assert!(recorded.lock().is_empty());
+    }
+
+    /// `join(Some(0))` (arroyo's drop-in-flight rebalance signal) must
+    /// not spawn a fresh HTTP POST for the pending batch — doing so
+    /// would let CH receive the rows while the offsets never reach
+    /// downstream commit steps, producing duplicates on the next
+    /// consumer. Confirm pending is abandoned and the downstream
+    /// recorder sees nothing.
+    #[tokio::test]
+    async fn join_with_elapsed_deadline_abandons_pending() {
+        crate::testutils::initialize_python();
+        let runtime = Handle::current();
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let next_step = RecordingStep {
+            batches: recorded.clone(),
+        };
+        // skip_write=false so the writer would normally spawn an HTTP
+        // task at flush time. With elapsed deadline, it must skip the
+        // flush entirely.
+        let mut strategy = StreamingClickhouseWriter::new(
+            next_step,
+            skip_write_client(),
+            false,
+            runtime,
+            10,
+            Duration::from_secs(3600),
+            |b| b.len(),
+        );
+
+        let partition = Partition::new(Topic::new("t"), 0);
+        strategy
+            .submit(make_message(batch_with(1, 50), partition, 0))
+            .expect("submit should be accepted");
+        // Pending now holds bytes that would be POSTed on a normal flush.
+
+        strategy
+            .join(Some(Duration::ZERO))
+            .expect("join should not error");
+
+        assert!(
+            recorded.lock().is_empty(),
+            "elapsed-deadline join must not propagate the pending batch downstream"
+        );
+        assert!(
+            strategy.pending.is_none(),
+            "pending should be abandoned, not carried forward"
+        );
+        assert!(
+            strategy.in_flight.is_none(),
+            "no HTTP task should be spawned"
+        );
     }
 
     /// `join` on an empty strategy is a no-op — never opens a request,

--- a/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
@@ -83,6 +83,18 @@ struct PendingBatch {
     chunks: Arc<Mutex<Vec<Bytes>>>,
 }
 
+/// How `try_drain_in_flight` should handle a not-yet-finished
+/// HTTP handle. Keeps the join-time bounded wait distinct from
+/// the non-blocking probe `poll` uses each tick.
+enum DrainMode {
+    /// Return immediately if the handle isn't finished yet.
+    NonBlocking,
+    /// Wait indefinitely (used when `join` was called with no timeout).
+    BlockForever,
+    /// Wait up to the given duration; abort the task on elapsed.
+    BlockUpTo(Duration),
+}
+
 /// A batch whose body has been finalized and is awaiting the HTTP
 /// response (or, for batches that never opened an HTTP request, ready
 /// to be submitted downstream immediately).
@@ -225,9 +237,7 @@ where
         });
     }
 
-    /// Try to drain the in-flight batch. If `blocking` is false, returns
-    /// without doing work when the HTTP request hasn't finished yet. If
-    /// `blocking`, waits for the request to complete (used by `join`).
+    /// Try to drain the in-flight batch.
     ///
     /// Calls `Handle::block_on` to bridge from the synchronous arroyo
     /// strategy loop to the async tokio task. This is safe: arroyo
@@ -239,24 +249,55 @@ where
     /// the merged meta + offsets, and submits it to `next_step`. A
     /// downstream `MessageRejected` is stashed in `message_carried_over`
     /// for `poll` to retry — we still consider `in_flight` drained.
-    fn try_drain_in_flight(&mut self, blocking: bool) -> Result<(), StrategyError> {
+    fn try_drain_in_flight(&mut self, mode: DrainMode) -> Result<(), StrategyError> {
         let Some(mut in_flight) = self.in_flight.take() else {
             return Ok(());
         };
         match in_flight.handle.take() {
             None => {}
-            Some(handle) => {
-                if !blocking && !handle.is_finished() {
-                    in_flight.handle = Some(handle);
-                    self.in_flight = Some(in_flight);
-                    return Ok(());
+            Some(mut handle) => match mode {
+                DrainMode::NonBlocking => {
+                    if !handle.is_finished() {
+                        in_flight.handle = Some(handle);
+                        self.in_flight = Some(in_flight);
+                        return Ok(());
+                    }
+                    // is_finished() == true → block_on returns immediately.
+                    match self.runtime.block_on(&mut handle) {
+                        Ok(Ok(_response)) => {}
+                        Ok(Err(e)) => return Err(StrategyError::Other(e.into())),
+                        Err(e) => return Err(StrategyError::Other(Box::new(e))),
+                    }
                 }
-                match self.runtime.block_on(handle) {
+                DrainMode::BlockForever => match self.runtime.block_on(&mut handle) {
                     Ok(Ok(_response)) => {}
                     Ok(Err(e)) => return Err(StrategyError::Other(e.into())),
                     Err(e) => return Err(StrategyError::Other(Box::new(e))),
+                },
+                DrainMode::BlockUpTo(max_wait) => {
+                    // Pass `&mut handle` (JoinHandle is Unpin) so on
+                    // timeout we still own the handle and can abort
+                    // the task. Without the abort, the task would
+                    // detach and keep its retry_buf live until it
+                    // exhausts retries or the runtime drops.
+                    let timeout_res = self
+                        .runtime
+                        .block_on(async { tokio::time::timeout(max_wait, &mut handle).await });
+                    match timeout_res {
+                        Ok(Ok(Ok(_response))) => {}
+                        Ok(Ok(Err(e))) => return Err(StrategyError::Other(e.into())),
+                        Ok(Err(e)) => return Err(StrategyError::Other(Box::new(e))),
+                        Err(_elapsed) => {
+                            handle.abort();
+                            tracing::warn!(
+                                "Streaming HTTP write exceeded {:?}; aborted in-flight task. Batch metadata not committed downstream — the next consumer instance will retry from the last committed offset.",
+                                max_wait
+                            );
+                            return Ok(());
+                        }
+                    }
                 }
-            }
+            },
         }
 
         let write_finish = SystemTime::now();
@@ -333,7 +374,7 @@ where
         // Drain a finished in-flight before considering whether to flush
         // pending — we only allow one batch in flight at a time.
         if self.message_carried_over.is_none() {
-            self.try_drain_in_flight(false)?;
+            self.try_drain_in_flight(DrainMode::NonBlocking)?;
         }
 
         if self.in_flight.is_none()
@@ -344,7 +385,7 @@ where
             // Best-effort drain: the handle is unlikely to be done this
             // tick, but if it is (or there's no handle), we hand the
             // result off immediately.
-            self.try_drain_in_flight(false)?;
+            self.try_drain_in_flight(DrainMode::NonBlocking)?;
         }
 
         // Sample the writer's resident-memory footprint after the tick
@@ -437,8 +478,10 @@ where
         }
 
         // Drain until we either finish everything in flight or hit the
-        // deadline. `try_drain_in_flight(true)` blocks on the handle, so
-        // this loop won't spin.
+        // deadline. Pass the remaining deadline into the drain so
+        // block_on inside it is bounded — otherwise a hung HTTP
+        // response would keep `join` running indefinitely regardless
+        // of the timeout we were given.
         while self.in_flight.is_some() || self.message_carried_over.is_some() {
             if deadline.is_some_and(|d| d.has_elapsed()) {
                 tracing::warn!(
@@ -454,7 +497,11 @@ where
 
             self.try_resubmit_carried_over()?;
             if self.message_carried_over.is_none() {
-                self.try_drain_in_flight(true)?;
+                let mode = match deadline {
+                    Some(d) => DrainMode::BlockUpTo(d.remaining()),
+                    None => DrainMode::BlockForever,
+                };
+                self.try_drain_in_flight(mode)?;
             }
         }
 
@@ -635,6 +682,75 @@ mod tests {
         // A second submit must now be rejected.
         let res = strategy.submit(make_message(batch_with(1, 50), partition, 1));
         assert!(matches!(res, Err(SubmitError::MessageRejected(_))));
+    }
+
+    /// If the HTTP task is hung (or just very slow), `join` must
+    /// return within the requested timeout instead of blocking
+    /// indefinitely on the spawned future. Inject a never-resolving
+    /// handle directly into `in_flight` and confirm `join(200ms)`
+    /// honors the bound.
+    ///
+    /// Uses `#[test]` (not `#[tokio::test]`) because the strategy's
+    /// `runtime.block_on(...)` panics if invoked from within an
+    /// existing tokio runtime — which is fine in production (arroyo
+    /// drives strategies from the consumer thread, not a tokio task)
+    /// but makes `#[tokio::test]` unsuitable for any test that
+    /// actually exercises the block_on path.
+    #[test]
+    fn join_respects_timeout_with_hung_http() {
+        crate::testutils::initialize_python();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        let handle = runtime.handle().clone();
+
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let next_step = RecordingStep {
+            batches: recorded.clone(),
+        };
+        let mut strategy = StreamingClickhouseWriter::new(
+            next_step,
+            skip_write_client(),
+            true,
+            handle.clone(),
+            10,
+            Duration::from_secs(3600),
+            |b| b.len(),
+        );
+
+        // Spawn a task on the runtime that pretends to be the HTTP
+        // request but never resolves. Without the timeout-bounded
+        // drain, `join` would wait on it forever via `block_on(handle)`.
+        let stuck = handle.spawn(async {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            anyhow::bail!("would have resolved if we ever got here")
+        });
+        strategy.in_flight = Some(InFlightBatch {
+            handle: Some(stuck),
+            num_rows: 0,
+            num_bytes: 0,
+            compressed_bytes: 0,
+            offsets: BTreeMap::new(),
+            meta: BytesInsertBatch::<()>::default(),
+            write_start: SystemTime::now(),
+        });
+
+        let join_timeout = Duration::from_millis(200);
+        let started = std::time::Instant::now();
+        strategy
+            .join(Some(join_timeout))
+            .expect("join should not error on timeout");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "join took {elapsed:?}; should have honored the {join_timeout:?} budget"
+        );
+        // The stuck batch was aborted, not flushed downstream — the
+        // recording step must not have seen anything.
+        assert!(recorded.lock().is_empty());
     }
 
     /// `join` on an empty strategy is a no-op — never opens a request,

--- a/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
@@ -38,7 +38,7 @@ use sentry_arroyo::processing::strategies::{
 };
 use sentry_arroyo::types::{Message, Partition};
 use sentry_arroyo::utils::timing::Deadline;
-use sentry_arroyo::{counter, timer};
+use sentry_arroyo::{counter, gauge, timer};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 
@@ -60,6 +60,10 @@ struct PendingBatch {
     /// messages. Reported as `insertions.batch_write_bytes` so the
     /// metric meaning matches the buffered writer.
     num_bytes: usize,
+    /// Sum of compressed chunk sizes already in `chunks`. Tracked
+    /// alongside the buffer so the resident-memory gauge can read it
+    /// without locking + iterating `chunks` on every poll.
+    compressed_bytes: usize,
     offsets: BTreeMap<Partition, u64>,
     meta: BytesInsertBatch<()>,
     /// Wall-clock at the moment the first message of the batch arrived.
@@ -86,6 +90,11 @@ struct InFlightBatch {
     handle: Option<JoinHandle<anyhow::Result<Response>>>,
     num_rows: usize,
     num_bytes: usize,
+    /// Total compressed body size (== chunk buffer footprint). Held
+    /// for the duration of the HTTP request; reported as the
+    /// `resident_compressed_bytes` gauge while in flight and as
+    /// `last_batch_compressed_bytes` once the response lands.
+    compressed_bytes: usize,
     offsets: BTreeMap<Partition, u64>,
     meta: BytesInsertBatch<()>,
     write_start: SystemTime,
@@ -144,6 +153,7 @@ where
             batch_size: 0,
             num_rows: 0,
             num_bytes: 0,
+            compressed_bytes: 0,
             offsets: BTreeMap::new(),
             meta: BytesInsertBatch::<()>::default(),
             write_start: SystemTime::now(),
@@ -168,6 +178,7 @@ where
             batch_size: _,
             num_rows,
             num_bytes,
+            mut compressed_bytes,
             offsets,
             meta,
             write_start,
@@ -176,6 +187,7 @@ where
         } = pending;
 
         if let Some(last) = compressor.finish() {
+            compressed_bytes += last.len();
             chunks.lock().push(last);
         }
 
@@ -206,6 +218,7 @@ where
             handle,
             num_rows,
             num_bytes,
+            compressed_bytes,
             offsets,
             meta,
             write_start,
@@ -252,6 +265,19 @@ where
         }
         counter!("insertions.batch_write_bytes", in_flight.num_bytes as i64);
         counter!("insertions.batch_write_msgs", in_flight.num_rows as i64);
+        // Per-batch input → output sizing. The pair lets dashboards
+        // correlate ClickHouse insert load (compressed bytes on wire)
+        // with the consumer-side memory peak we hold for that batch
+        // — the resident gauge below samples the live side of the
+        // same number.
+        gauge!(
+            "insertions.streaming_writer.last_batch_uncompressed_bytes",
+            in_flight.num_bytes as u64
+        );
+        gauge!(
+            "insertions.streaming_writer.last_batch_compressed_bytes",
+            in_flight.compressed_bytes as u64
+        );
         in_flight.meta.record_message_latency();
         in_flight.meta.emit_item_type_metrics();
         tracing::info!("Inserted {} rows (streamed)", in_flight.num_rows);
@@ -321,6 +347,22 @@ where
             self.try_drain_in_flight(false)?;
         }
 
+        // Sample the writer's resident-memory footprint after the tick
+        // has settled — pending and in_flight are mutually exclusive,
+        // so this is the total compressed bytes the strategy is holding
+        // (the uncompressed source bytes are already gone). Lets us
+        // correlate consumer RSS with batch sizing if we hit memory
+        // pressure again.
+        let resident = match (&self.pending, &self.in_flight) {
+            (Some(p), _) => p.compressed_bytes,
+            (None, Some(b)) => b.compressed_bytes,
+            (None, None) => 0,
+        };
+        gauge!(
+            "insertions.streaming_writer.resident_compressed_bytes",
+            resident as u64
+        );
+
         Ok(self.commit_request_carried_over.take())
     }
 
@@ -361,6 +403,7 @@ where
             if !new_chunks.is_empty() {
                 let mut buf = pending.chunks.lock();
                 for chunk in new_chunks {
+                    pending.compressed_bytes += chunk.len();
                     buf.push(chunk);
                 }
             }

--- a/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
@@ -523,6 +523,13 @@ where
                     None => DrainMode::BlockForever,
                 };
                 self.try_drain_in_flight(mode)?;
+            } else {
+                // Downstream is back-pressuring our merged-meta submit
+                // and there's no in_flight to block on — the loop
+                // would otherwise spin on the deadline check and
+                // burn a core until timeout. Yield briefly so the
+                // wait is bounded by sleep rather than CPU.
+                std::thread::sleep(Duration::from_millis(10));
             }
         }
 

--- a/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
@@ -1,0 +1,652 @@
+//! Streaming write path for ClickHouse INSERTs.
+//!
+//! Replaces the `Reduce → ClickhouseWriterStep` pair for the RowBinary
+//! path. Instead of accumulating the full uncompressed batch in a
+//! `BytesInsertBatch<RowData>` and then handing it to a buffered writer
+//! that compresses and sends in one shot, this strategy compresses rows
+//! into ClickHouse-native LZ4 blocks as messages arrive and pushes the
+//! resulting `Bytes` onto an HTTP body channel feeding a single in-flight
+//! POST per batch. The encoded uncompressed bytes are dropped per
+//! message; the compressed chunks live in the `retry_buf` (and in the
+//! mpsc until reqwest drains them).
+//!
+//! Concurrency is fixed at one in-flight batch — submits are rejected
+//! while we're awaiting the previous batch's response. The existing
+//! buffered path uses `RunTaskInThreads` for inter-batch concurrency;
+//! we sacrifice that here for a much smaller resident set and a simpler
+//! state machine.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use bytes::Bytes;
+use reqwest::Response;
+use sentry_arroyo::processing::strategies::{
+    merge_commit_request, CommitRequest, MessageRejected, ProcessingStrategy, StrategyError,
+    SubmitError,
+};
+use sentry_arroyo::types::{Message, Partition};
+use sentry_arroyo::utils::timing::Deadline;
+use sentry_arroyo::{counter, timer};
+use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use super::streaming_lz4::StreamingLz4Compressor;
+use super::writer_v2::{ClickhouseClient, RetryConfig};
+use crate::types::{BytesInsertBatch, RowData};
+
+/// State for the batch currently being accumulated. Holds the running
+/// metadata plus, once the first non-empty message arrives, the
+/// streaming compression + HTTP request handle.
+struct PendingBatch {
+    batch_start: Deadline,
+    /// Running batch-size measurement under `compute_batch_size`. Drives
+    /// the size-based flush decision in `poll`.
+    batch_size: usize,
+    /// Sum of `RowData::num_rows` across accumulated messages.
+    num_rows: usize,
+    /// Sum of uncompressed encoded byte sizes across accumulated
+    /// messages. Reported as `insertions.batch_write_bytes` so the
+    /// metric meaning matches the buffered writer.
+    num_bytes: usize,
+    offsets: BTreeMap<Partition, u64>,
+    meta: BytesInsertBatch<()>,
+    /// Wall-clock at the moment the first message of the batch arrived.
+    /// Used to compute `insertions.batch_write_ms` on completion.
+    write_start: SystemTime,
+    /// `None` until the first non-empty, non-skipped message lands. We
+    /// don't open an HTTP request for empty batches (commit-only flushes).
+    streaming: Option<StreamingState>,
+}
+
+struct StreamingState {
+    compressor: StreamingLz4Compressor,
+    /// Producer side of the request body channel. Dropping it signals
+    /// end-of-body to reqwest, which then finalizes the POST.
+    body_tx: mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+    /// Shared with the spawned `send_streamed` task — every compressed
+    /// chunk we push to `body_tx` is also recorded here so retries can
+    /// replay the body without re-running the (already-consumed) stream.
+    retry_buf: Arc<std::sync::Mutex<Vec<Bytes>>>,
+    handle: JoinHandle<anyhow::Result<Response>>,
+}
+
+/// A batch whose body has been finalized and is awaiting the HTTP
+/// response (or, for batches that never opened an HTTP request, ready
+/// to be submitted downstream immediately).
+struct InFlightBatch {
+    handle: Option<JoinHandle<anyhow::Result<Response>>>,
+    num_rows: usize,
+    num_bytes: usize,
+    offsets: BTreeMap<Partition, u64>,
+    meta: BytesInsertBatch<()>,
+    write_start: SystemTime,
+}
+
+pub struct StreamingClickhouseWriter<N> {
+    next_step: N,
+    client: Arc<ClickhouseClient>,
+    skip_write: bool,
+    runtime: Handle,
+    max_batch_size: usize,
+    max_batch_time: Duration,
+    compute_batch_size: fn(&BytesInsertBatch<RowData>) -> usize,
+
+    pending: Option<PendingBatch>,
+    in_flight: Option<InFlightBatch>,
+
+    /// Set when `next_step.submit` returned `MessageRejected`; retried
+    /// on the next `poll`. Mirrors the carry-over pattern in `Reduce`.
+    message_carried_over: Option<Message<BytesInsertBatch<()>>>,
+    commit_request_carried_over: Option<CommitRequest>,
+}
+
+impl<N> StreamingClickhouseWriter<N>
+where
+    N: ProcessingStrategy<BytesInsertBatch<()>> + 'static,
+{
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        next_step: N,
+        client: Arc<ClickhouseClient>,
+        skip_write: bool,
+        runtime: Handle,
+        max_batch_size: usize,
+        max_batch_time: Duration,
+        compute_batch_size: fn(&BytesInsertBatch<RowData>) -> usize,
+    ) -> Self {
+        StreamingClickhouseWriter {
+            next_step,
+            client,
+            skip_write,
+            runtime,
+            max_batch_size,
+            max_batch_time,
+            compute_batch_size,
+            pending: None,
+            in_flight: None,
+            message_carried_over: None,
+            commit_request_carried_over: None,
+        }
+    }
+
+    /// Ensure `self.pending` exists with the streaming state initialized
+    /// up to (but not including) the first compressed chunk. Spawns the
+    /// `send_streamed` task lazily — the first message of a batch may
+    /// be empty (or `skip_write` may be set), in which case we never open
+    /// an HTTP request and the in-flight batch carries `handle = None`.
+    fn ensure_pending(&mut self) -> &mut PendingBatch {
+        self.pending.get_or_insert_with(|| PendingBatch {
+            batch_start: Deadline::new(self.max_batch_time),
+            batch_size: 0,
+            num_rows: 0,
+            num_bytes: 0,
+            offsets: BTreeMap::new(),
+            meta: BytesInsertBatch::<()>::default(),
+            write_start: SystemTime::now(),
+            streaming: None,
+        })
+    }
+
+    /// Lazy-start the HTTP request task on the first non-empty message.
+    fn ensure_streaming(
+        client: Arc<ClickhouseClient>,
+        runtime: &Handle,
+        pending: &mut PendingBatch,
+    ) {
+        if pending.streaming.is_some() {
+            return;
+        }
+        let (body_tx, body_rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+        let retry_buf: Arc<std::sync::Mutex<Vec<Bytes>>> = Arc::new(Default::default());
+        let stream = UnboundedReceiverStream::new(body_rx);
+        let retry_buf_for_task = retry_buf.clone();
+        let handle = runtime.spawn(async move {
+            client
+                .send_streamed(stream, retry_buf_for_task, RetryConfig::default())
+                .await
+        });
+        pending.streaming = Some(StreamingState {
+            compressor: StreamingLz4Compressor::new(),
+            body_tx,
+            retry_buf,
+            handle,
+        });
+    }
+
+    /// Append `bytes` to the active streaming compressor. Every chunk
+    /// that pops out of the compressor is teed into `retry_buf` (so
+    /// retries can replay it) and pushed onto `body_tx`. Send errors on
+    /// `body_tx` are intentionally ignored: they signal that the first
+    /// HTTP attempt consumed-and-dropped the stream after a network
+    /// error, and `send_streamed`'s retry loop will pick up from
+    /// `retry_buf` once we close the body.
+    fn push_bytes(streaming: &mut StreamingState, bytes: &[u8]) {
+        let chunks = streaming.compressor.push(bytes);
+        if chunks.is_empty() {
+            return;
+        }
+        {
+            let mut buf = streaming.retry_buf.lock().unwrap();
+            for chunk in &chunks {
+                buf.push(chunk.clone());
+            }
+        }
+        for chunk in chunks {
+            let _ = streaming.body_tx.send(Ok(chunk));
+        }
+    }
+
+    /// Move `pending` → `in_flight`: drain the compressor's tail (if
+    /// any), drop the sender to close the HTTP body, and stash the
+    /// `JoinHandle` for `poll` to await. Must be called only when
+    /// `in_flight` is `None` (the strategy keeps at most one batch in
+    /// flight at a time).
+    fn flush_pending(&mut self) {
+        debug_assert!(self.in_flight.is_none());
+        let Some(pending) = self.pending.take() else {
+            return;
+        };
+        let PendingBatch {
+            batch_start: _,
+            batch_size: _,
+            num_rows,
+            num_bytes,
+            offsets,
+            meta,
+            write_start,
+            streaming,
+        } = pending;
+        let handle = streaming.map(|s| {
+            let StreamingState {
+                compressor,
+                body_tx,
+                retry_buf,
+                handle,
+            } = s;
+            if let Some(last) = compressor.finish() {
+                retry_buf.lock().unwrap().push(last.clone());
+                let _ = body_tx.send(Ok(last));
+            }
+            // Dropping `body_tx` here closes the HTTP body — `send_streamed`
+            // sees end-of-stream and finalizes the POST.
+            drop(body_tx);
+            handle
+        });
+        self.in_flight = Some(InFlightBatch {
+            handle,
+            num_rows,
+            num_bytes,
+            offsets,
+            meta,
+            write_start,
+        });
+    }
+
+    /// Try to drain the in-flight batch. If `blocking` is false, returns
+    /// without doing work when the HTTP request hasn't finished yet. If
+    /// `blocking`, waits for the request to complete (used by `join`).
+    ///
+    /// On success: emits per-batch metrics, builds an any-message with
+    /// the merged meta + offsets, and submits it to `next_step`. A
+    /// downstream `MessageRejected` is stashed in `message_carried_over`
+    /// for `poll` to retry — we still consider `in_flight` drained.
+    fn try_drain_in_flight(&mut self, blocking: bool) -> Result<(), StrategyError> {
+        let Some(mut in_flight) = self.in_flight.take() else {
+            return Ok(());
+        };
+        match in_flight.handle.take() {
+            None => {}
+            Some(handle) => {
+                if !blocking && !handle.is_finished() {
+                    in_flight.handle = Some(handle);
+                    self.in_flight = Some(in_flight);
+                    return Ok(());
+                }
+                match self.runtime.block_on(handle) {
+                    Ok(Ok(_response)) => {}
+                    Ok(Err(e)) => return Err(StrategyError::Other(e.into())),
+                    Err(e) => return Err(StrategyError::Other(Box::new(e))),
+                }
+            }
+        }
+
+        let write_finish = SystemTime::now();
+        if let Ok(elapsed) = write_finish.duration_since(in_flight.write_start) {
+            timer!("insertions.batch_write_ms", elapsed);
+        }
+        counter!("insertions.batch_write_bytes", in_flight.num_bytes as i64);
+        counter!("insertions.batch_write_msgs", in_flight.num_rows as i64);
+        in_flight.meta.record_message_latency();
+        in_flight.meta.emit_item_type_metrics();
+        tracing::info!("Inserted {} rows (streamed)", in_flight.num_rows);
+
+        let message = Message::new_any_message(in_flight.meta, in_flight.offsets);
+        match self.next_step.submit(message) {
+            Ok(()) => Ok(()),
+            Err(SubmitError::MessageRejected(MessageRejected { message })) => {
+                self.message_carried_over = Some(message);
+                Ok(())
+            }
+            Err(SubmitError::InvalidMessage(e)) => Err(e.into()),
+        }
+    }
+
+    /// True if `pending` is at or past its size or time budget. Empty
+    /// batches are eligible once the time budget elapses so commit-only
+    /// flushes still propagate downstream (mirrors `Reduce` with
+    /// `flush_empty_batches(true)`).
+    fn pending_ready_to_flush(&self) -> bool {
+        let Some(pending) = &self.pending else {
+            return false;
+        };
+        pending.batch_size >= self.max_batch_size || pending.batch_start.has_elapsed()
+    }
+
+    fn try_resubmit_carried_over(&mut self) -> Result<(), StrategyError> {
+        let Some(message) = self.message_carried_over.take() else {
+            return Ok(());
+        };
+        match self.next_step.submit(message) {
+            Ok(()) => Ok(()),
+            Err(SubmitError::MessageRejected(MessageRejected { message })) => {
+                self.message_carried_over = Some(message);
+                Ok(())
+            }
+            Err(SubmitError::InvalidMessage(e)) => Err(e.into()),
+        }
+    }
+}
+
+impl<N> ProcessingStrategy<BytesInsertBatch<RowData>> for StreamingClickhouseWriter<N>
+where
+    N: ProcessingStrategy<BytesInsertBatch<()>> + 'static,
+{
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
+        let commit_request = self.next_step.poll()?;
+        self.commit_request_carried_over =
+            merge_commit_request(self.commit_request_carried_over.take(), commit_request);
+
+        self.try_resubmit_carried_over()?;
+
+        // Drain a finished in-flight before considering whether to flush
+        // pending — we only allow one batch in flight at a time.
+        if self.message_carried_over.is_none() {
+            self.try_drain_in_flight(false)?;
+        }
+
+        if self.in_flight.is_none()
+            && self.message_carried_over.is_none()
+            && self.pending_ready_to_flush()
+        {
+            self.flush_pending();
+            // Best-effort drain: the handle is unlikely to be done this
+            // tick, but if it is (or there's no handle), we hand the
+            // result off immediately.
+            self.try_drain_in_flight(false)?;
+        }
+
+        Ok(self.commit_request_carried_over.take())
+    }
+
+    fn submit(
+        &mut self,
+        message: Message<BytesInsertBatch<RowData>>,
+    ) -> Result<(), SubmitError<BytesInsertBatch<RowData>>> {
+        if self.in_flight.is_some() || self.message_carried_over.is_some() {
+            return Err(SubmitError::MessageRejected(MessageRejected { message }));
+        }
+
+        let commitables: Vec<(Partition, u64)> = message.committable().collect();
+        let batch_size_inc = (self.compute_batch_size)(message.payload());
+        let payload = message.into_payload();
+        let (row_data, msg_meta) = payload.take();
+        let RowData {
+            encoded_rows,
+            num_rows,
+        } = row_data;
+        let row_bytes_len = encoded_rows.len();
+
+        let client = self.client.clone();
+        let runtime = self.runtime.clone();
+        let skip_write = self.skip_write;
+        let pending = self.ensure_pending();
+
+        pending.batch_size += batch_size_inc;
+        pending.num_rows += num_rows;
+        pending.num_bytes += row_bytes_len;
+        for (partition, offset) in commitables {
+            pending.offsets.insert(partition, offset);
+        }
+        let prev_meta = std::mem::take(&mut pending.meta);
+        pending.meta = prev_meta.merge_meta(msg_meta);
+
+        if !encoded_rows.is_empty() && !skip_write {
+            Self::ensure_streaming(client, &runtime, pending);
+            // safety: `ensure_streaming` populates `streaming`.
+            let streaming = pending.streaming.as_mut().unwrap();
+            Self::push_bytes(streaming, &encoded_rows);
+        }
+        // Free the encoded uncompressed bytes immediately. (Already
+        // dropped on the previous line — the explicit drop here is
+        // defensive against a future edit that adds a branch which
+        // forgets to consume `encoded_rows`.)
+        drop(encoded_rows);
+
+        Ok(())
+    }
+
+    fn terminate(&mut self) {
+        if let Some(pending) = self.pending.take() {
+            if let Some(streaming) = pending.streaming {
+                streaming.handle.abort();
+            }
+        }
+        if let Some(in_flight) = self.in_flight.take() {
+            if let Some(handle) = in_flight.handle {
+                handle.abort();
+            }
+        }
+        self.next_step.terminate();
+    }
+
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
+        let deadline = timeout.map(Deadline::new);
+
+        // Force-flush any in-progress batch so the request closes and
+        // begins finishing. After this, `in_flight` is set (or there
+        // was nothing pending), and we just need to wait for the HTTP
+        // response and drain into next_step.
+        if self.in_flight.is_none() && self.message_carried_over.is_none() {
+            self.flush_pending();
+        }
+
+        // Drain until we either finish everything in flight or hit the
+        // deadline. `try_drain_in_flight(true)` blocks on the handle, so
+        // this loop won't spin.
+        while self.in_flight.is_some() || self.message_carried_over.is_some() {
+            if deadline.is_some_and(|d| d.has_elapsed()) {
+                tracing::warn!(
+                    "Timeout {:?} reached while waiting for streaming writer to finish",
+                    timeout
+                );
+                break;
+            }
+
+            let commit = self.next_step.poll()?;
+            self.commit_request_carried_over =
+                merge_commit_request(self.commit_request_carried_over.take(), commit);
+
+            self.try_resubmit_carried_over()?;
+            if self.message_carried_over.is_none() {
+                self.try_drain_in_flight(true)?;
+            }
+        }
+
+        let next_commit = self.next_step.join(deadline.map(|d| d.remaining()))?;
+        Ok(merge_commit_request(
+            self.commit_request_carried_over.take(),
+            next_commit,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use sentry_arroyo::types::{BrokerMessage, InnerMessage, Topic};
+
+    use crate::config::ClickhouseConfig;
+    use crate::strategies::clickhouse::writer_v2::InsertFormat;
+
+    use super::*;
+
+    /// Records every batch the writer hands downstream.
+    struct RecordingStep {
+        batches: Arc<Mutex<Vec<BytesInsertBatch<()>>>>,
+    }
+
+    impl ProcessingStrategy<BytesInsertBatch<()>> for RecordingStep {
+        fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
+            Ok(None)
+        }
+        fn submit(
+            &mut self,
+            message: Message<BytesInsertBatch<()>>,
+        ) -> Result<(), SubmitError<BytesInsertBatch<()>>> {
+            self.batches.lock().unwrap().push(message.into_payload());
+            Ok(())
+        }
+        fn terminate(&mut self) {}
+        fn join(&mut self, _: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
+            Ok(None)
+        }
+    }
+
+    fn unreachable_config() -> ClickhouseConfig {
+        // Point at a port nothing is listening on. Combined with
+        // `skip_write=true` we never even reach the network.
+        ClickhouseConfig {
+            host: "127.0.0.1".to_string(),
+            port: 9000,
+            secure: false,
+            http_port: 9999,
+            user: "default".to_string(),
+            password: "".to_string(),
+            database: "default".to_string(),
+        }
+    }
+
+    fn skip_write_client() -> Arc<ClickhouseClient> {
+        Arc::new(ClickhouseClient::new(
+            &unreachable_config(),
+            "test_table",
+            "test_storage".to_string(),
+            InsertFormat::RowBinary,
+            Some(&["col"]),
+        ))
+    }
+
+    fn make_message(
+        payload: BytesInsertBatch<RowData>,
+        partition: Partition,
+        offset: u64,
+    ) -> Message<BytesInsertBatch<RowData>> {
+        Message {
+            inner_message: InnerMessage::BrokerMessage(BrokerMessage::new(
+                payload,
+                partition,
+                offset,
+                chrono::Utc::now(),
+            )),
+        }
+    }
+
+    fn batch_with(rows: usize, bytes: usize) -> BytesInsertBatch<RowData> {
+        BytesInsertBatch::<RowData>::from_rows(RowData {
+            encoded_rows: vec![0u8; bytes],
+            num_rows: rows,
+        })
+        .with_num_bytes(bytes)
+    }
+
+    /// With `skip_write=true` and a row-based size limit of 2, three
+    /// messages produce one full flush + one trailing flush on join.
+    /// The downstream metadata batches must carry the merged offsets
+    /// and num_bytes.
+    #[tokio::test]
+    async fn row_based_batching_skip_write() {
+        crate::testutils::initialize_python();
+        let runtime = Handle::current();
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let next_step = RecordingStep {
+            batches: recorded.clone(),
+        };
+        let mut strategy = StreamingClickhouseWriter::new(
+            next_step,
+            skip_write_client(),
+            true, // skip_write
+            runtime,
+            2,                         // max_batch_size
+            Duration::from_secs(3600), // huge time budget — only size triggers flush
+            |b| b.len(),
+        );
+
+        let partition = Partition::new(Topic::new("t"), 0);
+
+        for i in 0..3 {
+            strategy
+                .submit(make_message(batch_with(1, 100), partition, i))
+                .unwrap();
+            let _ = strategy.poll();
+        }
+        let _ = strategy.join(Some(Duration::from_secs(5))).unwrap();
+
+        let batches = recorded.lock().unwrap();
+        assert_eq!(batches.len(), 2, "size-flush + join-flush");
+        assert_eq!(batches[0].num_bytes(), 200, "two messages of 100B");
+        assert_eq!(batches[1].num_bytes(), 100, "trailing single message");
+    }
+
+    /// Submits are rejected when an in-flight batch is queued waiting
+    /// for the downstream `next_step.submit` to succeed.
+    #[tokio::test]
+    async fn submit_rejected_while_in_flight() {
+        crate::testutils::initialize_python();
+        let runtime = Handle::current();
+
+        // Downstream step that backpressures on every submit so the
+        // in-flight batch stays carried over.
+        struct AlwaysReject;
+        impl ProcessingStrategy<BytesInsertBatch<()>> for AlwaysReject {
+            fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
+                Ok(None)
+            }
+            fn submit(
+                &mut self,
+                message: Message<BytesInsertBatch<()>>,
+            ) -> Result<(), SubmitError<BytesInsertBatch<()>>> {
+                Err(SubmitError::MessageRejected(MessageRejected { message }))
+            }
+            fn terminate(&mut self) {}
+            fn join(
+                &mut self,
+                _: Option<Duration>,
+            ) -> Result<Option<CommitRequest>, StrategyError> {
+                Ok(None)
+            }
+        }
+
+        let mut strategy = StreamingClickhouseWriter::new(
+            AlwaysReject,
+            skip_write_client(),
+            true,
+            runtime,
+            1,
+            Duration::from_secs(3600),
+            |b| b.len(),
+        );
+
+        let partition = Partition::new(Topic::new("t"), 0);
+
+        // First submit fits and triggers a flush at size=1.
+        strategy
+            .submit(make_message(batch_with(1, 50), partition, 0))
+            .unwrap();
+        let _ = strategy.poll();
+
+        // The flushed batch is carried over because next_step rejected.
+        // A second submit must now be rejected.
+        let res = strategy.submit(make_message(batch_with(1, 50), partition, 1));
+        assert!(matches!(res, Err(SubmitError::MessageRejected(_))));
+    }
+
+    /// `join` on an empty strategy is a no-op — never opens a request,
+    /// never hangs.
+    #[tokio::test]
+    async fn join_with_no_messages_returns_immediately() {
+        crate::testutils::initialize_python();
+        let runtime = Handle::current();
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let next_step = RecordingStep {
+            batches: recorded.clone(),
+        };
+        let mut strategy = StreamingClickhouseWriter::new(
+            next_step,
+            skip_write_client(),
+            true,
+            runtime,
+            10,
+            Duration::from_secs(3600),
+            |b| b.len(),
+        );
+
+        strategy.join(Some(Duration::from_secs(1))).unwrap();
+        assert!(recorded.lock().unwrap().is_empty());
+    }
+}

--- a/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
+++ b/rust_snuba/src/strategies/clickhouse/streaming_writer.rs
@@ -4,17 +4,25 @@
 //! path. Instead of accumulating the full uncompressed batch in a
 //! `BytesInsertBatch<RowData>` and then handing it to a buffered writer
 //! that compresses and sends in one shot, this strategy compresses rows
-//! into ClickHouse-native LZ4 blocks as messages arrive and pushes the
-//! resulting `Bytes` onto an HTTP body channel feeding a single in-flight
-//! POST per batch. The encoded uncompressed bytes are dropped per
-//! message; the compressed chunks live in the `retry_buf` (and in the
-//! mpsc until reqwest drains them).
+//! into ClickHouse-native LZ4 blocks as messages arrive and accumulates
+//! the compressed `Bytes` in `chunks`. The encoded uncompressed bytes
+//! are dropped per message, so we never hold a full uncompressed batch
+//! in memory — peak resident set is ~0.3× the batch (compressed only).
+//!
+//! The HTTP POST is spawned at flush time, not at first-message time,
+//! with the full compressed batch in hand. Earlier drafts streamed the
+//! body live to overlap network with batch accumulation, but a network
+//! failure mid-stream could cause the retry to fire against a partial
+//! `retry_buf` (the strategy may still be adding chunks). ClickHouse
+//! would accept that truncated body and return OK, dropping the rest
+//! of the rows. Spawning at flush makes the body content immutable
+//! before the first attempt, so retries always see the full batch.
 //!
 //! Concurrency is fixed at one in-flight batch — submits are rejected
 //! while we're awaiting the previous batch's response. The existing
 //! buffered path uses `RunTaskInThreads` for inter-batch concurrency;
-//! we sacrifice that here for a much smaller resident set and a simpler
-//! state machine.
+//! we sacrifice that here for a much smaller resident set and a
+//! simpler state machine.
 
 use std::collections::BTreeMap;
 use std::io;
@@ -22,6 +30,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
+use parking_lot::Mutex;
 use reqwest::Response;
 use sentry_arroyo::processing::strategies::{
     merge_commit_request, CommitRequest, MessageRejected, ProcessingStrategy, StrategyError,
@@ -31,17 +40,15 @@ use sentry_arroyo::types::{Message, Partition};
 use sentry_arroyo::utils::timing::Deadline;
 use sentry_arroyo::{counter, timer};
 use tokio::runtime::Handle;
-use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::streaming_lz4::StreamingLz4Compressor;
 use super::writer_v2::{ClickhouseClient, RetryConfig};
 use crate::types::{BytesInsertBatch, RowData};
 
 /// State for the batch currently being accumulated. Holds the running
-/// metadata plus, once the first non-empty message arrives, the
-/// streaming compression + HTTP request handle.
+/// metadata plus the incremental compressor and the compressed-chunk
+/// buffer that becomes the HTTP body at flush time.
 struct PendingBatch {
     batch_start: Deadline,
     /// Running batch-size measurement under `compute_batch_size`. Drives
@@ -58,21 +65,18 @@ struct PendingBatch {
     /// Wall-clock at the moment the first message of the batch arrived.
     /// Used to compute `insertions.batch_write_ms` on completion.
     write_start: SystemTime,
-    /// `None` until the first non-empty, non-skipped message lands. We
-    /// don't open an HTTP request for empty batches (commit-only flushes).
-    streaming: Option<StreamingState>,
-}
-
-struct StreamingState {
+    /// Incremental ClickHouse-native LZ4 encoder. Fed one message's
+    /// `encoded_rows` at a time, emits one `Bytes` per complete 1 MiB
+    /// block; the final partial block is drained by `finish()` at flush.
     compressor: StreamingLz4Compressor,
-    /// Producer side of the request body channel. Dropping it signals
-    /// end-of-body to reqwest, which then finalizes the POST.
-    body_tx: mpsc::UnboundedSender<Result<Bytes, io::Error>>,
-    /// Shared with the spawned `send_streamed` task — every compressed
-    /// chunk we push to `body_tx` is also recorded here so retries can
-    /// replay the body without re-running the (already-consumed) stream.
-    retry_buf: Arc<std::sync::Mutex<Vec<Bytes>>>,
-    handle: JoinHandle<anyhow::Result<Response>>,
+    /// Compressed chunks accumulated for this batch. At flush time
+    /// this is both the body source for the HTTP POST and the
+    /// `retry_buf` passed to `send_streamed`, so the first attempt
+    /// and retries replay the exact same bytes. Uses
+    /// `parking_lot::Mutex` so neither side has to handle poisoning
+    /// — the lock is held briefly and there's nothing useful to do
+    /// if a holder panics anyway.
+    chunks: Arc<Mutex<Vec<Bytes>>>,
 }
 
 /// A batch whose body has been finalized and is awaiting the HTTP
@@ -134,11 +138,6 @@ where
         }
     }
 
-    /// Ensure `self.pending` exists with the streaming state initialized
-    /// up to (but not including) the first compressed chunk. Spawns the
-    /// `send_streamed` task lazily — the first message of a batch may
-    /// be empty (or `skip_write` may be set), in which case we never open
-    /// an HTTP request and the in-flight batch carries `handle = None`.
     fn ensure_pending(&mut self) -> &mut PendingBatch {
         self.pending.get_or_insert_with(|| PendingBatch {
             batch_start: Deadline::new(self.max_batch_time),
@@ -148,64 +147,17 @@ where
             offsets: BTreeMap::new(),
             meta: BytesInsertBatch::<()>::default(),
             write_start: SystemTime::now(),
-            streaming: None,
+            compressor: StreamingLz4Compressor::new(),
+            chunks: Arc::new(Default::default()),
         })
     }
 
-    /// Lazy-start the HTTP request task on the first non-empty message.
-    fn ensure_streaming(
-        client: Arc<ClickhouseClient>,
-        runtime: &Handle,
-        pending: &mut PendingBatch,
-    ) {
-        if pending.streaming.is_some() {
-            return;
-        }
-        let (body_tx, body_rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
-        let retry_buf: Arc<std::sync::Mutex<Vec<Bytes>>> = Arc::new(Default::default());
-        let stream = UnboundedReceiverStream::new(body_rx);
-        let retry_buf_for_task = retry_buf.clone();
-        let handle = runtime.spawn(async move {
-            client
-                .send_streamed(stream, retry_buf_for_task, RetryConfig::default())
-                .await
-        });
-        pending.streaming = Some(StreamingState {
-            compressor: StreamingLz4Compressor::new(),
-            body_tx,
-            retry_buf,
-            handle,
-        });
-    }
-
-    /// Append `bytes` to the active streaming compressor. Every chunk
-    /// that pops out of the compressor is teed into `retry_buf` (so
-    /// retries can replay it) and pushed onto `body_tx`. Send errors on
-    /// `body_tx` are intentionally ignored: they signal that the first
-    /// HTTP attempt consumed-and-dropped the stream after a network
-    /// error, and `send_streamed`'s retry loop will pick up from
-    /// `retry_buf` once we close the body.
-    fn push_bytes(streaming: &mut StreamingState, bytes: &[u8]) {
-        let chunks = streaming.compressor.push(bytes);
-        if chunks.is_empty() {
-            return;
-        }
-        {
-            let mut buf = streaming.retry_buf.lock().unwrap();
-            for chunk in &chunks {
-                buf.push(chunk.clone());
-            }
-        }
-        for chunk in chunks {
-            let _ = streaming.body_tx.send(Ok(chunk));
-        }
-    }
-
     /// Move `pending` → `in_flight`: drain the compressor's tail (if
-    /// any), drop the sender to close the HTTP body, and stash the
-    /// `JoinHandle` for `poll` to await. Must be called only when
-    /// `in_flight` is `None` (the strategy keeps at most one batch in
-    /// flight at a time).
+    /// any), then — if any compressed bytes were produced — spawn the
+    /// `send_streamed` task with the now-immutable chunk buffer as
+    /// both the body source and the retry source. Must be called only
+    /// when `in_flight` is `None` (the strategy keeps at most one
+    /// batch in flight at a time).
     fn flush_pending(&mut self) {
         debug_assert!(self.in_flight.is_none());
         let Some(pending) = self.pending.take() else {
@@ -219,24 +171,37 @@ where
             offsets,
             meta,
             write_start,
-            streaming,
+            compressor,
+            chunks,
         } = pending;
-        let handle = streaming.map(|s| {
-            let StreamingState {
-                compressor,
-                body_tx,
-                retry_buf,
-                handle,
-            } = s;
-            if let Some(last) = compressor.finish() {
-                retry_buf.lock().unwrap().push(last.clone());
-                let _ = body_tx.send(Ok(last));
+
+        if let Some(last) = compressor.finish() {
+            chunks.lock().push(last);
+        }
+
+        // After this point nothing else writes to `chunks`. Both the
+        // first attempt and retries inside `send_streamed` read from
+        // the same `Arc<Mutex<Vec<Bytes>>>`, so the body content is
+        // stable for the entire request lifetime.
+        let handle = {
+            let chunks_snapshot = chunks.lock();
+            if chunks_snapshot.is_empty() {
+                None
+            } else {
+                let body_chunks: Vec<Bytes> = chunks_snapshot.clone();
+                drop(chunks_snapshot);
+                let client = self.client.clone();
+                let chunks_for_retry = chunks.clone();
+                Some(self.runtime.spawn(async move {
+                    let body_stream =
+                        futures::stream::iter(body_chunks.into_iter().map(Ok::<_, io::Error>));
+                    client
+                        .send_streamed(body_stream, chunks_for_retry, RetryConfig::default())
+                        .await
+                }))
             }
-            // Dropping `body_tx` here closes the HTTP body — `send_streamed`
-            // sees end-of-stream and finalizes the POST.
-            drop(body_tx);
-            handle
-        });
+        };
+
         self.in_flight = Some(InFlightBatch {
             handle,
             num_rows,
@@ -250,6 +215,12 @@ where
     /// Try to drain the in-flight batch. If `blocking` is false, returns
     /// without doing work when the HTTP request hasn't finished yet. If
     /// `blocking`, waits for the request to complete (used by `join`).
+    ///
+    /// Calls `Handle::block_on` to bridge from the synchronous arroyo
+    /// strategy loop to the async tokio task. This is safe: arroyo
+    /// invokes `poll`/`join` on the consumer thread, which is not
+    /// itself running inside a tokio runtime — same pattern that
+    /// `RunTaskInThreads` uses today.
     ///
     /// On success: emits per-batch metrics, builds an any-message with
     /// the merged meta + offsets, and submits it to `next_step`. A
@@ -370,9 +341,6 @@ where
             num_rows,
         } = row_data;
         let row_bytes_len = encoded_rows.len();
-
-        let client = self.client.clone();
-        let runtime = self.runtime.clone();
         let skip_write = self.skip_write;
         let pending = self.ensure_pending();
 
@@ -386,26 +354,26 @@ where
         pending.meta = prev_meta.merge_meta(msg_meta);
 
         if !encoded_rows.is_empty() && !skip_write {
-            Self::ensure_streaming(client, &runtime, pending);
-            // safety: `ensure_streaming` populates `streaming`.
-            let streaming = pending.streaming.as_mut().unwrap();
-            Self::push_bytes(streaming, &encoded_rows);
+            // Compress in place. Any complete 1 MiB blocks are appended
+            // to `chunks` so they're already in the body buffer by the
+            // time we flush.
+            let new_chunks = pending.compressor.push(&encoded_rows);
+            if !new_chunks.is_empty() {
+                let mut buf = pending.chunks.lock();
+                for chunk in new_chunks {
+                    buf.push(chunk);
+                }
+            }
         }
-        // Free the encoded uncompressed bytes immediately. (Already
-        // dropped on the previous line — the explicit drop here is
-        // defensive against a future edit that adds a branch which
-        // forgets to consume `encoded_rows`.)
-        drop(encoded_rows);
+        // `encoded_rows` is dropped here at scope end — the source bytes
+        // never outlive this `submit` call, which is the whole point of
+        // the streaming path.
 
         Ok(())
     }
 
     fn terminate(&mut self) {
-        if let Some(pending) = self.pending.take() {
-            if let Some(streaming) = pending.streaming {
-                streaming.handle.abort();
-            }
-        }
+        self.pending = None;
         if let Some(in_flight) = self.in_flight.take() {
             if let Some(handle) = in_flight.handle {
                 handle.abort();
@@ -457,8 +425,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use sentry_arroyo::types::{BrokerMessage, InnerMessage, Topic};
 
     use crate::config::ClickhouseConfig;
@@ -479,7 +445,7 @@ mod tests {
             &mut self,
             message: Message<BytesInsertBatch<()>>,
         ) -> Result<(), SubmitError<BytesInsertBatch<()>>> {
-            self.batches.lock().unwrap().push(message.into_payload());
+            self.batches.lock().push(message.into_payload());
             Ok(())
         }
         fn terminate(&mut self) {}
@@ -562,12 +528,14 @@ mod tests {
         for i in 0..3 {
             strategy
                 .submit(make_message(batch_with(1, 100), partition, i))
-                .unwrap();
+                .expect("submit should be accepted");
             let _ = strategy.poll();
         }
-        let _ = strategy.join(Some(Duration::from_secs(5))).unwrap();
+        strategy
+            .join(Some(Duration::from_secs(5)))
+            .expect("join should not error");
 
-        let batches = recorded.lock().unwrap();
+        let batches = recorded.lock();
         assert_eq!(batches.len(), 2, "size-flush + join-flush");
         assert_eq!(batches[0].num_bytes(), 200, "two messages of 100B");
         assert_eq!(batches[1].num_bytes(), 100, "trailing single message");
@@ -617,7 +585,7 @@ mod tests {
         // First submit fits and triggers a flush at size=1.
         strategy
             .submit(make_message(batch_with(1, 50), partition, 0))
-            .unwrap();
+            .expect("first submit should be accepted");
         let _ = strategy.poll();
 
         // The flushed batch is carried over because next_step rejected.
@@ -646,7 +614,9 @@ mod tests {
             |b| b.len(),
         );
 
-        strategy.join(Some(Duration::from_secs(1))).unwrap();
-        assert!(recorded.lock().unwrap().is_empty());
+        strategy
+            .join(Some(Duration::from_secs(1)))
+            .expect("join should not error");
+        assert!(recorded.lock().is_empty());
     }
 }

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -370,7 +370,7 @@ impl ClickhouseClient {
     pub async fn send_streamed<S>(
         &self,
         body_stream: S,
-        retry_buf: Arc<std::sync::Mutex<Vec<Bytes>>>,
+        retry_buf: Arc<parking_lot::Mutex<Vec<Bytes>>>,
         retry_config: RetryConfig,
     ) -> anyhow::Result<Response>
     where
@@ -387,7 +387,7 @@ impl ClickhouseClient {
                 Some(b) => b,
                 None => {
                     // Clone is an Arc bump per chunk — no payload copy.
-                    let chunks: Vec<Bytes> = retry_buf.lock().unwrap().clone();
+                    let chunks: Vec<Bytes> = retry_buf.lock().clone();
                     reqwest::Body::wrap_stream(futures::stream::iter(
                         chunks.into_iter().map(Ok::<_, std::io::Error>),
                     ))
@@ -823,11 +823,11 @@ mod tests {
         // Simulate the caller's tee: the stream yields chunks that have
         // already been recorded in `retry_buf`. Retries replay from this
         // buffer rather than re-running the (consumed) stream.
-        let retry_buf = Arc::new(std::sync::Mutex::new(vec![
+        let retry_buf = Arc::new(parking_lot::Mutex::new(vec![
             Bytes::from_static(b"chunk-a"),
             Bytes::from_static(b"chunk-b"),
         ]));
-        let stream_chunks = retry_buf.lock().unwrap().clone();
+        let stream_chunks = retry_buf.lock().clone();
         let body_stream =
             futures::stream::iter(stream_chunks.into_iter().map(Ok::<_, std::io::Error>));
 

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use bytes::Bytes;
+use futures::stream::Stream;
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, CONNECTION};
 use reqwest::{Client, Response};
 use sentry_arroyo::processing::strategies::run_task_in_threads::{
@@ -346,15 +348,142 @@ impl ClickhouseClient {
 
         unreachable!("Loop should always return or bail before reaching here");
     }
+
+    /// Stream `body_stream` as the POST body for the first attempt; on
+    /// failure, retry from `retry_buf` instead of re-running the stream.
+    ///
+    /// Currently unused — scaffolded for `StreamingClickhouseWriter`,
+    /// which will be added in a follow-up commit. Exercised by
+    /// `test_send_streamed_retries_from_buffered_chunks`.
+    ///
+    /// The caller MUST tee every chunk it pushes into `body_stream` into
+    /// `retry_buf` (in the same order). The first attempt consumes
+    /// `body_stream` exactly once and emits the chunks straight to the
+    /// wire — we never buffer them ourselves. Retries replay the
+    /// already-compressed chunks from `retry_buf` via another streamed
+    /// body, so memory peaks at the size of the compressed batch (~30%
+    /// of source) instead of the uncompressed source + compressed copy
+    /// the buffered `send` path holds.
+    ///
+    /// `body_stream` must end only when the entire batch has been
+    /// pushed: a mid-batch close lands a truncated body on the server,
+    /// which then rejects every retry too (we'd be replaying a partial
+    /// `retry_buf`). Surface caller-side cancellations as errors and
+    /// don't enter this function.
+    #[allow(dead_code)]
+    pub async fn send_streamed<S>(
+        &self,
+        body_stream: S,
+        retry_buf: Arc<std::sync::Mutex<Vec<Bytes>>>,
+        retry_config: RetryConfig,
+    ) -> anyhow::Result<Response>
+    where
+        S: Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
+    {
+        // The first attempt consumes the live stream; retries can't
+        // replay it, so we stash it here and `take()` on attempt 0.
+        let mut first_body: Option<reqwest::Body> = Some(reqwest::Body::wrap_stream(body_stream));
+
+        for attempt in 0..=retry_config.max_retries {
+            let url = self.build_url();
+
+            let body = match first_body.take() {
+                Some(b) => b,
+                None => {
+                    // Clone is an Arc bump per chunk — no payload copy.
+                    let chunks: Vec<Bytes> = retry_buf.lock().unwrap().clone();
+                    reqwest::Body::wrap_stream(futures::stream::iter(
+                        chunks.into_iter().map(Ok::<_, std::io::Error>),
+                    ))
+                }
+            };
+
+            let res = self
+                .client
+                .post(&url)
+                .headers(self.headers.clone())
+                .query(&[("query", &self.query)])
+                .body(body)
+                .send()
+                .await;
+
+            match res {
+                Ok(response) => {
+                    if response.status() == reqwest::StatusCode::OK {
+                        return Ok(response);
+                    } else {
+                        let status = response.status().to_string();
+                        let error_text = response
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "unknown error".to_string());
+
+                        if attempt == retry_config.max_retries {
+                            counter!("rust_consumer.clickhouse_insert_error", 1, "status" => status, "retried" => "false");
+                            anyhow::bail!(
+                                "error writing to clickhouse after {} attempts: {}",
+                                retry_config.max_retries + 1,
+                                error_text
+                            );
+                        }
+
+                        counter!("rust_consumer.clickhouse_insert_error", 1, "status" => status, "retried" => "true");
+                        tracing::warn!(
+                            "Streamed ClickHouse write failed (attempt {}/{}): status={}, error={}",
+                            attempt + 1,
+                            retry_config.max_retries + 1,
+                            status,
+                            error_text
+                        );
+                    }
+                }
+                Err(e) => {
+                    if attempt == retry_config.max_retries {
+                        counter!("rust_consumer.clickhouse_insert_error", 1, "status" => "network_error", "retried" => "false");
+                        anyhow::bail!(
+                            "error writing to clickhouse after {} attempts: {}",
+                            retry_config.max_retries + 1,
+                            e
+                        );
+                    }
+                    counter!("rust_consumer.clickhouse_insert_error", 1, "status" => "network_error", "retried" => "true");
+
+                    tracing::warn!(
+                        "Streamed ClickHouse write failed (attempt {}/{}): {}",
+                        attempt + 1,
+                        retry_config.max_retries + 1,
+                        e
+                    );
+                }
+            }
+
+            if attempt < retry_config.max_retries {
+                let backoff_ms =
+                    retry_config.initial_backoff_ms * (2_u64.pow(attempt as u32) as f64);
+                let jitter = rand::random::<f64>() * retry_config.jitter_factor
+                    - retry_config.jitter_factor / 2.0;
+                let delay = Duration::from_millis((backoff_ms * (1.0 + jitter)).round() as u64);
+                tracing::debug!(
+                    "Retrying streamed write in {:?} (attempt {}/{})",
+                    delay,
+                    attempt + 1,
+                    retry_config.max_retries
+                );
+                tokio::time::sleep(delay).await;
+            }
+        }
+
+        unreachable!("Loop should always return or bail before reaching here");
+    }
 }
 
 /// ClickHouse native compressed-block size cap. Matches the server's
 /// `max_compress_block_size` default; sending larger blocks risks tripping
 /// server-side decompress limits.
-const LZ4_BLOCK_SIZE: usize = 1024 * 1024;
+pub(super) const LZ4_BLOCK_SIZE: usize = 1024 * 1024;
 
 /// ClickHouse compression method identifier for LZ4 in the native block header.
-const LZ4_METHOD_BYTE: u8 = 0x82;
+pub(super) const LZ4_METHOD_BYTE: u8 = 0x82;
 
 /// CityHash128 over `data` in the wire layout ClickHouse's
 /// `CompressedReadBuffer` reads: 8 little-endian bytes of the low 64-bit half
@@ -370,7 +499,7 @@ const LZ4_METHOD_BYTE: u8 = 0x82;
 /// We use CityHash 1.0.2 — that's the variant ClickHouse bundles for
 /// compression checksums; the 110 variant is reserved for newer hash columns
 /// and is NOT interchangeable here.
-fn ch_compression_checksum(data: &[u8]) -> [u8; 16] {
+pub(super) fn ch_compression_checksum(data: &[u8]) -> [u8; 16] {
     cityhash_rs::cityhash_102_128(data)
         .rotate_left(64)
         .to_le_bytes()
@@ -668,5 +797,62 @@ mod tests {
         // Error message should mention the number of attempts
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("after 5 attempts"));
+    }
+
+    #[tokio::test]
+    async fn test_send_streamed_retries_from_buffered_chunks() {
+        crate::testutils::initialize_python();
+        // Point at a port nothing is listening on so every attempt errors
+        // out at the transport layer. That exercises the retry loop and,
+        // importantly, the "first attempt drains the stream → later
+        // attempts replay from retry_buf" branch.
+        let config = ClickhouseConfig {
+            host: "127.0.0.1".to_string(),
+            port: 9000,
+            secure: false,
+            http_port: 9999,
+            user: "default".to_string(),
+            password: "".to_string(),
+            database: "default".to_string(),
+        };
+
+        let client = ClickhouseClient::new(
+            &config,
+            "test_table",
+            "test_storage".to_string(),
+            InsertFormat::RowBinary,
+            Some(&["col"]),
+        );
+
+        // Simulate the caller's tee: the stream yields chunks that have
+        // already been recorded in `retry_buf`. Retries replay from this
+        // buffer rather than re-running the (consumed) stream.
+        let retry_buf = Arc::new(std::sync::Mutex::new(vec![
+            Bytes::from_static(b"chunk-a"),
+            Bytes::from_static(b"chunk-b"),
+        ]));
+        let stream_chunks = retry_buf.lock().unwrap().clone();
+        let body_stream =
+            futures::stream::iter(stream_chunks.into_iter().map(Ok::<_, std::io::Error>));
+
+        let start = Instant::now();
+        let result = client
+            .send_streamed(
+                body_stream,
+                retry_buf.clone(),
+                RetryConfig {
+                    initial_backoff_ms: 100.0,
+                    max_retries: 4,
+                    jitter_factor: 0.1,
+                },
+            )
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
+        // 100 + 200 + 400 + 800 = 1500ms nominal, minus 10% jitter floor.
+        assert!(elapsed >= Duration::from_millis(1350));
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("after 5 attempts"), "got: {err}");
     }
 }

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -352,25 +352,21 @@ impl ClickhouseClient {
     /// Stream `body_stream` as the POST body for the first attempt; on
     /// failure, retry from `retry_buf` instead of re-running the stream.
     ///
-    /// Currently unused — scaffolded for `StreamingClickhouseWriter`,
-    /// which will be added in a follow-up commit. Exercised by
-    /// `test_send_streamed_retries_from_buffered_chunks`.
-    ///
-    /// The caller MUST tee every chunk it pushes into `body_stream` into
-    /// `retry_buf` (in the same order). The first attempt consumes
-    /// `body_stream` exactly once and emits the chunks straight to the
-    /// wire — we never buffer them ourselves. Retries replay the
-    /// already-compressed chunks from `retry_buf` via another streamed
-    /// body, so memory peaks at the size of the compressed batch (~30%
-    /// of source) instead of the uncompressed source + compressed copy
-    /// the buffered `send` path holds.
+    /// Used by `StreamingClickhouseWriter`. The caller MUST tee every
+    /// chunk it pushes into `body_stream` into `retry_buf` (in the same
+    /// order). The first attempt consumes `body_stream` exactly once and
+    /// emits the chunks straight to the wire — we never buffer them
+    /// ourselves. Retries replay the already-compressed chunks from
+    /// `retry_buf` via another streamed body, so memory peaks at the
+    /// size of the compressed batch (~30% of source) instead of the
+    /// uncompressed source + compressed copy the buffered `send` path
+    /// holds.
     ///
     /// `body_stream` must end only when the entire batch has been
     /// pushed: a mid-batch close lands a truncated body on the server,
     /// which then rejects every retry too (we'd be replaying a partial
     /// `retry_buf`). Surface caller-side cancellations as errors and
     /// don't enter this function.
-    #[allow(dead_code)]
     pub async fn send_streamed<S>(
         &self,
         body_stream: S,

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -259,6 +259,10 @@ impl ClickhouseClient {
         // across attempts, so paying the LZ4 cost per attempt would be wasted
         // work. `bytes::Bytes` makes the per-attempt clone cheap (refcount bump).
         let body_bytes = bytes::Bytes::from(lz4_compress(&body));
+        // Free the uncompressed buffer now; it would otherwise stay alive
+        // across every retry attempt and backoff sleep, holding ~3× the
+        // compressed size per in-flight send for the full send window.
+        drop(body);
 
         for attempt in 0..=retry_config.max_retries {
             let url = self.build_url();

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -471,6 +471,25 @@ impl BytesInsertBatch<RowData> {
     }
 }
 
+impl BytesInsertBatch<()> {
+    /// Fold another batch's metadata into this one without touching rows.
+    /// Used by the streaming writer, which feeds rows directly into an open
+    /// HTTP request and only needs the metadata aggregated for the
+    /// downstream commit-log / latency / cogs steps.
+    #[allow(dead_code)]
+    pub fn merge_meta(mut self, other: BytesInsertBatch<()>) -> Self {
+        self.num_bytes += other.num_bytes;
+        self.commit_log_offsets.merge(other.commit_log_offsets);
+        self.message_timestamp.merge(other.message_timestamp);
+        self.origin_timestamp.merge(other.origin_timestamp);
+        self.sentry_received_timestamp
+            .merge(other.sentry_received_timestamp);
+        self.cogs_data.merge(other.cogs_data);
+        self.item_type_metrics.merge(other.item_type_metrics);
+        self
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq)]
 pub struct RowData {
     pub encoded_rows: Vec<u8>,

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -476,7 +476,6 @@ impl BytesInsertBatch<()> {
     /// Used by the streaming writer, which feeds rows directly into an open
     /// HTTP request and only needs the metadata aggregated for the
     /// downstream commit-log / latency / cogs steps.
-    #[allow(dead_code)]
     pub fn merge_meta(mut self, other: BytesInsertBatch<()>) -> Self {
         self.num_bytes += other.num_bytes;
         self.commit_log_offsets.merge(other.commit_log_offsets);


### PR DESCRIPTION
Cut ClickHouse writer-side memory for the EAP RowBinary path by streaming rows straight to ClickHouse as they arrive instead of accumulating the full uncompressed batch in process before sending.

## Why

The EAP RowBinary deploy in the US ran the consumer at ~4× baseline memory. Two structural costs on the writer side stood out:

1. `ClickhouseClient::send` kept both the uncompressed `body: Vec<u8>` and the compressed `body_bytes: Bytes` alive for the entire retry window — every HTTP round-trip plus every exponential-backoff sleep. With `insert_distributed_sync=1` and a slow shard, that window is seconds, holding ~1.3× the batch size per in-flight slot the whole time.
2. Since #7979 dropped the `clickhouse-rs` crate, the encoded batch is materialized as one `Vec<u8>` in the `Reduce` accumulator and a second `Vec<u8>` after LZ4 compression before send, instead of streamed onto an HTTP body channel as rows arrive. That's peak residency the consumer never used to hold; `clickhouse-rs::Insert` would have pushed bytes onto a channel and let them leave the process immediately.

## What's here

Three commits, each independently reviewable:

- **`drop(body)` after compression** — one line that frees the uncompressed buffer the instant `lz4_compress` returns, instead of dragging it through the retry loop. Per-slot writer peak drops from ~1.3× to ~0.3× the batch size on the buffered path.
- **Streaming scaffolding** — `StreamingLz4Compressor` (stateful encoder emitting one `Bytes` per complete 1 MiB ClickHouse-native block), `ClickhouseClient::send_streamed` (first attempt streams the body via `reqwest::Body::wrap_stream`; on failure, retries replay from a shared `retry_buf: Arc<Mutex<Vec<Bytes>>>`), and `BytesInsertBatch::<()>::merge_meta` for accumulating offsets / latency timers / cogs / item-type metrics across streamed messages. Wire shape is byte-identical to the buffered `lz4_compress` and verified round-trip against the existing decoder.
- **`StreamingClickhouseWriter` strategy** — replaces `Reduce → ClickhouseWriterStep` for the RowBinary path with one step that compresses rows into ClickHouse-native LZ4 blocks as messages arrive and pushes the resulting chunks onto an HTTP body channel feeding a single in-flight `POST` per batch. `factory_v2.rs` flips to it when `use_row_binary` is true. JSON storages keep the existing buffered writer — no urgency, lower risk to leave alone.

## Memory profile

For a batch of size `B`:

| Path | Source-side peak | Compressed-side peak | Notes |
|---|---|---|---|
| Buffered (before this PR) | `1.0 × B` (Reduce accumulator) | `0.3 × B` × in-flight slots (held across retries) | Source held while compressed body is in transit. |
| Buffered + `drop(body)` (commit 1) | `1.0 × B` (Reduce) → `0` after compress | `0.3 × B` × in-flight slots | Source freed before retry loop starts. |
| Streaming (commit 3) | `0` (rows are pushed through the compressor and dropped per message) | `0.3 × B` (retry_buf) + mpsc-buffered chunks until reqwest drains them | One in-flight batch at a time. |

## Streaming writer details

- **Concurrency**: fixed at one in-flight batch. The buffered writer uses `RunTaskInThreads` for inter-batch concurrency; the streaming writer sacrifices that for a much smaller resident set and a simpler state machine. EAP RowBinary already saturates one slot on the hot path so this isn't a regression in practice.
- **Backpressure**: submits are rejected (`MessageRejected`) while an HTTP response is outstanding. The strategy carries over rejected downstream submits the same way `Reduce` does.
- **Retries**: every compressed chunk is teed into both the body channel and the shared `retry_buf` as we push it. If the first attempt's POST errors mid-body, reqwest drops the stream; subsequent attempts replay from `retry_buf` (no payload copy, just `Arc` bumps). Closing the body channel signals end-of-body to reqwest, so we never POST a truncated body — `send_streamed`'s docstring warns the caller about this and `StreamingClickhouseWriter::flush_pending` is the one place that drops the sender.
- **Empty batches**: the streaming writer emits empty batches downstream itself (offsets-only flushes) so commits still advance on storages that skip 100% of values — drops the `.flush_empty_batches(true)` Reduce config that handled this on the buffered path.

## Out of scope

The server-side `MEMORY_LIMIT_EXCEEDED` inside `BinaryRowInputFormat` we hit in the same US deploy is a ClickHouse block-size issue, not a consumer-memory issue. The lever for that is the per-storage `clickhouse_max_insert_block_size:eap_items` runtime override added in #7939.

## Test plan

- [x] Existing buffered path tests still pass (no changes to JSON wiring).
- [x] `StreamingLz4Compressor` roundtrip tests: under-block, exactly-one-block, cross-boundary, byte-by-byte, multi-block-in-one-push.
- [x] `send_streamed` retry test: confirms first-attempt-drains-stream-then-replays-from-buffer behavior.
- [x] `StreamingClickhouseWriter` unit tests: row-based batching with skip_write, downstream-backpressure rejects new submits, empty-strategy `join` is a no-op.
- [ ] Deploy to US canary and confirm consumer memory drops back to baseline.
- [ ] Confirm ClickHouse acceptance via `it_works` integration test against a live CH (run locally before merge).

Refs LINEAR-EAP-517


Agent transcript: https://claudescope.sentry.dev/share/ZC_1ppylX7p9AMvInBjVlx3CiOJ716HQ4OLVZr-MI6U