### PR TITLE
Fix mixed-version distributed reads in co-occurring attributes query

### DIFF
--- a/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_attribute_names.py
@@ -21,7 +21,7 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Storage
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import and_cond, column, in_cond, not_cond, or_cond
+from snuba.query.dsl import and_cond, column, not_cond, or_cond
 from snuba.query.expressions import Argument, Expression, FunctionCall, Lambda
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
@@ -150,7 +150,7 @@ def get_co_occurring_attributes(
 
       The query at the end looks something like this:
 
-          SELECT distinct(arrayJoin(arrayFilter(attr -> ((NOT ((attr.2) IN ['test_tag_1_0'])) AND startsWith(attr.2, 'test_')), arrayMap(x -> ('TYPE_STRING', x), attributes_string)))) AS attr_key
+          SELECT distinct(arrayJoin(arrayFilter(attr -> ((NOT has(['test_tag_1_0'], attr.2)) AND startsWith(attr.2, 'test_')), arrayMap(x -> ('TYPE_STRING', x), attributes_string)))) AS attr_key
           FROM eap_item_co_occurring_attrs_1_local
           WHERE (item_type = 1) AND (project_id IN [1]) AND (organization_id = 1) AND (date < toDateTime(toDate('2025-03-17', 'Universal'))) AND (date >= toDateTime(toDate('2025-03-10', 'Universal')))
 
@@ -180,7 +180,7 @@ def get_co_occurring_attributes(
       -- each of the co-occurring attributes becomes a row sent to the outer query
       arrayJoin(
               arrayFilter(
-                  attr -> NOT in(attr, ['test_tag_1_0']),
+                  attr -> NOT has(['test_tag_1_0'], attr),
                   attributes_string
               )
       ) AS attr_key
@@ -281,10 +281,20 @@ def get_co_occurring_attributes(
     else:
         array_func = f.arrayConcat(string_array, double_array, bool_array)
 
+    # Exclude the unsearchable keys with NOT has(array(...), x) rather than
+    # NOT (x IN (...)). A constant IN-set makes ClickHouse build an internal
+    # prepared set whose server-generated identifier (__set_String_<hash>_<hash>)
+    # is baked into the result-block column name. Because this filter lives inside
+    # the arrayJoin'd SELECT expression, that name is matched by string across
+    # `Remote`; on a mixed-version cluster the two sides hash the set differently,
+    # so the names disagree and distributed reads fail with
+    # "Code: 10 ... Not found column ... While executing Remote." (SNUBA-B82).
+    # has() over a constant array keeps the array inline in the column name, which
+    # is byte-stable across versions. The set here is tiny so there's no perf cost.
     attr_filter = not_cond(
-        in_cond(
-            f.tupleElement(column("attr"), 2),
+        f.has(
             f.array(*UNSEARCHABLE_ATTRIBUTE_KEYS),
+            f.tupleElement(column("attr"), 2),
         )
     )
     if request.value_substring_match:

--- a/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_attribute_names.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -13,8 +14,11 @@ from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query.expressions import FunctionCall, Lambda, Literal
 from snuba.web.rpc.v1.endpoint_trace_item_attribute_names import (
+    UNSEARCHABLE_ATTRIBUTE_KEYS,
     EndpointTraceItemAttributeNames,
+    get_co_occurring_attributes,
 )
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
@@ -235,6 +239,68 @@ class TestTraceItemAttributeNames(BaseApiTest):
             ),
         ]
         assert res.attributes == expected
+
+    def test_co_occurring_attrs_excludes_unsearchable_keys_without_in_set(self) -> None:
+        """Regression guard for SNUBA-B82 (mixed-version distributed reads).
+
+        The unsearchable-key exclusion must be emitted as ``NOT has(array(...), x)``,
+        never as ``NOT (x IN (...))``. A constant ``IN`` set makes ClickHouse build a
+        prepared set whose server-generated ``__set_String_<hash>_<hash>`` identifier
+        lands in the (arrayJoin'd) result-block column name. On a mixed-version cluster
+        the two sides hash the set differently, so the column names disagree across
+        ``Remote`` and the distributed read fails with
+        ``Code: 10 ... Not found column ... While executing Remote.``. ``has`` over a
+        constant array keeps the array inline in the column name, which is byte-stable
+        across versions.
+        """
+        req = TraceItemAttributeNamesRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                request_id=str(uuid.uuid4()),
+                start_timestamp=Timestamp(seconds=int((BASE_TIME - timedelta(days=1)).timestamp())),
+                end_timestamp=Timestamp(seconds=int((BASE_TIME + timedelta(days=1)).timestamp())),
+            ),
+            limit=TOTAL_GENERATED_ATTR_PER_TYPE,
+            type=AttributeKey.Type.TYPE_STRING,
+        )
+
+        query = get_co_occurring_attributes(req).query
+
+        # distinct(arrayJoin(arrayFilter((attr) -> not(has(array(...), attr.2)), ...)))
+        distinct = query.get_selected_columns()[0].expression
+        assert isinstance(distinct, FunctionCall) and distinct.function_name == "distinct"
+        array_join = distinct.parameters[0]
+        assert isinstance(array_join, FunctionCall) and array_join.function_name == "arrayJoin"
+        array_filter = array_join.parameters[0]
+        assert (
+            isinstance(array_filter, FunctionCall) and array_filter.function_name == "arrayFilter"
+        )
+        predicate = array_filter.parameters[0]
+        assert isinstance(predicate, Lambda)
+
+        body = predicate.transformation
+        assert isinstance(body, FunctionCall) and body.function_name == "not"
+        has_call = body.parameters[0]
+        assert isinstance(has_call, FunctionCall) and has_call.function_name == "has"
+
+        keys_array, needle = has_call.parameters
+        assert isinstance(keys_array, FunctionCall) and keys_array.function_name == "array"
+        key_values = [p.value for p in keys_array.parameters if isinstance(p, Literal)]
+        assert key_values == UNSEARCHABLE_ATTRIBUTE_KEYS
+        assert isinstance(needle, FunctionCall) and needle.function_name == "tupleElement"
+
+        # No IN set may be built over the unsearchable keys (that would reintroduce
+        # the __set_* prepared-set identifier and the mixed-version failure).
+        unsearchable = set(UNSEARCHABLE_ATTRIBUTE_KEYS)
+        for exp in query.get_all_expressions():
+            if isinstance(exp, FunctionCall) and exp.function_name == "in":
+                for param in exp.parameters:
+                    if isinstance(param, FunctionCall) and param.function_name == "array":
+                        values = {p.value for p in param.parameters if isinstance(p, Literal)}
+                        assert values != unsearchable
 
     def test_simple_boolean(self) -> None:
         req = TraceItemAttributeNamesRequest(


### PR DESCRIPTION
## Description

Fixes a regression in the co-occurring attributes query that causes distributed reads to fail on mixed-version ClickHouse clusters (SNUBA-B82).

### The Problem

The query was using `NOT (attr IN [...])` to exclude unsearchable attribute keys. When ClickHouse optimizes a constant `IN` set, it builds an internal prepared set with a server-generated identifier (`__set_String_<hash>_<hash>`) that gets baked into the result-block column name. Since this filter lives inside an `arrayJoin`'d SELECT expression, the column name is matched by string across `Remote` nodes. On a mixed-version cluster, the two sides hash the set differently, causing the column names to disagree and distributed reads fail with `Code: 10 ... Not found column ... While executing Remote.`

### The Solution

Replace the `IN` condition with `NOT has(array(...), x)`. The `has()` function keeps the array inline in the column name rather than creating a prepared set, making the column name byte-stable across different ClickHouse versions. Since the unsearchable keys set is tiny, there's no performance penalty.

### Changes

- Modified `get_co_occurring_attributes()` to use `f.has()` instead of `in_cond()` for filtering unsearchable keys
- Removed unused `in_cond` import
- Added comprehensive test case `test_co_occurring_attrs_excludes_unsearchable_keys_without_in_set()` that validates:
  - The query structure uses `has()` with a constant array
  - No `IN` sets are built over the unsearchable keys
  - The predicate is correctly nested in the `arrayFilter` lambda

### Test Plan

The new regression test validates the query structure and ensures the fix prevents the prepared-set identifier from being generated. Existing tests continue to pass.

https://claude.ai/code/session_01RoMNWh9uEoBAz263XXXrqR