### PR TITLE
Replays query tuning: max_execution_time, PREWHERE environment, and a HAVING→subquery optimizer

### DIFF
--- a/snuba/datasets/configuration/replays/storages/aggregated.yaml
+++ b/snuba/datasets/configuration/replays/storages/aggregated.yaml
@@ -350,6 +350,12 @@ query_processors:
       settings:
         max_rows_to_group_by: 1000000
         group_by_overflow_mode: any
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 allocation_policies:

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -214,6 +214,18 @@ query_processors:
   - processor: ArrayJoinKeyValueOptimizer
     args:
       column_name: tags
+  - processor: SubqueryFilterOptimizer
+    args:
+      key_column: replay_id
+      filter_columns:
+        - user_id
+        - user_email
+  - processor: PrewhereProcessor
+    args:
+      omit_if_final:
+        - environment
+      prewhere_candidates:
+        - environment
   - processor: ClickhouseSettingsOverride
     args:
       overwrite_existing: false

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -214,6 +214,12 @@ query_processors:
   - processor: ArrayJoinKeyValueOptimizer
     args:
       column_name: tags
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
 
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer

--- a/snuba/query/processors/physical/subquery_filter_optimizer.py
+++ b/snuba/query/processors/physical/subquery_filter_optimizer.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from snuba.clickhouse.formatter.query import format_query
+from snuba.clickhouse.query import Query
+from snuba.query import SelectedExpression
+from snuba.query.accessors import get_columns_in_expression
+from snuba.query.conditions import (
+    ConditionFunctions,
+    combine_and_conditions,
+    get_first_level_and_conditions,
+)
+from snuba.query.expressions import Column as ColumnExpr
+from snuba.query.expressions import DangerousRawSQL, Expression
+from snuba.query.expressions import FunctionCall as FunctionCallExpr
+from snuba.query.expressions import Literal as LiteralExpr
+from snuba.query.processors.physical import ClickhouseQueryProcessor
+from snuba.query.query_settings import QuerySettings
+
+# HAVING comparisons that mean "this group has at least one matching row".
+# For these, adding `key IN (subquery matching the same predicate)` to the
+# WHERE only removes rows belonging to groups that the HAVING would have
+# dropped anyway, so it is always safe (and the HAVING is left in place).
+_POSITIVE_EXISTENCE = {
+    ConditionFunctions.NEQ: (0,),  # sum(pred) != 0
+    ConditionFunctions.GT: (0,),  # sum(pred) > 0
+    ConditionFunctions.GTE: (1,),  # sum(pred) >= 1
+}
+
+
+class SubqueryFilterOptimizer(ClickhouseQueryProcessor):
+    """
+    Rewrites per-group existence filters expressed in the HAVING clause into a
+    semi-join subquery on the WHERE clause so that ClickHouse skip indexes can
+    prune granules before the (expensive) GROUP BY.
+
+    Queries that look for "replays where a specific user/attribute appears in at
+    least one segment" are generated as::
+
+        SELECT replay_id, ...
+        FROM replays_local
+        WHERE project_id = X AND timestamp >= A AND timestamp < B AND ...
+        GROUP BY replay_id
+        HAVING sum(user_id = '...') != 0
+
+    The only selective predicate (`user_id = '...'`) lives inside the HAVING, so
+    it cannot restrict the rows read: ClickHouse must scan every segment for the
+    project/time window before the HAVING can run. The bloom-filter skip indexes
+    on those columns are never consulted.
+
+    This processor detects each `sum(<pred>) != 0` (and `> 0` / `>= 1`) HAVING
+    condition whose predicate references only configured `filter_columns`, and
+    adds::
+
+        key_column (GLOBAL) IN (SELECT key_column FROM <table> WHERE <where> AND <pred>)
+
+    The inner query equality lets the bloom-filter index prune granules, and the
+    `key_column IN (...)` on the outer query lets the `key_column` bloom-filter
+    index prune granules there too. The original HAVING is intentionally kept so
+    the result is provably unchanged -- the subquery is purely an accelerator.
+
+    Args:
+        key_column: column projected by and joined on in the subquery (the
+            GROUP BY key, e.g. ``replay_id``). Must have a skip index for the
+            outer ``IN`` to prune.
+        filter_columns: columns eligible to drive the optimization. Should be
+            columns backed by a skip index (e.g. ``bloom_filter``) so the inner
+            query prunes granules.
+        use_global_in: emit ``globalIn`` instead of ``in``. Preferred when the
+            table is Distributed so the small subquery result is computed once
+            and broadcast, rather than re-evaluated per shard.
+    """
+
+    def __init__(
+        self,
+        key_column: str,
+        filter_columns: Sequence[str],
+        use_global_in: bool = True,
+    ) -> None:
+        self.__key_column = key_column
+        self.__filter_columns = set(filter_columns)
+        self.__in_function = "globalIn" if use_global_in else "in"
+
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
+        having = query.get_having()
+        if having is None:
+            return
+
+        condition = query.get_condition()
+
+        predicates = [
+            pred
+            for cond in get_first_level_and_conditions(having)
+            if (pred := self.__match_existence_predicate(cond)) is not None
+        ]
+        if not predicates:
+            return
+
+        for predicate in predicates:
+            subquery_condition: Expression = (
+                combine_and_conditions([condition, predicate])
+                if condition is not None
+                else predicate
+            )
+            subquery = Query(
+                from_clause=query.get_from_clause(),
+                selected_columns=[
+                    SelectedExpression(
+                        self.__key_column,
+                        ColumnExpr(None, None, self.__key_column),
+                    )
+                ],
+                condition=subquery_condition,
+            )
+            subquery_sql = format_query(subquery).get_sql()
+            query.add_condition_to_ast(
+                FunctionCallExpr(
+                    None,
+                    self.__in_function,
+                    (
+                        ColumnExpr(None, None, self.__key_column),
+                        DangerousRawSQL(None, f"({subquery_sql})"),
+                    ),
+                )
+            )
+
+    def __match_existence_predicate(self, cond: Expression) -> Optional[Expression]:
+        """
+        If ``cond`` is a positive-existence HAVING condition of the form
+        ``sum(<pred>) <op> <literal>`` where ``<pred>`` references only
+        ``filter_columns``, return ``<pred>``. Otherwise return ``None``.
+        """
+        if not isinstance(cond, FunctionCallExpr):
+            return None
+        allowed_literals = _POSITIVE_EXISTENCE.get(cond.function_name)
+        if allowed_literals is None or len(cond.parameters) != 2:
+            return None
+
+        agg, rhs = cond.parameters
+        if not isinstance(rhs, LiteralExpr) or rhs.value not in allowed_literals:
+            return None
+        if (
+            not isinstance(agg, FunctionCallExpr)
+            or agg.function_name != "sum"
+            or len(agg.parameters) != 1
+        ):
+            return None
+
+        predicate = agg.parameters[0]
+        columns = get_columns_in_expression(predicate)
+        if not columns or any(col.column_name not in self.__filter_columns for col in columns):
+            return None
+
+        return predicate

