### PR TITLE
fix(web): Return HTTP 404 for unknown dataset names

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -68,7 +68,7 @@ from snuba.consumers.dlq import (
     load_instruction,
     store_instruction,
 )
-from snuba.datasets.factory import InvalidDatasetError, get_enabled_dataset_names
+from snuba.datasets.factory import get_enabled_dataset_names
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.manual_jobs.runner import (
@@ -1012,12 +1012,6 @@ def snuba_debug() -> Response:
             400,
             {"Content-Type": "application/json"},
         )
-    except InvalidDatasetError as exception:
-        return Response(
-            json.dumps({"error": {"message": str(exception)}}, indent=4),
-            400,
-            {"Content-Type": "application/json"},
-        )
     finally:
         explain_cleanup()
 
@@ -1319,12 +1313,6 @@ def production_snql_query() -> Response:
             400,
             {"Content-Type": "application/json"},
         )
-    except InvalidDatasetError as exception:
-        return Response(
-            json.dumps({"error": {"message": str(exception)}}, indent=4),
-            400,
-            {"Content-Type": "application/json"},
-        )
 
 
 @application.route("/production_mql_query", methods=["POST"])
@@ -1335,12 +1323,6 @@ def production_mql_query() -> Response:
     try:
         return run_mql_query(body, g.user.email)
     except InvalidQueryException as exception:
-        return Response(
-            json.dumps({"error": {"message": str(exception)}}, indent=4),
-            400,
-            {"Content-Type": "application/json"},
-        )
-    except InvalidDatasetError as exception:
         return Response(
             json.dumps({"error": {"message": str(exception)}}, indent=4),
             400,

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -68,7 +68,7 @@ from snuba.consumers.dlq import (
     load_instruction,
     store_instruction,
 )
-from snuba.datasets.factory import get_enabled_dataset_names
+from snuba.datasets.factory import InvalidDatasetError, get_enabled_dataset_names
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.manual_jobs.runner import (
@@ -117,6 +117,16 @@ def handle_invalid_json(exception: UnauthorizedException) -> Response:
     return Response(
         json.dumps({"error": "Unauthorized"}),
         401,
+        {"Content-Type": "application/json"},
+    )
+
+
+@application.errorhandler(InvalidDatasetError)
+def handle_invalid_dataset(exception: InvalidDatasetError) -> Response:
+    data = {"error": {"type": "dataset", "message": str(exception)}}
+    return Response(
+        json.dumps(data, sort_keys=True, indent=4),
+        404,
         {"Content-Type": "application/json"},
     )
 

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -7,7 +7,7 @@ import sentry_sdk
 
 from snuba import environment, settings
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.factory import InvalidDatasetError, get_dataset, get_dataset_name
+from snuba.datasets.factory import get_dataset, get_dataset_name
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.pipeline.query_pipeline import QueryPipelineResult
 from snuba.pipeline.stages.query_execution import ExecutionStage
@@ -111,10 +111,7 @@ def run_query(
 
 def _get_dataset(dataset_name: Optional[str]) -> Dataset:
     if dataset_name:
-        try:
-            return get_dataset(dataset_name)
-        except InvalidDatasetError:
-            return PluggableDataset(name=dataset_name, all_entities=[])
+        return get_dataset(dataset_name)
     return PluggableDataset(name=settings.DEFAULT_DATASET_NAME, all_entities=[])
 
 

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -1023,7 +1023,7 @@ def test_prod_snql_query_invalid_dataset(admin_api: FlaskClient) -> None:
     response = admin_api.post(
         "/production_snql_query", data=json.dumps({"dataset": "", "query": ""})
     )
-    assert response.status_code == 400
+    assert response.status_code == 404
     data = json.loads(response.data)
     assert data["error"]["message"] == "dataset '' does not exist"
 
@@ -1121,7 +1121,7 @@ def test_prod_mql_query_invalid_dataset(admin_api: FlaskClient) -> None:
         "/production_mql_query",
         data=json.dumps({"dataset": "", "query": "", "mql_context": {}}),
     )
-    assert response.status_code == 400
+    assert response.status_code == 404
     data = json.loads(response.data)
     assert data["error"]["message"] == "dataset '' does not exist"
 


### PR DESCRIPTION
Stop crashing when a query references a dataset that does not exist, and return a clean HTTP 404 instead.

`_get_dataset` in `snuba/web/query.py` previously caught `InvalidDatasetError` and fell back to an empty `PluggableDataset(name=dataset_name, all_entities=[])`. That synthetic dataset propagated through `parse_and_run_query` and eventually crashed deeper in the pipeline. The fallback is removed so the exception reaches the existing `@application.errorhandler(InvalidDatasetError)` and the caller gets a 404 with a structured error body.

The admin endpoints (`/production_snql_query`, `/production_mql_query`, `/snuba_debug`) each had a local `except InvalidDatasetError → 400` block. With the global handler in place these were redundant, and the inconsistent status code (400 in admin, 404 everywhere else) was confusing. The local blocks are removed and the two admin tests that asserted the old 400 are updated to expect 404.


Agent transcript: https://claudescope.sentry.dev/share/KBP3mK0udOjuDIPqoaUh0t9ch81WKK2cebxoTrSlVEY