### PR TITLE
set max execution time of outcomes hourly to 10s

### DIFF
--- a/snuba/datasets/configuration/outcomes/storages/hourly.yaml
+++ b/snuba/datasets/configuration/outcomes/storages/hourly.yaml
@@ -51,5 +51,10 @@ query_processors:
       prewhere_candidates:
         - project_id
         - org_id
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 10
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer


### PR DESCRIPTION
In production, this never goes above 5s. But sometimes I see timeouts on the outcomes query of 30s. This should rule out outcomes clickhouse queries stalling as the cause
