### PR TITLE
ref(ci): run sentry tests under xdist with per-worker snuba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,8 @@ jobs:
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
       MATRIX_INSTANCE_TOTAL: 16
       TEST_GROUP_STRATEGY: ROUND_ROBIN
+      XDIST_WORKERS: 2
+      XDIST_PER_WORKER_SNUBA: '1'
 
     steps:
       - name: Checkout code
@@ -430,13 +432,21 @@ jobs:
             ghcr.io/getsentry/snuba-ci:${{ github.event.pull_request.head.sha || github.sha }}
           docker exec snuba-snuba-1 snuba migrations migrate --force
 
+      - name: Bootstrap per-worker Snuba instances
+        run: python3 sentry/.github/workflows/scripts/bootstrap-snuba.py
+
       - name: Run snuba tests
         if: needs.files-changed.outputs.api_changes == 'false'
         working-directory: sentry
         run: |
-          pytest -k 'not __In' tests \
+          # Only these dirs carry the `snuba_ci` marker; collecting all of tests/ just to find them is wasteful.
+          pytest -k 'not __In' \
+            tests/sentry/snuba \
+            tests/sentry/workflow_engine/endpoints \
+            tests/snuba/rules/conditions \
             -m snuba_ci \
-            -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
+            -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
+            -vv
 
       - name: Run full tests
         if: needs.files-changed.outputs.api_changes == 'true'
@@ -457,12 +467,20 @@ jobs:
               tests/sentry/api/endpoints/test_organization_traces.py \
               tests/sentry/api/endpoints/test_organization_spans_fields.py \
               tests/sentry/sentry_metrics/querying \
-              -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
+              -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
+              -vv
 
       - name: Run CI module tests
         if: needs.files-changed.outputs.api_changes == 'true'
         working-directory: sentry
-        run: pytest -k 'not __In' tests -vv -m snuba_ci
+        run: |
+          pytest -k 'not __In' \
+            tests/sentry/snuba \
+            tests/sentry/workflow_engine/endpoints \
+            tests/snuba/rules/conditions \
+            -m snuba_ci \
+            -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
+            -vv
 
   clickhouse-versions:
     needs: [linting, snuba-image, docker-deps]


### PR DESCRIPTION
Essentially reusing the xdist infrastructure I added for Sentry here. Also dropping a `--cov` that was going unused, and narrowing he `snuba_ci` collection to the three dirs that actually hold the marker instead of scanning all of `tests/`.

That takes the full-test path from ~17m to ~10m per shard. We leave it at 16 shards, which keeps that path under 10m. Split out of #8055 along with #8066 and #8067.

Validated run: https://github.com/getsentry/snuba/actions/runs/27735174740

Note on the timings here: the sentry job shows ~4m because this PR only touches workflow files, so it runs the light 
snuba_ci path. The 16 shards are sized for the full api_changes==true path (~10m/shard).
