### PR TITLE
feat(cbrs): Add per-organization ClickHouse setting overrides

### DIFF
--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -70,6 +70,14 @@ CBRS_HASH = "cbrs"
 RoutedRequestType = Union[TimeSeriesRequest, TraceItemTableRequest]
 ClickhouseQuerySettings = Dict[str, Any]
 
+# Allowlist of ClickHouse settings that operators may override per-organization
+# via routing-strategy config. Each entry adds an `organization_<name>_override`
+# Configuration to every routing strategy, keyed by organization_id. The override
+# is applied after _update_routing_decision and replaces any prior value.
+ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS: dict[str, type] = {
+    "max_threads": int,
+}
+
 
 @dataclass
 class RoutingContext:
@@ -259,6 +267,22 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                 default=100,
             ),
         ]
+        for setting_name, value_type in ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS.items():
+            sentinel = value_type()
+            self._default_config_definitions.append(
+                RoutingStrategyConfig(
+                    name=f"organization_{setting_name}_override",
+                    description=(
+                        f"Per-organization_id override for the ClickHouse '{setting_name}' "
+                        f"setting. Replaces any value set by allocation policies or the "
+                        f"routing strategy (including raising above the policy-derived value). "
+                        f"Default {sentinel!r} means no override."
+                    ),
+                    value_type=value_type,
+                    default=sentinel,
+                    param_types={"organization_id": int},
+                )
+            )
         self._overridden_additional_config_definitions = (
             self._get_overridden_additional_config_defaults(default_config_overrides)
         )
@@ -375,6 +399,22 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
     ) -> None:
         raise NotImplementedError
 
+    def _get_org_clickhouse_setting_overrides(
+        self, tenant_ids: dict[str, str | int]
+    ) -> dict[str, Any]:
+        org_id = tenant_ids.get("organization_id")
+        if org_id is None:
+            return {}
+        overrides: dict[str, Any] = {}
+        for setting_name, value_type in ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS.items():
+            value = self.get_config_value(
+                f"organization_{setting_name}_override",
+                {"organization_id": org_id},
+            )
+            if value != value_type():
+                overrides[setting_name] = value
+        return overrides
+
     def _get_combined_allocation_policies_recommendations(
         self, policy_recommendations: List[QuotaAllowance]
     ) -> CombinedAllocationPoliciesRecommendations:
@@ -453,6 +493,13 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                 )
 
                 self._update_routing_decision(routing_decision)
+
+                org_overrides = self._get_org_clickhouse_setting_overrides(
+                    routing_context.tenant_ids
+                )
+                if org_overrides:
+                    routing_decision.clickhouse_settings.update(org_overrides)
+                    routing_context.extra_info["org_clickhouse_setting_overrides"] = org_overrides
 
                 routing_context.timer.mark(_END_ESTIMATION_MARK)
                 self._record_value_in_span_and_DD(

--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -8,6 +8,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    NamedTuple,
     Optional,
     TypeAlias,
     TypedDict,
@@ -70,12 +71,38 @@ CBRS_HASH = "cbrs"
 RoutedRequestType = Union[TimeSeriesRequest, TraceItemTableRequest]
 ClickhouseQuerySettings = Dict[str, Any]
 
+
+class _OrgOverridableSetting(NamedTuple):
+    """One entry in the per-org ClickHouse setting override allowlist.
+
+    `unset_sentinel` is the value stored when no override is configured — chosen
+    so it cannot collide with a legitimate value an operator might want to set
+    (e.g. ClickHouse treats max_threads=0 as 'use all available cores', so 0 is
+    a real value and -1 is the sentinel). `description` is the operator-facing
+    string shown in the admin UI for this setting's override.
+    """
+
+    value_type: type
+    unset_sentinel: Any
+    description: str
+
+
 # Allowlist of ClickHouse settings that operators may override per-organization
 # via routing-strategy config. Each entry adds an `organization_<name>_override`
 # Configuration to every routing strategy, keyed by organization_id. The override
 # is applied after _update_routing_decision and replaces any prior value.
-ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS: dict[str, type] = {
-    "max_threads": int,
+ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS: dict[str, _OrgOverridableSetting] = {
+    "max_threads": _OrgOverridableSetting(
+        value_type=int,
+        unset_sentinel=-1,
+        description=(
+            "Per-organization_id override for the ClickHouse max_threads setting. "
+            "Replaces any value set by allocation policies or the routing strategy, "
+            "including raising it above the policy-derived value. Default -1 means "
+            "no override; note that 0 is a legitimate value (ClickHouse interprets "
+            "max_threads=0 as 'use all available physical cores')."
+        ),
+    ),
 }
 
 
@@ -267,19 +294,13 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                 default=100,
             ),
         ]
