### PR TITLE
feat(gocd): Run distroless image in de region

### DIFF
--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -9,6 +9,7 @@ checks-githubactions-checkruns \
   "Tests and code coverage (test_distributed, 1, 2)" \
   "Tests and code coverage (test_distributed_migrations)" \
   "Build and push production image" \
+  "Build and push distroless production image" \
   "Dataset Config Validation" \
   "sentry (0)" \
   "sentry (1)" \

--- a/gocd/templates/bash/deploy-py.sh
+++ b/gocd/templates/bash/deploy-py.sh
@@ -3,7 +3,7 @@
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 IMAGE_TAG="${GO_REVISION_SNUBA_REPO}"
-if [ "${SENTRY_REGION}" = "s4s2" ]; then
+if [ "${SENTRY_REGION}" = "s4s2" ] || [ "${SENTRY_REGION}" = "de" ]; then
   IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
 fi
 

--- a/gocd/templates/bash/deploy-rs.sh
+++ b/gocd/templates/bash/deploy-rs.sh
@@ -3,7 +3,7 @@
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
 IMAGE_TAG="${GO_REVISION_SNUBA_REPO}"
-if [ "${SENTRY_REGION}" = "s4s2" ]; then
+if [ "${SENTRY_REGION}" = "s4s2" ] || [ "${SENTRY_REGION}" = "de" ]; then
   IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
 fi
 


### PR DESCRIPTION
Extend the distroless image-tag switch to the `de` region in both `deploy-py.sh` and `deploy-rs.sh`, following successful validation in `s4s2`. `de` now selects the `-distroless` tag alongside `s4s2`; remaining regions stay on the standard image until they're rolled out in turn.

Also adds `"Build and push distroless production image"` to the GoCD deploy gate in `check-github.sh`. Production now pulls the `-distroless` tag in some regions, but the deploy gate wasn't waiting on the distroless build to succeed — so a failed distroless build could (and did) reach production. This makes the deploy depend on that build passing.