### PR TITLE
tmp(do-not-merge): cohesive CI speedup run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
     name: Build snuba CI image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
     steps:
@@ -175,16 +178,37 @@ jobs:
         # it can be used as a docker tag
         run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> "$GITHUB_OUTPUT"
 
-      - uses: getsentry/action-build-and-push-images@8fc75e483c09a68721f2c8951292ee17f8821766
-        with:
-          image_name: 'snuba-ci'
-          platforms: 'linux/amd64'
-          dockerfile_path: 'Dockerfile'
-          ghcr: false
-          tag_nightly: false
-          tag_latest: false
-          tags: 'ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }}'
-          outputs: 'type=docker,dest=/tmp/snuba-ci.tar'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR for build cache
+        # Forks have no packages:write; they read the (public) cache anonymously and skip writing it.
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
+        run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build snuba CI image
+        # Registry layer cache (not type=gha): no 10GB cap, so it actually holds the Rust target dir.
+        # cache-from is best-effort (forks fall back to a cold build); cache-to only runs with creds.
+        env:
+          IMAGE: ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }}
+          CACHE_REF: ghcr.io/getsentry/snuba-ci:buildcache
+          PUSH_CACHE: ${{ github.event.pull_request.head.repo.fork != true }}
+        run: |
+          cache_to=""
+          if [ "$PUSH_CACHE" = "true" ]; then
+            cache_to="--cache-to type=registry,ref=${CACHE_REF},mode=max,image-manifest=true,oci-mediatypes=true"
+          fi
+          docker buildx build \
+            --platform linux/amd64 \
+            --file Dockerfile \
+            --target testing \
+            --tag "$IMAGE" \
+            --cache-from "type=registry,ref=${CACHE_REF}" \
+            $cache_to \
+            --output "type=docker,dest=/tmp/snuba-ci.tar" \
+            .
 
       - name: Publish snuba-ci image to artifacts
       # we publish to github artifacts separately so that third-party

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,13 +281,25 @@ jobs:
         # so we split it across two runners by a stable hash of the test node id (see conftest.py).
         include:
           - snuba_settings: test
+            shard: 0
+            shard_total: 2
+          - snuba_settings: test
+            shard: 1
+            shard_total: 2
           - snuba_settings: test_rust
           - snuba_settings: test_distributed
             shard: 0
-            shard_total: 2
+            shard_total: 4
           - snuba_settings: test_distributed
             shard: 1
-            shard_total: 2
+            shard_total: 4
+          - snuba_settings: test_distributed
+            shard: 2
+            shard_total: 4
+          - snuba_settings: test_distributed
+            shard: 3
+            shard_total: 4
+          # test_migrations_distributed left unsharded: migration tests are order-sensitive, risky to split.
           - snuba_settings: test_distributed_migrations
           - snuba_settings: test_migrations
           - snuba_settings: test_migrations_distributed
@@ -398,11 +410,12 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        instance: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        # Trimmed 16 to 10: xdist + per-worker snuba made each shard fast enough; reclaimed runners go to the test_distributed/test/clickhouse sharding.
+        instance: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     env:
       MIGRATIONS_TEST_MIGRATE: 1
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
-      MATRIX_INSTANCE_TOTAL: 16
+      MATRIX_INSTANCE_TOTAL: 10
       TEST_GROUP_STRATEGY: ROUND_ROBIN
       # Run pytest with xdist inside each shard to use the idle cores; mirrors getsentry/sentry backend CI.
       # Each worker gets its own snuba container + ClickHouse DB so tests don't collide on shared state (max 7 workers).
