### PR TITLE
ref: Stop arroyo ChildProcessTerminated from creating Sentry issues

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -78,21 +78,53 @@ def setup_logging(level: Optional[str] = None) -> None:
 
 
 def before_send(event: Event, hint: Hint) -> Event | None:
-    """Filter out AllocationPolicyViolations and RPCAllocationPolicyException from being sent to Sentry"""
-    if "exc_info" in hint:
-        _, exc_value, _ = hint["exc_info"]
-        # Check if it's an AllocationPolicyViolations in the cause chain
-        if exc_value is not None:
-            from snuba.web.rpc.common.exceptions import RPCAllocationPolicyException
+    """
+    Drop transient/operational exceptions that recover on their own and aren't
+    actionable as Sentry issues. They are still captured as logs/breadcrumbs.
 
-            if isinstance(exc_value, RPCAllocationPolicyException):
-                return None  # Don't send to Sentry
+    - ``AllocationPolicyViolations`` / ``RPCAllocationPolicyException``: expected
+      query rejections, not bugs.
+    - arroyo ``ChildProcessTerminated``: a multiprocessing worker in a consumer
+      was killed by a signal (almost always an OOM-kill of the worker, sometimes
+      a native crash). arroyo logs this at ERROR via ``logger.exception`` and
+      then re-raises it, so a single worker death surfaces as several ERROR-level
+      Sentry issues (e.g. SNUBA-BA7/BA8/BA9/BAD/B1T, grouped by wherever the
+      SIGCHLD happened to interrupt the run loop) even though the consumer simply
+      shuts down and is restarted by the orchestrator. Because these are
+      ERROR-level they are not covered by the WARN->log policy, so filter them by
+      type here. The underlying worker death is still observable via logs and
+      arroyo's ``sigchld.detected`` metric.
+    """
+    if "exc_info" not in hint:
+        return event
 
-            cause = getattr(exc_value, "__cause__", None)
-            from snuba.query.allocation_policies import AllocationPolicyViolations
+    _, exc_value, _ = hint["exc_info"]
+    if exc_value is None:
+        return event
 
-            if isinstance(cause, AllocationPolicyViolations):
-                return None  # Don't send to Sentry
+    from arroyo.processing.strategies.run_task_with_multiprocessing import (
+        ChildProcessTerminated,
+    )
+
+    from snuba.query.allocation_policies import AllocationPolicyViolations
+    from snuba.web.rpc.common.exceptions import RPCAllocationPolicyException
+
+    noise_types = (
+        RPCAllocationPolicyException,
+        AllocationPolicyViolations,
+        ChildProcessTerminated,
+    )
+
+    # Walk the exception chain (the exception itself plus its __cause__ /
+    # __context__) and drop the event if any link is a known noise type.
+    seen: set[int] = set()
+    exc: Optional[BaseException] = exc_value
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        if isinstance(exc, noise_types):
+            return None  # Don't send to Sentry
+        exc = exc.__cause__ or exc.__context__
+
     return event
 
 

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -123,7 +123,17 @@ def before_send(event: Event, hint: Hint) -> Event | None:
         seen.add(id(exc))
         if isinstance(exc, noise_types):
             return None  # Don't send to Sentry
-        exc = exc.__cause__ or exc.__context__
+        # Follow the chain the way Python itself displays it: an explicit cause
+        # (`raise ... from other`) wins, otherwise the implicit context -- unless
+        # it was suppressed via `raise ... from None`, in which case we must not
+        # follow __context__ or we could drop an unrelated event whose suppressed
+        # context happens to contain a noise type.
+        if exc.__cause__ is not None:
+            exc = exc.__cause__
+        elif not exc.__suppress_context__:
+            exc = exc.__context__
+        else:
+            exc = None
 
     return event
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -70,7 +70,7 @@ def test_before_send_drops_allocation_policy_violations() -> None:
 
 def test_before_send_drops_rpc_allocation_policy_exception() -> None:
     try:
