### PR TITLE
ref(outcomes): use quantity64 in hourly, daily MVs

### DIFF
--- a/snuba/snuba_migrations/outcomes/0012_outcomes_matview_quantity64.py
+++ b/snuba/snuba_migrations/outcomes/0012_outcomes_matview_quantity64.py
@@ -1,0 +1,154 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, DateTime, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+hourly_materialized_view_columns: Sequence[Column[Modifiers]] = [
+    Column("org_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("key_id", UInt(64)),
+    Column("timestamp", DateTime()),
+    Column("outcome", UInt(8)),
+    Column("reason", String()),
+    Column("category", UInt(8)),
+    Column("quantity", UInt(64)),
+    Column("times_seen", UInt(64)),
+]
+
+daily_materialized_view_columns: Sequence[Column[Modifiers]] = [
+    Column("org_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("key_id", UInt(64)),
+    Column("timestamp", DateTime()),
+    Column("outcome", UInt(8)),
+    Column("reason", String()),
+    Column("category", UInt(8)),
+    Column("quantity", UInt(64)),
+    Column("times_seen", UInt(64)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Updates the hourly and daily materialized views to aggregate quantity from the
+    non-overflowing quantity64 raw column (sum(quantity64) AS quantity) instead of the
+    legacy UInt32 quantity column. The destination tables are unchanged.
+
+    Note that the consumer needs to be stopped for this migration.
+    """
+
+    blocking = True
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.OUTCOMES,
+                view_name="outcomes_mv_hourly_local_v2",
+                destination_table_name="outcomes_hourly_local",
+                columns=hourly_materialized_view_columns,
+                query="""
+                    SELECT
+                        org_id,
+                        project_id,
+                        ifNull(key_id, 0) AS key_id,
+                        toStartOfHour(timestamp) AS timestamp,
+                        outcome,
+                        ifNull(reason, 'none') AS reason,
+                        category,
+                        count() AS times_seen,
+                        sum(quantity64) AS quantity
+                    FROM outcomes_raw_local
+                    GROUP BY org_id, project_id, key_id, timestamp, outcome, reason, category
+                """,
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_hourly_local",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.OUTCOMES,
+                view_name="outcomes_mv_daily_local_v3",
+                destination_table_name="outcomes_daily_local_v2",
+                columns=daily_materialized_view_columns,
+                query="""
+                    SELECT
+                        org_id,
+                        project_id,
+                        ifNull(key_id, 0) AS key_id,
+                        toStartOfDay(timestamp) AS timestamp,
+                        outcome,
+                        ifNull(reason, 'none') AS reason,
+                        category,
+                        count() AS times_seen,
+                        sum(quantity64) AS quantity
+                    FROM outcomes_raw_local
+                    GROUP BY org_id, project_id, key_id, timestamp, outcome, reason, category
+                """,
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_daily_local_v2",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_hourly_local_v2",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.OUTCOMES,
+                view_name="outcomes_mv_hourly_local",
+                destination_table_name="outcomes_hourly_local",
+                columns=hourly_materialized_view_columns,
+                query="""
+                    SELECT
+                        org_id,
+                        project_id,
+                        ifNull(key_id, 0) AS key_id,
+                        toStartOfHour(timestamp) AS timestamp,
+                        outcome,
+                        ifNull(reason, 'none') AS reason,
+                        category,
+                        count() AS times_seen,
+                        sum(quantity) AS quantity
+                    FROM outcomes_raw_local
+                    GROUP BY org_id, project_id, key_id, timestamp, outcome, reason, category
+                """,
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_daily_local_v3",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.OUTCOMES,
+                view_name="outcomes_mv_daily_local_v2",
+                destination_table_name="outcomes_daily_local_v2",
+                columns=daily_materialized_view_columns,
+                query="""
+                    SELECT
+                        org_id,
+                        project_id,
+                        ifNull(key_id, 0) AS key_id,
+                        toStartOfDay(timestamp) AS timestamp,
+                        outcome,
+                        ifNull(reason, 'none') AS reason,
+                        category,
+                        count() AS times_seen,
+                        sum(quantity) AS quantity
+                    FROM outcomes_raw_local
+                    GROUP BY org_id, project_id, key_id, timestamp, outcome, reason, category
+                """,
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/outcomes/0012_outcomes_matview_quantity64.py
+++ b/snuba/snuba_migrations/outcomes/0012_outcomes_matview_quantity64.py
@@ -35,8 +35,6 @@ class Migration(migration.ClickhouseNodeMigration):
     Updates the hourly and daily materialized views to aggregate quantity from the
     non-overflowing quantity64 raw column (sum(quantity64) AS quantity) instead of the
     legacy UInt32 quantity column. The destination tables are unchanged.
-
-    Note that the consumer needs to be stopped for this migration.
     """
 
     blocking = True

--- a/snuba/snuba_migrations/outcomes/0012_outcomes_matview_quantity64.py
+++ b/snuba/snuba_migrations/outcomes/0012_outcomes_matview_quantity64.py
@@ -99,11 +99,6 @@ class Migration(migration.ClickhouseNodeMigration):
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [
-            operations.DropTable(
-                storage_set=StorageSetKey.OUTCOMES,
-                table_name="outcomes_mv_hourly_local_v2",
-                target=operations.OperationTarget.LOCAL,
-            ),
             operations.CreateMaterializedView(
                 storage_set=StorageSetKey.OUTCOMES,
                 view_name="outcomes_mv_hourly_local",
@@ -127,7 +122,7 @@ class Migration(migration.ClickhouseNodeMigration):
             ),
             operations.DropTable(
                 storage_set=StorageSetKey.OUTCOMES,
-                table_name="outcomes_mv_daily_local_v3",
+                table_name="outcomes_mv_hourly_local_v2",
                 target=operations.OperationTarget.LOCAL,
             ),
             operations.CreateMaterializedView(
@@ -149,6 +144,11 @@ class Migration(migration.ClickhouseNodeMigration):
                     FROM outcomes_raw_local
                     GROUP BY org_id, project_id, key_id, timestamp, outcome, reason, category
                 """,
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_mv_daily_local_v3",
                 target=operations.OperationTarget.LOCAL,
             ),
         ]

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -53,7 +53,7 @@ SETTINGS index_granularity = 8192
 """
 
 OUTCOMES_DAILY_MV = """
-CREATE MATERIALIZED VIEW IF NOT EXISTS {db}.outcomes_mv_daily_local_v2 ON CLUSTER 'test_cluster' TO {db}.outcomes_daily_local_v2
+CREATE MATERIALIZED VIEW IF NOT EXISTS {db}.outcomes_mv_daily_local_v3 ON CLUSTER 'test_cluster' TO {db}.outcomes_daily_local_v2
 (
     `org_id` UInt64,
     `project_id` UInt64,
@@ -74,7 +74,7 @@ AS SELECT
     ifNull(reason, 'none') AS reason,
     category,
     count() AS times_seen,
-    sum(quantity) AS quantity
+    sum(quantity64) AS quantity
 FROM {db}.outcomes_raw_local
 GROUP BY
     org_id,
@@ -88,7 +88,7 @@ GROUP BY
 
 TABLE_DATA = [
     ("outcomes_daily_local_v2", "outcomes_daily", OUTCOMES_DAILY_TABLE, True),
-    ("outcomes_mv_daily_local_v2", "outcomes_daily", OUTCOMES_DAILY_MV, False),
+    ("outcomes_mv_daily_local_v3", "outcomes_daily", OUTCOMES_DAILY_MV, False),
 ]
 
 
@@ -192,8 +192,8 @@ def test_create_tables_order() -> None:
         "migrations_dist",
         "outcomes_daily_dist_v2",
         "outcomes_hourly_dist",
-        "outcomes_mv_daily_local_v2",
-        "outcomes_mv_hourly_local",
+        "outcomes_mv_daily_local_v3",
+        "outcomes_mv_hourly_local_v2",
         "outcomes_raw_dist",
     ]
 


### PR DESCRIPTION
Follow up from https://github.com/getsentry/snuba/pull/8036, which actually populates the `quantity64` column in the raw outcomes table. 

Verified that `sum(quantity)` and `sum(quantity64)` match across various categories (sample of one org):

| category (UInt8) | sum(quantity) (UInt64) | sum(quantity64) (UInt64) |
| --- | --- | --- |
| 0 | 2 | 2 |
| 1 | 160279 | 160279 |
| 2 | 2125303236 | 2125303236 |
| 3 | 3487 | 3487 |
| 4 | 1445884403 | 1445884403 |
| 5 | 1391 | 1391 |
| 6 | 29490420 | 29490420 |
| 7 | 5455 | 5455 |
| 9 | 287441481 | 287441481 |
| 10 | 15786 | 15786 |
| 11 | 20045 | 20045 |
| 12 | 13834595015 | 13834595015 |
| 14 | 1 | 1 |
| 15 | 141 | 141 |
| 16 | 11774161809 | 11774161809 |
| 17 | 69496471 | 69496471 |
| 23 | 92500055 | 92500055 |
| 24 | 86971848844 | 86971848844 |
| 25 | 33511834 | 33511834 |
| 26 | 2832 | 2832 |
