### PR TITLE
ref(options): migrate rate-limit runtime config to sentry-options

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -296,6 +296,51 @@
       "type": "integer",
       "default": 1,
       "description": "Number of shards each rate-limit Redis set is split into. Increasing it multiplies the number of Redis keys and reduces the size of each set. Migrated from runtime config rate_limit_shard_factor."
+    },
+    "mandatory_condition_enforce": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, queries missing mandatory condition columns raise an assertion; otherwise the omission is only logged."
+    },
+    "skip_final_subscriptions_projects": {
+      "type": "string",
+      "default": "[]",
+      "description": "Bracketed comma-separated list of project ids for which subscription queries skip the FINAL keyword."
+    },
+    "post_replacement_consistency_projects_denylist": {
+      "type": "string",
+      "default": "[]",
+      "description": "Bracketed comma-separated list of project ids that are forced to FINAL after a replacement."
+    },
+    "max_group_ids_exclude": {
+      "type": "integer",
+      "default": 256,
+      "description": "Maximum number of group ids excluded from a query before it falls back to FINAL instead of an exclusion set."
+    },
+    "skip_seen_offsets": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the replacer skips replacement messages whose offset has already been seen."
+    },
+    "consumer_groups_to_reset_offset_check": {
+      "type": "string",
+      "default": "[]",
+      "description": "Bracketed comma-separated list of consumer groups whose replacer offset-seen check should be reset."
+    },
+    "write_node_replacements_global": {
+      "type": "number",
+      "default": 1.0,
+      "description": "Probability [0,1] that a replacement is written to every storage node rather than only the distributed table."
+    },
+    "replacements_bypass_projects": {
+      "type": "string",
+      "default": "[]",
+      "description": "JSON array of project ids for which error replacements are skipped."
+    },
+    "replacements_expiry_window_minutes": {
+      "type": "integer",
+      "default": 5,
+      "description": "Window in minutes for which a project that recently received replacements is kept in the auto-replacements bypass set. Migrated from runtime config replacements_expiry_window_minutes."
     }
   }
 }

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -258,6 +258,44 @@
       },
       "default": {},
       "description": "Dict mapping an outcomes-based routing strategy class name to the minimum query time range in seconds for which outcomes are queried. Strategies with no entry use 14400 (4 hours). Migrated from per-strategy runtime config <ClassName>.min_timerange_to_query_outcomes."
+    },
+    "project_quota_time_percentage": {
+      "type": "number",
+      "default": 1.0,
+      "description": "Fraction of the counter window a project may spend on replacements before it is reported as exceeding the time limit."
+    },
+    "counter_window_size_minutes": {
+      "type": "integer",
+      "default": 10,
+      "description": "Size in minutes of the rolling window the replacement bucket timer uses to track per-project processing time."
+    },
+    "allows_skipping_single_project_replacements": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, a single project that exceeds the replacement time limit can be skipped (otherwise only multi-project groups are skipped)."
+    },
+    "mem_rate_limit_per_sec": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "number"
+      },
+      "default": {},
+      "description": "Dict mapping in-process rate-limit bucket name to a maximum operations-per-second. Buckets with no entry are unlimited (rate limiter off). Migrated from per-bucket runtime config mem_rate_limit_per_sec_<bucket>."
+    },
+    "bypass_rate_limit": {
+      "type": "integer",
+      "default": 0,
+      "description": "When set to 1, all Redis-backed rate limits are bypassed (no limiting applied). Migrated from runtime config bypass_rate_limit."
+    },
+    "rate_history_sec": {
+      "type": "integer",
+      "default": 3600,
+      "description": "Number of seconds the rate limiter keeps per-request timestamps in its Redis sorted set. Migrated from runtime config rate_history_sec."
+    },
+    "rate_limit_shard_factor": {
+      "type": "integer",
+      "default": 1,
+      "description": "Number of shards each rate-limit Redis set is split into. Increasing it multiplies the number of Redis keys and reduces the size of each set. Migrated from runtime config rate_limit_shard_factor."
     }
   }
 }

--- a/snuba/query/processors/physical/conditions_enforcer.py
+++ b/snuba/query/processors/physical/conditions_enforcer.py
@@ -6,7 +6,7 @@ from snuba.query.conditions import get_first_level_and_conditions
 from snuba.query.processors.condition_checkers import ConditionChecker
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
-from snuba.state import get_config
+from snuba.state.sentry_options import get_option
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class MandatoryConditionEnforcer(ClickhouseQueryProcessor):
             inspect_expression(prewhere)
 
         missing_ids = {checker.get_id() for checker in missing_checkers}
-        if get_config("mandatory_condition_enforce", 0):
+        if get_option("mandatory_condition_enforce", False):
             assert not missing_checkers, (
                 f"Missing mandatory columns in query. Missing {missing_ids}"
             )

--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -14,7 +14,7 @@ from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings, SubscriptionQuerySettings
 from snuba.replacers.projects_query_flags import ProjectsQueryFlags
 from snuba.replacers.replacer_processor import ReplacerState