@@ -526,12 +539,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          [
-            "25.3.8.10041.altinitystable",
-            "25.8.16.10001.altinitystable",
-          ]
-        test_type: [snuba-test, snuba-test-migrations]
+        # snuba-test (the full suite) is sharded 2-way per version; snuba-test-migrations stays whole (order-sensitive).
+        include:
+          - { version: "25.3.8.10041.altinitystable", test_type: snuba-test, shard: 0, shard_total: 2 }
+          - { version: "25.3.8.10041.altinitystable", test_type: snuba-test, shard: 1, shard_total: 2 }
+          - { version: "25.8.16.10001.altinitystable", test_type: snuba-test, shard: 0, shard_total: 2 }
+          - { version: "25.8.16.10001.altinitystable", test_type: snuba-test, shard: 1, shard_total: 2 }
+          - { version: "25.3.8.10041.altinitystable", test_type: snuba-test-migrations }
+          - { version: "25.8.16.10001.altinitystable", test_type: snuba-test-migrations }
 
     steps:
       - name: Checkout code
@@ -577,9 +592,12 @@ jobs:
           docker network create --attachable cloudbuild
 
       - name: Docker Snuba Test other ClickHouse versions
+        env:
+          SNUBA_TEST_SHARD: ${{ matrix.shard || 0 }}
+          SNUBA_TEST_SHARD_TOTAL: ${{ matrix.shard_total || 1 }}
         run: |
           export CLICKHOUSE_IMAGE=ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:${{matrix.version}}
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm ${{ matrix.test_type }}
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=test docker compose -f docker-compose.gcb.yml run --rm -e SNUBA_TEST_SHARD -e SNUBA_TEST_SHARD_TOTAL ${{ matrix.test_type }}
 
       - name: Upload to codecov
         run: |
@@ -604,8 +622,9 @@ jobs:
           target: application-distroless
           load: true
           tags: snuba-distroless:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Read the shared snuba-ci registry buildcache (off the 10GB GHA budget; the old type=gha,mode=max
+          # was ~7.7GB and evicted the venv cache). Distroless shares the heavy Rust/base stages with snuba-ci.
+          cache-from: type=registry,ref=ghcr.io/getsentry/snuba-ci:buildcache
 
       - name: Verify --help works
         run: docker run --rm snuba-distroless:test --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,15 +277,20 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        snuba_settings:
-          [
-            "test",
-            "test_rust",
-            "test_distributed",
-            "test_distributed_migrations",
-            "test_migrations",
-            "test_migrations_distributed"
-          ]
+        # test_distributed is the heaviest entry (full suite against distributed ClickHouse),
+        # so we split it across two runners by a stable hash of the test node id (see conftest.py).
+        include:
+          - snuba_settings: test
+          - snuba_settings: test_rust
+          - snuba_settings: test_distributed
+            shard: 0
+            shard_total: 2
+          - snuba_settings: test_distributed
+            shard: 1
+            shard_total: 2
+          - snuba_settings: test_distributed_migrations
+          - snuba_settings: test_migrations
+          - snuba_settings: test_migrations_distributed
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -335,8 +340,11 @@ jobs:
         if: ${{ matrix.snuba_settings == 'test_rust' }}
 
       - name: Docker Snuba tests
+        env:
+          SNUBA_TEST_SHARD: ${{ matrix.shard || 0 }}
+          SNUBA_TEST_SHARD_TOTAL: ${{ matrix.shard_total || 1 }}
         run: |
-          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }} SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker compose -f docker-compose.gcb.yml run --rm -e SNUBA_TEST_SHARD -e SNUBA_TEST_SHARD_TOTAL snuba-test
         if: ${{ matrix.snuba_settings == 'test' || matrix.snuba_settings  == 'test_distributed' }}
 
       - name: Docker Snuba Migrations tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,10 @@ jobs:
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
       MATRIX_INSTANCE_TOTAL: 16
       TEST_GROUP_STRATEGY: ROUND_ROBIN
+      # Run pytest with xdist inside each shard to use the idle cores; mirrors getsentry/sentry backend CI.
+      # Each worker gets its own snuba container + ClickHouse DB so tests don't collide on shared state (max 7 workers).
+      XDIST_WORKERS: 2
+      XDIST_PER_WORKER_SNUBA: '1'
 
     steps:
       - name: Checkout code
@@ -430,13 +434,22 @@ jobs:
             ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }}
           docker exec snuba-snuba-1 snuba migrations migrate --force
 
