### PR TITLE
ref(eap-items): use ConditionFunctions.EQ in IndexedNameOptimizer

### DIFF
--- a/snuba/query/processors/logical/indexed_name_optimizer.py
+++ b/snuba/query/processors/logical/indexed_name_optimizer.py
@@ -2,7 +2,10 @@ from typing import Optional
 
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 
-from snuba.query.conditions import get_first_level_and_conditions
+from snuba.query.conditions import (
+    ConditionFunctions,
+    get_first_level_and_conditions,
+)
 from snuba.query.expressions import (
     Column,
     Expression,
@@ -54,7 +57,10 @@ class IndexedNameOptimizer(LogicalQueryProcessor):
 
         item_types: set[int] = set()
         for cond in get_first_level_and_conditions(condition):
-            if not isinstance(cond, FunctionCall) or cond.function_name != "equals":
+            if (
+                not isinstance(cond, FunctionCall)
+                or cond.function_name != ConditionFunctions.EQ
+            ):
                 continue
             if len(cond.parameters) != 2:
                 continue


### PR DESCRIPTION
## Summary

Addresses [@MeredithAnya's review nit](https://github.com/getsentry/snuba/pull/8052#discussion_r3437753237) on #8052: in `IndexedNameOptimizer._indexed_name_key`, reference the `ConditionFunctions.EQ` constant instead of the hardcoded `"equals"` string when matching the `item_type` equality condition.

This is a no-op behaviorally (`ConditionFunctions.EQ == "equals"`); it just keeps the processor consistent with the rest of the query layer.

This PR is stacked on top of `feat/eap-items-indexed-name-filter-optimizer` (#8052), so the diff contains only the nit fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CajnvSCYTxvJ9Hw5jELRPH)_