-from snuba.state import get_config
+from snuba.state.sentry_options import get_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "processors.replaced_groups")
@@ -52,7 +52,7 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
             return
 
         for no_final_subscriptions_project in (
-            get_config("skip_final_subscriptions_projects") or "[]"
+            get_option("skip_final_subscriptions_projects", "[]")
         )[1:-1].split(","):
             if (
                 no_final_subscriptions_project
@@ -64,7 +64,7 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
                 return
 
         for denied_project_id_string in (
-            get_config("post_replacement_consistency_projects_denylist") or "[]"
+            get_option("post_replacement_consistency_projects_denylist", "[]")
         )[1:-1].split(","):
             if denied_project_id_string and int(denied_project_id_string) in project_ids:
                 metrics.increment(name=CONSISTENCY_DENYLIST_METRIC)
@@ -96,11 +96,9 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
         elif flags.group_ids_to_exclude:
             # If the number of groups to exclude exceeds our limit, the query
             # should just use final instead of the exclusion set.
-            max_group_ids_exclude = get_config(
-                "max_group_ids_exclude",
-                settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE,
+            max_group_ids_exclude = get_option(
+                "max_group_ids_exclude", settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE
             )
-            assert isinstance(max_group_ids_exclude, int)
             groups_to_exclude = self._groups_to_exclude(query, flags.group_ids_to_exclude)
             if (
                 len(flags.group_ids_to_exclude) > 2 * max_group_ids_exclude

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -42,7 +42,7 @@ from snuba.replacers.replacer_processor import (
     ReplacementMessage,
     ReplacementMessageMetadata,
 )
-from snuba.state import get_int_config, get_str_config
+from snuba.state.sentry_options import get_option
 from snuba.utils.bucket_timer import Counter
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.rate_limiter import RateLimiter
@@ -416,7 +416,7 @@ class ReplacerWorker:
                     "offset": metadata.offset,
                 },
             )
-            if get_int_config("skip_seen_offsets"):
+            if get_option("skip_seen_offsets", False):
                 return None
         seq_message = json.loads(message.payload.value)
         [version, action_type, data] = seq_message
@@ -522,7 +522,7 @@ class ReplacerWorker:
         temporarily, then cleared once relevant consumers restart.
         """
         # expected format is "[consumer_group1,consumer_group2,..]"
-        consumer_groups = (get_str_config(RESET_CHECK_CONFIG) or "[]")[1:-1].split(",")
+        consumer_groups = (get_option(RESET_CHECK_CONFIG, "[]"))[1:-1].split(",")
         if self.__consumer_group in consumer_groups:
             self.__last_offset_processed_per_partition[key] = -1
             redis_client.delete(key)

--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -47,7 +47,7 @@ from snuba.replacers.replacer_processor import (
     ReplacerProcessor,
     ReplacerState,
 )
-from snuba.state import get_config, get_float_config
+from snuba.state.sentry_options import get_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 """
@@ -101,8 +101,7 @@ class Replacement(ReplacementBase):
         raise NotImplementedError()
 
     def should_write_every_node(self) -> bool:
-        write_node_replacement_setting = get_float_config("write_node_replacements_global", 1.0)
-        assert isinstance(write_node_replacement_setting, float)
+        write_node_replacement_setting = get_option("write_node_replacements_global", 1.0)
         return random.random() < write_node_replacement_setting
 
 
@@ -180,7 +179,7 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
             raise InvalidMessageType(f"Invalid message type: {type_}")
 
         if processed is not None:
-            manual_bypass_projects = get_config("replacements_bypass_projects", "[]")
+            manual_bypass_projects = get_option("replacements_bypass_projects", "[]")
             auto_bypass_projects = list(
                 get_config_auto_replacements_bypass_projects(datetime.now()).keys()
             )

--- a/snuba/replacers/projects_query_flags.py
+++ b/snuba/replacers/projects_query_flags.py
@@ -14,7 +14,7 @@ from snuba import settings
 from snuba.processor import ReplacementType
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.replacers.replacer_processor import ReplacerState
-from snuba.state import get_config
+from snuba.state.sentry_options import get_option
 
 redis_client = get_redis_client(RedisClientKey.REPLACEMENTS_STORE)
 
@@ -83,11 +83,9 @@ class ProjectsQueryFlags:
             # the redis key size limit is defined as 2 times the clickhouse query size
             # limit. there is an explicit check in the query processor for the same
             # limit
-            max_group_ids_exclude = get_config(
-                "max_group_ids_exclude",
-                settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE,
+            max_group_ids_exclude = get_option(
+                "max_group_ids_exclude", settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE
             )
-            assert isinstance(max_group_ids_exclude, int)
 
             group_id_data: MutableMapping[str | bytes, bytes | float | int | str] = {}
             for group_id in group_ids:

--- a/snuba/replacers/replacements_and_expiry.py
+++ b/snuba/replacers/replacements_and_expiry.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import logging
 import time
-import typing
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 
 from snuba import environment
 from snuba.redis import RedisClientKey, get_redis_client
-from snuba.state import get_int_config
+from snuba.state.sentry_options import get_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger(__name__)
@@ -29,9 +28,7 @@ def set_config_auto_replacements_bypass_projects(
     try:
         projects_within_expiry = get_config_auto_replacements_bypass_projects(curr_time)
         start = time.time()
-        expiry_window = typing.cast(
-            int, get_int_config(key=REPLACEMENTS_EXPIRY_WINDOW_MINUTES_KEY, default=5)
-        )
+        expiry_window = get_option(REPLACEMENTS_EXPIRY_WINDOW_MINUTES_KEY, 5)
         with redis_client.pipeline() as pipeline:
             for project_id in new_project_ids:
                 if project_id not in projects_within_expiry:

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -17,6 +17,7 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 from snuba import environment, state
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.state import get_configs, set_config
+from snuba.state.sentry_options import get_int_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.serializable_exception import SerializableException
 
@@ -347,24 +348,14 @@ def rate_limit(
             # will raise RateLimitExceeded if the rate limit is exceeded
 
     """
-    (
-        bypass_rate_limit,
-        rate_history_s,
-        rate_limit_shard_factor,
-    ) = state.get_configs(
-        [
-            # bool (0/1) flag to disable rate limits altogether
-            ("bypass_rate_limit", 0),
-            # number of seconds the timestamps are kept
-            ("rate_history_sec", 3600),
-            # number of shards that each redis set is supposed to have.
-            # increasing this value multiplies the number of redis keys by that
-            # factor, and (on average) reduces the size of each redis set
-            ("rate_limit_shard_factor", 1),
-        ]
-    )
-    assert isinstance(rate_history_s, int)
-    assert isinstance(rate_limit_shard_factor, int)
+    # bool (0/1) flag to disable rate limits altogether
+    bypass_rate_limit = get_int_option("bypass_rate_limit", 0)
+    # number of seconds the timestamps are kept
+    rate_history_s = get_int_option("rate_history_sec", 3600)
+    # number of shards that each redis set is supposed to have. increasing this
+    # value multiplies the number of redis keys by that factor, and (on average)
+    # reduces the size of each redis set
+    rate_limit_shard_factor = get_int_option("rate_limit_shard_factor", 1)
     assert rate_limit_shard_factor > 0
 
     if bypass_rate_limit == 1:

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -351,11 +351,11 @@ def rate_limit(
     # bool (0/1) flag to disable rate limits altogether
     bypass_rate_limit = get_option("bypass_rate_limit", 0)
     # number of seconds the timestamps are kept
-    rate_history_s = cast(int, get_option("rate_history_sec", 3600))
+    rate_history_s = get_option("rate_history_sec", 3600)
     # number of shards that each redis set is supposed to have. increasing this
     # value multiplies the number of redis keys by that factor, and (on average)
     # reduces the size of each redis set
-    rate_limit_shard_factor = cast(int, get_option("rate_limit_shard_factor", 1))
+    rate_limit_shard_factor = get_option("rate_limit_shard_factor", 1)
     assert rate_limit_shard_factor > 0
 
     if bypass_rate_limit == 1:

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -17,7 +17,7 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 from snuba import environment, state
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.state import get_configs, set_config
-from snuba.state.sentry_options import get_int_option
+from snuba.state.sentry_options import get_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.serializable_exception import SerializableException
 
@@ -349,13 +349,13 @@ def rate_limit(
 
     """
     # bool (0/1) flag to disable rate limits altogether
-    bypass_rate_limit = get_int_option("bypass_rate_limit", 0)
+    bypass_rate_limit = get_option("bypass_rate_limit", 0)
     # number of seconds the timestamps are kept
-    rate_history_s = get_int_option("rate_history_sec", 3600)
+    rate_history_s = cast(int, get_option("rate_history_sec", 3600))
     # number of shards that each redis set is supposed to have. increasing this
     # value multiplies the number of redis keys by that factor, and (on average)
     # reduces the size of each redis set
-    rate_limit_shard_factor = get_int_option("rate_limit_shard_factor", 1)
+    rate_limit_shard_factor = cast(int, get_option("rate_limit_shard_factor", 1))
     assert rate_limit_shard_factor > 0
 
     if bypass_rate_limit == 1:

--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import typing
 from collections import defaultdict
 from collections.abc import MutableMapping
 from datetime import datetime, timedelta
 
-from snuba import environment, state
-from snuba.state import get_int_config
+from snuba import environment
+from snuba.state.sentry_options import get_bool_option, get_float_option, get_int_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "bucket_timer")
@@ -37,11 +36,8 @@ class Counter:
         self.consumer_group: str = consumer_group
         self.buckets: Buckets = {}
 
-        percentage = state.get_config("project_quota_time_percentage", 1.0)
-        assert isinstance(percentage, float)
-        counter_window_size_minutes = typing.cast(
-            int, get_int_config(key="counter_window_size_minutes", default=10)
-        )
+        percentage = get_float_option("project_quota_time_percentage", 1.0)
+        counter_window_size_minutes = get_int_option("counter_window_size_minutes", 10)
         self.counter_window_size = timedelta(minutes=counter_window_size_minutes)
         self.limit = self.counter_window_size * percentage
 
@@ -92,7 +88,7 @@ class Counter:
         for project_id, total_processing_time in project_groups.items():
             if total_processing_time > self.limit and (
                 len(project_groups) > 1
-                or get_int_config("allows_skipping_single_project_replacements", default=0)
+                or get_bool_option("allows_skipping_single_project_replacements", False)
             ):
                 projects_exceeding_time_limit.append(project_id)
 

--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import MutableMapping
 from datetime import datetime, timedelta
+from typing import cast
 
 from snuba import environment
-from snuba.state.sentry_options import get_bool_option, get_float_option, get_int_option
+from snuba.state.sentry_options import get_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "bucket_timer")
@@ -36,8 +37,8 @@ class Counter:
         self.consumer_group: str = consumer_group
         self.buckets: Buckets = {}
 
-        percentage = get_float_option("project_quota_time_percentage", 1.0)
-        counter_window_size_minutes = get_int_option("counter_window_size_minutes", 10)
+        percentage = cast(float, get_option("project_quota_time_percentage", 1.0))
+        counter_window_size_minutes = cast(int, get_option("counter_window_size_minutes", 10))
         self.counter_window_size = timedelta(minutes=counter_window_size_minutes)
         self.limit = self.counter_window_size * percentage
 
@@ -88,7 +89,7 @@ class Counter:
         for project_id, total_processing_time in project_groups.items():
             if total_processing_time > self.limit and (
                 len(project_groups) > 1
-                or get_bool_option("allows_skipping_single_project_replacements", False)
+                or get_option("allows_skipping_single_project_replacements", False)
             ):
                 projects_exceeding_time_limit.append(project_id)
 

--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import MutableMapping
 from datetime import datetime, timedelta
-from typing import cast
 
 from snuba import environment
 from snuba.state.sentry_options import get_option
@@ -37,8 +36,8 @@ class Counter:
         self.consumer_group: str = consumer_group
         self.buckets: Buckets = {}
 
-        percentage = cast(float, get_option("project_quota_time_percentage", 1.0))
-        counter_window_size_minutes = cast(int, get_option("counter_window_size_minutes", 10))
+        percentage = get_option("project_quota_time_percentage", 1.0)
+        counter_window_size_minutes = get_option("counter_window_size_minutes", 10)
         self.counter_window_size = timedelta(minutes=counter_window_size_minutes)
         self.limit = self.counter_window_size * percentage
 

--- a/snuba/utils/rate_limiter.py
+++ b/snuba/utils/rate_limiter.py
@@ -5,9 +5,12 @@ from enum import Enum
 from threading import Lock
 from typing import Any
 
-from snuba import state
+from snuba.state.sentry_options import get_mapped_float_option
 
-RATE_LIMIT_PER_SEC_KEY_PREFIX = "mem_rate_limit_per_sec_"
+# sentry-options dict option whose keys are rate-limit bucket names and whose
+# values are the per-bucket max operations-per-second. Migrated from the
+# per-bucket runtime config keys "mem_rate_limit_per_sec_<bucket>".
+RATE_LIMIT_PER_SEC_OPTION = "mem_rate_limit_per_sec"
 
 
 class RateLimitResult(Enum):
@@ -39,7 +42,7 @@ class RateLimiter:
 
     def __enter__(self) -> tuple[RateLimitResult, int]:
         limit = (
-            state.get_config(f"{RATE_LIMIT_PER_SEC_KEY_PREFIX}{self.__bucket}", None)
+            get_mapped_float_option(RATE_LIMIT_PER_SEC_OPTION, self.__bucket, 0.0)
             if not self.__max_rate_per_sec
             else self.__max_rate_per_sec
         )

--- a/snuba/utils/rate_limiter.py
+++ b/snuba/utils/rate_limiter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from enum import Enum
 from threading import Lock
-from typing import Any, cast
+from typing import Any
 
 from snuba.state.sentry_options import get_mapped_option
 
@@ -42,7 +42,7 @@ class RateLimiter:
 
     def __enter__(self) -> tuple[RateLimitResult, int]:
         limit = (
-            cast(float, get_mapped_option(RATE_LIMIT_PER_SEC_OPTION, self.__bucket, 0.0))
+            (get_mapped_option(RATE_LIMIT_PER_SEC_OPTION, self.__bucket, 0.0))
             if not self.__max_rate_per_sec
             else self.__max_rate_per_sec
         )

--- a/snuba/utils/rate_limiter.py
+++ b/snuba/utils/rate_limiter.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import time
 from enum import Enum
 from threading import Lock
-from typing import Any
+from typing import Any, cast
 
-from snuba.state.sentry_options import get_mapped_float_option
+from snuba.state.sentry_options import get_mapped_option
 
 # sentry-options dict option whose keys are rate-limit bucket names and whose
 # values are the per-bucket max operations-per-second. Migrated from the
@@ -42,7 +42,7 @@ class RateLimiter:
 
     def __enter__(self) -> tuple[RateLimitResult, int]:
         limit = (
-            get_mapped_float_option(RATE_LIMIT_PER_SEC_OPTION, self.__bucket, 0.0)
+            cast(float, get_mapped_option(RATE_LIMIT_PER_SEC_OPTION, self.__bucket, 0.0))
             if not self.__max_rate_per_sec
             else self.__max_rate_per_sec
         )

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 
 import pytest
+from sentry_options.testing import override_options
 
-from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.storages.storage_key import StorageKey
@@ -139,7 +139,7 @@ def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> No
     )
 
     query_settings = HTTPQuerySettings()
-    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS).process_query(
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
         query, query_settings
     )
 
