### PR TITLE
ref(options): migrate Rust consumer runtime config to sentry-options

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
 use sentry_arroyo::counter;
+use sentry_options::options;
 use sentry_protos::snuba::v1::any_value::Value;
 use sentry_protos::snuba::v1::{ArrayValue, TraceItem, TraceItemType};
 
@@ -18,7 +19,6 @@ use crate::processors::utils::{
     enforce_retention, get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs,
     record_invalid_timestamp_metric, SilencedDLQMessage,
 };
-use crate::runtime_config::get_str_config;
 use crate::strategies::clickhouse::rowbinary;
 use crate::types::CogsData;
 use crate::types::{item_type_name, InsertBatch, ItemTypeMetrics, KafkaMessageMetadata};
@@ -153,10 +153,10 @@ fn get_dlq_grace_period_min(storage_name: &str) -> Option<i64> {
     if storage_name.is_empty() {
         return None;
     }
-    get_str_config(&format!("{DLQ_GRACE_PERIOD_MIN_KEY}:{storage_name}"))
+    options("snuba")
         .ok()
-        .flatten()
-        .and_then(|s| s.parse::<i64>().ok())
+        .and_then(|o| o.get(DLQ_GRACE_PERIOD_MIN_KEY).ok())
+        .and_then(|v| v.get(storage_name).and_then(|n| n.as_i64()))
         .filter(|&n| n >= 0)
 }
 
