### PR TITLE
ref(eap-items): add SilencedDLQMessage

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -16,7 +16,7 @@ use sentry_protos::snuba::v1::{ArrayValue, TraceItem, TraceItemType};
 use crate::config::ProcessorConfig;
 use crate::processors::utils::{
     enforce_retention, get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs,
-    record_invalid_timestamp_metric,
+    record_invalid_timestamp_metric, SilencedDLQMessage,
 };
 use crate::runtime_config::get_str_config;
 use crate::strategies::clickhouse::rowbinary;
@@ -82,9 +82,12 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
                 if should_dlq_for_prior_partition(event_ts, now, grace_min) {
                     let item_type_str = item_type_name(item_type);
                     counter!("eap_items.messages.dlqed_prior_partition", 1, "item_type" => item_type_str);
-                    anyhow::bail!(
+                    // `SilencedDLQMessage` must remain the root error: the processor
+                    // strategy silences it via `downcast_ref`, which only matches the
+                    // outermost error. Do not wrap this in `.context(...)`.
+                    anyhow::bail!(SilencedDLQMessage::new(format!(
                         "eap-items message DLQed: event timestamp {event_ts} is before the prior weekly partition boundary; routed to DLQ"
-                    );
+                    )));
                 }
             }
         }

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -82,9 +82,6 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
                 if should_dlq_for_prior_partition(event_ts, now, grace_min) {
                     let item_type_str = item_type_name(item_type);
                     counter!("eap_items.messages.dlqed_prior_partition", 1, "item_type" => item_type_str);
-                    // `SilencedDLQMessage` must remain the root error: the processor
-                    // strategy silences it via `downcast_ref`, which only matches the
-                    // outermost error. Do not wrap this in `.context(...)`.
                     anyhow::bail!(SilencedDLQMessage);
                 }
             }

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -85,9 +85,7 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
                     // `SilencedDLQMessage` must remain the root error: the processor
                     // strategy silences it via `downcast_ref`, which only matches the
                     // outermost error. Do not wrap this in `.context(...)`.
-                    anyhow::bail!(SilencedDLQMessage::new(format!(
-                        "eap-items message DLQed: event timestamp {event_ts} is before the prior weekly partition boundary; routed to DLQ"
-                    )));
+                    anyhow::bail!(SilencedDLQMessage);
                 }
             }
         }

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -6,7 +6,6 @@ use schemars::JsonSchema;
 use sentry_arroyo::counter;
 use sentry_protos::snuba::v1::TraceItemType;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::fmt;
 
 /// One week in seconds. The eap_items table is partitioned by
 /// `(retention_days, toMonday(timestamp))`, so any event more than a week
@@ -112,26 +111,9 @@ pub struct StringToIntDatetime64(
 /// reported to Sentry. The processor strategy downcasts to this type and skips
 /// the usual error-level logging / Sentry capture, treating the failure as an
 /// expected (silenced) DLQ outcome.
-#[derive(Debug, Clone)]
-pub struct SilencedDLQMessage {
-    err_msg: String,
-}
-
-impl SilencedDLQMessage {
-    pub fn new(err_msg: impl Into<String>) -> Self {
-        Self {
-            err_msg: err_msg.into(),
-        }
-    }
-}
-
-impl fmt::Display for SilencedDLQMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.err_msg)
-    }
-}
-
-impl std::error::Error for SilencedDLQMessage {}
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("message routed to DLQ (silenced)")]
+pub struct SilencedDLQMessage;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use sentry_arroyo::counter;
 use sentry_protos::snuba::v1::TraceItemType;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
 
 /// One week in seconds. The eap_items table is partitioned by
 /// `(retention_days, toMonday(timestamp))`, so any event more than a week
@@ -106,6 +107,31 @@ pub struct StringToIntDatetime64(
     #[schemars(with = "String")]
     pub u64,
 );
