### PR TITLE
fix(deletions): Count EAP delete rows on read-only replicas

### DIFF
--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -11,8 +11,12 @@ from snuba import environment, settings
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
+from snuba.clusters.cluster import UndefinedClickhouseCluster, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.deletion_settings import DeletionSettings, get_trace_item_type_name
+from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import WritableTableStorage
+from snuba.datasets.storages.factory import get_config_built_storages
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.lw_deletions.types import AttributeConditions, ConditionsBag, ConditionsType
 from snuba.query.conditions import combine_or_conditions
@@ -269,19 +273,63 @@ def _serialize_attribute_conditions(
     return result
 
 
+def _count_storage_key_by_local_table(
+    storage: WritableTableStorage,
+) -> dict[str, StorageKey]:
+    """
+    Maps each read/write local table to the read-only replica storage that its
+    rows should be counted against. Counting is a read-only query, so we run it
+    against the `*_ro` storages (in the `<storage set>_ro` storage set), keeping
+    it off the read/write cluster that handles ingestion and deletes. Each table
+    (e.g. the downsampled EAP tables) maps to its own replica so its rows are
+    counted individually.
+
+    Returns an empty mapping when there is no read-only replica to count against
+    (a storage without a read-only storage set, e.g. search_issues, or an
+    environment where the read-only cluster is not configured, e.g. self-hosted),
+    in which case the caller counts against the read/write table instead.
+    """
+    readonly_storage_set = StorageSetKey(f"{storage.get_storage_set_key().value}_ro")
+    mapping: dict[str, StorageKey] = {}
+    for storage_key, candidate in get_config_built_storages().items():
+        if candidate.get_storage_set_key() != readonly_storage_set:
+            continue
+        schema = candidate.get_schema()
+        if isinstance(schema, TableSchema):
+            mapping[schema.get_local_table_name()] = storage_key
+
+    # The read-only storages are always built from config, but their cluster may
+    # not be configured in this environment. Only route counts to them when it
+    # is; otherwise fall back to counting against the read/write table.
+    if mapping:
+        try:
+            get_cluster(readonly_storage_set)
+        except UndefinedClickhouseCluster:
+            return {}
+    return mapping
+
+
 def delete_from_tables(
     storage: WritableTableStorage,
     tables: Sequence[str],
     conditions: ConditionsBag,
     attribution_info: AttributionInfo,
 ) -> dict[str, Result]:
+    # Each table (the read/write table plus its downsampled counterparts) holds
+    # a different number of matching rows, so we count each one individually.
+    # Counting is read-only, so it runs against the read-only replica storages
+    # while the deletes themselves still target the read/write tables below.
+    count_storage_by_local = _count_storage_key_by_local_table(storage)
+    where_clause = _construct_condition(storage, conditions)
+
     highest_rows_to_delete = 0
     result: dict[str, Result] = {}
     for table in tables:
-        where_clause = _construct_condition(storage, conditions)
         query = construct_query(storage, table, where_clause)
         try:
-            num_rows_to_delete = _enforce_max_rows(query)
+            num_rows_to_delete = _enforce_max_rows(
+                query, count_storage_key=count_storage_by_local.get(table)
+            )
             highest_rows_to_delete = max(highest_rows_to_delete, num_rows_to_delete)
             result[table] = {"data": [{"rows_to_delete": num_rows_to_delete}]}
         except NoRowsToDeleteException:

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -13,6 +13,7 @@ from snuba.clickhouse.translators.snuba.mapping import SnubaClickhouseMappingTra
 from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseCluster
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -237,7 +238,7 @@ def _get_rows_to_delete(storage_key: StorageKey, select_query_to_count_rows: Que
     return typing.cast(int, select_query_results["data"][0]["count"])
 
 
-def _enforce_max_rows(delete_query: Query) -> int:
+def _enforce_max_rows(delete_query: Query, count_storage_key: Optional[StorageKey] = None) -> int:
     """
     The cost of a lightweight delete operation depends on the number of matching rows in the WHERE clause and the current number of data parts.
     This operation will be most efficient when matching a small number of rows, **and on wide parts** (where the `_row_exists` column is stored
@@ -245,8 +246,15 @@ def _enforce_max_rows(delete_query: Query) -> int:
 
     Because of the above, we want to limit the number of rows one deletes at a time. The `MaxRowsEnforcer` will query clickhouse to see how many
       rows we plan on deleting and if it crosses the `max_rows_to_delete` set for that storage we will reject the query.
+
+    Counting matching rows is a read-only query, so `count_storage_key` lets the
+    caller run it against a read-only replica storage (its cluster and table)
+    instead of the read/write storage that the delete itself targets. This both
+    keeps the count off the read/write cluster and lets each table (e.g. the
+    downsampled EAP tables, whose row counts differ) be counted individually.
     """
     storage_key = delete_query.get_from_clause().storage_key
+    reader_storage_key = count_storage_key or storage_key
 
     def get_new_from_clause() -> Table:
         """
@@ -254,12 +262,17 @@ def _enforce_max_rows(delete_query: Query) -> int:
         row count we are querying the dist tables (if applicable). This function
         updates the from_clause to have the correct table.
         """
-        dist_table_name = (
-            get_writable_storage((storage_key)).get_table_writer().get_schema().get_table_name()
-        )
+        if reader_storage_key == storage_key:
+            count_table_name = (
+                get_writable_storage(storage_key).get_table_writer().get_schema().get_table_name()
+            )
+        else:
+            count_schema = get_storage(reader_storage_key).get_schema()
+            assert isinstance(count_schema, TableSchema)
+            count_table_name = count_schema.get_table_name()
         from_clause = delete_query.get_from_clause()
         return Table(
-            table_name=dist_table_name,
+            table_name=count_table_name,
             schema=from_clause.schema,
             storage_key=from_clause.storage_key,
             allocation_policies=from_clause.allocation_policies,
@@ -273,7 +286,7 @@ def _enforce_max_rows(delete_query: Query) -> int:
         condition=delete_query.get_condition(),
     )
     rows_to_delete = _get_rows_to_delete(
-        storage_key=storage_key, select_query_to_count_rows=select_query_to_count_rows
+        storage_key=reader_storage_key, select_query_to_count_rows=select_query_to_count_rows
     )
     if rows_to_delete == 0:
         raise NoRowsToDeleteException

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -11,6 +11,7 @@ from confluent_kafka.admin import AdminClient
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba import settings
+from snuba.clusters.cluster import UndefinedClickhouseCluster
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.lw_deletions.types import AttributeConditions
@@ -354,9 +355,11 @@ def test_count_storage_key_mapping_without_readonly_cluster() -> None:
     """When the read-only cluster is not configured in this environment, the
     mapping is empty so counts fall back to the read/write table rather than
     failing against a missing cluster."""
-    from snuba.clusters.cluster import UndefinedClickhouseCluster
     from snuba.web.bulk_delete_query import _count_storage_key_by_local_table
 
+    # UndefinedClickhouseCluster is imported at module scope (before pytest
+    # collection) so its class identity matches bulk_delete_query's `except`
+    # binding even when another test reloads snuba.clusters.cluster.
     storage = get_writable_storage(StorageKey("eap_items"))
     with patch(
         "snuba.web.bulk_delete_query.get_cluster",

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -292,3 +292,74 @@ def test_attribute_conditions_feature_flag_enabled() -> None:
     finally:
         # Clean up: disable the feature flag
         set_config("permit_delete_by_attribute", 0)
+
+
+@pytest.mark.redis_db
+def test_eap_items_counts_each_table_against_its_readonly_replica() -> None:
+    """
+    The downsampled EAP tables hold different row counts than the read/write
+    table, so each must be counted individually (rather than re-running the same
+    count against eap_items_1_dist N times, which was an N+1). Counting is a
+    read-only query, so each count targets the table's read-only `*_ro` replica
+    storage, keeping it off the read/write cluster.
+    """
+    storage = get_writable_storage(StorageKey("eap_items"))
+    conditions = {"project_id": [1], "item_type": [TRACE_ITEM_TYPE_OCCURRENCE]}
+    attribute_conditions = AttributeConditions(
+        item_type=TRACE_ITEM_TYPE_OCCURRENCE,
+        attributes={
+            "group_id": (AttributeKey(type=AttributeKey.Type.TYPE_INT, name="group_id"), [12345])
+        },
+    )
+    attr_info = get_attribution_info()
+
+    set_config("permit_delete_by_attribute", 1)
+    try:
+        with patch(
+            "snuba.web.bulk_delete_query._enforce_max_rows", return_value=10
+        ) as mock_enforce:
+            with patch("snuba.web.bulk_delete_query.produce_delete_query"):
+                delete_from_storage(storage, conditions, attr_info, attribute_conditions)
+
+        count_storage_keys = [
+            call.kwargs["count_storage_key"] for call in mock_enforce.call_args_list
+        ]
+        # One count per table, each against a distinct read-only replica storage
+        # (not the same table N times, which was the N+1).
+        assert len(count_storage_keys) == 4
+        assert len(set(count_storage_keys)) == 4
+        # Every count runs against a read-only replica storage, never the
+        # read/write storage that the delete itself targets.
+        assert {key.value for key in count_storage_keys} == {
+            "eap_items_ro",
+            "eap_items_downsample_8_ro",
+            "eap_items_downsample_64_ro",
+            "eap_items_downsample_512_ro",
+        }
+    finally:
+        set_config("permit_delete_by_attribute", 0)
+
+
+def test_count_storage_key_mapping_without_readonly_storage_set() -> None:
+    """A storage without a read-only storage set (search_issues) has no replica
+    to count against, so the mapping is empty and the caller falls back to the
+    read/write table."""
+    from snuba.web.bulk_delete_query import _count_storage_key_by_local_table
+
+    storage = get_writable_storage(StorageKey("search_issues"))
+    assert _count_storage_key_by_local_table(storage) == {}
+
+
+def test_count_storage_key_mapping_without_readonly_cluster() -> None:
+    """When the read-only cluster is not configured in this environment, the
+    mapping is empty so counts fall back to the read/write table rather than
+    failing against a missing cluster."""
+    from snuba.clusters.cluster import UndefinedClickhouseCluster
+    from snuba.web.bulk_delete_query import _count_storage_key_by_local_table
+
+    storage = get_writable_storage(StorageKey("eap_items"))
+    with patch(
+        "snuba.web.bulk_delete_query.get_cluster",
+        side_effect=UndefinedClickhouseCluster("not configured"),
+    ):
+        assert _count_storage_key_by_local_table(storage) == {}


### PR DESCRIPTION
`EndpointDeleteTraceItems` enforced the row-count delete limit once per table in the storage's deletion settings — the read/write table plus its downsampled counterparts. Because `_enforce_max_rows` always resolved the count to the *writable* storage's distributed table, every iteration issued the identical `SELECT count() FROM eap_items_1_dist …`. This was both an N+1 (the same query run N times, ~25s each in production) and incorrect: the downsampled tables hold fewer rows, so their counts were silently wrong.

**Count each table on its read-only replica**

Each table is now counted individually. Since counting is a read-only query, it runs against the table's read-only replica storage (its own cluster and table) via a new `count_storage_key` argument to `_enforce_max_rows`. This keeps the count off the read/write cluster that handles ingestion — and the deletes themselves, which still target the read/write tables.

The read-only storage is resolved by looking up the `<storage set>_ro` storage set (e.g. `events_analytics_platform_ro`) for a storage with the same local table name.

**Falls back to the read/write table when there is no replica**

When no read-only replica is available the count runs against the read/write table, as before. This covers storages with no read-only storage set (e.g. `search_issues`) and environments where the read-only cluster is not configured (e.g. self-hosted) — guarded so a missing replica cluster never breaks a delete that previously worked.

Fixes SNUBA-B7W

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: [EAP-591](https://linear.app/getsentry/issue/EAP-591)