-        for setting_name, value_type in ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS.items():
-            sentinel = value_type()
+        for setting_name, setting in ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS.items():
             self._default_config_definitions.append(
                 RoutingStrategyConfig(
                     name=f"organization_{setting_name}_override",
-                    description=(
-                        f"Per-organization_id override for the ClickHouse '{setting_name}' "
-                        f"setting. Replaces any value set by allocation policies or the "
-                        f"routing strategy (including raising above the policy-derived value). "
-                        f"Default {sentinel!r} means no override."
-                    ),
-                    value_type=value_type,
-                    default=sentinel,
+                    description=setting.description,
+                    value_type=setting.value_type,
+                    default=setting.unset_sentinel,
                     param_types={"organization_id": int},
                 )
             )
@@ -406,12 +427,12 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
         if org_id is None:
             return {}
         overrides: dict[str, Any] = {}
-        for setting_name, value_type in ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS.items():
+        for setting_name, setting in ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS.items():
             value = self.get_config_value(
                 f"organization_{setting_name}_override",
                 {"organization_id": org_id},
             )
-            if value != value_type():
+            if value != setting.unset_sentinel:
                 overrides[setting_name] = value
         return overrides
 

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -540,7 +540,17 @@ def test_get_routing_strategy_configs(admin_api: FlaskClient) -> None:
         "value": 50,
         "params": {},
     } in strategy_data["configurations"]
-    assert strategy_data["optional_config_definitions"] == []
+    assert {
+        "name": "organization_max_threads_override",
+        "type": "int",
+        "default": 0,
+        "description": (
+            "Per-organization_id override for the ClickHouse 'max_threads' setting. "
+            "Replaces any value set by allocation policies or the routing strategy "
+            "(including raising above the policy-derived value). Default 0 means no override."
+        ),
+        "params": [{"name": "organization_id", "type": "int"}],
+    } in strategy_data["optional_config_definitions"]
 
     # Check policies data
     assert len(strategy_data["policies_data"]) == 2

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -543,11 +543,13 @@ def test_get_routing_strategy_configs(admin_api: FlaskClient) -> None:
     assert {
         "name": "organization_max_threads_override",
         "type": "int",
-        "default": 0,
+        "default": -1,
         "description": (
-            "Per-organization_id override for the ClickHouse 'max_threads' setting. "
-            "Replaces any value set by allocation policies or the routing strategy "
-            "(including raising above the policy-derived value). Default 0 means no override."
+            "Per-organization_id override for the ClickHouse max_threads setting. "
+            "Replaces any value set by allocation policies or the routing strategy, "
+            "including raising it above the policy-derived value. Default -1 means "
+            "no override; note that 0 is a legitimate value (ClickHouse interprets "
+            "max_threads=0 as 'use all available physical cores')."
         ),
         "params": [{"name": "organization_id", "type": "int"}],
     } in strategy_data["optional_config_definitions"]