+
+/// Error type for messages that should be routed to the DLQ without being
+/// reported to Sentry. The processor strategy downcasts to this type and skips
+/// the usual error-level logging / Sentry capture, treating the failure as an
+/// expected (silenced) DLQ outcome.
+#[derive(Debug, Clone)]
+pub struct SilencedDLQMessage {
+    err_msg: String,
+}
+
+impl SilencedDLQMessage {
+    pub fn new(err_msg: impl Into<String>) -> Self {
+        Self {
+            err_msg: err_msg.into(),
+        }
+    }
+}
+
+impl fmt::Display for SilencedDLQMessage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.err_msg)
+    }
+}
+
+impl std::error::Error for SilencedDLQMessage {}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -111,7 +111,7 @@ pub struct StringToIntDatetime64(
 /// reported to Sentry. The processor strategy downcasts to this type and skips
 /// the usual error-level logging / Sentry capture, treating the failure as an
 /// expected (silenced) DLQ outcome.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 #[error("message routed to DLQ (silenced)")]
 pub struct SilencedDLQMessage;
 

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -14,6 +14,7 @@ use sentry_arroyo::types::{BrokerMessage, InnerMessage, Message, Partition};
 use sentry_kafka_schemas::{Schema, SchemaError, SchemaType};
 
 use crate::config::ProcessorConfig;
+use crate::processors::utils::SilencedDLQMessage;
 use crate::processors::{ProcessingFunction, ProcessingFunctionWithReplacements};
 use crate::types::{
     BytesInsertBatch, CommitLogEntry, CommitLogOffsets, InsertBatch, InsertOrReplacement,
@@ -242,6 +243,16 @@ impl<TResult: Clone, TNext: Clone> MessageProcessor<TResult, TNext> {
 
         let processed_message = self.process_payload(msg).map_err(|error| {
             counter!("invalid_message");
+
+            // Some failures are expected DLQ outcomes that we don't want to
+            // report to Sentry as errors. These surface as `SilencedDLQMessage`.
+            // NOTE: `downcast_ref` only matches the outermost error, so the
+            // `SilencedDLQMessage` must be the root error — do not wrap it in
+            // `.context(...)` anywhere on the processing path, or it will be
+            // reported to Sentry instead of silenced.
+            if error.downcast_ref::<SilencedDLQMessage>().is_some() {
+                return maybe_err;
+            }
 
             sentry::with_scope(
                 |scope| {

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -246,11 +246,7 @@ impl<TResult: Clone, TNext: Clone> MessageProcessor<TResult, TNext> {
 
             // Some failures are expected DLQ outcomes that we don't want to
             // report to Sentry as errors. These surface as `SilencedDLQMessage`.
-            // NOTE: `downcast_ref` only matches the outermost error, so the
-            // `SilencedDLQMessage` must be the root error — do not wrap it in
-            // `.context(...)` anywhere on the processing path, or it will be
-            // reported to Sentry instead of silenced.
-            if error.downcast_ref::<SilencedDLQMessage>().is_some() {
+            if error.is::<SilencedDLQMessage>() {
                 return maybe_err;
             }
 

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -242,13 +242,13 @@ impl<TResult: Clone, TNext: Clone> MessageProcessor<TResult, TNext> {
         record_message_stats(payload);
 
         let processed_message = self.process_payload(msg).map_err(|error| {
-            counter!("invalid_message");
-
             // Some failures are expected DLQ outcomes that we don't want to
             // report to Sentry as errors. These surface as `SilencedDLQMessage`.
             if error.is::<SilencedDLQMessage>() {
                 return maybe_err;
             }
+
+            counter!("invalid_message");
 
             sentry::with_scope(
                 |scope| {


### PR DESCRIPTION
FIXES [SNUBA-B1E](https://sentry.sentry.io/issues/7492983615/?environment=us&project=300688&query=is%3Aunresolved&referrer=issue-stream)

We don't want to be creating errors for DLQ'd messages that are DLQ'd because of the partition boundary timestamp. This will still have the message be DLQ'd and we produce metrics for this `eap_items.messages.dlqed_prior_partition`
