### PR TITLE
fix(ci): point the deploy check gate at the sharded test_distributed checks

### DIFF
--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -5,7 +5,8 @@ checks-githubactions-checkruns \
   getsentry/snuba \
   ${GO_REVISION_SNUBA_REPO} \
   "Tests and code coverage (test)" \
-  "Tests and code coverage (test_distributed)" \
+  "Tests and code coverage (test_distributed, 0, 2)" \
+  "Tests and code coverage (test_distributed, 1, 2)" \
   "Tests and code coverage (test_distributed_migrations)" \
   "Build and push production image" \
   "Dataset Config Validation" \


### PR DESCRIPTION
The deploy pipeline's GitHub-checks gate (`gocd/templates/bash/check-github.sh`) waits up to 60 minutes for a check named `Tests and code coverage (test_distributed)`. Sharding that job (#8067) renamed it to `(test_distributed, 0, 2)` and `(test_distributed, 1, 2)`, so the old name never reports and the gate hangs, blocking deploys. We point the gate at the two sharded checks instead. Same fix we made to the merge ruleset; this was the second hardcoded consumer of the old name.
