### PR TITLE
fix(eap-items): Group sentry.timestamp on the raw column to match ORDER BY

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -255,6 +255,24 @@ def aggregation_filter_to_expression(
             raise BadSnubaRPCRequestException(f"Unsupported aggregation filter type: {default}")
 
 
+def _groupby_order_by_expression(attr_key: AttributeKey) -> Expression:
+    """
+    Maps an attribute key used in GROUP BY / ORDER BY to its expression.
+
+    `sentry.timestamp` is grouped and ordered on the raw primary-key `timestamp`
+    column rather than the `CAST(timestamp, 'Float64')` that
+    `attribute_key_to_expression` produces, so ClickHouse can read in primary-key
+    order. The GROUP BY and ORDER BY must use the *same* expression: grouping by
+    the bare `timestamp` identifier keeps the SELECT's `CAST(timestamp, 'Float64')`
+    valid (it is a function of the grouped column) while letting ORDER BY sort on
+    the raw column. If the two diverged, ClickHouse would reject the query with
+    "Column `timestamp` is not under aggregate function and not in GROUP BY".
+    """
+    if attr_key.name == "sentry.timestamp":
+        return snuba_column("timestamp")
+    return attribute_key_to_expression(attr_key)
+
+
 def _convert_order_by(
     groupby: List[Expression],
     order_by: Sequence[TraceItemTableRequest.OrderBy],
@@ -301,11 +319,10 @@ def _convert_order_by(
             # cast is monotonic, so ordering by the raw DateTime column yields the same
             # order while staying read-in-order friendly. (The i == 0 / single-project /
             # no-groupby branch above already expands to the full table sort key; this
-            # covers `sentry.timestamp` ordering anywhere else.)
-            if x.column.key.name == "sentry.timestamp":
-                expression: Expression = snuba_column("timestamp")
-            else:
-                expression = attribute_key_to_expression(x.column.key)
+            # covers `sentry.timestamp` ordering anywhere else.) The GROUP BY uses the
+            # same expression (see `_groupby_order_by_expression`) so an aggregation
+            # query that orders by `sentry.timestamp` stays valid.
+            expression = _groupby_order_by_expression(x.column.key)
             res.append(
                 OrderBy(
                     direction=direction,
@@ -593,7 +610,7 @@ def build_query(
     if page_token_filter:
         additional_conditions.append(page_token_filter)
 
-    groupby = [attribute_key_to_expression(attr_key) for attr_key in request.group_by]
+    groupby = [_groupby_order_by_expression(attr_key) for attr_key in request.group_by]
 
     res = Query(
         from_clause=entity,

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1118,6 +1118,38 @@ class TestTraceItemTable(BaseApiTest):
         )
         EndpointTraceItemTable().execute(message)
 
+    def test_order_by_timestamp_does_not_error_with_aggregation_and_groupby(self) -> None:
+        # Regression test: an aggregation query that groups by and orders by
+        # `sentry.timestamp`. `sentry.timestamp` is ordered on the raw `timestamp`
+        # column for read-in-order; the GROUP BY must use the same raw column so
+        # ClickHouse does not reject the query with "Column `timestamp` is not under
+        # aggregate function and not in GROUP BY" (Code 215).
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1],
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.timestamp")),
+                Column(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_COUNT,
+                        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.timestamp"),
+                    )
+                ),
+            ],
+            group_by=[AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.timestamp")],
+            order_by=[
+                TraceItemTableRequest.OrderBy(
+                    column=Column(
+                        key=AttributeKey(type=AttributeKey.TYPE_STRING, name="sentry.timestamp")
+                    ),
+                    descending=True,
+                ),
+            ],
+        )
+        EndpointTraceItemTable().execute(message)
+
     def test_aggregation_on_attribute_column_backward_compat(
         self,
         setup_teardown: Any,


### PR DESCRIPTION
Fixes a ClickHouse `Code: 215` error (`Column \`timestamp\` is not under aggregate function and not in GROUP BY`) on `EndpointTraceItemTable` aggregation queries that group and order by `sentry.timestamp`.

#8018 rewrote `ORDER BY sentry.timestamp` to the raw primary-key `timestamp` column so ClickHouse can read in primary-key order. But everywhere else `sentry.timestamp` is rendered as `CAST(timestamp, 'Float64')` (via `attribute_key_to_expression`), including the GROUP BY. In an aggregation query the GROUP BY held `CAST(timestamp, 'Float64')` while the ORDER BY held the bare `timestamp` identifier — ClickHouse's 215 check is at the identifier level, so the bare `timestamp` in ORDER BY counted as neither grouped nor aggregated and the query was rejected.

This groups `sentry.timestamp` on the bare `timestamp` identifier so it matches the ORDER BY. The SELECT keeps `CAST(timestamp, 'Float64')`, which stays valid because it is a function of the grouped `timestamp` column, so response values are unchanged and read-in-order is preserved even with a GROUP BY. Both the GROUP BY and ORDER BY rewrites now go through a single `_groupby_order_by_expression` helper so they cannot drift apart again.

An alternative was to keep the GROUP BY as the cast and instead order by the cast (dropping the read-in-order optimization for aggregation queries). Grouping on the raw column was preferred because it keeps the optimization.

Added a DB-backed regression test that executes an aggregation + `group_by sentry.timestamp` + `order_by sentry.timestamp` query; it raised 215 before this change. The existing `build_query` unit tests only inspected `get_orderby()` and never executed, so they did not catch it.

Surfaced by Sentry issue SNUBA-B79.


Agent transcript: https://claudescope.sentry.dev/share/OWaeckbsVRPL6Y8n7-HJxPcDseGJOL9_eiBQX9Q3DY0