### PR TITLE
fix(eap): Emit typed NULL in attribute existence check for new analyzer

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -249,6 +249,28 @@ def treeify_or_and_conditions(query: Query) -> None:
     query.transform_expressions(transform)
 
 
+# Map column -> the Nullable type its values resolve to, used to emit a typed
+# NULL as the `if(...)` else-branch below. A bare, untyped NULL default trips
+# the ClickHouse "new analyzer": it canonicalizes the very same `if(...)`
+# expression inconsistently when it appears both as an IN operand and elsewhere
+# (e.g. the NOT_IN predicate in `_get_field_existence_expression`), wrapping the
+# NULL in a redundant CAST in one place but not the other. The aggregate column
+# computed in the block then no longer matches the projection name, surfacing as
+# "Code: 10. DB::Exception: Not found column ... in block". Emitting an
+# already-typed NULL leaves nothing for the analyzer to fold inconsistently.
+_MAP_COLUMN_NULL_TYPE = {
+    "attributes_string": "Nullable(String)",
+    "attributes_float": "Nullable(Float64)",
+}
+
+
+def _typed_null_for_map_column(column_name: str) -> Expression:
+    for prefix, null_type in _MAP_COLUMN_NULL_TYPE.items():
+        if column_name.startswith(prefix):
+            return f.cast(literal(None), null_type)
+    return literal(None)
+
+
 def add_existence_check_to_subscriptable_references(query: Query) -> None:
     def transform(exp: Expression) -> Expression:
         if not isinstance(exp, SubscriptableReference):
@@ -260,7 +282,7 @@ def add_existence_check_to_subscriptable_references(query: Query) -> None:
             parameters=(
                 f.mapContains(exp.column, exp.key),
                 SubscriptableReference(None, exp.column, exp.key),
-                literal(None),
+                _typed_null_for_map_column(exp.column.column_name),
             ),
         )
 


### PR DESCRIPTION
After enabling the new ClickHouse analyzer, EAP queries with a `NOT IN` (or `!=`) filter on an optional attribute started failing with:

```
Code: 10. DB::Exception: Not found column sumOrNullIf(divide(1, sampling_factor), and(mapContains(...), or(not(in(if(mapContains(...), arrayElement(...), NULL), __set)), ...))) in block. There are only columns: ... sumOrNullIf(..., and(mapContains(...), or(not(in(if(..., NULL_Nullable(Nothing)), __set)), ...))) ...
```

The two column names differ in exactly one spot: the `NULL` else-branch of the `if(...)` that is the left operand of `in(...)`. The projection wants `_CAST(NULL_Nullable(Nothing), 'Nullable(Nothing)')` while the block computed a bare `NULL_Nullable(Nothing)`.

## Cause

`add_existence_check_to_subscriptable_references` wraps every Map subscriptable reference in `if(mapContains(...), col['key'], NULL)` using a bare, untyped `literal(None)`. That same `if(...)` is then referenced twice inside the `OP_NOT_IN` predicate — once as the `IN` operand and once inside `isNull(...)` — and that predicate is the condition of the extrapolation `-If` aggregate combinators (`sumOrNullIf`, `sumIf`, `countIf`).

The new analyzer canonicalizes the bare `NULL` inconsistently between those occurrences (redundant `CAST` in one, none in the other), so the aggregate column computed in the block no longer matches the projection name → `Not found column ... in block`. Snuba's generated SQL is internally consistent; the divergence is introduced by the analyzer.

## Fix

Emit an already-typed NULL matching the map's value type (`CAST(NULL, 'Nullable(String)')` / `CAST(NULL, 'Nullable(Float64)')`) so there is nothing left for the analyzer to fold inconsistently.

`attributes_string` and `attributes_float` are the only hash-bucketed columns reached via per-key subscriptable references (per the entity's `HashBucketFunctionTransformer` config), so they are the only columns this transform ever wraps:
- `TYPE_INT` reads from `attributes_float` and the existing outer `CAST(..., Nullable(Int64))` is unchanged — the inner `Nullable(Float64)` default is correct.
- `TYPE_BOOLEAN` reads `attributes_bool` via `arrayElement` directly (never a `SubscriptableReference`), so it is untouched.
- The unknown-column fallback preserves the previous bare-`NULL` behavior.

## Note for reviewers

This removes the bare-NULL trigger the error showed, but I could not exercise it against an analyzer-enabled ClickHouse locally (integration tests need a live CH). Worth replaying the failing query with `enable_analyzer=1` before re-enabling the analyzer in production. The analyzer is currently rolled back (option 1) and that mitigation should stay in place until this is verified.


Agent transcript: https://claudescope.sentry.dev/share/zOzTN3myM0ghrZn2224yyJpQxTADZxOY4T-x5_4Wy0c