--- a/tests/web/rpc/v1/routing_strategies/test_org_clickhouse_setting_overrides.py
+++ b/tests/web/rpc/v1/routing_strategies/test_org_clickhouse_setting_overrides.py
@@ -1,0 +1,95 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableRequest
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+
+from snuba.utils.metrics.timer import Timer
+from snuba.web.rpc.storage_routing.routing_strategies.outcomes_based import (
+    OutcomesBasedRoutingStrategy,
+)
+from snuba.web.rpc.storage_routing.routing_strategies.storage_routing import (
+    RoutingContext,
+)
+
+BASE_TIME = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(
+    hours=24
+)
+_PROJECT_ID = 1
+_ORG_ID = 1
+_OTHER_ORG_ID = 9999
+
+
+def _get_request_meta(organization_id: int = _ORG_ID) -> RequestMeta:
+    start = BASE_TIME - timedelta(hours=24)
+    end = BASE_TIME
+    return RequestMeta(
+        project_ids=[_PROJECT_ID],
+        organization_id=organization_id,
+        cogs_category="something",
+        referrer="something",
+        start_timestamp=Timestamp(seconds=int(start.timestamp())),
+        end_timestamp=Timestamp(seconds=int(end.timestamp())),
+        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+    )
+
+
+def _build_context(organization_id: int = _ORG_ID) -> RoutingContext:
+    request = TraceItemTableRequest(meta=_get_request_meta(organization_id=organization_id))
+    request.meta.downsampled_storage_config.mode = DownsampledStorageConfig.MODE_NORMAL
+    return RoutingContext(
+        in_msg=request,
+        timer=Timer("test"),
+        query_id=uuid.uuid4().hex,
+    )
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
+def test_no_override_uses_allocation_policy_value() -> None:
+    strategy = OutcomesBasedRoutingStrategy()
+    routing_decision = strategy.get_routing_decision(_build_context())
+    assert routing_decision.clickhouse_settings == {"max_threads": 10}
+    assert "org_clickhouse_setting_overrides" not in routing_decision.routing_context.extra_info
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
+def test_org_override_replaces_allocation_policy_value() -> None:
+    strategy = OutcomesBasedRoutingStrategy()
+    strategy.set_config_value("organization_max_threads_override", 4, {"organization_id": _ORG_ID})
+    routing_decision = strategy.get_routing_decision(_build_context())
+    assert routing_decision.clickhouse_settings["max_threads"] == 4
+    assert routing_decision.routing_context.extra_info["org_clickhouse_setting_overrides"] == {
+        "max_threads": 4
+    }
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
+def test_org_override_can_raise_above_allocation_policy_value() -> None:
+    strategy = OutcomesBasedRoutingStrategy()
+    # Baseline policy value is 10 (asserted in the no-override test); set the
+    # override higher to confirm absolute precedence — not min/cap semantics.
+    strategy.set_config_value("organization_max_threads_override", 32, {"organization_id": _ORG_ID})
+    routing_decision = strategy.get_routing_decision(_build_context())
+    assert routing_decision.clickhouse_settings["max_threads"] == 32
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
+def test_override_scoped_to_organization_id() -> None:
+    strategy = OutcomesBasedRoutingStrategy()
+    strategy.set_config_value("organization_max_threads_override", 4, {"organization_id": _ORG_ID})
+
+    # Same strategy instance, a different org_id should not be affected.
+    other_decision = strategy.get_routing_decision(_build_context(organization_id=_OTHER_ORG_ID))
+    assert other_decision.clickhouse_settings == {"max_threads": 10}
+    assert "org_clickhouse_setting_overrides" not in other_decision.routing_context.extra_info
+
+    # And the configured org still sees the override.
+    target_decision = strategy.get_routing_decision(_build_context())
+    assert target_decision.clickhouse_settings["max_threads"] == 4

--- a/tests/web/rpc/v1/routing_strategies/test_org_clickhouse_setting_overrides.py
+++ b/tests/web/rpc/v1/routing_strategies/test_org_clickhouse_setting_overrides.py
@@ -81,6 +81,20 @@ def test_org_override_can_raise_above_allocation_policy_value() -> None:
 
 @pytest.mark.eap
 @pytest.mark.redis_db
