### PR TITLE
test(migrations): Deflake test_reverse_idempotency_all

### DIFF
--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -351,13 +351,17 @@ def test_reverse_idempotency_all() -> None:
                     ClickhouseClientSettings.MIGRATE
                 )
 
-                before_state = cluster_connection.execute(
-                    "SELECT create_table_query FROM system.tables"
-                ).results
+                # `system.tables` has no guaranteed row order, and the
+                # reverse_twice() cycle in between can perturb the order rows
+                # are returned in (e.g. ON CLUSTER DDL re-registering tables).
+                # Order the snapshots so the comparison reflects the set of
+                # tables and their definitions, not the iteration order.
+                snapshot_query = (
+                    "SELECT create_table_query FROM system.tables ORDER BY create_table_query"
+                )
+                before_state = cluster_connection.execute(snapshot_query).results
                 reverse_twice()
-                after_state = cluster_connection.execute(
-                    "SELECT create_table_query FROM system.tables"
-                ).results
+                after_state = cluster_connection.execute(snapshot_query).results
                 assert before_state == after_state
             except UndefinedClickhouseCluster:
                 # Some groups do not have a cluster defined (e.g. test_migration)
@@ -489,7 +493,7 @@ def test_check_inactive_replica() -> None:
     with pytest.raises(InactiveClickhouseReplica) as exc:
         check_for_inactive_replicas([mock_cluster])
 
-    assert exc.value.args[0] == (
+    assert str(exc.value) == (
         "Cluster test_cluster has inactive replicas for table bad_table_1 "
         "with 2 out of 3 replicas active.\n"
         "Cluster test_cluster has inactive replicas for table bad_table_2 "


### PR DESCRIPTION
`test_reverse_idempotency_all` snapshots `system.tables` before and after a reverse/fake-forward cycle and compares the two results for equality. The snapshot query had no `ORDER BY`, and `system.tables` has no guaranteed row order, so the comparison was order-sensitive.

In the distributed setup the `reverse_twice()` cycle between the two snapshots issues `ON CLUSTER` DDL (`CREATE … IF NOT EXISTS` / `DROP … IF EXISTS`) which can re-register tables and change the order rows come back in without changing the set of tables. That produced intermittent failures in the `test_migrations_distributed` CI job — e.g. on #7980, whose latest EAP migration drops and recreates three downsample materialized views on reverse, which is exactly the kind of churn that perturbs the row order. The reverse cycle itself is a no-op on the table set (fake-forward only updates status; the create/drop are guarded by `IF [NOT] EXISTS`), so the failures were spurious, not real state differences.

This orders both snapshots by `create_table_query` so the assertion reflects the set of tables and their definitions rather than the iteration order. A genuine difference in tables or definitions is still caught.

Also replaces `exc.value.args[0]` with `str(exc.value)` in `test_check_inactive_replica` — a pre-existing mypy error (`BaseExcT_co_default has no attribute "args"`) in this file that `pre-commit` only surfaces once the file is otherwise modified. `str(exc.value)` is the equivalent message check and types cleanly.


Agent transcript: https://claudescope.sentry.dev/share/5BgPWGjZzfAo_gfbl1kqFzjsOJKf5sz8T4u3s0en9OY