### PR TITLE
feat(search_issues): add ClickhouseSettingsOverride query processor

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
@@ -130,6 +130,7 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_downsample_64.yaml
@@ -130,7 +130,6 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
-        distributed_product_mode: global
 
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -146,7 +146,6 @@ query_processors:
       settings:
         max_execution_time: 25
         timeout_before_checking_execution_speed: 0
-        distributed_product_mode: global
 
 deletion_settings:
   is_enabled: 1

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -140,6 +140,13 @@ query_processors:
           sentry:user: user
         contexts:
           trace.trace_id: trace_id
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
 
 deletion_settings:
   is_enabled: 1


### PR DESCRIPTION
Adds the `ClickhouseSettingsOverride` query processor to the `search_issues` storage:

```yaml
- processor: ClickhouseSettingsOverride
  args:
    overwrite_existing: false
    settings:
      max_execution_time: 25
      timeout_before_checking_execution_speed: 0
```

We see queries that continue beyond 30 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)