### PR TITLE
tmp(do-not-merge): CI speedup prototype - shard test_distributed + GHCR image cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
     name: Build snuba CI image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
     steps:
@@ -175,16 +178,37 @@ jobs:
         # it can be used as a docker tag
         run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> "$GITHUB_OUTPUT"
 
-      - uses: getsentry/action-build-and-push-images@8fc75e483c09a68721f2c8951292ee17f8821766
-        with:
-          image_name: 'snuba-ci'
-          platforms: 'linux/amd64'
-          dockerfile_path: 'Dockerfile'
-          ghcr: false
-          tag_nightly: false
-          tag_latest: false
-          tags: 'ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }}'
-          outputs: 'type=docker,dest=/tmp/snuba-ci.tar'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR for build cache
+        # Forks have no packages:write; they read the (public) cache anonymously and skip writing it.
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
+        run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build snuba CI image
+        # Registry layer cache (not type=gha): no 10GB cap, so it actually holds the Rust target dir.
+        # cache-from is best-effort (forks fall back to a cold build); cache-to only runs with creds.
+        env:
+          IMAGE: ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }}
+          CACHE_REF: ghcr.io/getsentry/snuba-ci:buildcache
+          PUSH_CACHE: ${{ github.event.pull_request.head.repo.fork != true }}
+        run: |
+          cache_to=""
+          if [ "$PUSH_CACHE" = "true" ]; then
+            cache_to="--cache-to type=registry,ref=${CACHE_REF},mode=max,image-manifest=true,oci-mediatypes=true"
+          fi
+          docker buildx build \
+            --platform linux/amd64 \
+            --file Dockerfile \
+            --target testing \
+            --tag "$IMAGE" \
+            --cache-from "type=registry,ref=${CACHE_REF}" \
+            $cache_to \
+            --output "type=docker,dest=/tmp/snuba-ci.tar" \
+            .
 
       - name: Publish snuba-ci image to artifacts
       # we publish to github artifacts separately so that third-party
@@ -253,15 +277,20 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        snuba_settings:
-          [
-            "test",
-            "test_rust",
-            "test_distributed",
-            "test_distributed_migrations",
-            "test_migrations",
-            "test_migrations_distributed"
-          ]
+        # test_distributed is the heaviest entry (full suite against distributed ClickHouse),
+        # so we split it across two runners by a stable hash of the test node id (see conftest.py).
+        include:
+          - snuba_settings: test
+          - snuba_settings: test_rust
+          - snuba_settings: test_distributed
+            shard: 0
+            shard_total: 2
+          - snuba_settings: test_distributed
+            shard: 1
+            shard_total: 2
+          - snuba_settings: test_distributed_migrations
+          - snuba_settings: test_migrations
+          - snuba_settings: test_migrations_distributed
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -311,6 +340,9 @@ jobs:
         if: ${{ matrix.snuba_settings == 'test_rust' }}
 
       - name: Docker Snuba tests
+        env:
+          SNUBA_TEST_SHARD: ${{ matrix.shard || 0 }}
+          SNUBA_TEST_SHARD_TOTAL: ${{ matrix.shard_total || 1 }}
         run: |
           SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
           SNUBA_TEST_SHARD: ${{ matrix.shard || 0 }}
           SNUBA_TEST_SHARD_TOTAL: ${{ matrix.shard_total || 1 }}
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm -e SNUBA_TEST_SHARD -e SNUBA_TEST_SHARD_TOTAL snuba-test
         if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}
 
       - name: Docker Snuba Migrations tests

--- a/conftest.py
+++ b/conftest.py
@@ -1,27 +1,4 @@
-import hashlib
 import os
-import sys
-
-import pytest
 
 os.environ.setdefault("SNUBA_SETTINGS", "test")
 os.environ.setdefault("CLICKHOUSE_DATABASE", "snuba_test")
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    # Optional CI sharding: split the collected tests across N runners by a stable
-    # hash of the node id. Inert unless SNUBA_TEST_SHARD_TOTAL > 1 is set.
-    total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
-    shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
-    print(
-        f"[shard-config] SNUBA_TEST_SHARD={shard} SNUBA_TEST_SHARD_TOTAL={total}", file=sys.stderr
-    )
-    if total <= 1:
-        return
-    selected: list[pytest.Item] = []
-    deselected: list[pytest.Item] = []
-    for item in items:
-        digest = int(hashlib.md5(item.nodeid.encode()).hexdigest(), 16)
-        (selected if digest % total == shard else deselected).append(item)
-    items[:] = selected
-    config.hook.pytest_deselected(items=deselected)

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import sys
 
 import pytest
 
@@ -11,9 +12,10 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     # Optional CI sharding: split the collected tests across N runners by a stable
     # hash of the node id. Inert unless SNUBA_TEST_SHARD_TOTAL > 1 is set.
     total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
+    shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
+    print(f"[shard-config] SNUBA_TEST_SHARD={shard} SNUBA_TEST_SHARD_TOTAL={total}", file=sys.stderr)
     if total <= 1:
         return
-    shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
     selected: list[pytest.Item] = []
     deselected: list[pytest.Item] = []
     for item in items:

--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,9 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     # hash of the node id. Inert unless SNUBA_TEST_SHARD_TOTAL > 1 is set.
     total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
     shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
