### PR TITLE
feat(eap-items): add generic name column with bloom_filter index

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
@@ -12,7 +12,6 @@ new_columns = [
         "name",
         String(
             Modifiers(
-                low_cardinality=True,
                 codecs=[
                     "ZSTD(1)",
                 ],

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
@@ -20,7 +20,7 @@ new_columns = [
         ),
     ),
 ]
-after = "attributes_int"
+after = "retention_days"
 sampling_weights = [8, 8**2, 8**3]
 local_table_name = f"{table_name_prefix}_local"
 index_name = "bf_name"

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
@@ -9,7 +9,7 @@ ro_storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO
 table_name_prefix = "eap_items_1"
 new_columns = [
     Column(
-        "trace_metric_name",
+        "name",
         String(
             Modifiers(
                 low_cardinality=True,
@@ -22,6 +22,11 @@ new_columns = [
 ]
 after = "attributes_array"
 sampling_weights = [8, 8**2, 8**3]
+local_table_name = f"{table_name_prefix}_local"
+index_name = "bf_name"
+index_expression = "name"
+index_type = "bloom_filter"
+index_granularity = 1
 
 
 class Migration(migration.ClickhouseNodeMigration):
@@ -84,22 +89,45 @@ class Migration(migration.ClickhouseNodeMigration):
             ]
         )
 
+        ops.append(
+            operations.AddIndex(
+                storage_set=storage_set,
+                table_name=local_table_name,
+                index_name=index_name,
+                index_expression=index_expression,
+                index_type=index_type,
+                granularity=index_granularity,
+                target=OperationTarget.LOCAL,
+            )
+        )
+
         return ops
 
     def backwards_ops(self) -> list[operations.SqlOperation]:
         ops: list[operations.SqlOperation] = [
-            operations.DropColumn(
+            operations.DropIndex(
                 storage_set=storage_set,
-                table_name=f"{table_name_prefix}_{suffix}",
-                column_name=new_column.name,
-                target=target,
+                table_name=local_table_name,
+                index_name=index_name,
+                target=OperationTarget.LOCAL,
             )
-            for suffix, target in [
-                ("dist", OperationTarget.DISTRIBUTED),
-                ("local", OperationTarget.LOCAL),
-            ]
-            for new_column in new_columns
         ]
+
+        ops.extend(
+            [
+                operations.DropColumn(
+                    storage_set=storage_set,
+                    table_name=f"{table_name_prefix}_{suffix}",
+                    column_name=new_column.name,
+                    target=target,
+                )
+                for suffix, target in [
+                    ("dist", OperationTarget.DISTRIBUTED),
+                    ("local", OperationTarget.LOCAL),
+                ]
+                for new_column in new_columns
+            ]
+        )
 
         for sampling_weight in sampling_weights:
             downsampled_table_prefix = f"eap_items_1_downsample_{sampling_weight}"

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
@@ -89,28 +89,40 @@ class Migration(migration.ClickhouseNodeMigration):
             ]
         )
 
-        ops.append(
-            operations.AddIndex(
-                storage_set=storage_set,
-                table_name=local_table_name,
-                index_name=index_name,
-                index_expression=index_expression,
-                index_type=index_type,
-                granularity=index_granularity,
-                target=OperationTarget.LOCAL,
-            )
+        local_table_names = [local_table_name] + [
+            f"eap_items_1_downsample_{sampling_weight}_local"
+            for sampling_weight in sampling_weights
+        ]
+        ops.extend(
+            [
+                operations.AddIndex(
+                    storage_set=storage_set,
+                    table_name=table_name,
+                    index_name=index_name,
+                    index_expression=index_expression,
+                    index_type=index_type,
+                    granularity=index_granularity,
+                    target=OperationTarget.LOCAL,
+                )
+                for table_name in local_table_names
+            ]
         )
 
         return ops
 
     def backwards_ops(self) -> list[operations.SqlOperation]:
+        local_table_names = [local_table_name] + [
+            f"eap_items_1_downsample_{sampling_weight}_local"
+            for sampling_weight in sampling_weights
+        ]
         ops: list[operations.SqlOperation] = [
             operations.DropIndex(
                 storage_set=storage_set,
-                table_name=local_table_name,
+                table_name=table_name,
                 index_name=index_name,
                 target=OperationTarget.LOCAL,
             )
+            for table_name in local_table_names
         ]
 
         ops.extend(

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
@@ -9,7 +9,7 @@ ro_storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO
 table_name_prefix = "eap_items_1"
 new_columns = [
     Column(
-        "name",
+        "indexed_name",
         String(
             Modifiers(
                 codecs=[
@@ -22,8 +22,8 @@ new_columns = [
 after = "retention_days"
 sampling_weights = [8, 8**2, 8**3]
 local_table_name = f"{table_name_prefix}_local"
-index_name = "bf_name"
-index_expression = "name"
+index_name = "bf_indexed_name"
+index_expression = "indexed_name"
 index_type = "bloom_filter"
 index_granularity = 1
 

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
@@ -3,13 +3,15 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import UUID, Bool, DateTime, Float, Int, Map, UInt
 
 storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
 ro_storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO
 table_name_prefix = "eap_items_1"
+column_name = "indexed_name"
 new_columns = [
     Column(
-        "indexed_name",
+        column_name,
         String(
             Modifiers(
                 codecs=[
@@ -26,6 +28,136 @@ index_name = "bf_indexed_name"
 index_expression = "indexed_name"
 index_type = "bloom_filter"
 index_granularity = 1
+
+# Materialized views that feed the downsampled tables select an explicit column
+# list from eap_items_1_local, so the new column has to be added to the views
+# (not just the tables) for it to be populated on the downsampled read paths.
+# These columns mirror the current mv_4 definition (migration 0049) with the new
+# `indexed_name` column inserted after `retention_days`.
+num_attr_buckets = 40
+mv_old_version = 4
+mv_new_version = mv_old_version + 1
+
+mv_columns: list[Column[Modifiers]] = [
+    Column("organization_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("item_type", UInt(8)),
+    Column("timestamp", DateTime(Modifiers(codecs=["DoubleDelta", "ZSTD(1)"]))),
+    Column("trace_id", UUID()),
+    Column("item_id", UInt(128)),
+    Column("sampling_weight", UInt(64, modifiers=Modifiers(codecs=["ZSTD(1)"]))),
+    Column("sampling_factor", Float(64, modifiers=Modifiers(codecs=["ZSTD(1)"]))),
+    Column(
+        "retention_days",
+        UInt(16, modifiers=Modifiers(codecs=["T64", "ZSTD(1)"])),
+    ),
+    new_columns[0],
+    Column(
+        "attributes_bool",
+        Map(
+            String(),
+            Bool(),
+        ),
+    ),
+    Column(
+        "attributes_int",
+        Map(
+            String(),
+            Int(64),
+        ),
+    ),
+]
+mv_columns.extend(
+    [
+        Column(
+            f"attributes_string_{i}",
+            Map(
+                String(),
+                String(),
+                modifiers=Modifiers(
+                    codecs=["ZSTD(1)"],
+                ),
+            ),
+        )
+        for i in range(num_attr_buckets)
+    ]
+)
+mv_columns.extend(
+    [
+        Column(
+            f"attributes_float_{i}",
+            Map(
+                String(),
+                Float(64),
+                modifiers=Modifiers(
+                    codecs=["ZSTD(1)"],
+                ),
+            ),
+        )
+        for i in range(num_attr_buckets)
+    ]
+)
+
+
+def _should_passthrough_column(name: str) -> bool:
+    # Columns computed in the SELECT rather than copied straight through.
+    return name not in {
+        "sampling_weight",
+        "sampling_factor",
+        "retention_days",
+        "client_sample_rate",
+        "server_sample_rate",
+    }
+
+
+def _materialized_view_query(sampling_weight: int, include_indexed_name: bool) -> str:
+    passthrough = [
+        c.name
+        for c in mv_columns
+        if _should_passthrough_column(c.name) and (include_indexed_name or c.name != column_name)
+    ]
+    return " ".join(
+        [
+            "SELECT",
+            f"{', '.join(passthrough)},",
+            "downsampled_retention_days AS retention_days,",
+            f"sampling_weight * {sampling_weight} AS sampling_weight,",
+            f"sampling_factor / {sampling_weight} AS sampling_factor,",
+            f"client_sample_rate / {sampling_weight} AS client_sample_rate,",
+            f"server_sample_rate / {sampling_weight} AS server_sample_rate",
+            "FROM eap_items_1_local",
+            f"WHERE (cityHash64(item_id + {sampling_weight})  % {sampling_weight}) = 0",
+        ]
+    )
+
+
+def _recreate_materialized_views_ops(
+    create_version: int,
+    drop_version: int,
+    columns: list[Column[Modifiers]],
+    include_indexed_name: bool,
+) -> list[operations.SqlOperation]:
+    ops: list[operations.SqlOperation] = []
+    for sampling_weight in sampling_weights:
+        downsampled_local_table = f"eap_items_1_downsample_{sampling_weight}_local"
+        ops.extend(
+            [
+                operations.CreateMaterializedView(
+                    storage_set=storage_set,
+                    view_name=f"eap_items_1_downsample_{sampling_weight}_mv_{create_version}",
+                    columns=columns,
+                    destination_table_name=downsampled_local_table,
+                    target=OperationTarget.LOCAL,
+                    query=_materialized_view_query(sampling_weight, include_indexed_name),
+                ),
+                operations.DropTable(
+                    storage_set=storage_set,
+                    table_name=f"eap_items_1_downsample_{sampling_weight}_mv_{drop_version}",
+                    target=OperationTarget.LOCAL,
+                ),
+            ]
+        )
+    return ops
 
 
 class Migration(migration.ClickhouseNodeMigration):
@@ -107,22 +239,46 @@ class Migration(migration.ClickhouseNodeMigration):
             ]
         )
 
+        # Recreate the downsample materialized views so they select the new
+        # column and populate it on the downsampled tables. The column must
+        # already exist on both eap_items_1_local and the downsampled tables
+        # (added above) before the views are recreated.
+        ops.extend(
+            _recreate_materialized_views_ops(
+                create_version=mv_new_version,
+                drop_version=mv_old_version,
+                columns=mv_columns,
+                include_indexed_name=True,
+            )
+        )
+
         return ops
 
     def backwards_ops(self) -> list[operations.SqlOperation]:
+        # Restore the previous materialized views (which do not reference the
+        # new column) before dropping the column the new views read from.
+        ops: list[operations.SqlOperation] = _recreate_materialized_views_ops(
+            create_version=mv_old_version,
+            drop_version=mv_new_version,
+            columns=[c for c in mv_columns if c.name != column_name],
+            include_indexed_name=False,
+        )
+
         local_table_names = [local_table_name] + [
             f"eap_items_1_downsample_{sampling_weight}_local"
             for sampling_weight in sampling_weights
         ]
-        ops: list[operations.SqlOperation] = [
-            operations.DropIndex(
-                storage_set=storage_set,
-                table_name=table_name,
-                index_name=index_name,
-                target=OperationTarget.LOCAL,
-            )
-            for table_name in local_table_names
-        ]
+        ops.extend(
+            [
+                operations.DropIndex(
+                    storage_set=storage_set,
+                    table_name=table_name,
+                    index_name=index_name,
+                    target=OperationTarget.LOCAL,
+                )
+                for table_name in local_table_names
+            ]
+        )
 
         ops.extend(
             [

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_name_column_and_index.py
@@ -20,7 +20,7 @@ new_columns = [
         ),
     ),
 ]
-after = "attributes_array"
+after = "attributes_int"
 sampling_weights = [8, 8**2, 8**3]
 local_table_name = f"{table_name_prefix}_local"
 index_name = "bf_name"

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_trace_metric_name_column.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_trace_metric_name_column.py
@@ -5,6 +5,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.migrations.operations import OperationTarget
 
 storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+ro_storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO
 table_name_prefix = "eap_items_1"
 new_columns = [
     Column(
@@ -62,6 +63,27 @@ class Migration(migration.ClickhouseNodeMigration):
                 ]
             )
 
+        # The read-only distributed tables (created via `CREATE TABLE ... AS`)
+        # do not inherit schema changes from their source tables, so the column
+        # must be added explicitly for queries on the read path to see it.
+        ro_table_names = [f"{table_name_prefix}_dist_ro"] + [
+            f"eap_items_1_downsample_{sampling_weight}_dist_ro"
+            for sampling_weight in sampling_weights
+        ]
+        ops.extend(
+            [
+                operations.AddColumn(
+                    storage_set=ro_storage_set,
+                    table_name=ro_table_name,
+                    column=new_column,
+                    after=after,
+                    target=OperationTarget.DISTRIBUTED,
+                )
+                for ro_table_name in ro_table_names
+                for new_column in new_columns
+            ]
+        )
+
         return ops
 
     def backwards_ops(self) -> list[operations.SqlOperation]:
@@ -97,5 +119,22 @@ class Migration(migration.ClickhouseNodeMigration):
                     for new_column in new_columns
                 ]
             )
+
+        ro_table_names = [f"{table_name_prefix}_dist_ro"] + [
+            f"eap_items_1_downsample_{sampling_weight}_dist_ro"
+            for sampling_weight in sampling_weights
+        ]
+        ops.extend(
+            [
+                operations.DropColumn(
+                    storage_set=ro_storage_set,
+                    table_name=ro_table_name,
+                    column_name=new_column.name,
+                    target=OperationTarget.DISTRIBUTED,
+                )
+                for ro_table_name in ro_table_names
+                for new_column in new_columns
+            ]
+        )
 
         return ops

--- a/snuba/snuba_migrations/events_analytics_platform/0057_add_trace_metric_name_column.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0057_add_trace_metric_name_column.py
@@ -1,0 +1,101 @@
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+table_name_prefix = "eap_items_1"
+new_columns = [
+    Column(
+        "trace_metric_name",
+        String(
+            Modifiers(
+                low_cardinality=True,
+                codecs=[
+                    "ZSTD(1)",
+                ],
+            ),
+        ),
+    ),
+]
+after = "attributes_array"
+sampling_weights = [8, 8**2, 8**3]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> list[operations.SqlOperation]:
+        ops: list[operations.SqlOperation] = [
+            operations.AddColumn(
+                storage_set=storage_set,
+                table_name=f"{table_name_prefix}_{suffix}",
+                column=new_column,
+                after=after,
+                target=target,
+            )
+            for suffix, target in [
+                ("local", OperationTarget.LOCAL),
+                ("dist", OperationTarget.DISTRIBUTED),
+            ]
+            for new_column in new_columns
+        ]
+
+        for sampling_weight in sampling_weights:
+            downsampled_table_prefix = f"eap_items_1_downsample_{sampling_weight}"
+
+            ops.extend(
+                [
+                    operations.AddColumn(
+                        storage_set=storage_set,
+                        table_name=f"{downsampled_table_prefix}_{suffix}",
+                        column=new_column,
+                        after=after,
+                        target=target,
+                    )
+                    for suffix, target in [
+                        ("local", OperationTarget.LOCAL),
+                        ("dist", OperationTarget.DISTRIBUTED),
+                    ]
+                    for new_column in new_columns
+                ]
+            )
+
+        return ops
+
+    def backwards_ops(self) -> list[operations.SqlOperation]:
+        ops: list[operations.SqlOperation] = [
+            operations.DropColumn(
+                storage_set=storage_set,
+                table_name=f"{table_name_prefix}_{suffix}",
+                column_name=new_column.name,
+                target=target,
+            )
+            for suffix, target in [
+                ("dist", OperationTarget.DISTRIBUTED),
+                ("local", OperationTarget.LOCAL),
+            ]
+            for new_column in new_columns
+        ]
+
+        for sampling_weight in sampling_weights:
+            downsampled_table_prefix = f"eap_items_1_downsample_{sampling_weight}"
+
+            ops.extend(
+                [
+                    operations.DropColumn(
+                        storage_set=storage_set,
+                        table_name=f"{downsampled_table_prefix}_{suffix}",
+                        column_name=new_column.name,
+                        target=target,
+                    )
+                    for suffix, target in [
+                        ("dist", OperationTarget.DISTRIBUTED),
+                        ("local", OperationTarget.LOCAL),
+                    ]
+                    for new_column in new_columns
+                ]
+            )
+
+        return ops


### PR DESCRIPTION
## Summary

Adds a generic `indexed_name` column to the `eap_items_1` tables, with a `bloom_filter` index, to store and index a per-item-type "name" attribute that we frequently filter on. Promoting this commonly-filtered attribute to a dedicated indexed column lets those queries skip granules via the bloom_filter instead of scanning the attribute maps.

The column is intentionally generic (`indexed_name`) rather than tied to a single item type, since each item type has its own notion of a primary name attribute it gets filtered by.

## Changes

- **New column** `indexed_name`: `String CODEC(ZSTD(1))`, positioned after `retention_days` so it sits ahead of the entire attributes block (`attributes_bool`, `attributes_int`, and the string/float buckets).
  - Added to all eap_items tables: `eap_items_1_local`/`_dist`, the three downsampled tables (`_downsample_8/64/512`, local + dist), and the read-only distributed tables (`_dist_ro`) under the `EVENTS_ANALYTICS_PLATFORM_RO` storage set.
  - `retention_days` is used as the placement anchor because it's the only pre-attributes column present on every target table (the downsampled and `_dist_ro` variants lack `downsampled_retention_days`). Column order has no effect on correctness since ClickHouse inserts/selects are by name.
- **New `bf_indexed_name` `bloom_filter` index** (granularity 1) on every local table: `eap_items_1_local` and the three `_downsample_{8,64,512}_local` tables, so name filtering is accelerated on the full-resolution and downsampled read paths alike.
- **Recreated downsample materialized views** (`mv_4` → `mv_5`) for all three sampling weights, adding `indexed_name` to the SELECT so the column is actually populated on the downsampled tables (the views select an explicit column list from `eap_items_1_local`, so the column has to be added to the views, not just the tables). The column is added to the downsample tables before the views are recreated so they have a destination to write into.
- Fully reversible: `backwards_ops` restores the `mv_4` views (byte-for-byte identical to migration 0049, without `indexed_name`) first, then drops the indexes, then the column from every table.

### Generated SQL (forwards)

```sql
ALTER TABLE eap_items_1_local ADD COLUMN IF NOT EXISTS indexed_name String CODEC (ZSTD(1)) AFTER retention_days;
-- + dist, the 3 downsampled local/dist tables, and the 4 _dist_ro tables
ALTER TABLE eap_items_1_local ADD INDEX IF NOT EXISTS bf_indexed_name indexed_name TYPE bloom_filter GRANULARITY 1;
-- + the 3 _downsample_{8,64,512}_local tables
CREATE MATERIALIZED VIEW IF NOT EXISTS eap_items_1_downsample_8_mv_5 TO eap_items_1_downsample_8_local (...) AS SELECT ..., indexed_name, ... FROM eap_items_1_local WHERE ...;
DROP TABLE IF EXISTS eap_items_1_downsample_8_mv_4 SYNC;
-- + the 64 and 512 downsample views
```

## Notes

- `_dist_ro` tables are created via `CREATE TABLE ... AS` and don't inherit later schema changes, so the column is added explicitly there for the read path.
- This extends the bloom_filter index to the downsampled local tables, which goes a step beyond the existing `bf_trace_id`/`bf_hashed_keys` indexes (those live on the main local table only) — intentional here so name filtering benefits on downsampled queries too.

## Testing

Verified the migration loads and renders the expected forward/backward SQL via `EventsAnalyticsPlatformLoader`, including that the backward `mv_4` definition matches migration 0049 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
