### PR TITLE
fix(events): Promote tags[platform] to the platform column

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -332,6 +332,7 @@ query_processors:
           sentry:user: user
           transaction: transaction_name
           level: level
+          platform: platform
         contexts:
           trace.trace_id: trace_id
           trace.span_id: span_id

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -319,6 +319,7 @@ query_processors:
           sentry:user: user
           transaction: transaction_name
           level: level
+          platform: platform
         contexts:
           trace.trace_id: trace_id
           trace.span_id: span_id

--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -75,3 +75,51 @@ def test_events_processing() -> None:
             ),
         ),
     ]
+
+
+@pytest.mark.clickhouse_db
+def test_platform_tag_promotion() -> None:
+    # `platform` is a real top-level column on the errors table, so `tags[platform]`
+    # must be promoted to it (like `tags[transaction]` -> transaction_name). Without
+    # the promotion the reference falls back to a `tags` map lookup, which is always
+    # empty for events whose SDK never wrote a `platform` tag (e.g. sentry-cocoa) and
+    # produces wrong filter results. Regression test for COCOA-1467.
+    query_body = {
+        "query": """
+        MATCH (events)
+        SELECT tags[platform]
+        WHERE project_id = 1
+        AND timestamp >= toDateTime('2020-01-01 12:00:00')
+        AND timestamp < toDateTime('2020-01-02 12:00:00')
+        """,
+        "dataset": "events",
+    }
+
+    events_dataset = get_dataset("events")
+
+    query = parse_snql_query(query_body["query"], events_dataset)
+    request = Request(
+        id="",
+        original_body=query_body,
+        query=query,
+        query_settings=HTTPQuerySettings(referrer=""),
+        attribution_info=AttributionInfo(
+            get_app_id("blah"), {"tenant_type": "tenant_id"}, "blah", None, None, None
+        ),
+    )
+    pipeline_result = EntityProcessingStage().execute(
+        QueryPipelineResult(
+            data=request,
+            query_settings=request.query_settings,
+            timer=Timer(name="bloop"),
+            error=None,
+        )
+    )
+    clickhouse_query = StorageProcessingStage().execute(pipeline_result).data
+
+    assert clickhouse_query.get_selected_columns() == [
+        SelectedExpression(
+            "tags[platform]",
+            Column("_snuba_tags[platform]", None, "platform"),
+        ),
+    ]

--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from snuba.attribution import get_app_id
@@ -33,7 +35,7 @@ def test_events_processing() -> None:
 
     query = parse_snql_query(query_body["query"], events_dataset)
     request = Request(
-        id="",
+        id=uuid.uuid4(),
         original_body=query_body,
         query=query,
         query_settings=HTTPQuerySettings(referrer=""),
@@ -50,6 +52,7 @@ def test_events_processing() -> None:
         )
     )
     clickhouse_query = StorageProcessingStage().execute(pipeline_result).data
+    assert clickhouse_query is not None
 
     assert clickhouse_query.get_selected_columns() == [
         SelectedExpression(
@@ -99,7 +102,7 @@ def test_platform_tag_promotion() -> None:
 
     query = parse_snql_query(query_body["query"], events_dataset)
     request = Request(
-        id="",
+        id=uuid.uuid4(),
         original_body=query_body,
         query=query,
         query_settings=HTTPQuerySettings(referrer=""),
@@ -116,6 +119,7 @@ def test_platform_tag_promotion() -> None:
         )
     )
     clickhouse_query = StorageProcessingStage().execute(pipeline_result).data
+    assert clickhouse_query is not None
 
     assert clickhouse_query.get_selected_columns() == [
         SelectedExpression(


### PR DESCRIPTION
## Summary

`platform` is a real top-level column on the errors table, but it was missing from the `MappingColumnPromoter` `tags` mapping (`errors.yaml` / `errors_ro.yaml`) — unlike `level`, `environment`, `transaction`, etc.

As a result, a query referencing `tags[platform]` was never rewritten to the column. It fell back to a `tags` map lookup, which the `MappingOptimizer` turned into:

```
has(_tags_hash_map, cityHash64('platform=cocoa'))
```

That map is **empty** for events whose SDK never wrote a `platform` *tag* (e.g. sentry-cocoa, which only sets the top-level `platform` field). So the filter matched nothing.

## The bug (COCOA-1467)

In Discover, the two query paths diverged for the same `platform:cocoa` filter:

| | Filter expression | Resolves against | Result |
|---|---|---|---|
| **Table** (correct) | `equals(platform, 'cocoa')` | the `platform` **column** | count = X ✅ |
| **Timeseries / graph** (wrong) | `has(_tags_hash_map, …'platform=cocoa')` | the `tags[platform]` **map** | empty graph ❌ |

- `platform = cocoa` → `has(...)` matched nothing → empty graph despite a non-zero count.
- `platform != cocoa` → `NOT has(...)` matched everything → graph identical to `level:fatal` alone, despite a zero count.

This also explains why it reproduced for some orgs and not others: the tag-based filter only "worked" by coincidence for event sources that happened to also write a `platform` tag.

## Fix

Add `platform: platform` to the `tags` `mapping_specs` in both `errors.yaml` and `errors_ro.yaml` (the latter backs the `errors_dist_ro` storage the broken graph query hit). `tags[platform]` now promotes to the always-populated `platform` column, making the timeseries and table paths consistent.

## Test

Added `test_platform_tag_promotion` in `tests/datasets/test_events_processing.py`, mirroring the existing `tags[transaction]` → `transaction_name` test. Verified it **fails** without the config change (resolves to the `arrayElement(tags.value, indexOf(tags.key, 'platform'))` map lookup) and **passes** with it.

Fixes COCOA-1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/n_HHujWyCEOblhZxHjSp-qZug7DNPSKZV0xyZKWEN9Y