@@ -166,22 +166,22 @@ def test_remove_final_subscriptions(query: ClickhouseQuery) -> None:
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
-    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS).process_query(
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
         query, SubscriptionQuerySettings()
     )
     assert query.get_condition() == build_in("project_id", [2])
     assert query.get_from_clause().final
 
-    state.set_config("skip_final_subscriptions_projects", "[2,3,4]")
-    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS).process_query(
-        query, SubscriptionQuerySettings()
-    )
-    assert not query.get_from_clause().final
+    with override_options("snuba", {"skip_final_subscriptions_projects": "[2,3,4]"}):
+        PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+            query, SubscriptionQuerySettings()
+        )
+        assert not query.get_from_clause().final
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 5})
 def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
-    state.set_config("max_group_ids_exclude", 5)
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
@@ -189,7 +189,7 @@ def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
-    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS).process_query(
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
         query, HTTPQuerySettings()
     )
 
@@ -216,8 +216,8 @@ def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 2})
 def test_too_many_groups_to_exclude(query: ClickhouseQuery) -> None:
-    state.set_config("max_group_ids_exclude", 2)
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
@@ -225,7 +225,7 @@ def test_too_many_groups_to_exclude(query: ClickhouseQuery) -> None:
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
-    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS).process_query(
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
         query, HTTPQuerySettings()
     )
 
