### PR TITLE
feat(image): Publish distroless image to Google AR

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -59,6 +59,33 @@ jobs:
           google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
           google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
 
+  # Distroless image published to Google AR (amd64) for parity with the
+  # production image. Mirrors build-production, producing
+  # us-docker.pkg.dev/sentryio/snuba-mr/image:<sha>-distroless.
+  build-distroless-production:
+    runs-on: ubuntu-24.04
+    name: Build and push distroless production image
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ github.ref_name == 'master' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: getsentry/action-build-and-push-images@8fc75e483c09a68721f2c8951292ee17f8821766
+        with:
+          image_name: 'snuba'
+          platforms: linux/amd64
+          dockerfile_path: './Dockerfile'
+          build_target: 'application-distroless'
+          tag_suffix: -distroless
+          ghcr: false
+          tag_nightly: false
+          tag_latest: false
+          google_ar: true
+          google_ar_image_name: us-docker.pkg.dev/sentryio/snuba-mr/image
+          google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
+
   # Distroless image — for testing before switching production
   build-distroless-multiplatform:
     strategy:


### PR DESCRIPTION
Adds a `build-distroless-production` job that builds the `application-distroless` target for `linux/amd64` and pushes it to Google Artifact Registry as `us-docker.pkg.dev/sentryio/snuba-mr/image:<sha>-distroless`, mirroring the existing `build-production` job.

### Why
The distroless variant is currently published to GHCR only, while the production image is also published to Google AR. Publishing the distroless image to Google AR gives it parity with the production image (same registry and tagging scheme), so it can be exercised the same way as production.

### Scope
- Purely additive — a new tag alongside the existing `<sha>`; no existing build behavior changes.
- amd64 only, matching the production image.
- Same registry, workload-identity provider, and service account as `build-production`.

> [!NOTE]
> The `-distroless` tag is produced via the action's `tag_suffix: -distroless` combined with `google_ar: true` (same way the existing GHCR distroless job derives `<sha>-distroless-<platform>`). Worth confirming the exact AR tag on the first master run.