### PR TITLE
ref(rpc): always apply a limit to GetTrace queries

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -478,7 +478,10 @@ MAX_PARTS_MUTATING_FOR_DELETE = 20
 LW_DELETES_PARTITION_TRACKING_TTL = 86400
 SNQL_DISABLED_DATASETS: set[str] = set([])
 
-ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS: int = 0  # 0 means no limit
+# Per-page cap for EndpointGetTrace. When <= 0 there is no configured global cap,
+# and the endpoint falls back to a default row limit so the query is always
+# bounded (see _get_pagination_limit in endpoint_get_trace.py).
+ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS: int = 0
 ENABLE_TRACE_PAGINATION_DEFAULT = 1
 
 

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -68,6 +68,11 @@ NORMALIZED_COLUMNS_TO_INCLUDE_EAP_ITEMS = [
 ]
 APPLY_FINAL_ROLLOUT_PERCENTAGE_CONFIG_KEY = "EndpointGetTrace.apply_final_rollout_percentage"
 
+# Fallback limit applied to a GetTrace query when neither the request nor the
+# ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS setting provide a positive limit. This
+# guarantees the underlying ClickHouse query is always bounded.
+_DEFAULT_ROW_LIMIT = 10_000
+
 TIMESTAMP_FIELD_BY_ITEM_TYPE: dict[TraceItemType.ValueType, str] = {
     TraceItemType.TRACE_ITEM_TYPE_SPAN: "sentry.start_timestamp_precise",
 }
@@ -551,23 +556,30 @@ def _process_results(
     )
 
 
-def _get_pagination_limit(user_requested_limit: int) -> int | None:
+def _get_pagination_limit(user_requested_limit: int) -> int:
     """
+    Returns the limit to apply to a GetTrace query. The result is always a
+    positive integer so the underlying ClickHouse query is never unbounded.
+
     If the user requested a limit, we use the minimum of the user requested limit and
     the ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS snuba setting.
 
     If the user requested a limit of 0, we assume the user did not pass a limit, we
     use the default ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS.
+
+    When ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS is non-positive (no global cap
+    configured), we fall back to _DEFAULT_ROW_LIMIT so the query stays bounded.
     """
     if ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS <= 0:
-        # no limit unless the user requests one
+        # No global cap configured; honor the user's limit if present, otherwise
+        # fall back to the default so the query is never unbounded.
         if ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS < 0:
             sentry_sdk.capture_message(
-                f"Pagination max items is negative, no global limit will be applied: {ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS}"
+                f"Pagination max items is negative, falling back to the default limit: {ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS}"
             )
         if user_requested_limit > 0:
             return user_requested_limit
-        return None
+        return _DEFAULT_ROW_LIMIT
 
     if user_requested_limit > 0:
         return min(user_requested_limit, ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS)
@@ -588,18 +600,24 @@ class EndpointGetTrace(RPCEndpoint[GetTraceRequest, GetTraceResponse]):
         return GetTraceResponse
 
     def _execute(self, in_msg: GetTraceRequest) -> GetTraceResponse:
-        self.metrics.increment(
-            "eap_trace_request_without_limit", 1, tags={"referrer": in_msg.meta.referrer}
-        )
+        if in_msg.limit <= 0:
+            # The request did not specify a limit, so a default cap is applied to
+            # keep the query bounded. Track how often this happens per referrer.
+            self.metrics.increment(
+                "eap_trace_request_without_limit",
+                1,
+                tags={"referrer": in_msg.meta.referrer},
+            )
 
         enable_pagination = state.get_int_config(
             "enable_trace_pagination", ENABLE_TRACE_PAGINATION_DEFAULT
         )
+        # A limit is always applied so the underlying ClickHouse query is never
+        # unbounded, regardless of whether pagination is enabled.
+        limit = _get_pagination_limit(in_msg.limit)
         if enable_pagination:
-            limit = _get_pagination_limit(in_msg.limit)
             page_token = EndpointGetTracePageToken.from_protobuf(in_msg.page_token)
         else:
-            limit = None
             page_token = None
 
         query_results = []
@@ -608,9 +626,10 @@ class EndpointGetTrace(RPCEndpoint[GetTraceRequest, GetTraceResponse]):
             start = 0
         else:
             start = page_token.last_item_index
