### PR TITLE
ref: Silence spurious google_auth_httplib2 per-request timeout warning (SNUBA-8P5)

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -56,6 +56,17 @@ def setup_logging(level: Optional[str] = None) -> None:
         force=True,
     )
 
+    # google-auth's httplib2 transport emits a spurious WARNING on every token
+    # refresh: "httplib2 transport does not support per-request timeout. Set the
+    # timeout when constructing the httplib2.Http instance." Since google-auth
+    # >= 2.39.0 the transport is always handed a per-request timeout (e.g. when
+    # refreshing service-account tokens against the GKE metadata server), and the
+    # warning fires regardless of how the Http instance was built -- googleapiclient
+    # already constructs it with a construction-time timeout, so there is nothing
+    # to "fix" on our side. The message is pure noise (132k+ events on snuba-admin
+    # with zero user impact), so drop everything below ERROR for this logger. (SNUBA-8P5)
+    logging.getLogger("google_auth_httplib2").setLevel(logging.ERROR)
+
     structlog.configure(
         cache_logger_on_first_use=True,
         wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),


### PR DESCRIPTION
## Summary

Gets rid of Sentry issue [SNUBA-8P5](https://sentry.sentry.io/issues/SNUBA-8P5) — a `warning`-level log spamming snuba-admin (132k+ occurrences, 0 users impacted, `super_low` Seer actionability):

> httplib2 transport does not support per-request timeout. Set the timeout when constructing the httplib2.Http instance.

## Root cause

The warning is emitted by `google_auth_httplib2`'s `Request.__call__`, which logs **unconditionally whenever a per-request `timeout` is passed**:

```python
if timeout is not None:
    _LOGGER.warning("httplib2 transport does not support per-request timeout. ...")
```

Since **google-auth ≥ 2.39.0**, the transport is always handed a per-request timeout — e.g. when refreshing service-account tokens against the GKE metadata server (`snuba/admin/google.py` builds the `cloudidentity` client and executes group-membership lookups on every admin request).

Crucially, the message fires **regardless of how the `httplib2.Http` instance is constructed**. Seer's suggestion ("pass a timeout-configured `httplib2.Http` to `build()`") does not silence it, and is already moot: googleapiclient's default `build_http()` constructs the `Http` *with* a construction-time timeout. There is no source-level fix on our side — the warning is pure noise we can't prevent google-auth from logging.

## Fix

Drop everything below `ERROR` for the `google_auth_httplib2` logger in `setup_logging()`. This:

- Prevents the warning from becoming a Sentry issue (independent of, and complementary to, #8077 which only routes WARN→logs and would still capture pre-deploy events).
- Stops the warning from spamming logs/breadcrumbs (which #8077 does **not** address).
- Leaves genuine `ERROR`+ messages from the logger intact.

`setup_logging()` is on the snuba-admin code path (`snuba/admin/wsgi.py`), which is where this warning originates, and on every other service path too.

## Verification

Confirmed via a standalone check that a `google_auth_httplib2` WARNING record is filtered at the logger level (never reaches any handler, including Sentry's `LoggingIntegration` handler), while `ERROR` still propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJBvBVj68XBb4iFvoBe9A4)_