### PR TITLE
feat(deploy): Run the distroless snuba image in s4s2

### DIFF
--- a/gocd/templates/bash/deploy-py.sh
+++ b/gocd/templates/bash/deploy-py.sh
@@ -2,10 +2,18 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
+# Temporarily run the distroless image variant in s4s2 to validate it before
+# switching production. The "-distroless" tag is published to the same registry
+# by .github/workflows/image.yml (build-distroless-production).
+IMAGE_TAG="${GO_REVISION_SNUBA_REPO}"
+if [ "${SENTRY_REGION}" = "s4s2" ]; then
+  IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
+fi
+
 /devinfra/scripts/get-cluster-credentials \
 && k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
-  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${IMAGE_TAG}" \
   --container-name="api" \
   --container-name="dlq-consumer" \
   --container-name="eap-items-subscriptions-executor" \
@@ -31,7 +39,7 @@ eval $(regions-project-env-vars --region="${SENTRY_REGION}")
   --container-name="transactions-subscriptions-scheduler" \
 && k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
-  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${IMAGE_TAG}" \
   --type="cronjob" \
   --container-name="optimize" \
   --container-name="cleanup" \


### PR DESCRIPTION
Points the **s4s2** region at the distroless image tag — `us-docker.pkg.dev/sentryio/snuba-mr/image:<sha>-distroless` — so the distroless variant can be validated in a single region before rolling it out more widely. Every other region is unchanged and keeps using the standard `<sha>` tag.

`deploy-py.sh` computes the tag once and branches only on `SENTRY_REGION`, so the diff is minimal and trivially reversible.

> [!IMPORTANT]
> Merge **after** the build PR (#8046), which publishes the `-distroless` tag to the registry. Until that lands and runs on master, `…/image:<sha>-distroless` won't exist for s4s2 to pull.