--- a/tests/query/processors/test_subquery_filter_optimizer.py
+++ b/tests/query/processors/test_subquery_filter_optimizer.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import pytest
+
+from snuba.clickhouse.columns import UUID, ColumnSet, DateTime, String, UInt
+from snuba.clickhouse.columns import SchemaModifiers as Mods
+from snuba.clickhouse.formatter.query import format_query
+from snuba.clickhouse.query import Query
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query.data_source.simple import Table
+from snuba.query.dsl import and_cond, in_cond
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.processors.physical.subquery_filter_optimizer import (
+    SubqueryFilterOptimizer,
+)
+from snuba.query.query_settings import HTTPQuerySettings
+
+COLUMNS = ColumnSet(
+    [
+        ("project_id", UInt(64)),
+        ("timestamp", DateTime()),
+        ("replay_id", UUID()),
+        ("segment_id", UInt(16, Mods(nullable=True))),
+        ("environment", String(Mods(nullable=True))),
+        ("user_id", String(Mods(nullable=True))),
+        ("user_email", String(Mods(nullable=True))),
+        ("retention_days", UInt(16)),
+    ]
+)
+
+
+def _col(name: str) -> Column:
+    return Column(f"_snuba_{name}", None, name)
+
+
+def _base_where() -> Expression:
+    return and_cond(
+        FunctionCall(None, "equals", (_col("project_id"), Literal(None, 42))),
+        in_cond(
+            _col("environment"),
+            FunctionCall(None, "tuple", (Literal(None, "debug"), Literal(None, "release"))),
+        ),
+    )
+
+
+def _build_query(having: Expression | None) -> Query:
+    return Query(
+        from_clause=Table("replays_local", COLUMNS, storage_key=StorageKey("replays")),
+        selected_columns=[
+            SelectedExpression("replay_id", _col("replay_id")),
+            SelectedExpression(
+                "max_segment_id", FunctionCall("_snuba_max", "max", (_col("segment_id"),))
+            ),
+        ],
+        condition=_base_where(),
+        groupby=[_col("replay_id")],
+        having=having,
+        order_by=[OrderBy(OrderByDirection.ASC, FunctionCall(None, "min", (_col("timestamp"),)))],
+        limit=100,
+    )
+
+
+def _exists_having(column_name: str, value: str, op: str = "notEquals", rhs: int = 0) -> Expression:
+    return FunctionCall(
+        None,
+        op,
+        (
+            FunctionCall(
+                None,
+                "sum",
+                (FunctionCall(None, "equals", (_col(column_name), Literal(None, value))),),
+            ),
+            Literal(None, rhs),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "op,rhs",
+    [
+        ("notEquals", 0),
+        ("greater", 0),
+        ("greaterOrEquals", 1),
+    ],
+)
+def test_rewrites_positive_existence(op: str, rhs: int) -> None:
+    query = _build_query(_exists_having("user_id", "xyz", op=op, rhs=rhs))
+    SubqueryFilterOptimizer("replay_id", ["user_id", "user_email"]).process_query(
+        query, HTTPQuerySettings()
+    )
+    sql = format_query(query).get_sql()
+
+    # A semi-join subquery on replay_id is added with the user_id predicate so
+    # the bloom-filter skip indexes can prune granules.
+    assert "globalIn(replay_id, (SELECT replay_id FROM replays_local" in sql
+    assert "equals((user_id AS _snuba_user_id), 'xyz')" in sql
+    # The original HAVING is preserved (the subquery is purely an accelerator).
+    assert query.get_having() is not None
+    assert "HAVING" in sql
+
+
+def test_use_plain_in_when_not_global() -> None:
+    query = _build_query(_exists_having("user_id", "xyz"))
+    SubqueryFilterOptimizer("replay_id", ["user_id"], use_global_in=False).process_query(
+        query, HTTPQuerySettings()
+    )
+    sql = format_query(query).get_sql()
+    assert "in(replay_id, (SELECT replay_id FROM replays_local" in sql
+    assert "globalIn(replay_id" not in sql
+
+
+def test_multiple_existence_filters_each_get_a_subquery() -> None:
+    query = _build_query(
+        and_cond(
+            _exists_having("user_id", "xyz"),
+            _exists_having("user_email", "a@b.com"),
+        )
+    )
+    SubqueryFilterOptimizer("replay_id", ["user_id", "user_email"]).process_query(
+        query, HTTPQuerySettings()
+    )
+    sql = format_query(query).get_sql()
+    assert sql.count("globalIn(replay_id, (SELECT replay_id FROM replays_local") == 2
+    assert "equals((user_id AS _snuba_user_id), 'xyz')" in sql
+    assert "equals((user_email AS _snuba_user_email), 'a@b.com')" in sql
+
+
+def test_no_having_is_noop() -> None:
+    query = _build_query(None)
+    before = format_query(query).get_sql()
+    SubqueryFilterOptimizer("replay_id", ["user_id"]).process_query(query, HTTPQuerySettings())
+    assert format_query(query).get_sql() == before
+
+
+def test_column_not_in_filter_list_is_noop() -> None:
+    # segment_id is not a configured (bloom-filter) filter column.
+    query = _build_query(_exists_having("segment_id", "1"))
+    before = format_query(query).get_sql()
+    SubqueryFilterOptimizer("replay_id", ["user_id", "user_email"]).process_query(
+        query, HTTPQuerySettings()
+    )
+    assert format_query(query).get_sql() == before
+
+
+def test_non_existence_having_is_noop() -> None:
+    # `sum(...) == 0` means "no matching row" -- the IN rewrite would be wrong,
+    # so it must be skipped.
+    query = _build_query(_exists_having("user_id", "xyz", op="equals", rhs=0))
+    before = format_query(query).get_sql()
+    SubqueryFilterOptimizer("replay_id", ["user_id"]).process_query(query, HTTPQuerySettings())
+    assert format_query(query).get_sql() == before


### PR DESCRIPTION
## Summary

A few related performance changes for the replays storages.

### 1. Cap `max_execution_time` at 25s

Adds a `ClickhouseSettingsOverride` (with `overwrite_existing: false`) to both replays storages, matching the convention already used by `search_issues` / `eap_items`:

- `replays` (`.../replays/storages/replays.yaml`)
- `replays_aggregated` (`.../replays/storages/aggregated.yaml`)

```yaml
- processor: ClickhouseSettingsOverride
  args:
    overwrite_existing: false
    settings:
      max_execution_time: 25
      timeout_before_checking_execution_speed: 0
```

### 2. `SubqueryFilterOptimizer` (new physical query processor)

Replays "find replays where an attribute appears in at least one segment" queries are generated with the selective predicate trapped in the `HAVING`:

```sql
SELECT replay_id, ...
FROM replays_local
WHERE project_id = X AND timestamp BETWEEN ...
GROUP BY replay_id
HAVING sum(user_id = '...') != 0
```

Because `user_id` only appears in `HAVING`, neither the `bloom_filter` skip index on `user_id` nor on `replay_id` can prune granules — ClickHouse scans every segment for the project/time window before grouping.

The new processor detects each positive-existence HAVING condition (`sum(pred) != 0` / `> 0` / `>= 1`) whose predicate references only configured skip-indexed `filter_columns`, and adds a semi-join to the `WHERE`:

```sql
replay_id GLOBAL IN (
    SELECT replay_id FROM replays_local WHERE <where> AND <pred>
)
```

- The inner equality lets the `user_id` bloom filter prune granules.
- The outer `replay_id IN (...)` prunes via the `replay_id` bloom filter.
- The original `HAVING` is **left in place**, so the result is provably unchanged — the subquery is purely an accelerator.

It reuses the existing `DangerousRawSQL` subquery pattern (as used by the EAP `get_traces` endpoint). Wired into the `replays` storage for `user_id` / `user_email` keyed on `replay_id`. Unit tests cover the positive rewrites, the `globalIn`/`in` toggle, multiple existence filters, and the no-op cases (no HAVING, non-indexed column, non-existence `sum(...) = 0`).

### 3. PREWHERE for `environment`

Adds a `PrewhereProcessor` to the `replays` storage so the low-cardinality `environment` filter can be moved into `PREWHERE` (with `omit_if_final`, since it's a `LowCardinality(Nullable)` column).

## Notes
- `SubqueryFilterOptimizer` defaults to `globalIn` (preferred for Distributed tables: the small subquery result is computed once and broadcast).
- This is a prototype of the optimization discussed for the slow replays-by-user query; it's storage-config-driven, so the eligible columns can be tuned without code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)