@@ -234,12 +234,13 @@ def test_too_many_groups_to_exclude(query: ClickhouseQuery) -> None:
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 2})
 def test_query_overlaps_replacements_processor(
     query: ClickhouseQuery,
     query_with_timestamp: ClickhouseQuery,
     query_with_future_timestamp: ClickhouseQuery,
 ) -> None:
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     # replacement time unknown, default to "overlaps" but no groups to exclude so shouldn't be final
     enforcer._set_query_final(query_with_timestamp, True)
@@ -247,7 +248,6 @@ def test_query_overlaps_replacements_processor(
     assert not query_with_timestamp.get_from_clause().final
 
     # overlaps replacement and should be final due to too many groups to exclude
-    state.set_config("max_group_ids_exclude", 2)
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
@@ -270,12 +270,13 @@ def test_query_overlaps_replacements_processor(
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 2})
 def test_single_no_replacements(query_with_single_group_id: ClickhouseQuery) -> None:
     """
     Query is looking for a group that has not been replaced, but the project itself
     has replacements.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -285,7 +286,6 @@ def test_single_no_replacements(query_with_single_group_id: ClickhouseQuery) -> 
     )
 
     enforcer._set_query_final(query_with_single_group_id, True)
-    state.set_config("max_group_ids_exclude", 2)
 
     enforcer.process_query(query_with_single_group_id, HTTPQuerySettings())
     assert query_with_single_group_id.get_condition() == build_and(
@@ -295,12 +295,13 @@ def test_single_no_replacements(query_with_single_group_id: ClickhouseQuery) -> 
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 2})
 def test_single_too_many_exclude(query_with_single_group_id: ClickhouseQuery) -> None:
     """
     Query is looking for a group that has been replaced, and there are too many
     groups to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -310,7 +311,6 @@ def test_single_too_many_exclude(query_with_single_group_id: ClickhouseQuery) ->
     )
 
     enforcer._set_query_final(query_with_single_group_id, True)
-    state.set_config("max_group_ids_exclude", 2)
 
     enforcer.process_query(query_with_single_group_id, HTTPQuerySettings())
     assert query_with_single_group_id.get_condition() == build_and(
@@ -321,6 +321,7 @@ def test_single_too_many_exclude(query_with_single_group_id: ClickhouseQuery) ->
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 5})
 def test_single_not_too_many_exclude(
     query_with_single_group_id: ClickhouseQuery,
 ) -> None:
@@ -328,7 +329,7 @@ def test_single_not_too_many_exclude(
     Query is looking for a group that has been replaced, and there are not too many
     groups to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -338,7 +339,6 @@ def test_single_not_too_many_exclude(
     )
 
     enforcer._set_query_final(query_with_single_group_id, True)
-    state.set_config("max_group_ids_exclude", 5)
 
     enforcer.process_query(query_with_single_group_id, HTTPQuerySettings())
     assert query_with_single_group_id.get_condition() == build_and(
@@ -349,6 +349,7 @@ def test_single_not_too_many_exclude(
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 5})
 def test_multiple_disjoint_replaced(
     query_with_multiple_group_ids: ClickhouseQuery,
 ) -> None:
@@ -356,7 +357,7 @@ def test_multiple_disjoint_replaced(
     Query is looking for multiple groups and there are replaced groups, but these
     sets of group ids are disjoint. (No queried groups have been replaced)
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -366,7 +367,6 @@ def test_multiple_disjoint_replaced(
     )
 
     enforcer._set_query_final(query_with_multiple_group_ids, True)
-    state.set_config("max_group_ids_exclude", 5)
 
     enforcer.process_query(query_with_multiple_group_ids, HTTPQuerySettings())
     assert query_with_multiple_group_ids.get_condition() == build_and(
@@ -376,6 +376,7 @@ def test_multiple_disjoint_replaced(
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 5})
 def test_multiple_fewer_exclude_than_queried(
     query_with_multiple_group_ids: ClickhouseQuery,
 ) -> None:
@@ -383,7 +384,7 @@ def test_multiple_fewer_exclude_than_queried(
     Query is looking for multiple groups and there are replaced groups, but there
     are fewer excluded groups than queried groups.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -393,7 +394,6 @@ def test_multiple_fewer_exclude_than_queried(
     )
 
     enforcer._set_query_final(query_with_multiple_group_ids, True)
-    state.set_config("max_group_ids_exclude", 5)
 
     enforcer.process_query(query_with_multiple_group_ids, HTTPQuerySettings())
     assert query_with_multiple_group_ids.get_condition() == build_and(
@@ -404,6 +404,7 @@ def test_multiple_fewer_exclude_than_queried(
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 2})
 def test_multiple_too_many_excludes(
     query_with_multiple_group_ids: ClickhouseQuery,
 ) -> None:
@@ -411,7 +412,7 @@ def test_multiple_too_many_excludes(
     Query is looking for multiple groups and there are too many groups to exclude, but
     there are fewer groups queried for than replaced.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -421,7 +422,6 @@ def test_multiple_too_many_excludes(
     )
 
     enforcer._set_query_final(query_with_multiple_group_ids, True)
-    state.set_config("max_group_ids_exclude", 2)
 
     enforcer.process_query(query_with_multiple_group_ids, HTTPQuerySettings())
     assert query_with_multiple_group_ids.get_condition() == build_and(
@@ -433,6 +433,7 @@ def test_multiple_too_many_excludes(
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 5})
 def test_multiple_not_too_many_excludes(
     query_with_multiple_group_ids: ClickhouseQuery,
 ) -> None:
@@ -440,7 +441,7 @@ def test_multiple_not_too_many_excludes(
     Query is looking for multiple groups and there are not too many groups to exclude, but
     there are fewer groups queried for than replaced.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -450,7 +451,6 @@ def test_multiple_not_too_many_excludes(
     )
 
     enforcer._set_query_final(query_with_multiple_group_ids, True)
-    state.set_config("max_group_ids_exclude", 5)
 
     enforcer.process_query(query_with_multiple_group_ids, HTTPQuerySettings())
     assert query_with_multiple_group_ids.get_condition() == build_and(
@@ -461,11 +461,12 @@ def test_multiple_not_too_many_excludes(
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 3})
 def test_no_groups_not_too_many_excludes(query: ClickhouseQuery) -> None:
     """
     Query has no groups, and not too many to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -475,7 +476,6 @@ def test_no_groups_not_too_many_excludes(query: ClickhouseQuery) -> None:
     )
 
     enforcer._set_query_final(query, True)
-    state.set_config("max_group_ids_exclude", 3)
 
     enforcer.process_query(query, HTTPQuerySettings())
     assert query.get_condition() == build_and(
@@ -486,11 +486,12 @@ def test_no_groups_not_too_many_excludes(query: ClickhouseQuery) -> None:
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"max_group_ids_exclude": 1})
 def test_no_groups_too_many_excludes(query: ClickhouseQuery) -> None:
     """
     Query has no groups, and too many to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value)
 
     ProjectsQueryFlags.set_project_exclude_groups(
         2,
@@ -500,7 +501,6 @@ def test_no_groups_too_many_excludes(query: ClickhouseQuery) -> None:
     )
 
     enforcer._set_query_final(query, True)
-    state.set_config("max_group_ids_exclude", 1)
 
     enforcer.process_query(query, HTTPQuerySettings())
     assert query.get_condition() == build_in("project_id", [2])

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -9,6 +9,7 @@ import pytest
 import simplejson as json
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
+from sentry_options.testing import override_options
 
 from snuba import replacer, settings
 from snuba.clickhouse import DATETIME_FORMAT
@@ -20,7 +21,6 @@ from snuba.processor import ReplacementType
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.replacers import errors_replacer
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
-from snuba.state import delete_config, set_config
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from tests.fixtures import get_raw_event
 from tests.helpers import write_unprocessed_events
@@ -28,6 +28,11 @@ from tests.helpers import write_unprocessed_events
 redis_client = get_redis_client(RedisClientKey.REPLACEMENTS_STORE)
 
 CONSUMER_GROUP = "consumer_group"
+
+
+def _normalize_query(query: str | None) -> str:
+    assert query is not None
+    return re.sub("[\n ]+", " ", query).strip()
 
 
 class BaseTest:
@@ -93,7 +98,7 @@ class TestReplacer(BaseTest):
         run_optimize(clickhouse, self.storage, cluster.get_database())
 
     def _issue_count(self, project_id: int, group_id: int | None = None) -> Any:
-        args = {
+        args: dict[str, Any] = {
             "project": [project_id],
             "selected_columns": [],
             "aggregations": [["count()", "", "count"]],
@@ -159,6 +164,7 @@ class TestReplacer(BaseTest):
         )
 
         processed = self.replacer.process_message(message)
+        assert processed is not None
         self.replacer.flush_batch([processed])
 
         assert self._issue_count(self.project_id) == []
@@ -203,6 +209,7 @@ class TestReplacer(BaseTest):
         # the other events. Event 1 gets manually tombstoned by Sentry while
         # Event 2 prevails.
         processed = self.replacer.process_message(message)
+        assert processed is not None
         self.replacer.flush_batch([processed])
 
         # At this point the count doesn't make any sense but we don't care.
@@ -237,6 +244,7 @@ class TestReplacer(BaseTest):
         # regular group deletion, except only a subset of events have been
         # tombstoned (the ones that will *not* be reprocessed).
         processed = self.replacer.process_message(message)
+        assert processed is not None
         self.replacer.flush_batch([processed])
 
         # Group 2 should contain the one event that the user chose to
@@ -282,6 +290,7 @@ class TestReplacer(BaseTest):
         )
 
         processed = self.replacer.process_message(message)
+        assert processed is not None
         self.replacer.flush_batch([processed])
 
         assert self._issue_count(1) == [{"count": 1, "group_id": 2}]
@@ -324,12 +333,13 @@ class TestReplacer(BaseTest):
         )
 
         processed = self.replacer.process_message(message)
+        assert processed is not None
         self.replacer.flush_batch([processed])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 2}]
 
+    @override_options("snuba", {"skip_seen_offsets": True})
     def test_process_offset_twice(self) -> None:
-        set_config("skip_seen_offsets", True)
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
@@ -361,16 +371,17 @@ class TestReplacer(BaseTest):
         )
 
         processed = self.replacer.process_message(message)
