### PR TITLE
fix(admin): Validate host/port before constructing any admin ClickhousePool

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -79,6 +79,34 @@ def _validate_node(
 NODE_CONNECTIONS: MutableMapping[str, ClickhousePool] = {}
 
 
+def _build_validated_pool(
+    clickhouse_host: str,
+    clickhouse_port: int,
+    storage_name: str,
+    cluster: ClickhouseCluster,
+    database: str,
+    username: str,
+    password: str,
+    client_settings: ClickhouseClientSettings,
+) -> ClickhousePool:
+    # Single chokepoint for admin ClickhousePool construction. ClickhousePool
+    # ships the user/password in the first hello packet of the native protocol,
+    # so an unvalidated host means credentials reach whatever listener answers.
+    # All admin helpers must go through here — never call ClickhousePool
+    # directly from this module. The regression test
+    # test_no_direct_clickhouse_pool_construction_in_admin enforces this.
+    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
+    return ClickhousePool(
+        clickhouse_host,
+        clickhouse_port,
+        username,
+        password,
+        database,
+        max_pool_size=2,
+        client_settings=client_settings.value.settings,
+    )
+
+
 def get_ro_node_connection(
     clickhouse_host: str,
     clickhouse_port: int,
@@ -93,7 +121,6 @@ def get_ro_node_connection(
 
     cluster = storage.get_cluster()
     database = cluster.get_database()
-    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
 
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
@@ -115,14 +142,15 @@ def get_ro_node_connection(
         username = settings.CLICKHOUSE_TRACE_USER
         password = settings.CLICKHOUSE_TRACE_PASSWORD
 
-    connection = ClickhousePool(
+    connection = _build_validated_pool(
         clickhouse_host,
         clickhouse_port,
+        storage_name,
+        cluster,
+        database,
         username,
         password,
-        database,
-        max_pool_size=2,
-        client_settings=client_settings.value.settings,
+        client_settings,
     )
     NODE_CONNECTIONS[key] = connection
     return connection
@@ -162,17 +190,17 @@ def get_sudo_node_connection(
 
     cluster = storage.get_cluster()
     database = cluster.get_database()
-    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
+    (clickhouse_user, clickhouse_password) = cluster.get_credentials()
 
-    (clickhouse_user, clickhouse_password) = storage.get_cluster().get_credentials()
-    connection = ClickhousePool(
+    connection = _build_validated_pool(
         clickhouse_host,
         clickhouse_port,
+        storage_name,
+        cluster,
+        database,
         clickhouse_user,
         clickhouse_password,
-        database,
-        max_pool_size=2,
-        client_settings=client_settings.value.settings,
+        client_settings,
     )
     NODE_CONNECTIONS[key] = connection
     return connection
@@ -192,21 +220,16 @@ def get_clusterless_node_connection(
     if key in NODE_CONNECTIONS:
         return NODE_CONNECTIONS[key]
 
-    # ClickhousePool sends the configured user/password in the very first hello
-    # packet on connection — if we let an unvalidated host/port through, an
-    # attacker who controls the listener at that address sees those credentials
-    # before any query runs.
-    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
-
-    (clickhouse_user, clickhouse_password) = storage.get_cluster().get_credentials()
-    connection = ClickhousePool(
+    (clickhouse_user, clickhouse_password) = cluster.get_credentials()
+    connection = _build_validated_pool(
         clickhouse_host,
         clickhouse_port,
+        storage_name,
+        cluster,
+        database,
         clickhouse_user,
         clickhouse_password,
-        database,
-        max_pool_size=2,
-        client_settings=client_settings.value.settings,
+        client_settings,
     )
     NODE_CONNECTIONS[key] = connection
     return connection
@@ -231,18 +254,15 @@ def get_ro_clusterless_node_connection(
         ClickhouseClientSettings.QUERYLOG,
     }, "ro clusterless connections must use a read-only client settings profile"
 
-    # See get_clusterless_node_connection: even readonly credentials leak in the
-    # hello packet, so reject hosts that don't belong to the storage's cluster.
-    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
-
-    connection = ClickhousePool(
+    connection = _build_validated_pool(
         clickhouse_host,
         clickhouse_port,
+        storage_name,
+        cluster,
+        database,
         settings.CLICKHOUSE_READONLY_USER,
         settings.CLICKHOUSE_READONLY_PASSWORD,
-        database,
-        max_pool_size=2,
-        client_settings=client_settings.value.settings,
+        client_settings,
     )
     NODE_CONNECTIONS[key] = connection
     return connection

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -192,6 +192,12 @@ def get_clusterless_node_connection(
     if key in NODE_CONNECTIONS:
         return NODE_CONNECTIONS[key]
 
+    # ClickhousePool sends the configured user/password in the very first hello
+    # packet on connection — if we let an unvalidated host/port through, an
+    # attacker who controls the listener at that address sees those credentials
+    # before any query runs.
+    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
+
     (clickhouse_user, clickhouse_password) = storage.get_cluster().get_credentials()
     connection = ClickhousePool(
         clickhouse_host,
@@ -224,6 +230,10 @@ def get_ro_clusterless_node_connection(
         ClickhouseClientSettings.QUERY,
         ClickhouseClientSettings.QUERYLOG,
     }, "ro clusterless connections must use a read-only client settings profile"
+
+    # See get_clusterless_node_connection: even readonly credentials leak in the
+    # hello packet, so reject hosts that don't belong to the storage's cluster.
+    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name)
 
     connection = ClickhousePool(
         clickhouse_host,

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -506,6 +506,19 @@ def copy_table_query() -> Response:
             "code": err.code,
         }
         return make_response(jsonify({"error": details}), 400)
+    except InvalidNodeError as err:
+        logger.error(err, exc_info=True)
+        return make_response(
+            jsonify(
+                {
+                    "error": {
+                        "type": "request",
+                        "message": err.message or "Invalid node",
+                    }
+                }
+            ),
+            400,
+        )
 
     try:
         return make_response(jsonify(resp), 200)

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -240,6 +240,36 @@ def test_system_query(admin_api: FlaskClient) -> None:
 
 
 @pytest.mark.redis_db
+def test_run_copy_table_query_invalid_node_returns_400(admin_api: FlaskClient) -> None:
+    """
+    Regression for EAP-488 follow-up: the clusterless connection helper now
+    raises InvalidNodeError for an attacker-supplied host, and the endpoint
+    must surface that as a 400 (like /run_clickhouse_system_query) rather
+    than letting it bubble into a 500.
+    """
+    from snuba.admin.clickhouse.common import InvalidNodeError
+
+    with mock.patch(
+        "snuba.admin.views.copy_tables",
+        side_effect=InvalidNodeError("host attacker.example.com not in cluster"),
+    ):
+        response = admin_api.post(
+            "/run_copy_table_query",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {
+                    "storage": "errors",
+                    "source_host": "attacker.example.com",
+                }
+            ),
+        )
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert data["error"]["type"] == "request"
+    assert "attacker.example.com" in data["error"]["message"]
+
+
+@pytest.mark.redis_db
 def test_predefined_system_queries(admin_api: FlaskClient) -> None:
     response = admin_api.get(
         "/clickhouse_queries",

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -1,3 +1,5 @@
+import ast
+from pathlib import Path
 from typing import Sequence
 from unittest.mock import patch
 
@@ -381,3 +383,88 @@ def test_sudo_mode_skips_experimental_analyzer(sql_query: str, sudo_mode: bool) 
             assert "allow_experimental_analyzer" in explain_query, (
                 f"Non-sudo mode should use experimental analyzer, but got: {explain_query}"
             )
+
+
+def _find_clickhouse_pool_calls(tree: ast.AST) -> list[tuple[ast.Call, list[str]]]:
+    """
+    Walks an AST and returns every `ClickhousePool(...)` call site, paired
+    with the chain of enclosing function names (outermost first) so the
+    regression guard below can assert *where* construction happens.
+    """
+    results: list[tuple[ast.Call, list[str]]] = []
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.scope: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.scope.append(node.name)
+            self.generic_visit(node)
+            self.scope.pop()
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self.scope.append(node.name)
+            self.generic_visit(node)
+            self.scope.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            func = node.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else func.attr
+                if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name == "ClickhousePool":
+                results.append((node, list(self.scope)))
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return results
+
+
+def test_no_direct_clickhouse_pool_construction_in_admin() -> None:
+    """
+    Defense-in-depth for EAP-488: ClickhousePool ships the configured
+    user/password in the first hello packet of the native protocol, so any
+    admin code path that constructs one against a caller-supplied host
+    leaks credentials to whatever listener answers. `_build_validated_pool`
+    in snuba/admin/clickhouse/common.py is the single chokepoint that runs
+    `_validate_node` first — every other admin module must go through it.
+
+    This test enforces that structural invariant by AST-walking every
+    snuba/admin/**/*.py file:
+
+    * common.py may only construct ClickhousePool from inside
+      `_build_validated_pool`.
+    * No other admin module may construct ClickhousePool at all.
+
+    If this fails, a new caller has likely re-introduced the vulnerability.
+    """
+    admin_root = Path(__file__).resolve().parents[2] / "snuba" / "admin"
+    assert admin_root.is_dir(), f"expected admin root at {admin_root}"
+
+    common_path = admin_root / "clickhouse" / "common.py"
+    offenders: list[str] = []
+
+    for py_file in sorted(admin_root.rglob("*.py")):
+        tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        for call, scope in _find_clickhouse_pool_calls(tree):
+            rel = py_file.relative_to(admin_root.parent.parent)
+            location = f"{rel}:{call.lineno}"
+            if py_file == common_path:
+                if scope != ["_build_validated_pool"]:
+                    offenders.append(
+                        f"{location} constructs ClickhousePool inside "
+                        f"{'.'.join(scope) or '<module>'} — must be inside "
+                        "_build_validated_pool so _validate_node runs first."
+                    )
+            else:
+                offenders.append(
+                    f"{location} constructs ClickhousePool directly — call "
+                    "_build_validated_pool (or a helper that wraps it) so "
+                    "_validate_node guards the host before credentials are sent."
+                )
+
+    assert not offenders, "\n".join(offenders)

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -1,9 +1,11 @@
 from typing import Sequence
+from unittest.mock import patch
 
 import pytest
 
 from snuba import settings
 from snuba.admin.auth_roles import ROLES, Role
+from snuba.admin.clickhouse.common import InvalidNodeError
 from snuba.admin.clickhouse.system_queries import (
     UnauthorizedForSudo,
     is_valid_system_query,
@@ -11,6 +13,7 @@ from snuba.admin.clickhouse.system_queries import (
     validate_query,
 )
 from snuba.admin.user import AdminUser
+from snuba.clusters.cluster import ClickhouseClientSettings
 
 
 @pytest.mark.parametrize(
@@ -273,6 +276,59 @@ def test_clusterless_uses_readonly_for_non_sudo(sudo_mode: bool, expected_helper
 
         assert mock_used.called, f"Expected {expected_helper} to be used"
         assert not mock_forbidden.called, f"{forbidden} must not be used in this mode"
+
+
+@pytest.mark.parametrize(
+    "helper_name, client_settings",
+    [
+        pytest.param(
+            "get_clusterless_node_connection",
+            ClickhouseClientSettings.QUERY,
+            id="sudo clusterless helper",
+        ),
+        pytest.param(
+            "get_ro_clusterless_node_connection",
+            ClickhouseClientSettings.QUERY,
+            id="readonly clusterless helper",
+        ),
+    ],
+)
+def test_clusterless_rejects_unvalidated_host(
+    helper_name: str, client_settings: ClickhouseClientSettings
+) -> None:
+    """
+    Regression for EAP-488: the clusterless helpers used to construct a
+    ClickhousePool against any attacker-supplied host/port, which leaked the
+    configured ClickHouse user/password in the first hello packet of the
+    native protocol. Both helpers must now call _validate_node before
+    constructing the pool, so an invalid host produces InvalidNodeError and
+    no credentials ever leave the process.
+    """
+    from snuba.admin.clickhouse import common
+
+    helper = getattr(common, helper_name)
+
+    with (
+        patch.object(
+            common,
+            "_validate_node",
+            side_effect=InvalidNodeError("host not in cluster"),
+        ) as mock_validate,
+        patch.object(common, "ClickhousePool") as mock_pool,
+    ):
+        # Clear any cached connection for this storage so the cache lookup
+        # can't short-circuit validation.
+        for key in [k for k in common.NODE_CONNECTIONS if k.startswith("errors-")]:
+            del common.NODE_CONNECTIONS[key]
+
+        with pytest.raises(InvalidNodeError):
+            helper("attacker.example.com", 9009, "errors", client_settings)
+
+        assert mock_validate.called, "_validate_node must run before pool construction"
+        assert not mock_pool.called, (
+            "ClickhousePool must not be constructed for an unvalidated host — "
+            "doing so would transmit ClickHouse credentials to the attacker"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The clusterless system-query helpers (`get_clusterless_node_connection` and `get_ro_clusterless_node_connection`) built a `ClickhousePool` with caller-supplied `host`/`port` before any validation. Because `ClickhousePool` ships the configured ClickHouse user/password in the very first hello packet of the native protocol, an unauthenticated caller — `ADMIN_AUTH_PROVIDER=NOOP` plus the default `ProductTools` role — could point `/run_clickhouse_system_query` (or `/run_copy_table_query`) at a listener they control and capture backend credentials before any query ran. The earlier readonly-credential fix (#7974) only downgraded which credentials leaked.

This PR closes the hole in three steps:

1. **Validate before constructing the pool in the two clusterless helpers.** Both helpers now call `_validate_node` before instantiating `ClickhousePool`, matching the pattern already used by `get_ro_node_connection` and `get_sudo_node_connection`. Invalid hosts raise `InvalidNodeError`; no socket is opened, so no credentials leave the process.

2. **Return 400 from `/run_copy_table_query` on `InvalidNodeError`.** The new validation in the clusterless helper raises `InvalidNodeError` for bad `source_host`/`target_host`. `/run_clickhouse_system_query` already mapped that to 400; the copy-table endpoint did not, so it surfaced a 500 with no actionable message. It now matches the system-query path.

3. **Funnel all four admin pool constructions through a single validated chokepoint.** Each helper previously had to remember to call `_validate_node`. `_build_validated_pool` now runs the validation and constructs the pool in one place; every helper delegates to it. The invariant ("validate the host before opening a socket, because the native-protocol hello packet ships the configured user/password") is now structural, not reviewer-enforced.

**Regression tests**

- `tests/admin/test_system_queries.py::test_clusterless_rejects_unvalidated_host` patches `_validate_node` to fail and asserts `ClickhousePool` is never constructed for either the sudo or readonly clusterless helper — directly encoding the security property.
- `test_no_direct_clickhouse_pool_construction_in_admin` is an AST-based guard that walks every `snuba/admin/**/*.py` and fails if any module constructs `ClickhousePool` outside `_build_validated_pool`.
- `tests/admin/test_api.py` covers the new 400 path on `/run_copy_table_query`.

Fixes EAP-488


Agent transcripts:
- https://claudescope.sentry.dev/share/bt9C9T_XewsqOyGJVcHlaY1MfkhYhv1SzvLqpg09Kfc
- https://claudescope.sentry.dev/share/TdKyXXm8iCD3EEW_WMgUAfjJrBxtvcbB4y7awlEwPl4
- https://claudescope.sentry.dev/share/uHyZHvzGFQjUhOMhtKV5LcO6Tgx8ZQbaEgTle9YdX0U
