### PR TITLE
perf(eap): Drop uncompressed insert body before retry loop

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -259,6 +259,11 @@ impl ClickhouseClient {
         // across attempts, so paying the LZ4 cost per attempt would be wasted
         // work. `bytes::Bytes` makes the per-attempt clone cheap (refcount bump).
         let body_bytes = bytes::Bytes::from(lz4_compress(&body));
+        // Free the uncompressed buffer before entering the retry loop. With
+        // `insert_distributed_sync=1` against a slow shard the loop can hold
+        // each in-flight slot for seconds — dragging `body` through it kept
+        // ~1× the batch size resident per slot for no reason.
+        drop(body);
 
         for attempt in 0..=retry_config.max_retries {
             let url = self.build_url();


### PR DESCRIPTION
Free the uncompressed `body: Vec<u8>` in `ClickhouseClient::send` the
instant `lz4_compress` returns, instead of dragging it through the
retry loop.

## Why

`ClickhouseClient::send` keeps both the uncompressed `body: Vec<u8>` and
the compressed `body_bytes: Bytes` alive for the entire retry window —
every HTTP round-trip plus every exponential-backoff sleep. With
`insert_distributed_sync=1` and a slow shard that window is seconds,
holding ~1× the batch size per in-flight slot on top of the compressed
body the whole time, even though only `body_bytes` is sent.

Per-slot writer peak resident memory drops from ~1.3× to ~0.3× the
batch size on the buffered path.

## Scope

One line. Buffered `Reduce → ClickhouseWriterStep` pipeline and
`RunTaskInThreads` clickhouse concurrency are untouched. This is purely
a `Drop` timing change.

## Context

Salvaged from #8001, which was reverted in a7e894a97. That PR bundled
this `drop(body)` win with a switch to a streaming writer that fixed
in-flight POSTs to one, dropping inter-batch concurrency. The streaming
half caused visible consumer pause time (backpressure from rejected
submits while a slow POST was outstanding) and was reverted. The
`drop(body)` half is independent of that and pays back ~most of the
memory savings without changing the strategy graph.

Refs LINEAR-EAP-517


Agent transcript: https://claudescope.sentry.dev/share/3W4l_9TUCJQoGqNV4lp8w5KltDb-AwnVeL_IfaQEI0w