### PR TITLE
fix(rpc): Honor should_report when capturing RPC exceptions

### DIFF
--- a/snuba/query/processors/physical/hexint_column_processor.py
+++ b/snuba/query/processors/physical/hexint_column_processor.py
@@ -64,7 +64,7 @@ class HexIntArrayColumnProcessor(BaseTypeConverter):
             assert isinstance(exp.value, str)
             return Literal(alias=exp.alias, value=int(exp.value, 16))
         except (AssertionError, ValueError):
-            raise ColumnTypeError("Invalid hexint", report=False)
+            raise ColumnTypeError("Invalid hexint", should_report=False)
 
     def _process_expressions(self, exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in self.columns:

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -359,7 +359,13 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
                     tags=self._timer.tags,
                 )
             else:
-                sentry_sdk.capture_exception(error)
+                # `should_report=False` marks an exception (e.g. an invalid
+                # query from a client, like an empty-string filter on a hexint
+                # column) that we deliberately do not want surfaced in Sentry.
+                # Honor that flag here, matching the legacy HTTP path in
+                # `snuba/web/views.py`.
+                if getattr(error, "should_report", True):
+                    sentry_sdk.capture_exception(error)
                 self.metrics.increment(
                     "request_error",
                     tags=self._timer.tags,
@@ -431,7 +437,12 @@ def run_rpc_handler(name: str, version: str, data: bytes) -> ProtobufMessage | E
     except (RPCRequestException, QueryException) as e:
         return convert_rpc_exception_to_proto(e)
     except Exception as e:
-        sentry_sdk.capture_exception(e)
+        # Don't report exceptions that opted out via `should_report=False`
+        # (e.g. invalid client queries). `execute` re-raises after
+        # `__after_execute`, so this is the second capture site for the same
+        # error and must honor the flag too.
+        if getattr(e, "should_report", True):
+            sentry_sdk.capture_exception(e)
         return convert_rpc_exception_to_proto(
             RPCRequestException(
                 status_code=500,

--- a/tests/web/rpc/test_base.py
+++ b/tests/web/rpc/test_base.py
@@ -15,6 +15,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
+from snuba.query.processors.physical.type_converters import ColumnTypeError
 from snuba.web import QueryException
 from snuba.web.rpc import RPCEndpoint, list_all_endpoint_names
 from snuba.web.rpc.common.exceptions import (
@@ -78,6 +79,23 @@ class ErrorRPC(RPCEndpoint[TimeSeriesRequest, TimeSeriesRequest]):
     def _execute(self, in_msg: TimeSeriesRequest) -> TimeSeriesRequest:
         time.sleep(self.duration_millis / 1000)
         raise RPCException("This is meant to error!")
+
+
+class SilentErrorRPC(RPCEndpoint[TimeSeriesRequest, TimeSeriesRequest]):
+    duration_millis = 100
+
+    @classmethod
+    def response_class(cls) -> Type[TimeSeriesRequest]:
+        return TimeSeriesRequest
+
+    @classmethod
+    def version(cls) -> str:
+        return "v1"
+
+    def _execute(self, in_msg: TimeSeriesRequest) -> TimeSeriesRequest:
+        # Mirrors an invalid client query (e.g. an empty-string filter on a
+        # hexint column) which is raised with should_report=False.
+        raise ColumnTypeError("Invalid hexint", should_report=False)
 
 
 class TimeoutRPC(RPCEndpoint[TimeSeriesRequest, TimeSeriesRequest]):
@@ -177,6 +195,22 @@ def test_error_metrics() -> None:
         metric_names_to_metric = {m.name: m for m in metrics_backend.calls}  # type: ignore
         assert metric_names_to_metric["rpc.request_error"].value == 1  # type: ignore
         sentry_sdk_mock.assert_called()
+
+
+@pytest.mark.redis_db
+@pytest.mark.clickhouse_db
+def test_should_report_false_not_captured() -> None:
+    # Exceptions raised with should_report=False (e.g. invalid client queries)
+    # must not be reported to Sentry, even though they still count as errors.
+    with patch("snuba.web.rpc.sentry_sdk.capture_exception") as sentry_sdk_mock:
+        metrics_backend = TestingMetricsBackend()
+        rpc_call = SilentErrorRPC(metrics_backend=metrics_backend)
+        with pytest.raises(ColumnTypeError):
+            rpc_call.execute(_get_in_msg())
+
+        metric_names_to_metric = {m.name: m for m in metrics_backend.calls}  # type: ignore
+        assert metric_names_to_metric["rpc.request_error"].value == 1  # type: ignore
+        sentry_sdk_mock.assert_not_called()
 
 
 def test_list_all_endpoint_names() -> None:


### PR DESCRIPTION
## Summary

Fixes the `ColumnTypeError: Invalid hexint` noise driving the **Snuba Errors** metric alert ([SNUBA-A1M](https://sentry.sentry.io/issues/SNUBA-A1M)).

An empty-string `item_id` filter (`item_id = ''`) — sent by the Explore spans-timeseries API to `EndpointTimeSeries/v1` — hits the `HexIntColumnProcessor`, which does `int('', 16)` and raises `ColumnTypeError("Invalid hexint", should_report=False)` during storage processing. This is correct: the query is invalid and should be rejected. The problem is that the RPC layer **ignored `should_report=False`** and captured the exception to Sentry **twice**:

- `RPCEndpoint.__after_execute` — the generic `else` branch
- `run_rpc_handler` — the generic `except Exception`

`should_report`'s sole documented purpose is "whether or not the error should be reported to sentry," and the legacy HTTP handler (`snuba/web/views.py`) already honors it (returns 400, never captures). This PR makes the RPC path consistent.

## Changes

- **`snuba/web/rpc/__init__.py`**: guard both `sentry_sdk.capture_exception` call sites with `getattr(error, "should_report", True)`. Errors still count toward the `request_error` metric.
- **`snuba/query/processors/physical/hexint_column_processor.py`**: fix latent typo `report=False` → `should_report=False` in `HexIntArrayColumnProcessor` (the wrong kwarg was silently absorbed into `extra_data`, so `should_report` stayed `True`).
- **`tests/web/rpc/test_base.py`**: add `test_should_report_false_not_captured` (raises `should_report=False` → asserts no capture, `request_error` still incremented). Existing `test_error_metrics` confirms the default path still captures.

## Scope note

This only suppresses the Sentry reporting; invalid queries still return 500 to the caller. Mapping `InvalidQueryException` to a proper 400 in the RPC layer is a separate, client-facing change left out of this PR.

## Test plan

- [x] `pytest tests/web/rpc/test_base.py tests/query/processors/test_hexint_column_processor.py` — 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/aOw9rxIqyCAj6VSGorwGrg1F0lAlWOebJ4x3iPRCn_A