+      - name: Bootstrap per-worker Snuba instances
+        # Replaces the single shared snuba with one container + ClickHouse DB per xdist worker so they don't collide.
+        run: python3 sentry/.github/workflows/scripts/bootstrap-snuba.py
+
       - name: Run snuba tests
         if: needs.files-changed.outputs.api_changes == 'false'
         working-directory: sentry
         run: |
-          pytest -k 'not __In' tests \
+          # Only these dirs carry the `snuba_ci` marker; collecting all of tests/ just to find them is wasteful.
+          pytest -k 'not __In' \
+            tests/sentry/snuba \
+            tests/sentry/workflow_engine/endpoints \
+            tests/snuba/rules/conditions \
             -m snuba_ci \
-            -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
+            -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
+            -vv
 
       - name: Run full tests
         if: needs.files-changed.outputs.api_changes == 'true'
@@ -457,12 +470,21 @@ jobs:
               tests/sentry/api/endpoints/test_organization_traces.py \
               tests/sentry/api/endpoints/test_organization_spans_fields.py \
               tests/sentry/sentry_metrics/querying \
-              -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
+              -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
+              -vv
 
       - name: Run CI module tests
         if: needs.files-changed.outputs.api_changes == 'true'
         working-directory: sentry
-        run: pytest -k 'not __In' tests -vv -m snuba_ci
+        run: |
+          # Only these dirs carry the `snuba_ci` marker; collecting all of tests/ just to find them is wasteful.
+          pytest -k 'not __In' \
+            tests/sentry/snuba \
+            tests/sentry/workflow_engine/endpoints \
+            tests/snuba/rules/conditions \
+            -m snuba_ci \
+            -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
+            -vv
 
   clickhouse-versions:
     needs: [linting, snuba-image, docker-deps]

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -23,6 +23,8 @@ x-test-common: &test-common
     REDIS_PORT: 7000
     REDIS_DB: 0
     DEFAULT_BROKERS: "kafka:9092"
+    SNUBA_TEST_SHARD: "${SNUBA_TEST_SHARD:-0}"
+    SNUBA_TEST_SHARD_TOTAL: "${SNUBA_TEST_SHARD_TOTAL:-1}"
   # override the `snuba` user to write to the /.artifacts mount
   user: root
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import os
 import traceback
 from typing import (
     Any,
@@ -87,7 +89,24 @@ def create_databases() -> None:
             connection.execute(f"CREATE DATABASE {database_name};")
 
 
-def pytest_collection_modifyitems(items: Sequence[Any]) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: List[Any]) -> None:
+    # Optional CI sharding: split tests across N runners by a stable hash of the test FILE.
+    # We shard by file (not node id) so a file's tests stay together and keep their order;
+    # some files have intra-file ordering deps (e.g. test_querylog_audit_log reloads a module
+    # in the first test that later tests rely on). Inert unless SNUBA_TEST_SHARD_TOTAL > 1.
+    # Lives here, not the root conftest, which .dockerignore drops.
+    total = int(os.environ.get("SNUBA_TEST_SHARD_TOTAL", "1"))
+    if total > 1:
+        shard = int(os.environ.get("SNUBA_TEST_SHARD", "0"))
+        selected: List[Any] = []
+        deselected: List[Any] = []
+        for item in items:
+            file_id = item.nodeid.split("::", 1)[0]
+            digest = int(hashlib.md5(file_id.encode()).hexdigest(), 16)
+            (selected if digest % total == shard else deselected).append(item)
+        items[:] = selected
+        config.hook.pytest_deselected(items=deselected)
+
     for item in items:
         if item.get_closest_marker("eap"):
             item.fixturenames.append("eap")


### PR DESCRIPTION
Cohesive measurement run on top of #8055: distroless GHCR cache (14m->1.2m), test_distributed sharded 4-way, test + clickhouse snuba-test sharded 2-way, sentry trimmed 16->10 (reclaimed runners go to the test sharding). test_migrations_distributed left whole (order-sensitive). Note: the venv-cache recovery (lint 7.4m->2.5m) only fully lands once distroless-cache is on master, so this run still pays the ~7.6m lint prefix. Do not merge.