### PR TITLE
ci(sentry): Shard sentry tests over 16 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,11 +366,11 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        instance: [0, 1, 2, 3]
+        instance: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     env:
       MIGRATIONS_TEST_MIGRATE: 1
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
-      MATRIX_INSTANCE_TOTAL: 4
+      MATRIX_INSTANCE_TOTAL: 16
       TEST_GROUP_STRATEGY: ROUND_ROBIN
 
     steps:


### PR DESCRIPTION
Increase the `sentry` job's test matrix from 4 to 16 instances to cut wall-clock time of the cross-repo sentry test run.

Sharding is driven by round-robin grouping: the `setup-sentry` action reads the matrix instance and exports `TEST_GROUP`/`TOTAL_TEST_GROUPS`, and sentry's pytest plugin keeps only `hash(test) % TOTAL_TEST_GROUPS == TEST_GROUP`. Both knobs are bumped in lockstep, as the inline comment requires.

**Tradeoff**

Each shard pays a fixed setup cost (image load, sentry checkout, devservices, snuba migrations) regardless of test volume, so this trades ~4x runner-minutes for faster wall-clock and won't yield a full 4x speedup. Worth watching per-shard timing after merge to confirm 16 beats a smaller count like 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/yP9pFj3TliBk-_-vXWAKh7eHEAJil2TLbhmu92JgDVk