+        assert processed is not None
         self.replacer.flush_batch([processed])
 
         # should be None since the offset should be in Redis, indicating it should be skipped
         assert self.replacer.process_message(message) is None
 
+    @override_options("snuba", {"skip_seen_offsets": True})
     def test_multiple_partitions(self) -> None:
         """
         Different partitions should have independent offset checks.
         """
-        set_config("skip_seen_offsets", True)
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
@@ -414,12 +425,13 @@ class TestReplacer(BaseTest):
         )
 
         processed = self.replacer.process_message(partition_one)
+        assert processed is not None
         self.replacer.flush_batch([processed])
         # different partition should be unaffected even if it's the same offset
         assert self.replacer.process_message(partition_two) is not None
 
+    @override_options("snuba", {"skip_seen_offsets": True})
     def test_reset_consumer_group_offset_check(self) -> None:
-        set_config("skip_seen_offsets", True)
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
@@ -450,18 +462,19 @@ class TestReplacer(BaseTest):
             )
         )
 
-        self.replacer.flush_batch([self.replacer.process_message(message)])
+        processed = self.replacer.process_message(message)
+        assert processed is not None
+        self.replacer.flush_batch([processed])
 
-        set_config(replacer.RESET_CHECK_CONFIG, f"[{CONSUMER_GROUP}]")
+        with override_options("snuba", {replacer.RESET_CHECK_CONFIG: f"[{CONSUMER_GROUP}]"}):
+            # Offset to check against should be reset so this message shouldn't be skipped
+            assert self.replacer.process_message(message) is not None
 
-        # Offset to check against should be reset so this message shouldn't be skipped
-        assert self.replacer.process_message(message) is not None
-
+    @override_options("snuba", {"skip_seen_offsets": True})
     def test_offset_already_processed(self) -> None:
         """
         Don't process an offset that already exists in Redis.
         """
-        set_config("skip_seen_offsets", True)
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
@@ -529,7 +542,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         query_args = {
             "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, flags.key, flags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, exception_main_thread, sdk_integrations, modules.name, modules.version, trace_sampled, num_processing_errors, replay_id, symbolicated_in_app, timestamp_ms, sample_weight, group_first_seen",
@@ -541,13 +554,13 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == "SELECT count() FROM {table_name} FINAL WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted AND has(`tags.key`, {tag_str})".format(
                 **query_args
             )
         )
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == "INSERT INTO {table_name} ({all_columns}) SELECT {select_columns} FROM {table_name} FINAL WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted AND has(`tags.key`, {tag_str})".format(
                 **query_args
             )
@@ -569,7 +582,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         query_args = {
             "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, flags.key, flags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, exception_main_thread, sdk_integrations, modules.name, modules.version, trace_sampled, num_processing_errors, replay_id, symbolicated_in_app, timestamp_ms, sample_weight, group_first_seen",
@@ -581,13 +594,13 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == "SELECT count() FROM {table_name} FINAL WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted AND has(`tags.key`, {tag_str})".format(
                 **query_args
             )
         )
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == "INSERT INTO {table_name} ({all_columns}) SELECT {select_columns} FROM {table_name} FINAL WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted AND has(`tags.key`, {tag_str})".format(
                 **query_args
             )
@@ -596,7 +609,7 @@ class TestReplacerProcess(BaseTest):
         assert replacement.get_query_time_flags() == errors_replacer.NeedsFinal()
 
     @pytest.mark.parametrize("old_primary_hash", ["e3d704f3542b44a621ebed70dc0efe13", False, None])
-    def test_tombstone_events_process(self, old_primary_hash) -> None:
+    def test_tombstone_events_process(self, old_primary_hash: str | bool | None) -> None:
         timestamp = datetime.now()
         message_kwargs = {
             "project_id": self.project_id,
@@ -612,6 +625,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         old_primary_condition = (
             " AND primary_hash = 'e3d704f3-542b-44a6-21eb-ed70dc0efe13'" if old_primary_hash else ""
@@ -626,12 +640,12 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == f"SELECT count() FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s){old_primary_condition} WHERE project_id = %(project_id)s AND NOT deleted"
             % query_args
         )
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s){old_primary_condition} WHERE project_id = %(project_id)s AND NOT deleted"
             % query_args
         )