+        remaining = limit
         for i, item in enumerate(in_msg.items[start:], start=start):
             item_group, query_result, last_seen_timestamp_precise, last_seen_id = (
-                self._query_item_group(in_msg, item, limit, page_token)
+                self._query_item_group(in_msg, item, remaining, page_token)
             )
             page_token = None
             query_results.append(query_result)
@@ -619,13 +638,14 @@ class EndpointGetTrace(RPCEndpoint[GetTraceRequest, GetTraceResponse]):
 
             item_groups.append(item_group)
 
-            if limit is not None:
-                limit -= len(item_group.items)
-
-            if limit is not None and limit <= 0:
-                # create a page token, we have reached the limit
-                page_token = EndpointGetTracePageToken(i, last_seen_timestamp_precise, last_seen_id)
-                break
+            if enable_pagination:
+                remaining -= len(item_group.items)
+                if remaining <= 0:
+                    # create a page token, we have reached the limit
+                    page_token = EndpointGetTracePageToken(
+                        i, last_seen_timestamp_precise, last_seen_id
+                    )
+                    break
 
         with sentry_sdk.start_span(op="function", description="assemble_response"):
             response_meta = extract_response_meta(

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -34,8 +34,8 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.settings import ENABLE_TRACE_PAGINATION_DEFAULT
 from snuba.web.rpc.common.common import ATTRIBUTES_ARRAY_ALLOWLIST
 from snuba.web.rpc.v1.endpoint_get_trace import (
-    APPLY_FINAL_ROLLOUT_PERCENTAGE_CONFIG_KEY,
     _DEFAULT_ROW_LIMIT,
+    APPLY_FINAL_ROLLOUT_PERCENTAGE_CONFIG_KEY,
     EndpointGetTrace,
     _build_query,
     _get_pagination_limit,

--- a/tests/web/rpc/v1/test_endpoint_get_trace.py
+++ b/tests/web/rpc/v1/test_endpoint_get_trace.py
@@ -35,8 +35,10 @@ from snuba.settings import ENABLE_TRACE_PAGINATION_DEFAULT
 from snuba.web.rpc.common.common import ATTRIBUTES_ARRAY_ALLOWLIST
 from snuba.web.rpc.v1.endpoint_get_trace import (
     APPLY_FINAL_ROLLOUT_PERCENTAGE_CONFIG_KEY,
+    _DEFAULT_ROW_LIMIT,
     EndpointGetTrace,
     _build_query,
+    _get_pagination_limit,
     _process_results,
     _value_to_attribute,
 )
@@ -573,6 +575,35 @@ def test_process_results_keeps_empty_string_attribute() -> None:
     assert attribute.value.val_str == ""
 
 
+@pytest.mark.parametrize(
+    "configured_max, user_limit, expected",
+    [
+        # No configured global cap (default): always bounded.
+        (0, 0, _DEFAULT_ROW_LIMIT),  # no user limit -> default cap
+        (0, 50, 50),  # user limit honored
+        # Negative configured cap: still bounded, never unbounded.
+        (-1, 0, _DEFAULT_ROW_LIMIT),
+        (-1, 50, 50),
+        # Configured global cap.
+        (9, 0, 9),  # no user limit -> configured cap
+        (9, 5, 5),  # user limit below cap -> user limit
+        (9, 100, 9),  # user limit above cap -> configured cap
+    ],
+)
+def test_get_pagination_limit_is_always_bounded(
+    configured_max: int, user_limit: int, expected: int
+) -> None:
+    with patch(
+        "snuba.web.rpc.v1.endpoint_get_trace.ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS",
+        configured_max,
+    ):
+        result = _get_pagination_limit(user_limit)
+    assert result == expected
+    # The result must always be a positive integer so the query is never unbounded.
+    assert result is not None
+    assert result > 0
+
+
 @pytest.mark.eap
 @pytest.mark.redis_db
 class TestGetTracePagination(BaseApiTest):
@@ -702,3 +733,50 @@ class TestGetTracePagination(BaseApiTest):
                     break
                 message.page_token.CopyFrom(response.page_token)
             assert len(items_received) == len(_SPANS) + len(_LOGS)
+
+    def test_query_is_bounded_when_pagination_disabled(self, setup_teardown: Any) -> None:
+        """
+        Even with pagination disabled and no user-provided limit, every query
+        sent to ClickHouse must carry a (default) limit so it is never unbounded.
+        """
+        import snuba.web.rpc.v1.endpoint_get_trace as endpoint_get_trace
+
+        state.set_config("enable_trace_pagination", 0)
+        ts = Timestamp(seconds=int(_BASE_TIME.timestamp()))
+        three_hours_later = int((_BASE_TIME + timedelta(hours=3)).timestamp())
+        message = GetTraceRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=ts,
+                end_timestamp=Timestamp(seconds=three_hours_later),
+                request_id=_REQUEST_ID,
+            ),
+            trace_id=_TRACE_ID,
+            items=[
+                GetTraceRequest.TraceItem(
+                    item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                    attributes=[
+                        AttributeKey(
+                            name="sentry.item_id",
+                            type=AttributeKey.Type.TYPE_STRING,
+                        ),
+                    ],
+                ),
+            ],
+        )
+        with patch.object(
+            endpoint_get_trace,
+            "_build_snuba_request",
+            wraps=endpoint_get_trace._build_snuba_request,
+        ) as spy:
+            response = EndpointGetTrace().execute(message)
+
+        assert spy.call_count >= 1
+        for call in spy.call_args_list:
+            limit_arg = call.args[2] if len(call.args) > 2 else call.kwargs["limit"]
+            assert limit_arg == _DEFAULT_ROW_LIMIT
+        # The data is still returned (data set is far smaller than the cap).
+        assert len(response.item_groups) == 1