-    print(f"[shard-config] SNUBA_TEST_SHARD={shard} SNUBA_TEST_SHARD_TOTAL={total}", file=sys.stderr)
+    print(
+        f"[shard-config] SNUBA_TEST_SHARD={shard} SNUBA_TEST_SHARD_TOTAL={total}", file=sys.stderr
+    )
     if total <= 1:
         return
     selected: list[pytest.Item] = []

--- a/conftest.py
+++ b/conftest.py
@@ -1,18 +1,21 @@
 import hashlib
 import os
 
+import pytest
+
 os.environ.setdefault("SNUBA_SETTINGS", "test")
 os.environ.setdefault("CLICKHOUSE_DATABASE", "snuba_test")
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     # Optional CI sharding: split the collected tests across N runners by a stable
     # hash of the node id. Inert unless SNUBA_TEST_SHARD_TOTAL > 1 is set.
     total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
     if total <= 1:
         return
     shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
-    selected, deselected = [], []
+    selected: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
     for item in items:
         digest = int(hashlib.md5(item.nodeid.encode()).hexdigest(), 16)
         (selected if digest % total == shard else deselected).append(item)

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,20 @@
+import hashlib
 import os
 
 os.environ.setdefault("SNUBA_SETTINGS", "test")
 os.environ.setdefault("CLICKHOUSE_DATABASE", "snuba_test")
+
+
+def pytest_collection_modifyitems(config, items):
+    # Optional CI sharding: split the collected tests across N runners by a stable
+    # hash of the node id. Inert unless SNUBA_TEST_SHARD_TOTAL > 1 is set.
+    total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
+    if total <= 1:
+        return
+    shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
+    selected, deselected = [], []
+    for item in items:
+        digest = int(hashlib.md5(item.nodeid.encode()).hexdigest(), 16)
+        (selected if digest % total == shard else deselected).append(item)
+    items[:] = selected
+    config.hook.pytest_deselected(items=deselected)

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -23,6 +23,8 @@ x-test-common: &test-common
     REDIS_PORT: 7000
     REDIS_DB: 0
     DEFAULT_BROKERS: "kafka:9092"
+    SNUBA_TEST_SHARD: "${SNUBA_TEST_SHARD:-0}"
+    SNUBA_TEST_SHARD_TOTAL: "${SNUBA_TEST_SHARD_TOTAL:-1}"
   # override the `snuba` user to write to the /.artifacts mount
   user: root
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,15 +90,19 @@ def create_databases() -> None:
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: List[Any]) -> None:
-    # Optional CI sharding: split tests across N runners by a stable hash of the node id.
-    # Inert unless SNUBA_TEST_SHARD_TOTAL > 1. (Lives here, not the root conftest, which .dockerignore drops.)
+    # Optional CI sharding: split tests across N runners by a stable hash of the test FILE.
+    # We shard by file (not node id) so a file's tests stay together and keep their order;
+    # some files have intra-file ordering deps (e.g. test_querylog_audit_log reloads a module
+    # in the first test that later tests rely on). Inert unless SNUBA_TEST_SHARD_TOTAL > 1.
+    # Lives here, not the root conftest, which .dockerignore drops.
     total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
     if total > 1:
         shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
         selected: List[Any] = []
         deselected: List[Any] = []
         for item in items:
-            digest = int(hashlib.md5(item.nodeid.encode()).hexdigest(), 16)
+            file_id = item.nodeid.split("::", 1)[0]
+            digest = int(hashlib.md5(file_id.encode()).hexdigest(), 16)
             (selected if digest % total == shard else deselected).append(item)
         items[:] = selected
         config.hook.pytest_deselected(items=deselected)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import os
 import traceback
 from typing import (
     Any,
@@ -87,7 +89,20 @@ def create_databases() -> None:
             connection.execute(f"CREATE DATABASE {database_name};")
 
 
-def pytest_collection_modifyitems(items: Sequence[Any]) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: List[Any]) -> None:
+    # Optional CI sharding: split tests across N runners by a stable hash of the node id.
+    # Inert unless SNUBA_TEST_SHARD_TOTAL > 1. (Lives here, not the root conftest, which .dockerignore drops.)
+    total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
+    if total > 1:
+        shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
+        selected: List[Any] = []
+        deselected: List[Any] = []
+        for item in items:
+            digest = int(hashlib.md5(item.nodeid.encode()).hexdigest(), 16)
+            (selected if digest % total == shard else deselected).append(item)
+        items[:] = selected
+        config.hook.pytest_deselected(items=deselected)
+
     for item in items:
         if item.get_closest_marker("eap"):
             item.fixturenames.append("eap")


### PR DESCRIPTION
Prototype off DI-2057 investigation, measuring only. Two independent changes:

1. Shard the heaviest tests-job entry (test_distributed, ~21m single-process) across 2 runners via a stable hash of the test node id (conftest.py hook, no new dependency since snuba bans public PyPI). Target ~halved wall-clock for that job.

2. Swap the snuba-image build to a GHCR registry layer cache (the shared action hardcodes type=gha, which overruns the 10GB Actions cache for snuba's Rust target dir). cache-from is best-effort so forks fall back to a cold build; cache-to only runs with creds. Image still ships as a tar artifact, so forks are unaffected.

Cache warm benefit shows on the second run. Do not merge.