@@ -654,7 +668,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         query_args = {
             "event_ids": "'00e24a15-0d7f-4ee4-b142-b61b4d893b6d'",
@@ -665,14 +679,14 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == "SELECT count() FROM {table_name} FINAL PREWHERE event_id IN ({event_ids}) WHERE project_id = {project_id} AND NOT deleted".format(
                 **query_args
             )
         )
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == "INSERT INTO {table_name} ({all_columns}) SELECT {select_columns} FROM {table_name} FINAL PREWHERE event_id IN ({event_ids}) WHERE project_id = {project_id} AND NOT deleted".format(
                 **query_args
             )
@@ -695,7 +709,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         query_args = {
             "event_ids": "'00e24a15-0d7f-4ee4-b142-b61b4d893b6d'",
@@ -706,14 +720,14 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == "SELECT count() FROM {table_name} FINAL PREWHERE event_id IN ({event_ids}) WHERE project_id = {project_id} AND NOT deleted".format(
                 **query_args
             )
         )
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == "INSERT INTO {table_name} ({all_columns}) SELECT {select_columns} FROM {table_name} FINAL PREWHERE event_id IN ({event_ids}) WHERE project_id = {project_id} AND NOT deleted".format(
                 **query_args
             )
@@ -736,7 +750,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         query_args = {
             "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, flags.key, flags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, exception_main_thread, sdk_integrations, modules.name, modules.version, trace_sampled, num_processing_errors, replay_id, symbolicated_in_app, timestamp_ms, sample_weight, group_first_seen",
@@ -748,13 +762,13 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == "SELECT count() FROM {table_name} FINAL PREWHERE group_id IN ({previous_group_ids}) WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted".format(
                 **query_args
             )
         )
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == "INSERT INTO {table_name} ({all_columns}) SELECT {select_columns} FROM {table_name} FINAL PREWHERE group_id IN ({previous_group_ids}) WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted".format(
                 **query_args
             )
@@ -779,6 +793,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         query_args = {
             "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, flags.key, flags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, exception_main_thread, sdk_integrations, modules.name, modules.version, trace_sampled, num_processing_errors, replay_id, symbolicated_in_app, timestamp_ms, sample_weight, group_first_seen",
@@ -791,13 +806,13 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == "SELECT count() FROM {table_name} FINAL PREWHERE primary_hash IN ({hashes}) WHERE group_id = {previous_group_id} AND project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted".format(
                 **query_args
             )
         )
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == "INSERT INTO {table_name} ({all_columns}) SELECT {select_columns} FROM {table_name} FINAL PREWHERE primary_hash IN ({hashes}) WHERE group_id = {previous_group_id} AND project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted".format(
                 **query_args
             )
@@ -822,7 +837,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
 
         query_args = {
             "event_ids": "'00e24a15-0d7f-4ee4-b142-b61b4d893b6d'",
@@ -833,12 +848,12 @@ class TestReplacerProcess(BaseTest):
         }
 
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == f"SELECT count() FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}')"
             % query_args
         )
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}')"
             % query_args
         )
@@ -859,7 +874,7 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
         query_args = {
             "group_ids": "1, 2, 3",
             "project_id": self.project_id,
@@ -869,13 +884,13 @@ class TestReplacerProcess(BaseTest):
             "table_name": "foo",
         }
         assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
+            _normalize_query(replacement.get_count_query("foo"))
             == "SELECT count() FROM {table_name} FINAL PREWHERE group_id IN ({group_ids}) WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted".format(
                 **query_args
             )
         )
         assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
+            _normalize_query(replacement.get_insert_query("foo"))
             == "INSERT INTO {table_name} ({required_columns}) SELECT {select_columns} FROM {table_name} FINAL PREWHERE group_id IN ({group_ids}) WHERE project_id = {project_id} AND received <= CAST('{timestamp}' AS DateTime) AND NOT deleted".format(
                 **query_args
             )
@@ -899,15 +914,19 @@ class TestReplacerProcess(BaseTest):
         meta_and_replacement = self.replacer.process_message(self._wrap(message))
         assert meta_and_replacement is not None
         _, replacement = meta_and_replacement
-        assert replacement is not None
+        assert isinstance(replacement, errors_replacer.Replacement)
 
-        set_config("replacements_bypass_projects", f"[{self.project_id + 1}]")
-        meta_and_replacement = self.replacer.process_message(self._wrap(message))
-        assert meta_and_replacement is not None
-        _, replacement = meta_and_replacement
-        assert replacement is not None
+        with override_options(
+            "snuba", {"replacements_bypass_projects": f"[{self.project_id + 1}]"}
+        ):
+            meta_and_replacement = self.replacer.process_message(self._wrap(message))
+            assert meta_and_replacement is not None
+            _, replacement = meta_and_replacement
+            assert isinstance(replacement, errors_replacer.Replacement)
 
-        set_config("replacements_bypass_projects", f"[{self.project_id + 1},{self.project_id}]")
-        meta_and_replacement = self.replacer.process_message(self._wrap(message))
-        assert meta_and_replacement is None
-        delete_config("replacements_bypass_projects")
+        with override_options(
+            "snuba",
+            {"replacements_bypass_projects": f"[{self.project_id + 1},{self.project_id}]"},
+        ):
+            meta_and_replacement = self.replacer.process_message(self._wrap(message))
+            assert meta_and_replacement is None

--- a/tests/query/processors/test_mandatory_condition_enforcer.py
+++ b/tests/query/processors/test_mandatory_condition_enforcer.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
@@ -22,7 +23,6 @@ from snuba.query.processors.physical.conditions_enforcer import (
     MandatoryConditionEnforcer,
 )
 from snuba.query.query_settings import HTTPQuerySettings
-from snuba.state import set_config
 
 TABLE = Table("errors", ColumnSet([]), storage_key=StorageKey("errors"))
 