### PR DESCRIPTION
## Summary

`EndpointGetTrace` could issue **unbounded** ClickHouse queries. When a request arrived without a limit and no global cap was configured — which is the default, since `ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS = 0` ("0 means no limit") — or whenever pagination was disabled, `limit` was left as `None` and the query ran with no `LIMIT` clause at all. These unbounded queries are the worst offenders for both ClickHouse and granian memory.

This came out of investigating the `snuba.rpc.eap_trace_request_without_limit` metric, which turned out to be doubly misleading:
- It was emitted **unconditionally** on every `GetTrace` request, so it tracked total call volume, not requests without a limit (~3.5M/week, exclusively `endpoint_name:endpointgettrace`).
- The sibling endpoints already cap themselves (the trace-item **table** resolver and `GetTraces` both fall back to a default row limit), so `GetTrace` was the one genuinely emitting `LIMIT`-less SQL.

## Changes

- **Always bound the query.** `_get_pagination_limit` now always returns a positive `int`, falling back to a default row limit (`_DEFAULT_ROW_LIMIT = 10_000`, matching the sibling table/traces endpoints) when there is neither a user-supplied limit nor a configured cap.
- **Apply the limit even when pagination is disabled.** The limit is now computed regardless of the `enable_trace_pagination` flag; only the cross-item decrement / page-token logic stays gated on pagination being enabled. (Trade-off: with pagination disabled *and* a trace larger than the cap, results are truncated to the cap with no page token — bounded beats unbounded, and pagination is on by default.)
- **Fix the misleading metric.** `eap_trace_request_without_limit` now increments only when the request arrives without a user-supplied limit (`in_msg.limit <= 0`), so the name is accurate and it gives real signal on how often the default cap is relied upon, per referrer.
- Updated the `ENDPOINT_GET_TRACE_PAGINATION_MAX_ITEMS` doc comment to reflect that `<= 0` now means "fall back to the default" rather than "no limit".

## Out of scope (flagged for follow-up)

`GetTraces` (plural) cross-item path technically has a `LIMIT`, but its default fallback is `_TRACE_LIMIT = 50_000_000` — a nominal cap so high it's effectively unbounded for memory. Left untouched here since it does emit a `LIMIT` clause and lowering it has broader trace-explorer implications worth a separate discussion.

## Test plan

- [x] New parametrized unit test `test_get_pagination_limit_is_always_bounded` covering the full truth table (no/negative/positive configured cap × with/without user limit) — asserts the result is always a positive int.
- [x] New integration test `test_query_is_bounded_when_pagination_disabled` spies on the built Snuba request and asserts the query carries `_DEFAULT_ROW_LIMIT` even with pagination disabled and no user limit.
- [x] Existing `GetTrace` / pagination tests still describe the same behavior (data sets are far below the 10k cap).
- [ ] CI (full EAP suite requires ClickHouse; could not run locally in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TheCLK7ZEBCnw5bc3Qboth

---
_Generated by [Claude Code](https://claude.ai/code/session_01TheCLK7ZEBCnw5bc3Qboth)_