-        raise RPCAllocationPolicyException("rejected")
+        raise RPCAllocationPolicyException("rejected", {})
     except RPCAllocationPolicyException as err:
         assert before_send({"message": "rejected"}, _hint_for(err)) is None
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,26 +1,28 @@
 from arroyo.processing.strategies.run_task_with_multiprocessing import (
     ChildProcessTerminated,
 )
+from sentry_sdk.types import Event, Hint
 
 from snuba.environment import before_send
 from snuba.query.allocation_policies import AllocationPolicyViolations
 from snuba.web.rpc.common.exceptions import RPCAllocationPolicyException
 
 
-def _hint_for(exc: BaseException) -> dict:
+def _hint_for(exc: BaseException) -> Hint:
     return {"exc_info": (type(exc), exc, exc.__traceback__)}
 
 
 def test_before_send_passes_through_without_exc_info() -> None:
-    event = {"message": "hello"}
-    assert before_send(dict(event), {}) == event
+    event: Event = {"message": "hello"}
+    assert before_send(event, {}) is event
 
 
 def test_before_send_passes_through_unrelated_exception() -> None:
+    event: Event = {"message": "boom"}
     try:
         raise ValueError("a real bug")
     except ValueError as err:
-        assert before_send({"message": "boom"}, _hint_for(err)) is not None
+        assert before_send(event, _hint_for(err)) is event
 
 
 def test_before_send_drops_child_process_terminated() -> None:
@@ -28,22 +30,22 @@ def test_before_send_drops_child_process_terminated() -> None:
     A consumer multiprocessing worker dying (SIGCHLD) is logged at ERROR and
     re-raised by arroyo; it recovers on restart and is not an actionable issue.
     """
+    event: Event = {"message": "Caught exception, shutting down..."}
     try:
         raise ChildProcessTerminated(17)
     except ChildProcessTerminated as err:
-        assert (
-            before_send({"message": "Caught exception, shutting down..."}, _hint_for(err)) is None
-        )
+        assert before_send(event, _hint_for(err)) is None
 
 
 def test_before_send_drops_child_process_terminated_in_cause_chain() -> None:
+    event: Event = {"message": "wrapped"}
     try:
         try:
             raise ChildProcessTerminated(17)
         except ChildProcessTerminated as inner:
             raise RuntimeError("wrapped") from inner
     except RuntimeError as err:
-        assert before_send({"message": "wrapped"}, _hint_for(err)) is None
+        assert before_send(event, _hint_for(err)) is None
 
 
 def test_before_send_keeps_event_when_noise_is_in_suppressed_context() -> None:
@@ -52,6 +54,7 @@ def test_before_send_keeps_event_when_noise_is_in_suppressed_context() -> None:
     it; we must not follow it, otherwise a legitimate error would be dropped just
     because a noise type sits in its (explicitly suppressed) context.
     """
+    event: Event = {"message": "a real bug"}
     try:
         try:
             raise ChildProcessTerminated(17)
@@ -60,33 +63,37 @@ def test_before_send_keeps_event_when_noise_is_in_suppressed_context() -> None:
     except ValueError as err:
         assert err.__suppress_context__ is True
         assert isinstance(err.__context__, ChildProcessTerminated)
-        assert before_send({"message": "a real bug"}, _hint_for(err)) is not None
+        assert before_send(event, _hint_for(err)) is event
 
 
 def test_before_send_drops_allocation_policy_violations() -> None:
+    event: Event = {"message": "rejected"}
     try:
         raise AllocationPolicyViolations("rejected")
     except AllocationPolicyViolations as err:
-        assert before_send({"message": "rejected"}, _hint_for(err)) is None
+        assert before_send(event, _hint_for(err)) is None
 
 
 def test_before_send_drops_rpc_allocation_policy_exception() -> None:
+    event: Event = {"message": "rejected"}
     try:
         raise RPCAllocationPolicyException("rejected", {})
     except RPCAllocationPolicyException as err:
-        assert before_send({"message": "rejected"}, _hint_for(err)) is None
+        assert before_send(event, _hint_for(err)) is None
 
 
 def test_before_send_handles_none_exc_value() -> None:
-    event = {"message": "no exc"}
-    assert before_send(dict(event), {"exc_info": (None, None, None)}) == event
+    event: Event = {"message": "no exc"}
+    hint: Hint = {"exc_info": (None, None, None)}
+    assert before_send(event, hint) is event
 
 
 def test_before_send_terminates_on_cyclic_cause_chain() -> None:
     # Defensive: a self-referential context must not loop forever.
+    event: Event = {"message": "cycle"}
     err = ValueError("self")
     try:
         raise err
     except ValueError:
         err.__context__ = err
-        assert before_send({"message": "cycle"}, _hint_for(err)) is not None
+        assert before_send(event, _hint_for(err)) is event

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,73 @@
+from arroyo.processing.strategies.run_task_with_multiprocessing import (
+    ChildProcessTerminated,
+)
+
+from snuba.environment import before_send
+from snuba.query.allocation_policies import AllocationPolicyViolations
+from snuba.web.rpc.common.exceptions import RPCAllocationPolicyException
+
+
+def _hint_for(exc: BaseException) -> dict:
+    return {"exc_info": (type(exc), exc, exc.__traceback__)}
+
+
+def test_before_send_passes_through_without_exc_info() -> None:
+    event = {"message": "hello"}
+    assert before_send(dict(event), {}) == event
+
+
+def test_before_send_passes_through_unrelated_exception() -> None:
+    try:
+        raise ValueError("a real bug")
+    except ValueError as err:
+        assert before_send({"message": "boom"}, _hint_for(err)) is not None
+
+
+def test_before_send_drops_child_process_terminated() -> None:
+    """
+    A consumer multiprocessing worker dying (SIGCHLD) is logged at ERROR and
+    re-raised by arroyo; it recovers on restart and is not an actionable issue.
+    """
+    try:
+        raise ChildProcessTerminated(17)
+    except ChildProcessTerminated as err:
+        assert before_send({"message": "Caught exception, shutting down..."}, _hint_for(err)) is None
+
+
+def test_before_send_drops_child_process_terminated_in_cause_chain() -> None:
+    try:
+        try:
+            raise ChildProcessTerminated(17)
+        except ChildProcessTerminated as inner:
+            raise RuntimeError("wrapped") from inner
+    except RuntimeError as err:
+        assert before_send({"message": "wrapped"}, _hint_for(err)) is None
+
+
+def test_before_send_drops_allocation_policy_violations() -> None:
+    try:
+        raise AllocationPolicyViolations("rejected")
+    except AllocationPolicyViolations as err:
+        assert before_send({"message": "rejected"}, _hint_for(err)) is None
+
+
+def test_before_send_drops_rpc_allocation_policy_exception() -> None:
+    try:
+        raise RPCAllocationPolicyException("rejected")
+    except RPCAllocationPolicyException as err:
+        assert before_send({"message": "rejected"}, _hint_for(err)) is None
+
+
+def test_before_send_handles_none_exc_value() -> None:
+    event = {"message": "no exc"}
+    assert before_send(dict(event), {"exc_info": (None, None, None)}) == event
+
+
+def test_before_send_terminates_on_cyclic_cause_chain() -> None:
+    # Defensive: a self-referential context must not loop forever.
+    err = ValueError("self")
+    try:
+        raise err
+    except ValueError:
+        err.__context__ = err
+        assert before_send({"message": "cycle"}, _hint_for(err)) is not None

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -44,6 +44,23 @@ def test_before_send_drops_child_process_terminated_in_cause_chain() -> None:
         assert before_send({"message": "wrapped"}, _hint_for(err)) is None
 
 
+def test_before_send_keeps_event_when_noise_is_in_suppressed_context() -> None:
+    """
+    `raise ... from None` keeps the prior exception on __context__ but suppresses
+    it; we must not follow it, otherwise a legitimate error would be dropped just
+    because a noise type sits in its (explicitly suppressed) context.
+    """
+    try:
+        try:
+            raise ChildProcessTerminated(17)
+        except ChildProcessTerminated:
+            raise ValueError("a real bug") from None
+    except ValueError as err:
+        assert err.__suppress_context__ is True
+        assert isinstance(err.__context__, ChildProcessTerminated)
+        assert before_send({"message": "a real bug"}, _hint_for(err)) is not None
+
+
 def test_before_send_drops_allocation_policy_violations() -> None:
     try:
         raise AllocationPolicyViolations("rejected")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -31,7 +31,9 @@ def test_before_send_drops_child_process_terminated() -> None:
     try:
         raise ChildProcessTerminated(17)
     except ChildProcessTerminated as err:
-        assert before_send({"message": "Caught exception, shutting down..."}, _hint_for(err)) is None
+        assert (
+            before_send({"message": "Caught exception, shutting down..."}, _hint_for(err)) is None
+        )
 
 
 def test_before_send_drops_child_process_terminated_in_cause_chain() -> None:


### PR DESCRIPTION
## Summary

`SNUBA-BA7`, `SNUBA-BA8`, `SNUBA-BA9`, `SNUBA-BAD`, and `SNUBA-B1T` are all the **same underlying event**: a multiprocessing worker in the `transactions` consumer was killed by a signal (`ChildProcessTerminated: 17`, where `17` is `SIGCHLD` — i.e. the parent was notified a child died, *not* the child's own exit code).

### Root cause

arroyo's `RunTaskWithMultiprocessing` installs a `SIGCHLD` handler. When a worker child terminates unexpectedly while the strategy is still running, the handler raises `ChildProcessTerminated`. In `StreamProcessor.run()` arroyo does:

```python
except Exception:
    logger.exception("Caught exception, shutting down...")  # ERROR level, with exc_info
```

...and then **re-raises**. So a single worker death fans out into multiple Sentry issues:

- **4 issues** (`SNUBA-BA7/BA8/BAD/B1T`, `handled: yes`, `logger: arroyo.processing.processor`) — the ERROR-level `"Caught exception, shutting down..."` log, captured by `LoggingIntegration`. They're separate issues only because Sentry groups them by *wherever the SIGCHLD happened to interrupt the run loop* (`submit`, `pickle.dumps`, `buffer_callback`, `poll`, …).
- **1 issue** (`SNUBA-BA9`, `handled: no`, `mechanism: excepthook`) — the same exception, re-raised and uncaught, crashing the process.

The worker death itself is almost always an **OOM-kill** of the worker (sometimes a native crash). The consumer then shuts down and is **restarted by the orchestrator** — it recovers on its own. These have `0` users impacted and `super_low`/`low` Seer actionability.

These are **ERROR-level**, so the `WARN → log` policy from #8077 does not cover them, which is why they surfaced as top unresolved issues the day after #8077 shipped.

### Change

Extend `before_send` in `snuba/environment.py` to drop `ChildProcessTerminated` by **exception type** (an `isinstance` check walking the `__cause__`/`__context__` chain — the robust, non-string approach #8077's review preferred), alongside the existing `AllocationPolicyViolations` / `RPCAllocationPolicyException` filtering. Both the logging path and the excepthook path flow through `before_send` with `hint["exc_info"]` set, so this suppresses all 5 issues at once.

The events are still captured as **logs/breadcrumbs**, and the underlying worker death remains observable via arroyo's `sigchld.detected` metric.

### Note / trade-off

This stops the **noise**; it does not stop workers from dying. If the worker deaths are OOM-kills (the most likely cause), the real mitigation is operational — worker memory limits, `--processes`, and `input_block_size`/`output_block_size` — which live in the deployment config, not this repo. Worth keeping an eye on the `sigchld.detected` metric for the `transactions` consumer; a sustained spike there would indicate a genuine crash-loop rather than occasional worker churn.

### Test

Adds `tests/test_environment.py` covering `before_send`: pass-through (no/None/unrelated exc), dropping `ChildProcessTerminated` (top-level and nested in a cause chain), dropping the allocation-policy exceptions, and safe termination on a cyclic exception chain.

Fixes SNUBA-BA7
Fixes SNUBA-BA8
Fixes SNUBA-BA9
Fixes SNUBA-BAD
Fixes SNUBA-B1T

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmYA6zVesfHV8aXRSFGkjB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmYA6zVesfHV8aXRSFGkjB)_