@@ -142,8 +142,8 @@ test_data = [
 
 @pytest.mark.parametrize("query, valid, org_id_enforcer", test_data)
 @pytest.mark.redis_db
+@override_options("snuba", {"mandatory_condition_enforce": True})
 def test_condition_enforcer(query: Query, valid: bool, org_id_enforcer: OrgIdEnforcer) -> None:
-    set_config("mandatory_condition_enforce", 1)
     query_settings = HTTPQuerySettings(consistent=True)
     processor = MandatoryConditionEnforcer([org_id_enforcer, ProjectIdEnforcer()])
     if valid:

--- a/tests/replacer/test_cluster_replacements.py
+++ b/tests/replacer/test_cluster_replacements.py
@@ -8,6 +8,7 @@ from typing import (
 )
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters import cluster
@@ -182,20 +183,22 @@ def test_write_each_node(
     Test the execution of replacement queries on both storage nodes and
     query nodes.
     """
-    set_config("write_node_replacements_global", write_node_replacements_global)
-    override_func = request.getfixturevalue(override_fixture)
-    test_cluster = override_func(True)
+    with override_options(
+        "snuba", {"write_node_replacements_global": write_node_replacements_global}
+    ):
+        override_func = request.getfixturevalue(override_fixture)
+        test_cluster = override_func(True)
 
-    replacer = ReplacerWorker(
-        get_writable_storage(StorageKey.ERRORS),
-        "consumer_group",
-        DummyMetricsBackend(),
-    )
+        replacer = ReplacerWorker(
+            get_writable_storage(StorageKey.ERRORS),
+            "consumer_group",
+            DummyMetricsBackend(),
+        )
 
-    replacer.flush_batch([(ReplacementMessageMetadata(0, 0, ""), DummyReplacement())])
+        replacer.flush_batch([(ReplacementMessageMetadata(0, 0, ""), DummyReplacement())])
 
-    queries = test_cluster.get_queries()
-    assert queries == expected_queries
+        queries = test_cluster.get_queries()
+        assert queries == expected_queries
 
 
 @pytest.mark.redis_db

--- a/tests/replacer/test_replacements_and_expiry.py
+++ b/tests/replacer/test_replacements_and_expiry.py
@@ -1,4 +1,3 @@
-import typing
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -10,15 +9,13 @@ from snuba.replacers.replacements_and_expiry import (
     get_config_auto_replacements_bypass_projects,
     set_config_auto_replacements_bypass_projects,
 )
-from snuba.state import get_int_config
+from snuba.state.sentry_options import get_option
 
 
 @freeze_time("2024-5-13 09:00:00")
 class TestState:
     start_test_time = datetime.now()
-    expiry_window_minutes = typing.cast(
-        int, get_int_config(REPLACEMENTS_EXPIRY_WINDOW_MINUTES_KEY, 5)
-    )
+    expiry_window_minutes = get_option(REPLACEMENTS_EXPIRY_WINDOW_MINUTES_KEY, 5)
     proj1_add_time = start_test_time
     proj2_add_time = start_test_time + timedelta(minutes=expiry_window_minutes // 2)
     proj1_expiry = proj1_add_time + timedelta(minutes=expiry_window_minutes)
@@ -73,7 +70,7 @@ class TestState:
 
     @pytest.mark.redis_db
     @mock.patch(
-        "snuba.replacers.replacements_and_expiry.get_int_config",
+        "snuba.replacers.replacements_and_expiry.get_option",
     )
     def test_expiry_window_changes(self, mock: mock.MagicMock) -> None:
         mock.side_effect = [5, 10]

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import time
 import uuid
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba import state
 from snuba.redis import RedisClientKey, get_redis_client
@@ -21,12 +23,13 @@ from snuba.state.rate_limit import (
 
 
 @pytest.fixture(params=[1, 20])
-def rate_limit_shards(request: Any) -> None:
+def rate_limit_shards(request: Any) -> Iterator[None]:
     """
     Use this fixture to run the test automatically against both 1
     and 20 shards.
     """
-    state.set_config("rate_limit_shard_factor", request.param)
+    with override_options("snuba", {"rate_limit_shard_factor": request.param}):
+        yield
 
 
 class TestRateLimit:
@@ -179,9 +182,10 @@ class TestRateLimit:
     @pytest.mark.redis_db
     def test_bypass_rate_limit(self) -> None:
         rate_limit_params = RateLimitParameters("foo", "bar", None, None)
-        state.set_config("bypass_rate_limit", 1)
-
-        with rate_limit(rate_limit_params) as stats:
+        with (
+            override_options("snuba", {"bypass_rate_limit": 1}),
+            rate_limit(rate_limit_params) as stats,
+        ):
             assert stats is None
 
     @pytest.mark.redis_db

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -12,6 +12,7 @@ import simplejson as json
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies.healthcheck import Healthcheck
 from arroyo.types import BrokerValue, Message, Partition, Topic
+from sentry_options.testing import override_options
 
 from snuba import replacer, settings
 from snuba.clickhouse.optimize.optimize import run_optimize
@@ -366,7 +367,7 @@ class TestReplacer:
             {ReplacementType.EXCLUDE_GROUPS},
         )
 
-    @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 2)
+    @override_options("snuba", {"max_group_ids_exclude": 2})
     def test_query_time_flags_bounded_size(self) -> None:
         redis_client.flushdb()
         project_id = 256


### PR DESCRIPTION
## What

Module slice of the runtime-config → sentry-options migration (splitting #8096). Migrates the **rate-limiter and per-project quota-timing** runtime config to sentry-options. Schema defaults match the prior `get_*_config` defaults, so behavior is unchanged until set in sentry-options-automator.

> **Stacked on #8115 → #8114 → #8113.** Review/merge the base PRs first; bases retarget down the stack as they merge.

## Keys migrated here

`bypass_rate_limit`, `rate_history_sec`, `rate_limit_shard_factor`, `mem_rate_limit_per_sec`, `project_quota_time_percentage`, `counter_window_size_minutes`, `allows_skipping_single_project_replacements`.

Tests that toggled these via `state.set_config(...)` now use `sentry_options.testing.override_options(...)`.

## Verification

`ruff check` + `ruff format --check` clean; `mypy` clean; **21/21** `tests/state/test_rate_limit.py` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2Cu68uGZRcCVS14jcyd3E)_