@@ -689,11 +689,20 @@ mod tests {
     use std::time::SystemTime;
 
     use prost_types::Timestamp;
+    use sentry_options::init_with_schemas;
+    use sentry_options::testing::override_options;
     use sentry_protos::snuba::v1::any_value::Value;
     use sentry_protos::snuba::v1::{AnyValue, ArrayValue, TraceItemType};
     use serde::Deserialize;
+    use serde_json::json;
+    use std::sync::Once;
 
     use super::*;
+
+    static INIT: Once = Once::new();
+    fn init_options() {
+        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
+    }
 
     fn generate_trace_item(item_id: Uuid) -> TraceItem {
         TraceItem {
@@ -1154,8 +1163,36 @@ mod tests {
 
     #[test]
     fn test_get_dlq_grace_period_min_unset_storage_returns_none() {
-        // Empty storage_name short-circuits to None without hitting Python.
+        // Empty storage_name short-circuits to None without reading options.
         assert_eq!(get_dlq_grace_period_min(""), None);
+    }
+
+    #[test]
+    fn test_get_dlq_grace_period_min_reads_dict_option() {
+        init_options();
+        {
+            let _guard = override_options(&[(
+                "snuba",
+                "eap_items_dlq_grace_period_min",
+                json!({ "eap_items_dlq_test": 45 }),
+            )])
+            .unwrap();
+            // Reads the per-storage entry out of the dict option (the nested get
+            // on the serde_json::Value returned by options(...).get(...)).
+            assert_eq!(get_dlq_grace_period_min("eap_items_dlq_test"), Some(45));
+            // A storage with no entry in the dict falls back to None.
+            assert_eq!(get_dlq_grace_period_min("eap_items_dlq_other"), None);
+        }
+        {
+            // Negative values are rejected.
+            let _guard = override_options(&[(
+                "snuba",
+                "eap_items_dlq_grace_period_min",
+                json!({ "eap_items_dlq_test": -1 }),
+            )])
+            .unwrap();
+            assert_eq!(get_dlq_grace_period_min("eap_items_dlq_test"), None);
+        }
     }
 
     #[test]

--- a/rust_snuba/src/processors/generic_metrics.rs
+++ b/rust_snuba/src/processors/generic_metrics.rs
@@ -1,6 +1,7 @@
 use adler::Adler32;
-use anyhow::{anyhow, Context, Error};
+use anyhow::{anyhow, Context};
 use chrono::DateTime;
+use sentry_options::options;
 use serde::{
     de::value::{MapAccessDeserializer, SeqAccessDeserializer},
     Deserialize, Deserializer, Serialize,
@@ -8,7 +9,6 @@ use serde::{
 use std::{collections::BTreeMap, marker::PhantomData, vec};
 
 use crate::{
-    runtime_config::get_str_config,
     types::{CogsData, InsertBatch, RowData},
     KafkaMessageMetadata, ProcessorConfig,
 };
@@ -339,8 +339,8 @@ impl Parse for CountersRawRow {
     }
 }
 
-fn should_use_killswitch(config: Result<Option<String>, Error>, use_case: &MessageUseCase) -> bool {
-    if let Some(killswitch) = config.ok().flatten() {
+fn should_use_killswitch(config: Option<String>, use_case: &MessageUseCase) -> bool {
+    if let Some(killswitch) = config {
         return killswitch.contains(use_case.use_case_id.as_str());
     }
 
@@ -355,7 +355,10 @@ where
     T: Parse + Serialize,
 {
     let payload_bytes = payload.payload().context("Expected payload")?;
-    let killswitch_config = get_str_config("generic_metrics_use_case_killswitch");
+    let killswitch_config = options("snuba")
+        .ok()
+        .and_then(|o| o.get("generic_metrics_use_case_killswitch").ok())
+        .and_then(|v| v.as_str().map(String::from));
     let use_case: MessageUseCase = serde_json::from_slice(payload_bytes)?;
 
     if should_use_killswitch(killswitch_config, &use_case) {
@@ -1358,7 +1361,7 @@ mod tests {
 
     #[test]
     fn test_shouldnt_killswitch() {
-        let fake_config = Ok(Some("[custom]".to_string()));
+        let fake_config = Some("[custom]".to_string());
         let use_case = MessageUseCase {
             use_case_id: "transactions".to_string(),
         };
@@ -1371,7 +1374,7 @@ mod tests {
         let use_case = MessageUseCase {
             use_case_id: "transactions".to_string(),
         };
-        let fake_config = Ok(Some("[transactions]".to_string()));
+        let fake_config = Some("[transactions]".to_string());
 
         assert!(should_use_killswitch(fake_config, &use_case));
     }
@@ -1381,7 +1384,7 @@ mod tests {
         let use_case = MessageUseCase {
             use_case_id: "transactions".to_string(),
         };
-        let fake_config = Ok(Some("[transactions, custom]".to_string()));
+        let fake_config = Some("[transactions, custom]".to_string());
 
         assert!(should_use_killswitch(fake_config, &use_case));
     }
@@ -1391,7 +1394,7 @@ mod tests {
         let use_case = MessageUseCase {
             use_case_id: "transactions".to_string(),
         };
-        let fake_config = Ok(Some("[]".to_string()));
+        let fake_config = Some("[]".to_string());
 
         assert!(!should_use_killswitch(fake_config, &use_case));
     }
@@ -1401,7 +1404,7 @@ mod tests {
         let use_case = MessageUseCase {
             use_case_id: "transactions".to_string(),
         };
-        let fake_config = Ok(Some("".to_string()));
+        let fake_config = Some("".to_string());
 
         assert!(!should_use_killswitch(fake_config, &use_case));
     }
@@ -1411,7 +1414,7 @@ mod tests {
         let use_case = MessageUseCase {
             use_case_id: "transactions".to_string(),
         };
-        let fake_config = Ok(None);
+        let fake_config: Option<String> = None;
 
         assert!(!should_use_killswitch(fake_config, &use_case));
     }

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -1,9 +1,9 @@
 use crate::config::EnvConfig;
-use crate::runtime_config::get_str_config;
 use crate::types::item_type_name;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use schemars::JsonSchema;
 use sentry_arroyo::counter;
+use sentry_options::options;
 use sentry_protos::snuba::v1::TraceItemType;
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -16,7 +16,7 @@ pub const INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS: i64 = 7 * 24 * 60 * 60;
 /// timestamp dropping is enabled.
 pub const INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
 
-/// Runtime config key. When set to `"1"`, the eap-items consumer skips messages
+/// sentry-options key. When `true`, the eap-items consumer skips messages
 /// whose event `timestamp` is more than one week in the future or more than
 /// thirty days in the past (see `out_of_valid_interval_secs`).
 pub const DROP_INVALID_TIMESTAMPS_KEY: &str = "eap_items_drop_invalid_timestamps";
@@ -34,10 +34,10 @@ pub fn out_of_valid_interval_secs(ts: DateTime<Utc>, now: DateTime<Utc>) -> bool
 }
 
 pub fn get_drop_invalid_timestamps_enabled() -> bool {
-    get_str_config(DROP_INVALID_TIMESTAMPS_KEY)
+    options("snuba")
         .ok()
-        .flatten()
-        .map(|s| s == "1")
+        .and_then(|o| o.get(DROP_INVALID_TIMESTAMPS_KEY).ok())
+        .and_then(|v| v.as_bool())
         .unwrap_or(false)
 }
 

--- a/rust_snuba/src/rebalancing.rs
+++ b/rust_snuba/src/rebalancing.rs
@@ -1,4 +1,4 @@
-use crate::runtime_config;
+use sentry_options::options;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -29,45 +29,46 @@ pub fn delay_kafka_rebalance(configured_delay_secs: u64) {
 }
 
 pub fn get_rebalance_delay_secs(consumer_group: &str) -> Option<u64> {
-    runtime_config::get_str_config(
-        format!("quantized_rebalance_consumer_group_delay_secs__{consumer_group}").as_str(),
-    )
-    .ok()??
-    .parse()
-    .ok()
+    // Migrated from the per-group runtime config key
+    // `quantized_rebalance_consumer_group_delay_secs__<consumer_group>` to a
+    // single `snuba` sentry-options dict keyed by consumer group. A group with
+    // no entry (or a non-integer value) yields no delay.
+    options("snuba")
+        .ok()
+        .and_then(|o| o.get("quantized_rebalance_consumer_group_delay_secs").ok())
+        .and_then(|v| v.get(consumer_group).and_then(|n| n.as_u64()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sentry_options::init_with_schemas;
+    use sentry_options::testing::override_options;
+    use serde_json::json;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_options() {
+        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
+    }
 
     #[test]
     fn test_delay_config() {
-        // teardown, even when the test fails
-        let _guard = scopeguard::guard((), |_| {
-            runtime_config::patch_str_config_for_test(
-                "quantized_rebalance_consumer_group_delay_secs__spans",
-                None,
-            );
-        });
+        init_options();
 
-        runtime_config::patch_str_config_for_test(
-            "quantized_rebalance_consumer_group_delay_secs__spans",
-            None,
-        );
-        let delay_secs = get_rebalance_delay_secs("spans");
-        assert_eq!(delay_secs, None);
-        runtime_config::patch_str_config_for_test(
-            "quantized_rebalance_consumer_group_delay_secs__spans",
-            Some("420"),
-        );
-        let delay_secs = get_rebalance_delay_secs("spans");
-        assert_eq!(delay_secs, Some(420));
-        runtime_config::patch_str_config_for_test(
-            "quantized_rebalance_consumer_group_delay_secs__spans",
-            Some("garbage"),
-        );
-        let delay_secs = get_rebalance_delay_secs("spans");
-        assert_eq!(delay_secs, None);
+        // A consumer group with no entry in the dict yields no delay.
+        assert_eq!(get_rebalance_delay_secs("spans"), None);
+
+        let _guard = override_options(&[(
+            "snuba",
+            "quantized_rebalance_consumer_group_delay_secs",
+            json!({ "spans": 420 }),
+        )])
+        .unwrap();
+
+        // The configured group reads its delay; an unconfigured one stays None.
+        assert_eq!(get_rebalance_delay_secs("spans"), Some(420));
+        assert_eq!(get_rebalance_delay_secs("transactions"), None);
     }
 }

--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -1,52 +1,4 @@
-use anyhow::Error;
-use parking_lot::RwLock;
-use pyo3::prelude::{PyModule, Python};
-use pyo3::types::PyAnyMethods;
-use std::collections::BTreeMap;
-use std::time::Duration;
-
-use sentry_arroyo::timer;
-use sentry_arroyo::utils::timing::Deadline;
-
-static CONFIG: RwLock<BTreeMap<String, (Option<String>, Deadline)>> = RwLock::new(BTreeMap::new());
-
-#[cfg(test)]
-pub fn patch_str_config_for_test(key: &str, value: Option<&str>) {
-    let deadline = Deadline::new(Duration::from_secs(10));
-
-    CONFIG
-        .write()
-        .insert(key.to_string(), (value.map(str::to_string), deadline));
-}
-
-/// Runtime config is cached for 10 seconds
-pub fn get_str_config(key: &str) -> Result<Option<String>, Error> {
-    let deadline = Deadline::new(Duration::from_secs(10));
-
-    if let Some(value) = CONFIG.read().get(key) {
-        let (config, deadline) = value;
-        if !deadline.has_elapsed() {
-            return Ok(config.clone());
-        }
-    }
-
-    let rv = Python::with_gil(|py| {
-        let snuba_state = PyModule::import(py, "snuba.state")?;
-        let config = snuba_state
-            .getattr("get_str_config")?
-            .call1((key,))?
-            .extract::<Option<String>>()?;
-
-        CONFIG
-            .write()
-            .insert(key.to_string(), (config.clone(), deadline));
-        Ok(CONFIG.read().get(key).unwrap().0.clone())
-    });
-
-    timer!("runtime_config.get_str_config", deadline.elapsed());
-
-    rv
-}
+use sentry_options::options;
 
 pub struct LoadBalancingConfig {
     pub load_balancing: String,
@@ -54,16 +6,29 @@ pub struct LoadBalancingConfig {
 }
 
 pub fn get_load_balancing_config(storage_name: &str) -> LoadBalancingConfig {
-    let load_balancing = get_str_config(&format!("clickhouse_load_balancing:{storage_name}"))
-        .ok()
-        .flatten()
+    // Both keys live in the `snuba` sentry-options namespace as dicts keyed by
+    // storage name (migrated from the per-storage runtime config keys
+    // `clickhouse_load_balancing[_first_offset]:<storage>`).
+    let snuba_options = options("snuba").ok();
+
+    let load_balancing = snuba_options
+        .as_ref()
+        .and_then(|o| o.get("clickhouse_load_balancing").ok())
+        .and_then(|v| {
+            v.get(storage_name)
+                .and_then(|s| s.as_str())
+                .map(String::from)
+        })
         .unwrap_or_else(|| "in_order".to_string());
 
-    let first_offset = get_str_config(&format!(
-        "clickhouse_load_balancing_first_offset:{storage_name}"
-    ))
-    .ok()
-    .flatten();
+    let first_offset = snuba_options
+        .as_ref()
+        .and_then(|o| o.get("clickhouse_load_balancing_first_offset").ok())
+        .and_then(|v| {
+            v.get(storage_name)
+                .and_then(|s| s.as_str())
+                .map(String::from)
+        });
 
     LoadBalancingConfig {
         load_balancing,
@@ -82,27 +47,30 @@ pub const CLICKHOUSE_DEFAULT_MAX_INSERT_BLOCK_SIZE: u64 = 1_048_449;
 /// past what ClickHouse already does by default. Callers should append
 /// `&max_insert_block_size=<n>` to the INSERT URL when Some.
 pub fn get_max_insert_block_size(storage_name: &str) -> Option<u64> {
-    get_str_config(&format!("clickhouse_max_insert_block_size:{storage_name}"))
+    options("snuba")
         .ok()
-        .flatten()
-        .and_then(|s| s.parse::<u64>().ok())
+        .and_then(|o| o.get("clickhouse_max_insert_block_size").ok())
+        .and_then(|v| v.get(storage_name).and_then(|n| n.as_u64()))
         .filter(|&n| n >= CLICKHOUSE_DEFAULT_MAX_INSERT_BLOCK_SIZE)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sentry_options::init_with_schemas;
+    use sentry_options::testing::override_options;
+    use serde_json::json;
+    use std::sync::Once;
 
-    #[test]
-    fn test_runtime_config() {
-        crate::testutils::initialize_python();
-        let config = get_str_config("test");
-        assert_eq!(config.unwrap(), None);
+    static INIT: Once = Once::new();
+
+    fn init_options() {
+        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
     }
 
     #[test]
     fn test_load_balancing_config_defaults() {
-        crate::testutils::initialize_python();
+        init_options();
         let config = get_load_balancing_config("lb_defaults_test");
         assert_eq!(config.load_balancing, "in_order");
         assert_eq!(config.first_offset, None);
@@ -110,15 +78,20 @@ mod tests {
 
     #[test]
     fn test_load_balancing_config_overrides() {
-        crate::testutils::initialize_python();
-        patch_str_config_for_test(
-            "clickhouse_load_balancing:lb_overrides_test",
-            Some("first_or_random"),
-        );
-        patch_str_config_for_test(
-            "clickhouse_load_balancing_first_offset:lb_overrides_test",
-            Some("1"),
-        );
+        init_options();
+        let _guard = override_options(&[
+            (
+                "snuba",
+                "clickhouse_load_balancing",
+                json!({ "lb_overrides_test": "first_or_random" }),
+            ),
+            (
+                "snuba",
+                "clickhouse_load_balancing_first_offset",
+                json!({ "lb_overrides_test": "1" }),
+            ),
+        ])
+        .unwrap();
 
         let config = get_load_balancing_config("lb_overrides_test");
         assert_eq!(config.load_balancing, "first_or_random");

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -414,7 +414,16 @@ fn lz4_compress(input: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sentry_options::init_with_schemas;
+    use sentry_options::testing::override_options;
+    use serde_json::json;
+    use std::sync::Once;
     use tokio::time::Instant;
+
+    static INIT: Once = Once::new();
+    fn init_options() {
+        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
+    }
 
     fn make_test_config() -> ClickhouseConfig {
         ClickhouseConfig {
@@ -463,6 +472,7 @@ mod tests {
     #[test]
     fn test_url_with_runtime_config_override() {
         crate::testutils::initialize_python();
+        init_options();
         let config = make_test_config();
         let client = ClickhouseClient::new(
             &config,
@@ -478,14 +488,19 @@ mod tests {
         assert!(!url.contains("load_balancing_first_offset"));
 
         // Override to first_or_random with offset
-        crate::runtime_config::patch_str_config_for_test(
-            "clickhouse_load_balancing:writer_v2_lb_test",
-            Some("first_or_random"),
-        );
-        crate::runtime_config::patch_str_config_for_test(
-            "clickhouse_load_balancing_first_offset:writer_v2_lb_test",
-            Some("1"),
-        );
+        let _guard = override_options(&[
+            (
+                "snuba",
+                "clickhouse_load_balancing",
+                json!({ "writer_v2_lb_test": "first_or_random" }),
+            ),
+            (
+                "snuba",
+                "clickhouse_load_balancing_first_offset",
+                json!({ "writer_v2_lb_test": "1" }),
+            ),
+        ])
+        .unwrap();
 
         let url = client.build_url();
         assert!(url.contains("load_balancing=first_or_random"));
@@ -495,6 +510,7 @@ mod tests {
     #[test]
     fn test_url_with_max_insert_block_size() {
         crate::testutils::initialize_python();
+        init_options();
         let config = make_test_config();
         let client = ClickhouseClient::new(
             &config,
@@ -503,20 +519,6 @@ mod tests {
             InsertFormat::JsonEachRow,
             None,
         );
-
-        // Default (key absent): no suffix.
-        let url = client.build_url();
-        assert!(!url.contains("max_insert_block_size"));
-
-        // Per-storage override at or above the ClickHouse default sets the suffix.
-        crate::runtime_config::patch_str_config_for_test(
-            "clickhouse_max_insert_block_size:writer_v2_block_size_test",
-            Some("2000000"),
-        );
-        let url = client.build_url();
-        assert!(url.contains("&max_insert_block_size=2000000"));
-
-        // A different storage isn't affected.
         let other_client = ClickhouseClient::new(
             &config,
             "test_table",
@@ -524,24 +526,48 @@ mod tests {
             InsertFormat::JsonEachRow,
             None,
         );
-        let url = other_client.build_url();
-        assert!(!url.contains("max_insert_block_size"));
+
+        // Default (key absent): no suffix.
+        assert!(!client.build_url().contains("max_insert_block_size"));
+
+        // Per-storage override at or above the ClickHouse default sets the suffix.
+        {
+            let _guard = override_options(&[(
+                "snuba",
+                "clickhouse_max_insert_block_size",
+                json!({ "writer_v2_block_size_test": 2_000_000 }),
+            )])
+            .unwrap();
+            assert!(client
+                .build_url()
+                .contains("&max_insert_block_size=2000000"));
+            // A different storage isn't affected.
+            assert!(!other_client.build_url().contains("max_insert_block_size"));
+        }
 
         // Values below the ClickHouse default (1_048_449) are rejected.
-        crate::runtime_config::patch_str_config_for_test(
-            "clickhouse_max_insert_block_size:writer_v2_block_size_test",
-            Some("1000000"),
-        );
-        let url = client.build_url();
-        assert!(!url.contains("max_insert_block_size"));
+        {
+            let _guard = override_options(&[(
+                "snuba",
+                "clickhouse_max_insert_block_size",
+                json!({ "writer_v2_block_size_test": 1_000_000 }),
+            )])
+            .unwrap();
+            assert!(!client.build_url().contains("max_insert_block_size"));
+        }
 
         // Exactly the default is accepted.
-        crate::runtime_config::patch_str_config_for_test(
-            "clickhouse_max_insert_block_size:writer_v2_block_size_test",
-            Some("1048449"),
-        );
-        let url = client.build_url();
-        assert!(url.contains("&max_insert_block_size=1048449"));
+        {
+            let _guard = override_options(&[(
+                "snuba",
+                "clickhouse_max_insert_block_size",
+                json!({ "writer_v2_block_size_test": 1_048_449 }),
+            )])
+            .unwrap();
+            assert!(client
+                .build_url()
+                .contains("&max_insert_block_size=1048449"));
+        }
     }
 
     /// Walks a buffer of concatenated ClickHouse-native compressed blocks,

--- a/rust_snuba/src/strategies/healthcheck.rs
+++ b/rust_snuba/src/strategies/healthcheck.rs
@@ -7,7 +7,7 @@ use sentry_arroyo::processing::strategies::{
 };
 use sentry_arroyo::types::Message;
 
-use crate::runtime_config::get_str_config;
+use sentry_options::options;
 
 const TOUCH_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -57,11 +57,11 @@ where
     fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
         let poll_result = self.next_step.poll();
 
-        if get_str_config("experimental_healthcheck")
+        if options("snuba")
             .ok()
-            .flatten()
-            .unwrap_or("0".to_string())
-            == "1"
+            .and_then(|o| o.get("experimental_healthcheck").ok())
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
         {
             // If we are receiving a commit request, it means we are making progress and this can be considered a healthy state
             if let Ok(Some(_commit_request)) = poll_result.as_ref() {
@@ -97,15 +97,23 @@ where
 #[cfg(test)]
 mod tests {
     use super::HealthCheck;
-    use crate::runtime_config::patch_str_config_for_test;
     use sentry_arroyo::processing::strategies::{
         CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
     };
     use sentry_arroyo::types::Message;
+    use sentry_options::init_with_schemas;
+    use sentry_options::testing::override_options;
+    use serde_json::json;
     use std::collections::HashMap;
     use std::fs;
     use std::path::Path;
+    use std::sync::Once;
     use std::time::Duration;
+
+    static INIT: Once = Once::new();
+    fn init_config() {
+        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
+    }
 
     // Mock strategy that can be configured to return commit requests
     struct MockStrategy {
@@ -148,7 +156,9 @@ mod tests {
     #[test]
     fn test_file_created_when_making_progress() {
         // Setup
-        patch_str_config_for_test("experimental_healthcheck", Some("1"));
+        init_config();
+        let _guard =
+            override_options(&[("snuba", "experimental_healthcheck", json!(true))]).unwrap();
         let file_path = format!("/tmp/healthcheck_test_{}", uuid::Uuid::new_v4());
 
         // Create a mock strategy that returns a commit request
@@ -167,7 +177,9 @@ mod tests {
     #[test]
     fn test_not_making_progress() {
         // Setup
-        patch_str_config_for_test("experimental_healthcheck", Some("1"));
+        init_config();
+        let _guard =
+            override_options(&[("snuba", "experimental_healthcheck", json!(true))]).unwrap();
         let file_path = format!("/tmp/healthcheck_test_{}", uuid::Uuid::new_v4());
 
         // Create a mock strategy that doesn't return a commit request

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -26,6 +26,61 @@
       "type": "integer",
       "default": 120,
       "description": "BLQ hysteresis in seconds. Once routing stale, keep routing messages at least (stale_threshold - static_friction) old. Set to 0 to disable friction."
+    },
+    "eap_items_drop_invalid_timestamps": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the eap-items consumer skips messages whose event timestamp is more than one week in the future or more than thirty days in the past."
+    },
+    "experimental_healthcheck": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the consumer healthcheck strategy treats commit requests (progress) as healthy and touches the healthcheck file accordingly."
+    },
+    "generic_metrics_use_case_killswitch": {
+      "type": "string",
+      "default": "",
+      "description": "Substring-matched list of generic-metrics use case ids to drop in the consumer; a message is skipped when its use_case_id appears in this string."
+    },
+    "clickhouse_load_balancing": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Dict mapping storage name to the ClickHouse load_balancing mode (e.g. \"in_order\", \"first_or_random\") used by that storage's consumer writer. Storages with no entry default to \"in_order\". Migrated from per-storage runtime config clickhouse_load_balancing:<storage>."
+    },
+    "clickhouse_load_balancing_first_offset": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Dict mapping storage name to the first_offset used with the first_or_random load_balancing mode. Storages with no entry have no first_offset. Migrated from per-storage runtime config clickhouse_load_balancing_first_offset:<storage>."
+    },
+    "clickhouse_max_insert_block_size": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "default": {},
+      "description": "Dict mapping storage name to a max_insert_block_size override for that storage's INSERTs. Values below ClickHouse's default (1048449) are ignored. Storages with no entry use the server default. Migrated from per-storage runtime config clickhouse_max_insert_block_size:<storage>."
+    },
+    "eap_items_dlq_grace_period_min": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "default": {},
+      "description": "Dict mapping storage name to a grace period in minutes; eap-items messages from before the current partition older than this are routed to the DLQ. Storages with no entry have no grace-period dropping. Migrated from per-storage runtime config eap_items_dlq_grace_period_min:<storage>."
+    },
+    "quantized_rebalance_consumer_group_delay_secs": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "default": {},
+      "description": "Dict mapping consumer group name to a quantized rebalance delay in seconds. Consumer groups with no entry use no delay. Migrated from per-group runtime config quantized_rebalance_consumer_group_delay_secs__<consumer_group>."
     }
   }
 }


### PR DESCRIPTION
## What

First slice of the runtime-config → sentry-options migration (splitting #8096 into reviewable, module-scoped PRs per review feedback). This PR is the **Rust consumer** slice and is fully self-contained — it touches only `rust_snuba/src/**` and the option schema, with no Python changes.

It migrates the Rust consumers' runtime-config reads from the PyO3 round-trip into Python/Redis (`runtime_config::get_str_config`) to native sentry-options reads via `options("snuba")` — the same client `blq_router.rs` already uses.

## Keys migrated

Schema type/default match the prior `get_str_config` parse + default, so behavior is unchanged until a value is set in sentry-options-automator.

| key | type | file |
|---|---|---|
| `eap_items_drop_invalid_timestamps` | boolean | `processors/eap_items.rs` |
| `eap_items_dlq_grace_period_min` | object (map) | `processors/utils.rs` |
| `generic_metrics_use_case_killswitch` | string | `processors/generic_metrics.rs` |
| `experimental_healthcheck` | boolean | `strategies/healthcheck.rs` |
| `quantized_rebalance_consumer_group_delay_secs` | object (map) | `rebalancing.rs` |
| `clickhouse_load_balancing` | object (map) | `strategies/clickhouse/writer_v2.rs` |
| `clickhouse_load_balancing_first_offset` | object (map) | `strategies/clickhouse/writer_v2.rs` |
| `clickhouse_max_insert_block_size` | object (map) | `strategies/clickhouse/writer_v2.rs` |

Dynamically-named per-storage / per-consumer-group keys (e.g. `clickhouse_load_balancing:<storage>`) collapse into a single **map option** keyed by the dynamic suffix, since sentry-options requires a static schema.

## Cleanup

The now-dead `get_str_config` / `patch_str_config_for_test` helpers and their PyO3 plumbing are removed from `runtime_config.rs`. Tests that toggled these via `patch_str_config_for_test(...)` now use `sentry_options::testing::override_options(...)`.

## Verification

- `cargo +stable fmt --check` ✓, `cargo check` ✓, `cargo clippy --all-targets` ✓ (no new warnings).
- `cargo test --lib`: 165 unit tests pass. The migrated-read tests (`writer_v2::tests::test_url_with_max_insert_block_size`, `test_url_with_runtime_config_override`) pass. The remaining failures (`it_works`, `test_row_binary_clickhouse_insert`, `test_python`) are ClickHouse / Python-multiprocessing tests that need infra not present in the local sandbox — they build the correct URL/config first (e.g. `load_balancing=in_order` from the migrated default) and only fail at the network step; CI provides ClickHouse + the Python bootstrap.

## Operational note

After cutover these keys are read-only from the Rust consumers and edited in sentry-options-automator (not the admin UI). The Rust consumer pods already mount the options ConfigMap. Set any current production overrides in automator before this lands; effective defaults are otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2Cu68uGZRcCVS14jcyd3E)_