### PR TITLE
ref(deletes): add option for lightweight_delete_mode

### DIFF
--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -204,6 +204,20 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
         if lw_sync is not None:
             query_settings.set_clickhouse_settings({"lightweight_deletes_sync": lw_sync})
 
+        lw_updates_enabled = get_str_config("lightweight_delete_mode")
+        if lw_updates_enabled:
+            mode = (
+                lw_updates_enabled
+                if lw_updates_enabled
+                in ("alter_update", "lightweight_update", "lightweight_update_force")
+                else "lightweight_update"
+            )
+            # Options for `lightweight_delete_mode` setting:
+            # alter_update - run ALTER UPDATE query that creates a heavyweight mutation.
+            # lightweight_update - run lightweight update if possible, run ALTER UPDATE otherwise.
+            # lightweight_update_force - run lightweight update if possible, throw otherwise.
+            query_settings.set_clickhouse_settings({"lightweight_delete_mode": mode})
+
         split_enabled = bool(
             self.__partition_column
             and get_int_config(f"lw_deletes_split_by_partition_{self.__storage_name}", default=0)

--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -202,7 +202,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
         # starting in 24.4 the default is 2
         lw_sync = get_int_config("lightweight_deletes_sync")
         if lw_sync is not None:
-            query_settings.set_clickhouse_settings({"lightweight_deletes_sync": lw_sync})
+            query_settings.push_clickhouse_setting("lightweight_deletes_sync", lw_sync)
 
         lw_updates_enabled = get_str_config("lightweight_delete_mode")
         if lw_updates_enabled:
@@ -216,7 +216,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
             # alter_update - run ALTER UPDATE query that creates a heavyweight mutation.
             # lightweight_update - run lightweight update if possible, run ALTER UPDATE otherwise.
             # lightweight_update_force - run lightweight update if possible, throw otherwise.
-            query_settings.set_clickhouse_settings({"lightweight_delete_mode": mode})
+            query_settings.push_clickhouse_setting("lightweight_delete_mode", mode)
 
         split_enabled = bool(
             self.__partition_column


### PR DESCRIPTION
In CH versions 25.8+ lightweight updates are now in beta and we can start using them for our lightweight deletes. This is done through the [lightweight_delete_mode]( https://clickhouse.com/docs/operations/settings/settings#lightweight_delete_mode) setting

Pre-Requisites for this to be turned on:
- [ ] Be on version 25.8 (where [`enable_lightweight_update`](https://clickhouse.com/docs/operations/settings/settings#enable_lightweight_update) is 1 by default )
- [ ] Table settings `enable_block_number_column` and  `enable_block_offset_column` set to `1` 
       * Run ```ALTER TABLE <table> MODIFY SETTING enable_block_number_column = 1, enable_block_offset_column = 1```
 - [ ] No batching on the consumer - for lightweight updates we want smaller deletes not big batched deletes