+def test_override_value_of_zero_is_honored() -> None:
+    # ClickHouse treats max_threads=0 as "use all available cores", so 0 is a
+    # legitimate override value — must not be mistaken for the unset sentinel.
+    strategy = OutcomesBasedRoutingStrategy()
+    strategy.set_config_value("organization_max_threads_override", 0, {"organization_id": _ORG_ID})
+    routing_decision = strategy.get_routing_decision(_build_context())
+    assert routing_decision.clickhouse_settings["max_threads"] == 0
+    assert routing_decision.routing_context.extra_info["org_clickhouse_setting_overrides"] == {
+        "max_threads": 0
+    }
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
 def test_override_scoped_to_organization_id() -> None:
     strategy = OutcomesBasedRoutingStrategy()
     strategy.set_config_value("organization_max_threads_override", 4, {"organization_id": _ORG_ID})


### PR DESCRIPTION
Add a per-organization override mechanism on `BaseRoutingStrategy` keyed on `organization_id`. The new config replaces any prior value from allocation policies or the routing strategy itself for the listed ClickHouse settings — letting an operator dial a specific value for one organization (e.g. raising `max_threads` above the policy-derived `min` for a chosen org's SELECT queries).

Today the path to `max_threads` is the `min` across allocation-policy `QuotaAllowance.max_threads` values in `BaseRoutingStrategy._get_combined_allocation_policies_recommendations`. The only existing tenant-scoped knobs are referrer-keyed (`ReferrerGuardRailPolicy.referrer_max_threads_override`); there is no direct lever to raise or lower the value for one organization. This PR adds that lever.

The set of overridable settings is gated by an explicit allowlist (`ORG_OVERRIDABLE_CLICKHOUSE_SETTINGS`), starting with `max_threads`. Adding another setting (e.g. `max_memory_usage`, `max_execution_time`) is a one-line append to the dict.

### How it works

- One `RoutingStrategyConfig` per allowlist entry is appended to `BaseRoutingStrategy._default_config_definitions` at init, named `organization_<setting>_override` with `param_types={"organization_id": int}` and a zero-value sentinel meaning "no override".
- Configs are added to `_default_config_definitions` rather than `_additional_config_definitions` so that subclasses which override `_additional_config_definitions` without calling `super()` (e.g. `OutcomesBasedRoutingStrategy`) don't clobber them.
- `_get_org_clickhouse_setting_overrides` walks the allowlist and returns the active overrides for the requesting `organization_id`.
- In `get_routing_decision`, the override is applied immediately after `_update_routing_decision`, so it wins absolutely over both allocation-policy combined values and any setting the strategy itself pushed (including raising above the `min`).
- The applied overrides are recorded in `routing_context.extra_info["org_clickhouse_setting_overrides"]` so they land in `to_log_dict()` → querylog, making it easy to verify a fired override in production.

### Design choices

- **Override wins absolutely** (not a cap): the motivating use case is *raising* `max_threads` for one org, so a `min` semantic wouldn't work. Operator responsibility for setting sane values.
- **Allowlist over open-ended**: avoids ops misconfiguring dangerous settings like `max_memory_usage=0`.
- **On `BaseRoutingStrategy` directly**, not as a new allocation policy: settings are a routing-strategy concept, not a quota concept, and this avoids extending the `QuotaAllowance` schema for non-quota fields.

### Admin UI

No UI changes required. The new configs surface automatically through the existing `GET /routing_strategy_configs/<strategy_name>` and `POST /set_configurable_component_configuration` endpoints (with `params: {"organization_id": <id>}`), and render as a parameterized config row under each routing strategy in Capacity Management.


Agent transcript: https://claudescope.sentry.dev/share/p2g-BoXCmlF3BZkgTsTiuXEPDSKQdkZMFtSyEqzocHQ