### PR TITLE
feat(gocd): Run distroless image in s4s2 for rust consumers

### DIFF
--- a/gocd/templates/bash/deploy-py.sh
+++ b/gocd/templates/bash/deploy-py.sh
@@ -2,9 +2,6 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-# Temporarily run the distroless image variant in s4s2 to validate it before
-# switching production. The "-distroless" tag is published to the same registry
-# by .github/workflows/image.yml (build-distroless-production).
 IMAGE_TAG="${GO_REVISION_SNUBA_REPO}"
 if [ "${SENTRY_REGION}" = "s4s2" ]; then
   IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"

--- a/gocd/templates/bash/deploy-rs.sh
+++ b/gocd/templates/bash/deploy-rs.sh
@@ -2,10 +2,15 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
+IMAGE_TAG="${GO_REVISION_SNUBA_REPO}"
+if [ "${SENTRY_REGION}" = "s4s2" ]; then
+  IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
+fi
+
 /devinfra/scripts/get-cluster-credentials \
 && k8s-deploy \
   --label-selector="${LABEL_SELECTOR}" \
-  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  --image="us-docker.pkg.dev/sentryio/snuba-mr/image:${IMAGE_TAG}" \
   --container-name="consumer" \
   --container-name="eap-accepted-outcomes-consumer" \
   --container-name="eap-items-consumer" \


### PR DESCRIPTION
Apply the s4s2 distroless image-tag switch to `deploy-rs.sh`, which was missed during the initial s4s2 rollout that only touched `deploy-py.sh`. The rust consumer deploy now selects the `-distroless` tag for `s4s2` the same way the python deploy does, so both halves of the s4s2 deploy validate the distroless variant together.

Also removes the now-redundant explanatory comment in `deploy-py.sh`.

s4s2 is the validation region; once it's confirmed healthy, the same switch will be extended to the next region (us2) in both files.