### PR TITLE
fix(routing): exempt outcomes routing query from allocation policies

### DIFF
--- a/snuba/web/rpc/storage_routing/routing_strategies/outcomes_based.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/outcomes_based.py
@@ -180,6 +180,17 @@ class OutcomesBasedRoutingStrategy(BaseRoutingStrategy):
                 tenant_ids={
                     "organization_id": in_msg_meta.organization_id,
                     "referrer": "eap.route_outcomes",
+                    # This is an internal, system-initiated query that Snuba runs against
+                    # the (tiny) outcomes table purely to decide which tier to route the
+                    # real query to. It must never be rejected by the outcomes storage's
+                    # allocation policies: a rejection here doesn't protect EAP, it just
+                    # breaks tier routing and forces the fallback path (see SNUBA-A3V,
+                    # "Error getting routing decision: Query cannot be run due to
+                    # allocation policies"). Under load a busy org can exceed the outcomes
+                    # ConcurrentRateLimitAllocationPolicy limit (keyed by organization_id,
+                    # since this query carries no project_id) and get rejected. Marking it
+                    # as a cross-org/system query exempts it from those per-tenant limits.
+                    "cross_org_query": 1,
                 },
                 app_id=AppID("eap"),
                 parent_api="eap.route_outcomes",

--- a/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
+++ b/tests/web/rpc/v1/routing_strategies/test_outcomes_based.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from unittest import mock
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -18,6 +19,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 from snuba import state
 from snuba.downsampled_storage_tiers import Tier
 from snuba.utils.metrics.timer import Timer
+from snuba.web import QueryResult
 from snuba.web.rpc.storage_routing.common import extract_message_meta
 from snuba.web.rpc.storage_routing.routing_strategies.outcomes_based import (
     OutcomesBasedRoutingStrategy,
@@ -253,6 +255,41 @@ def test_outcomes_based_routing_normal_mode(store_outcomes_fixture: Any) -> None
     assert routing_decision.tier == Tier.TIER_1
     assert routing_decision.clickhouse_settings == {"max_threads": 10}
     assert routing_decision.can_run
+
+
+@pytest.mark.redis_db
+def test_routing_query_is_exempt_from_allocation_policies() -> None:
+    # The outcomes estimation query that decides the tier must never be rejected by the
+    # outcomes storage's allocation policies (SNUBA-A3V). It is marked as a cross-org
+    # / system query so the per-tenant policies (e.g. ConcurrentRateLimitAllocationPolicy)
+    # let it pass through instead of rejecting it under load.
+    strategy = OutcomesBasedRoutingStrategy()
+    request = TraceItemTableRequest(meta=_get_request_meta())
+
+    captured_requests = []
+
+    def fake_run_query(dataset: Any, request: Any, timer: Any) -> Any:
+        captured_requests.append(request)
+        return QueryResult(
+            result={"data": [{"num_items": 0}]},
+            extra={"stats": {}, "sql": "", "experiments": {}},
+        )
+
+    with mock.patch(
+        "snuba.web.rpc.storage_routing.routing_strategies.outcomes_based.run_query",
+        side_effect=fake_run_query,
+    ):
+        strategy.get_ingested_items_for_timerange(
+            RoutingContext(
+                in_msg=request,
+                timer=Timer("test"),
+                query_id=uuid.uuid4().hex,
+            )
+        )
+
+    assert len(captured_requests) == 1
+    tenant_ids = captured_requests[0].attribution_info.tenant_ids
+    assert tenant_ids["cross_org_query"] == 1
 
 
 @pytest.mark.eap


### PR DESCRIPTION
## Summary

Fixes [SNUBA-A3V](https://sentry.sentry.io/issues/SNUBA-A3V): `Error getting routing decision: Query cannot be run due to allocation policies` (3304 events, 0 users impacted, Seer actionability `super_low`).

### Root cause

`OutcomesBasedRoutingStrategy._update_routing_decision` runs an internal **estimation query** against the `outcomes` table (`get_ingested_items_for_timerange`) purely to decide which downsampling tier to route the real EAP query to (`EndpointTimeSeries`, `EndpointTraceItemTable`, ...).

That estimation query goes through `run_query` → `db_query`, and is therefore subject to the **outcomes storage's allocation policies**. The outcomes storage has an enforced `ConcurrentRateLimitAllocationPolicy`. Because the routing query carries only `organization_id` + `referrer` (no `project_id`), the concurrent limit is keyed by `organization_id` with a default limit of `22`. Under load, a busy org running many concurrent EAP queries — each spawning its own outcomes estimation query — exceeds that limit, the estimation query is rejected with `AllocationPolicyViolations` ("Query cannot be run due to allocation policies"), and `get_routing_decision`'s `except` block reports it to Sentry via `capture_message`.

Rejecting this system query does **not** protect EAP — it just breaks tier routing and forces the fallback path, while flooding Sentry with noise.

### Fix

Mark the routing/estimation query as a cross-org / system query (`tenant_ids["cross_org_query"] = 1`) so the outcomes storage's per-tenant allocation policies let it pass through instead of rejecting it. The outcomes storage does not use `CrossOrgQueryAllocationPolicy`, so this only flips the existing per-tenant policies (`ConcurrentRateLimitAllocationPolicy`, `BytesScannedWindowAllocationPolicy`) into pass-through mode for this one internal query.

Genuine, unexpected routing failures are still captured by the existing `capture_message` handler.

### Testing

Added `test_routing_query_is_exempt_from_allocation_policies`, which asserts the estimation query's `attribution_info.tenant_ids` carry `cross_org_query == 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QswMtaH2FE7wW49det7HBY)_