### PR TITLE
ref(options): migrate query-execution / ClickHouse / cache config to sentry-options

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -354,6 +354,136 @@
       },
       "default": {},
       "description": "Dict of base ClickHouse query settings (setting name -> value as a string) applied to all queries. Migrated from per-setting runtime config query_settings/<setting>."
+    },
+    "use.low.cardinality.processor": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable the low-cardinality query processor that hints ClickHouse to treat certain columns as low cardinality. When false, the processor is a no-op."
+    },
+    "enable_cache_partitioning": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true, query results use the per-storage cache partition; when false they fall back to the default cache partition."
+    },
+    "randomize_query_id": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, assign a random ClickHouse query_id per execution instead of the deterministic content-based id."
+    },
+    "retry_duplicate_query_id": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, retry a query that ClickHouse rejected because another query with the same id is already running."
+    },
+    "enable_bypass_cache_referrers": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, referrers in settings.BYPASS_CACHE_REFERRERS skip the read-through query cache."
+    },
+    "debug_buffer_size_bytes": {
+      "type": "integer",
+      "default": 0,
+      "description": "Size in bytes of the prefix of an INSERT stream kept in memory so a failing row can be attached to the Sentry error. 0 disables the debug buffer."
+    },
+    "throw_on_uniq_select_and_having": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, raise MismatchedAggregationException if a uniq aggregation appears in HAVING but not SELECT instead of only logging it."
+    },
+    "function-validator.enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, invalid function names raise InvalidFunctionCall; otherwise only an invalid_funcs metric is emitted."
+    },
+    "cache_expiry_sec": {
+      "type": "integer",
+      "default": 1,
+      "description": "TTL in seconds applied to query-result cache entries written to Redis."
+    },
+    "ignore_clickhouse_settings_override": {
+      "type": "string",
+      "default": "",
+      "description": "Comma/space-delimited ClickHouse setting names to strip from a query's settings override; empty keeps all."
+    },
+    "ignore_consistent_queries_sample_rate": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "number"
+      },
+      "default": {},
+      "description": "Dict mapping dataset name to a [0,1] probability of dropping consistency for an otherwise-consistent query. Datasets with no entry default to 0 (never drop consistency). Migrated from per-dataset runtime config <dataset>_ignore_consistent_queries_sample_rate."
+    },
+    "slicing_mega_cluster_partitions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Dict mapping sliced storage-set name to a bracketed list of logical partitions that must query the mega cluster (e.g. \"[1, 2]\"). Storage sets with no entry never use the mega cluster. Migrated from per-storage-set runtime config slicing_mega_cluster_partitions_<storage_set>."
+    },
+    "async_query_settings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Dict of ClickHouse query settings (setting name -> value as a string) applied additionally when the async override is active. Migrated from per-setting runtime config async_query_settings/<setting>."
+    },
+    "query_settings_by_prefix": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Dict mapping a query prefix to a JSON-object string of ClickHouse query settings ({\"setting\": \"value\"}) applied for that prefix, overriding the base query_settings. Migrated from per-setting runtime config <prefix>/query_settings/<setting>."
+    },
+    "query_settings_by_referrer": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Dict mapping a referrer to a JSON-object string of ClickHouse query settings ({\"setting\": \"value\"}) applied for that referrer, taking precedence over prefix and base settings. Migrated from per-setting runtime config referrer/<referrer>/query_settings/<setting>."
+    },
+    "optimize_parallel_threads": {
+      "type": "integer",
+      "default": 0,
+      "description": "Number of parallel threads the table-optimize cron uses when running OPTIMIZE. 0 (the default) means unset: the optimize command's --parallel flag is used instead. Migrated from runtime config optimize_parallel_threads."
+    },
+    "http_batch_join_timeout": {
+      "type": "integer",
+      "default": 0,
+      "description": "Timeout in seconds the ClickHouse HTTP batch writer waits when joining the upload thread. 0 (the default) means unset: settings.BATCH_JOIN_TIMEOUT is used instead. Migrated from runtime config http_batch_join_timeout."
+    },
+    "simultaneous_queries_sleep_seconds": {
+      "type": "integer",
+      "default": 0,
+      "description": "Base sleep in seconds used when retrying a ClickHouse query rejected with TOO_MANY_SIMULTANEOUS_QUERIES. 0 disables the native-driver retry (it re-raises immediately); the robust-execute path always uses at least 1 second. Migrated from runtime config simultaneous_queries_sleep_seconds."
+    },
+    "max_days": {
+      "type": "integer",
+      "default": 0,
+      "description": "Maximum number of days a query time range may span before the lower bound is clamped. 0 means no limit (the time range is left unchanged). Migrated from runtime config max_days."
+    },
+    "date_align_seconds": {
+      "type": "integer",
+      "default": 1,
+      "description": "Granularity in seconds to which query time-range bounds are aligned (truncated). Must be non-zero. Migrated from runtime config date_align_seconds."
+    },
+    "tags_hash_map_enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Killswitch for the MappingOptimizer tags-hashmap query optimization (transactions, search_issues, discover, replays storages). When false the optimizer is a no-op for those storages."
+    },
+    "events_tags_hash_map_enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Killswitch for the MappingOptimizer tags-hashmap query optimization on the errors/errors_ro storages. When false the optimizer is a no-op."
+    },
+    "events_flags_hash_map_enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Killswitch for the MappingOptimizer flags-hashmap query optimization on the errors/errors_ro storages. When false the optimizer is a no-op."
     }
   }
 }

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -286,6 +286,74 @@
       "type": "integer",
       "default": 5,
       "description": "Window in minutes for which a project that recently received replacements is kept in the auto-replacements bypass set. Migrated from runtime config replacements_expiry_window_minutes."
+    },
+    "lw_deletions_offpeak_enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, lightweight deletes are only processed during the configured off-peak window."
+    },
+    "lw_deletions_offpeak_start": {
+      "type": "integer",
+      "default": 0,
+      "description": "UTC hour (0-24) at which the lightweight-deletes off-peak window starts."
+    },
+    "lw_deletions_offpeak_end": {
+      "type": "integer",
+      "default": 24,
+      "description": "UTC hour (0-24) at which the lightweight-deletes off-peak window ends."
+    },
+    "org_ids_delete_allowlist": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated org ids allowed to issue EAP-items lightweight deletes; empty means all orgs are allowed."
+    },
+    "max_parts_mutating_for_delete": {
+      "type": "integer",
+      "default": 20,
+      "description": "Maximum number of parts that may be mutating before a lightweight delete is deferred."
+    },
+    "permit_delete_by_attribute": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, delete-by-attribute requests are permitted; otherwise they are ignored."
+    },
+    "MAX_ONGOING_MUTATIONS_FOR_DELETE": {
+      "type": "integer",
+      "default": 5,
+      "description": "Maximum number of ongoing mutations allowed before a delete is rejected."
+    },
+    "storage_deletes_enabled": {
+      "type": "boolean",
+      "default": true,
+      "description": "Master switch for storage delete (DELETE FROM) support; when false all delete requests are rejected."
+    },
+    "enforce_max_rows_to_delete": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true, reject deletes whose estimated row count exceeds the storage's max_rows_to_delete."
+    },
+    "lightweight_deletes_sync": {
+      "type": "integer",
+      "default": -1,
+      "description": "Value for the ClickHouse lightweight_deletes_sync setting applied to lightweight-delete queries. -1 (the default) means unset: ClickHouse's own default (2 since 24.4) is left in place. Migrated from runtime config lightweight_deletes_sync."
+    },
+    "lightweight_delete_mode": {
+      "type": "string",
+      "default": "",
+      "description": "ClickHouse lightweight_delete_mode applied to lightweight-delete queries. Empty (the default) leaves the setting unset. One of: alter_update (heavyweight ALTER UPDATE mutation), lightweight_update (lightweight if possible, else ALTER UPDATE), lightweight_update_force (lightweight if possible, else throw); any other non-empty value is treated as lightweight_update. Migrated from runtime config lightweight_delete_mode."
+    },
+    "read_through_cache.short_circuit": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, bypass the read-through query cache entirely and call the underlying function directly (escape hatch for Redis issues)."
+    },
+    "query_settings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Dict of base ClickHouse query settings (setting name -> value as a string) applied to all queries. Migrated from per-setting runtime config query_settings/<setting>."
     }
   }
 }

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -17,11 +17,12 @@ import sentry_sdk
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.exceptions import HTTPError
 
-from snuba import settings, state
+from snuba import settings
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.clickhouse.errors import ClickhouseWriterError
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
 from snuba.clickhouse.query import Expression
+from snuba.state.sentry_options import get_int_option
 from snuba.utils.codecs import Encoder
 from snuba.utils.iterators import chunked
 from snuba.utils.metrics import MetricsBackend
@@ -306,11 +307,7 @@ class HTTPBatchWriter(BatchWriter[bytes]):
         self.__statement = statement
         self.__buffer_size = buffer_size
         self.__chunk_size = chunk_size
-        self.__debug_buffer_size_bytes = state.get_config("debug_buffer_size_bytes", None)
-        assert (
-            isinstance(self.__debug_buffer_size_bytes, int)
-            or self.__debug_buffer_size_bytes is None
-        )
+        self.__debug_buffer_size_bytes = get_int_option("debug_buffer_size_bytes", 0)
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__}: {self.__statement.get_qualified_table()} on {self.__pool.host}:{self.__pool.port}>"
@@ -342,8 +339,11 @@ class HTTPBatchWriter(BatchWriter[bytes]):
             batch.append(value)
 
         batch.close()
-        batch_join_timeout = state.get_config(
-            "http_batch_join_timeout", settings.BATCH_JOIN_TIMEOUT
+        # A 0 (the schema default) means "unset": fall back to the env-configured
+        # settings.BATCH_JOIN_TIMEOUT, preserving the prior runtime-config
+        # behavior where the option was only an override.
+        batch_join_timeout = (
+            get_int_option("http_batch_join_timeout", 0) or settings.BATCH_JOIN_TIMEOUT
         )
         # IMPORTANT: Please read the docstring of this method if you ever decide to remove the
         # timeout argument from the join method.

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -21,10 +21,11 @@ from clickhouse_driver import Client, errors
 from dateutil.tz import tz
 from sentry_sdk.integrations.logging import ignore_logger
 
-from snuba import environment, settings, state
+from snuba import environment, settings
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
 from snuba.reader import Reader, Result, build_result_transformer
+from snuba.state.sentry_options import get_int_option
 from snuba.utils.metrics.gauge import ThreadSafeGauge
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
@@ -232,8 +233,8 @@ class ClickhousePool:
                         if attempts_remaining <= 0:
                             raise ClickhouseError(e.message, code=e.code) from e
 
-                        sleep_interval_seconds = state.get_config(
-                            "simultaneous_queries_sleep_seconds", None
+                        sleep_interval_seconds = get_int_option(
+                            "simultaneous_queries_sleep_seconds", 0
                         )
                         if not sleep_interval_seconds:
                             raise ClickhouseError(e.message, code=e.code) from e
@@ -312,11 +313,11 @@ class ClickhousePool:
                     attempts_remaining -= 1
                     if attempts_remaining <= 0:
                         raise e
-                    sleep_interval_seconds = state.get_config(
-                        "simultaneous_queries_sleep_seconds", 1
+                    # Linear backoff. Adds one second at each iteration. Falls
+                    # back to a 1-second base when the option is unset (0).
+                    sleep_interval_seconds = (
+                        get_int_option("simultaneous_queries_sleep_seconds", 0) or 1
                     )
-                    assert sleep_interval_seconds is not None
-                    # Linear backoff. Adds one second at each iteration.
                     time.sleep(
                         float((total_attempts - attempts_remaining) * sleep_interval_seconds)
                     )

--- a/snuba/clickhouse/optimize/util.py
+++ b/snuba/clickhouse/optimize/util.py
@@ -1,7 +1,6 @@
-import typing
 from dataclasses import dataclass
 
-from snuba.state import get_config
+from snuba.state.sentry_options import get_int_option
 
 _OPTIMIZE_PARALLEL_THREADS_KEY = "optimize_parallel_threads"
 
@@ -20,4 +19,7 @@ class MergeInfo:
 
 
 def get_num_threads(default_parallel_threads: int) -> int:
-    return typing.cast(int, get_config(_OPTIMIZE_PARALLEL_THREADS_KEY, default_parallel_threads))
+    # A 0 (the schema default) means "unset": fall back to the value passed via
+    # the optimize command's --parallel flag, preserving the prior runtime-config
+    # behavior where the option was only an override.
+    return get_int_option(_OPTIMIZE_PARALLEL_THREADS_KEY, 0) or default_parallel_threads

--- a/snuba/datasets/plans/cluster_selector.py
+++ b/snuba/datasets/plans/cluster_selector.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 
-from snuba import state
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
 from snuba.clusters.cluster import ClickhouseCluster, get_cluster
@@ -13,6 +12,7 @@ from snuba.datasets.slicing import (
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.query_settings import QuerySettings
+from snuba.state.sentry_options import get_mapped_str_option
 
 MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX = "slicing_mega_cluster_partitions"
 
@@ -41,11 +41,11 @@ def _should_use_mega_cluster(storage_set: StorageSetKey, logical_partition: int)
     to a new slice. In such cases, the old data resides in some different
     slice than what the new mapping says.
     """
-    key = f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_{storage_set.value}"
-    state.get_config(key, None)
-    slicing_read_override_config = state.get_config(key, None)
+    slicing_read_override_config = get_mapped_str_option(
+        MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX, storage_set.value, ""
+    )
 
-    if slicing_read_override_config is None:
+    if not slicing_read_override_config:
         return False
 
     slicing_read_override_config = slicing_read_override_config[1:-1]

--- a/snuba/lw_deletions/off_peak.py
+++ b/snuba/lw_deletions/off_peak.py
@@ -6,7 +6,7 @@ from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.abstract import MessageRejected
 from arroyo.types import Message
 
-from snuba.state import get_int_config
+from snuba.state.sentry_options import get_bool_option, get_int_option
 from snuba.utils.metrics import MetricsBackend
 
 _CACHE_TTL_SECONDS = 60
@@ -48,14 +48,14 @@ class OffPeakProcessingStrategy(ProcessingStrategy[KafkaPayload]):
         if self.__cached_result is not None and (now - self.__cached_at) < _CACHE_TTL_SECONDS:
             return self.__cached_result
 
-        enabled = get_int_config("lw_deletions_offpeak_enabled", default=0)
+        enabled = get_bool_option("lw_deletions_offpeak_enabled", False)
         if not enabled:
             self.__cached_result = True
             self.__cached_at = now
             return True
 
-        start = get_int_config("lw_deletions_offpeak_start", default=0) or 0
-        end = get_int_config("lw_deletions_offpeak_end", default=24) or 24
+        start = get_int_option("lw_deletions_offpeak_start", 0)
+        end = get_int_option("lw_deletions_offpeak_end", 24) or 24
         current_hour = datetime.now(UTC).hour
 
         if start == end:

--- a/snuba/lw_deletions/strategy.py
+++ b/snuba/lw_deletions/strategy.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import logging
 import time
-import typing
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import TypeVar
@@ -36,7 +35,11 @@ from snuba.query.dsl import column, equals, literal
 from snuba.query.expressions import Expression, FunctionCall
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.redis import RedisClientKey, get_redis_client
-from snuba.state import get_int_config, get_str_config
+from snuba.state.sentry_options import (
+    get_int_option,
+    get_mapped_int_option,
+    get_str_option,
+)
 from snuba.utils.metrics import MetricsBackend
 from snuba.web import QueryException
 from snuba.web.bulk_delete_query import construct_or_conditions, construct_query
@@ -86,7 +89,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
         if self.__storage.get_storage_key() != StorageKey.EAP_ITEMS:
             return conditions
 
-        str_config = get_str_config("org_ids_delete_allowlist", "")
+        str_config = get_str_option("org_ids_delete_allowlist", "")
         if not str_config:
             return conditions  # allowlist not set → allow all
 
@@ -200,12 +203,13 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
     def _execute_delete(self, conditions: Sequence[ConditionsBag]) -> None:
         self._check_ongoing_mutations()
         query_settings = HTTPQuerySettings()
-        # starting in 24.4 the default is 2
-        lw_sync = get_int_config("lightweight_deletes_sync")
-        if lw_sync is not None:
+        # starting in 24.4 the default is 2; -1 (the schema default) means
+        # "unset", leaving ClickHouse's own default in place.
+        lw_sync = get_int_option("lightweight_deletes_sync", -1)
+        if lw_sync >= 0:
             query_settings.push_clickhouse_setting("lightweight_deletes_sync", lw_sync)
 
-        lw_updates_enabled = get_str_config("lightweight_delete_mode")
+        lw_updates_enabled = get_str_option("lightweight_delete_mode", "")
         if lw_updates_enabled:
             mode = (
                 lw_updates_enabled
@@ -221,7 +225,7 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
 
         split_enabled = bool(
             self.__partition_column
-            and get_int_config(f"lw_deletes_split_by_partition_{self.__storage_name}", default=0)
+            and get_mapped_int_option("lw_deletes_split_by_partition", self.__storage_name, 0)
         )
 
         for table in self.__tables:
@@ -333,12 +337,8 @@ class FormatQuery(ProcessingStrategy[ValuesBatch[KafkaPayload]]):
         start = time.time()
         parts_mutating = _num_parts_currently_mutating(self.__storage.get_cluster())
         self.__last_ongoing_mutations_check = time.time()
-        max_parts_mutating = typing.cast(
-            int,
-            get_int_config(
-                "max_parts_mutating_for_delete",
-                default=settings.MAX_PARTS_MUTATING_FOR_DELETE,
-            ),
+        max_parts_mutating = get_int_option(
+            "max_parts_mutating_for_delete", settings.MAX_PARTS_MUTATING_FOR_DELETE
         )
         self.__metrics.timing("ongoing_mutations_query_ms", (time.time() - start) * 1000)
         if parts_mutating > max_parts_mutating:

--- a/snuba/query/processors/logical/low_cardinality_processor.py
+++ b/snuba/query/processors/logical/low_cardinality_processor.py
@@ -1,6 +1,5 @@
 from dataclasses import replace
 
-from snuba import state
 from snuba.query.expressions import (
     Column,
     Expression,
@@ -11,6 +10,7 @@ from snuba.query.expressions import (
 from snuba.query.logical import Query
 from snuba.query.processors.logical import LogicalQueryProcessor
 from snuba.query.query_settings import QuerySettings
+from snuba.state.sentry_options import get_bool_option
 
 
 class LowCardinalityProcessor(LogicalQueryProcessor):
@@ -66,7 +66,7 @@ class LowCardinalityProcessor(LogicalQueryProcessor):
                     )
             return exp
 
-        if state.get_int_config("use.low.cardinality.processor", 1) == 0:
+        if not get_bool_option("use.low.cardinality.processor", True):
             return
 
         query.transform_expressions(transform_expressions)

--- a/snuba/query/processors/physical/clickhouse_settings_override.py
+++ b/snuba/query/processors/physical/clickhouse_settings_override.py
@@ -4,7 +4,7 @@ from typing import Any
 from snuba.clickhouse.query import Query
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
-from snuba.state import get_str_config
+from snuba.state.sentry_options import get_str_option
 
 
 class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
@@ -40,7 +40,7 @@ class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
             new_settings.update(self.__settings)
             new_settings.update(query_settings.get_clickhouse_settings())
 
-        ignored_settings = get_str_config("ignore_clickhouse_settings_override")
+        ignored_settings = get_str_option("ignore_clickhouse_settings_override", "")
         if ignored_settings:
             new_settings = {
                 setting: value

--- a/snuba/query/processors/physical/mapping_optimizer.py
+++ b/snuba/query/processors/physical/mapping_optimizer.py
@@ -26,7 +26,7 @@ from snuba.query.matchers import Any, AnyOptionalString, FunctionCall, Literal, 
 from snuba.query.matchers import Column as ColumnMatcher
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
-from snuba.state import get_config
+from snuba.state.sentry_options import get_bool_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "processors.tags_hash_map")
@@ -363,7 +363,7 @@ class MappingOptimizer(ClickhouseQueryProcessor):
         return clause, cond_class
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
-        if not get_config(self.__killswitch, 1):
+        if not get_bool_option(self.__killswitch, True):
             return
         condition, cond_class = self.__get_reduced_and_classified_query_clause(
             query.get_condition(), query

--- a/snuba/query/processors/physical/uniq_in_select_and_having.py
+++ b/snuba/query/processors/physical/uniq_in_select_and_having.py
@@ -17,7 +17,7 @@ from snuba.query.matchers import FunctionCall as FunctionCallMatch
 from snuba.query.matchers import Param, String
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
-from snuba.state import get_config
+from snuba.state.sentry_options import get_bool_option
 
 
 class MismatchedAggregationException(InvalidQueryException):
@@ -54,7 +54,7 @@ class UniqInSelectAndHavingProcessor(ClickhouseQueryProcessor):
             for col in selected_columns:
                 col.expression.accept(matcher)
             if not all(matcher.found_expressions):
-                should_throw = get_config("throw_on_uniq_select_and_having", False)
+                should_throw = get_bool_option("throw_on_uniq_select_and_having", False)
                 error = MismatchedAggregationException(
                     "Aggregation is in HAVING clause but not SELECT", query=str(query)
                 )

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -16,7 +16,6 @@ from parsimonious.exceptions import IncompleteParseError
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import Node, NodeVisitor
 
-from snuba import state
 from snuba.clickhouse.columns import Array, ColumnSet
 from snuba.clickhouse.query_dsl.accessors import get_time_range_expressions
 from snuba.datasets.dataset import Dataset
@@ -101,6 +100,7 @@ from snuba.query.snql.expression_visitor import (
 )
 from snuba.query.snql.joins import RelationshipTuple, build_join_clause
 from snuba.state import explain_meta
+from snuba.state.sentry_options import get_int_option
 from snuba.util import parse_datetime
 from snuba.utils.metrics.timer import Timer
 
@@ -1241,10 +1241,11 @@ def _replace_time_condition(
 ) -> None:
     condition = query.get_condition()
     top_level = get_first_level_and_conditions(condition) if condition is not None else []
-    max_days, date_align = state.get_configs([("max_days", None), ("date_align_seconds", 1)])
-    assert isinstance(date_align, int)
-    if max_days is not None:
-        max_days = int(max_days)
+    # max_days defaults to 0 in the schema, which we treat as "no limit" (None)
+    # to preserve the prior runtime-config behavior where an unset value meant
+    # no clamping of the query time range.
+    date_align = get_int_option("date_align_seconds", 1)
+    max_days = get_int_option("max_days", 0) or None
 
     if isinstance(query, LogicalQuery):
         new_top_level = _align_max_days_date_align(

--- a/snuba/query/validation/functions.py
+++ b/snuba/query/validation/functions.py
@@ -1,10 +1,11 @@
 from collections.abc import Sequence
 
-from snuba import environment, state
+from snuba import environment
 from snuba.query.data_source import DataSource
 from snuba.query.expressions import Expression
 from snuba.query.functions import is_valid_global_function
 from snuba.query.validation import FunctionCallValidator, InvalidFunctionCall
+from snuba.state.sentry_options import get_bool_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "validation.functions")
@@ -22,6 +23,6 @@ class AllowedFunctionValidator(FunctionCallValidator):
         if is_valid_global_function(func_name):
             return
 
-        if state.get_config("function-validator.enabled", False):
+        if get_bool_option("function-validator.enabled", False):
             raise InvalidFunctionCall(f"Invalid function name: {func_name}")
         metrics.increment("invalid_funcs", tags={"func_name": func_name})

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -8,8 +8,8 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from snuba import environment, settings
 from snuba.redis import RedisClientType
-from snuba.state import get_config
 from snuba.state.cache.abstract import Cache, TValue
+from snuba.state.sentry_options import get_bool_option, get_int_option
 from snuba.utils.codecs import ExceptionAwareCodec
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.wrapper import MetricsWrapper
@@ -73,7 +73,7 @@ class RedisCache(Cache[TValue]):
         self.__client.set(
             self.__build_key(key),
             self.__codec.encode(value),
-            ex=get_config("cache_expiry_sec", 1),
+            ex=get_int_option("cache_expiry_sec", 1),
         )
 
     def __get_value_with_simple_readthrough(
@@ -109,9 +109,8 @@ class RedisCache(Cache[TValue]):
                 self.__client.set(
                     result_key,
                     self.__codec.encode(value),
-                    ex=get_config("cache_expiry_sec", 1),
+                    ex=get_int_option("cache_expiry_sec", 1),
                 )
-
             except Exception as e:
                 metrics.increment("redis_cache_set_error", tags={"error": str(e), **metric_tags})
                 if e not in DONT_CAPTURE_ERRORS:
@@ -134,7 +133,7 @@ class RedisCache(Cache[TValue]):
     ) -> TValue:
         # in case something is wrong with redis, we want to be able to
         # disable the read_through_cache but still serve traffic.
-        if get_config("read_through_cache.short_circuit", 0):
+        if get_bool_option("read_through_cache.short_circuit", False):
             return function()
 
         try:

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -26,7 +26,7 @@ from snuba.query.dsl import literal
 from snuba.query.exceptions import InvalidQueryException, NoRowsToDeleteException
 from snuba.query.expressions import Expression
 from snuba.reader import Result
-from snuba.state import get_int_config, get_str_config
+from snuba.state.sentry_options import get_bool_option, get_mapped_str_option
 from snuba.utils.metrics.util import with_span
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.schemas import ColumnValidator, InvalidColumnType
@@ -229,7 +229,7 @@ def delete_from_storage(
     if attribute_conditions:
         _validate_attribute_conditions(attribute_conditions, delete_settings)
 
-        if not get_int_config("permit_delete_by_attribute", default=0):
+        if not get_bool_option("permit_delete_by_attribute", False):
             metrics.increment("delete_query.delete_ignored")
             return {}
 
@@ -374,5 +374,5 @@ def construct_or_conditions(
 
 
 def should_use_killswitch(storage_name: str, project_id: str) -> bool:
-    killswitch_config = get_str_config(f"lw_deletes_killswitch_{storage_name}", default="")
+    killswitch_config = get_mapped_str_option("lw_deletes_killswitch", storage_name, "")
     return project_id in killswitch_config if killswitch_config else False

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -16,7 +16,7 @@ from clickhouse_driver.errors import ErrorCodes
 from sentry_kafka_schemas.schema_types import snuba_queries_v1
 from sentry_sdk.api import configure_scope
 
-from snuba import environment, settings, state
+from snuba import environment, settings
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
@@ -59,6 +59,12 @@ from snuba.state.cache.redis.backend import (
 )
 from snuba.state.quota import ResourceQuota
 from snuba.state.rate_limit import RateLimitExceeded
+from snuba.state.sentry_options import (
+    get_bool_option,
+    get_mapped_float_option,
+    get_mapped_str_option,
+    get_option,
+)
 from snuba.util import force_bytes
 from snuba.utils.codecs import ExceptionAwareCodec
 from snuba.utils.metrics.timer import Timer
@@ -202,7 +208,7 @@ def get_query_cache_key(formatted_query: FormattedQuery) -> str:
 
 
 def _get_cache_partition(reader: Reader) -> Cache[Result]:
-    enable_cache_partitioning = state.get_config("enable_cache_partitioning", 1)
+    enable_cache_partitioning = get_bool_option("enable_cache_partitioning", True)
     if not enable_cache_partitioning:
         return cache_partitions[DEFAULT_CACHE_PARTITION_ID]
 
@@ -236,7 +242,7 @@ def execute_query_with_query_id(
     robust: bool,
     referrer: str,
 ) -> Result:
-    if state.get_config("randomize_query_id", False):
+    if get_bool_option("randomize_query_id", False):
         query_id = uuid.uuid4().hex
     else:
         query_id = get_query_cache_key(formatted_query)
@@ -255,7 +261,7 @@ def execute_query_with_query_id(
             referrer,
         )
     except ClickhouseError as e:
-        if e.code != ErrorCodes.QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING or not state.get_config(
+        if e.code != ErrorCodes.QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING or not get_bool_option(
             "retry_duplicate_query_id", False
         ):
             raise
@@ -292,8 +298,8 @@ def execute_query_with_readthrough_caching(
     query_id: str,
     referrer: str,
 ) -> Result:
-    if referrer in settings.BYPASS_CACHE_REFERRERS and state.get_config(
-        "enable_bypass_cache_referrers"
+    if referrer in settings.BYPASS_CACHE_REFERRERS and get_bool_option(
+        "enable_bypass_cache_referrers", False
     ):
         query_id = f"randomized-{uuid.uuid4().hex}"
         clickhouse_query_settings["query_id"] = query_id
@@ -349,44 +355,61 @@ def execute_query_with_readthrough_caching(
     )
 
 
+def _query_settings_dict(option: str) -> Mapping[str, Any]:
+    """A dict-typed sentry-option of {clickhouse_setting: value}."""
+    value = get_option(option, {})
+    return value if isinstance(value, dict) else {}
+
+
+def _query_settings_override(option: str, name: str) -> Mapping[str, Any]:
+    """One entry of a dict-typed sentry-option whose values are JSON-object
+    strings ({"clickhouse_setting": "value"}), keyed by ``name`` (a query
+    prefix or referrer). sentry-options can't express dict-of-dict natively, so
+    the second level is a JSON string parsed here."""
+    raw = get_mapped_str_option(option, name, "")
+    if not raw:
+        return {}
+    try:
+        parsed = rapidjson.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _get_query_settings_from_config(
     override_prefix: str | None,
     async_override: bool,
     referrer: str | None,
 ) -> MutableMapping[str, Any]:
     """
-    Helper function to get the query settings from the config. Order of precedence
-    for overlapping config within this method is:
-    1. referrer/<referrer>/query_settings/<setting>
-    2. <override_prefix>/query_settings/<setting>
-    3. query_settings/<setting>
+    Helper function to get the query settings from sentry-options. Order of
+    precedence for overlapping settings within this method is:
+    1. referrer/<referrer>  (query_settings_by_referrer)
+    2. <override_prefix>    (query_settings_by_prefix)
+    3. base                 (query_settings)
 
     #TODO: Make this configurable by entity/dataset. Since we want to use
     #      different settings across different clusters belonging to the
     #      same entity/dataset, using cache_partition right now. This is
     #      not ideal but it works for now.
     """
-    all_confs = state.get_all_configs()
-
-    # Populate the query settings with the default values
-    clickhouse_query_settings: MutableMapping[str, Any] = {
-        k.split("/", 1)[1]: v for k, v in all_confs.items() if k.startswith("query_settings/")
-    }
+    # Populate the query settings with the base values.
+    clickhouse_query_settings: MutableMapping[str, Any] = dict(
+        _query_settings_dict("query_settings")
+    )
 
     if async_override:
-        for k, v in all_confs.items():
-            if k.startswith("async_query_settings/"):
-                clickhouse_query_settings[k.split("/", 1)[1]] = v
+        clickhouse_query_settings.update(_query_settings_dict("async_query_settings"))
 
     if override_prefix:
-        for k, v in all_confs.items():
-            if k.startswith(f"{override_prefix}/query_settings/"):
-                clickhouse_query_settings[k.split("/", 2)[2]] = v
+        clickhouse_query_settings.update(
+            _query_settings_override("query_settings_by_prefix", override_prefix)
+        )
 
     if referrer:
-        for k, v in all_confs.items():
-            if k.startswith(f"referrer/{referrer}/query_settings/"):
-                clickhouse_query_settings[k.split("/", 3)[3]] = v
+        clickhouse_query_settings.update(
+            _query_settings_override("query_settings_by_referrer", referrer)
+        )
 
     return clickhouse_query_settings
 
@@ -429,9 +452,10 @@ def _raw_query(
     consistent = query_settings.get_consistent()
     stats["consistent"] = consistent
     if consistent:
-        sample_rate = state.get_config(f"{dataset_name}_ignore_consistent_queries_sample_rate", 0)
-        assert sample_rate is not None
-        ignore_consistent = random.random() < float(sample_rate)
+        sample_rate = get_mapped_float_option(
+            "ignore_consistent_queries_sample_rate", dataset_name, 0.0
+        )
+        ignore_consistent = random.random() < sample_rate
         if not ignore_consistent:
             clickhouse_query_settings["load_balancing"] = "in_order"
             clickhouse_query_settings["max_threads"] = 1

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -37,7 +37,7 @@ from snuba.query.exceptions import (
 from snuba.query.expressions import Expression, FunctionCall
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.reader import Result
-from snuba.state import get_config, get_int_config
+from snuba.state.sentry_options import get_bool_option, get_int_option
 from snuba.utils.metrics.util import with_span
 from snuba.utils.schemas import ColumnValidator, InvalidColumnType
 from snuba.web import QueryException, QueryExtraData, QueryResult
@@ -98,9 +98,8 @@ def delete_from_storage(
 
     # fail if too many mutations ongoing
     ongoing_mutations = _num_ongoing_mutations(storage.get_cluster(), delete_settings.tables)
-    max_ongoing_mutations = get_int_config(
-        "MAX_ONGOING_MUTATIONS_FOR_DELETE",
-        default=settings.MAX_ONGOING_MUTATIONS_FOR_DELETE,
+    max_ongoing_mutations = get_int_option(
+        "MAX_ONGOING_MUTATIONS_FOR_DELETE", settings.MAX_ONGOING_MUTATIONS_FOR_DELETE
     )
     assert max_ongoing_mutations
     if ongoing_mutations > max_ongoing_mutations:
@@ -225,7 +224,7 @@ WHERE metric = 'PartMutation'
 
 
 def deletes_are_enabled() -> bool:
-    return bool(get_config("storage_deletes_enabled", 1))
+    return get_bool_option("storage_deletes_enabled", True)
 
 
 def _get_rows_to_delete(storage_key: StorageKey, select_query_to_count_rows: Query) -> int:
@@ -292,10 +291,7 @@ def _enforce_max_rows(delete_query: Query, count_storage_key: StorageKey | None 
     if rows_to_delete == 0:
         raise NoRowsToDeleteException
     max_rows_allowed = get_storage(storage_key).get_deletion_settings().max_rows_to_delete
-    if (
-        get_int_config("enforce_max_rows_to_delete", default=1)
-        and rows_to_delete > max_rows_allowed
-    ):
+    if get_bool_option("enforce_max_rows_to_delete", True) and rows_to_delete > max_rows_allowed:
         raise TooManyDeleteRowsException(
             f"Too many rows to delete ({rows_to_delete}), maximum allowed is {max_rows_allowed}"
         )

--- a/tests/clickhouse/test_native.py
+++ b/tests/clickhouse/test_native.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 from clickhouse_driver import errors
 from dateutil.tz import tz
+from sentry_options.testing import override_options
 
 from snuba import state
 from snuba.clickhouse.errors import ClickhouseError
@@ -57,11 +58,10 @@ class TestConcurrentError(errors.Error):  # type: ignore[misc]
 
 @pytest.mark.skip(reason="broke all of a sudden, blocking CI but not critical")
 @pytest.mark.redis_db
+@override_options("snuba", {"simultaneous_queries_sleep_seconds": 1})
 def test_concurrency_limit() -> None:
     connection = mock.Mock()
     connection.execute.side_effect = TestError("some error")
-
-    state.set_config("simultaneous_queries_sleep_seconds", 0.5)
 
     pool = ClickhousePool("host", 100, "test", "test", "test")
     pool.pool = queue.LifoQueue(1)

--- a/tests/datasets/plans/test_cluster_selector.py
+++ b/tests/datasets/plans/test_cluster_selector.py
@@ -2,6 +2,8 @@ import os
 from unittest.mock import patch
 
 import pytest
+from sentry_options import OptionValue
+from sentry_options.testing import override_options
 
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.entities.entity_key import EntityKey
@@ -18,7 +20,6 @@ from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, Literal
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.query_settings import HTTPQuerySettings
-from snuba.state import delete_config, set_config
 
 DISTS_ENTITY_KEY = EntityKey("generic_metrics_distributions")
 DISTS_STORAGE_KEY = StorageKey("generic_metrics_distributions")
@@ -90,12 +91,14 @@ def test_column_based_partition_selector(
     Tests that the column based partition selector selects the right cluster
     for a query.
     """
+    override: dict[str, OptionValue] = {}
     if set_override:
         logical_partition = map_org_id_to_logical_partition(org_id)
-        set_config(
-            f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_generic_metrics_distributions",
-            f"[{logical_partition}]",
-        )
+        override = {
+            MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX: {
+                "generic_metrics_distributions": f"[{logical_partition}]"
+            }
+        }
     query = LogicalQuery(
         QueryEntity(
             DISTS_ENTITY_KEY,
@@ -115,11 +118,9 @@ def test_column_based_partition_selector(
         DISTS_STORAGE_SET_KEY,
         "org_id",
     )
-    cluster = selector.select_cluster(query, settings)
-
-    assert cluster.get_database() == expected_slice_db
-    if set_override:
-        delete_config(f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_generic_metrics_distributions")
+    with override_options("snuba", override):
+        cluster = selector.select_cluster(query, settings)
+        assert cluster.get_database() == expected_slice_db
 
 
 mega_cluster_test_data = [
@@ -165,8 +166,10 @@ def test_should_use_mega_cluster(
     override_config: str | None,
     expected: bool,
 ) -> None:
-    if override_config:
-        set_config(f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_{storage_set.value}", override_config)
-    assert _should_use_mega_cluster(storage_set, logical_partition) == expected
-    if override_config:
-        delete_config(f"MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX_{storage_set}")
+    override: dict[str, OptionValue] = (
+        {MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX: {storage_set.value: override_config}}
+        if override_config
+        else {}
+    )
+    with override_options("snuba", override):
+        assert _should_use_mega_cluster(storage_set, logical_partition) == expected

--- a/tests/lw_deletions/test_lw_deletions.py
+++ b/tests/lw_deletions/test_lw_deletions.py
@@ -8,8 +8,8 @@ import pytest
 import rapidjson
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
+from sentry_options.testing import override_options
 
-from snuba import state
 from snuba.clusters.cluster import ClickhouseNode
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -98,16 +98,16 @@ def test_clickhouse_settings(mock_execute: Mock, mock_num_mutations: Mock) -> No
         next_step=FormatQuery(commit_step, storage, SearchIssuesFormatter(), metrics),
         increment_by=increment_by,
     )
-    state.set_config("lightweight_deletes_sync", 2)
     make_message = generate_message()
-    strategy.submit(next(make_message))
-    strategy.submit(next(make_message))
-    strategy.submit(next(make_message))
+    with override_options("snuba", {"lightweight_deletes_sync": 2}):
+        strategy.submit(next(make_message))
+        strategy.submit(next(make_message))
+        strategy.submit(next(make_message))
     # use different setting for second execute_query
-    state.set_config("lightweight_deletes_sync", 0)
-    strategy.submit(next(make_message))
-    strategy.close()
-    strategy.join()
+    with override_options("snuba", {"lightweight_deletes_sync": 0}):
+        strategy.submit(next(make_message))
+        strategy.close()
+        strategy.join()
 
     assert mock_execute.call_count == 2
     assert commit_step.submit.call_count == 2
@@ -229,6 +229,7 @@ def _make_single_message(
     create=True,
 )
 @pytest.mark.redis_db
+@override_options("snuba", {"lw_deletes_split_by_partition": {"search_issues": 1}})
 def test_split_by_partition_enabled(mock_execute: Mock, mock_num_mutations: Mock) -> None:
     """
     When partition splitting is enabled and system.parts returns 3 Monday dates,
@@ -237,8 +238,6 @@ def test_split_by_partition_enabled(mock_execute: Mock, mock_num_mutations: Mock
     commit_step = Mock()
     metrics = Mock()
     storage = get_writable_storage(StorageKey("search_issues"))
-
-    state.set_config("lw_deletes_split_by_partition_search_issues", 1)
 
     format_query = FormatQuery(commit_step, storage, SearchIssuesFormatter(), metrics)
 
@@ -286,9 +285,7 @@ def test_split_by_partition_disabled(mock_execute: Mock, mock_num_mutations: Moc
     metrics = Mock()
     storage = get_writable_storage(StorageKey("search_issues"))
 
-    # Ensure config is off (default)
-    state.set_config("lw_deletes_split_by_partition_search_issues", 0)
-
+    # Config is off by default (no entry in the lw_deletes_split_by_partition dict).
     strategy = BatchStepCustom(
         max_batch_size=8,
         max_batch_time=1000,
@@ -306,6 +303,7 @@ def test_split_by_partition_disabled(mock_execute: Mock, mock_num_mutations: Moc
 @patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
 @patch("snuba.lw_deletions.strategy._execute_query")
 @pytest.mark.redis_db
+@override_options("snuba", {"lw_deletes_split_by_partition": {"search_issues": 1}})
 def test_split_by_partition_redis_tracking(mock_execute: Mock, mock_num_mutations: Mock) -> None:
     """
     Issue a batch with partition splitting enabled. Verify Redis SET is populated.
@@ -315,8 +313,6 @@ def test_split_by_partition_redis_tracking(mock_execute: Mock, mock_num_mutation
     commit_step = Mock()
     metrics = Mock()
     storage = get_writable_storage(StorageKey("search_issues"))
-
-    state.set_config("lw_deletes_split_by_partition_search_issues", 1)
 
     partition_dates = ["2024-01-15", "2024-01-22"]
 
@@ -396,6 +392,7 @@ def test_split_by_partition_redis_tracking(mock_execute: Mock, mock_num_mutation
 @patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
 @patch("snuba.lw_deletions.strategy._execute_query")
 @pytest.mark.redis_db
+@override_options("snuba", {"lw_deletes_split_by_partition": {"search_issues": 1}})
 def test_split_by_partition_fallback(mock_execute: Mock, mock_num_mutations: Mock) -> None:
     """
     When partition splitting is enabled but system.parts returns no partitions,
@@ -404,8 +401,6 @@ def test_split_by_partition_fallback(mock_execute: Mock, mock_num_mutations: Moc
     commit_step = Mock()
     metrics = Mock()
     storage = get_writable_storage(StorageKey("search_issues"))
-
-    state.set_config("lw_deletes_split_by_partition_search_issues", 1)
 
     format_query = FormatQuery(commit_step, storage, SearchIssuesFormatter(), metrics)
 
@@ -518,6 +513,7 @@ def _make_eap_message(
 @patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
 @patch("snuba.lw_deletions.strategy._execute_query")
 @pytest.mark.redis_db
+@override_options("snuba", {"org_ids_delete_allowlist": "1"})
 def test_allowlist_partial_batch(mock_execute: Mock, mock_num_mutations: Mock) -> None:
     """
     Batch with 2 conditions (org 1 and org 2), allowlist = "1".
@@ -527,8 +523,6 @@ def test_allowlist_partial_batch(mock_execute: Mock, mock_num_mutations: Mock) -
     commit_step = Mock()
     metrics = Mock()
     storage = get_writable_storage(StorageKey("eap_items"))
-
-    state.set_config("org_ids_delete_allowlist", "1")
 
     format_query = FormatQuery(commit_step, storage, EAPItemsFormatter(), metrics)
 
@@ -558,6 +552,7 @@ def test_allowlist_partial_batch(mock_execute: Mock, mock_num_mutations: Mock) -
 @patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
 @patch("snuba.lw_deletions.strategy._execute_query")
 @pytest.mark.redis_db
+@override_options("snuba", {"org_ids_delete_allowlist": "999"})
 def test_allowlist_all_blocked(mock_execute: Mock, mock_num_mutations: Mock) -> None:
     """
     All conditions have unallowed org IDs. _execute_query should not be called,
@@ -566,8 +561,6 @@ def test_allowlist_all_blocked(mock_execute: Mock, mock_num_mutations: Mock) -> 
     commit_step = Mock()
     metrics = Mock()
     storage = get_writable_storage(StorageKey("eap_items"))
-
-    state.set_config("org_ids_delete_allowlist", "999")
 
     format_query = FormatQuery(commit_step, storage, EAPItemsFormatter(), metrics)
 
@@ -597,6 +590,7 @@ def test_allowlist_all_blocked(mock_execute: Mock, mock_num_mutations: Mock) -> 
 @patch("snuba.lw_deletions.strategy._num_parts_currently_mutating", return_value=1)
 @patch("snuba.lw_deletions.strategy._execute_query")
 @pytest.mark.redis_db
+@override_options("snuba", {"org_ids_delete_allowlist": "1,2"})
 def test_allowlist_all_allowed(mock_execute: Mock, mock_num_mutations: Mock) -> None:
     """
     All conditions have allowed org IDs. Normal execution, no delete_skipped.
@@ -604,8 +598,6 @@ def test_allowlist_all_allowed(mock_execute: Mock, mock_num_mutations: Mock) -> 
     commit_step = Mock()
     metrics = Mock()
     storage = get_writable_storage(StorageKey("eap_items"))
-
-    state.set_config("org_ids_delete_allowlist", "1,2")
 
     format_query = FormatQuery(commit_step, storage, EAPItemsFormatter(), metrics)
 

--- a/tests/lw_deletions/test_off_peak.py
+++ b/tests/lw_deletions/test_off_peak.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -8,8 +10,8 @@ import time_machine
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies.abstract import MessageRejected
 from arroyo.types import BrokerValue, Message, Partition, Topic
+from sentry_options.testing import override_options
 
-from snuba import state
 from snuba.lw_deletions.off_peak import OffPeakProcessingStrategy
 from snuba.state import get_raw_configs
 
@@ -54,10 +56,17 @@ def _make_strategy(
     return strategy, next_step, metrics
 
 
-def _set_offpeak_config(start: int, end: int) -> None:
-    state.set_config("lw_deletions_offpeak_enabled", 1)
-    state.set_config("lw_deletions_offpeak_start", start)
-    state.set_config("lw_deletions_offpeak_end", end)
+@contextmanager
+def _offpeak_config(start: int, end: int) -> Generator[None]:
+    with override_options(
+        "snuba",
+        {
+            "lw_deletions_offpeak_enabled": True,
+            "lw_deletions_offpeak_start": start,
+            "lw_deletions_offpeak_end": end,
+        },
+    ):
+        yield
 
 
 @pytest.mark.redis_db
@@ -70,8 +79,8 @@ class TestOffPeakDisabled:
         strategy.submit(msg)
         next_step.submit.assert_called_once_with(msg)
 
+    @override_options("snuba", {"lw_deletions_offpeak_enabled": False})
     def test_messages_pass_through_when_explicitly_disabled(self) -> None:
-        state.set_config("lw_deletions_offpeak_enabled", 0)
         strategy, next_step, _ = _make_strategy()
         msg = _make_message()
         strategy.submit(msg)
@@ -83,15 +92,13 @@ class TestOffPeakSameDayWindow:
     """Window like 2-8 (2am to 8am UTC)."""
 
     def test_within_window_passes(self) -> None:
-        with time_machine.travel(_tomorrow_at(5), tick=False):
-            _set_offpeak_config(start=2, end=8)
+        with time_machine.travel(_tomorrow_at(5), tick=False), _offpeak_config(start=2, end=8):
             strategy, next_step, _ = _make_strategy()
             strategy.submit(_make_message())
             next_step.submit.assert_called_once()
 
     def test_outside_window_rejects(self) -> None:
-        with time_machine.travel(_tomorrow_at(12), tick=False):
-            _set_offpeak_config(start=2, end=8)
+        with time_machine.travel(_tomorrow_at(12), tick=False), _offpeak_config(start=2, end=8):
             strategy, next_step, metrics = _make_strategy()
             with pytest.raises(MessageRejected):
                 strategy.submit(_make_message())
@@ -99,15 +106,13 @@ class TestOffPeakSameDayWindow:
             metrics.increment.assert_called_with("off_peak_rejected")
 
     def test_at_start_boundary_passes(self) -> None:
-        with time_machine.travel(_tomorrow_at(2), tick=False):
-            _set_offpeak_config(start=2, end=8)
+        with time_machine.travel(_tomorrow_at(2), tick=False), _offpeak_config(start=2, end=8):
             strategy, next_step, _ = _make_strategy()
             strategy.submit(_make_message())
             next_step.submit.assert_called_once()
 
     def test_at_end_boundary_rejects(self) -> None:
-        with time_machine.travel(_tomorrow_at(8), tick=False):
-            _set_offpeak_config(start=2, end=8)
+        with time_machine.travel(_tomorrow_at(8), tick=False), _offpeak_config(start=2, end=8):
             strategy, next_step, _ = _make_strategy()
             with pytest.raises(MessageRejected):
                 strategy.submit(_make_message())
@@ -118,22 +123,19 @@ class TestOffPeakMidnightSpanningWindow:
     """Window like 22-6 (10pm to 6am UTC, spanning midnight)."""
 
     def test_before_midnight_passes(self) -> None:
-        with time_machine.travel(_tomorrow_at(23), tick=False):
-            _set_offpeak_config(start=22, end=6)
+        with time_machine.travel(_tomorrow_at(23), tick=False), _offpeak_config(start=22, end=6):
             strategy, next_step, _ = _make_strategy()
             strategy.submit(_make_message())
             next_step.submit.assert_called_once()
 
     def test_after_midnight_passes(self) -> None:
-        with time_machine.travel(_tomorrow_at(3), tick=False):
-            _set_offpeak_config(start=22, end=6)
+        with time_machine.travel(_tomorrow_at(3), tick=False), _offpeak_config(start=22, end=6):
             strategy, next_step, _ = _make_strategy()
             strategy.submit(_make_message())
             next_step.submit.assert_called_once()
 
     def test_during_day_rejects(self) -> None:
-        with time_machine.travel(_tomorrow_at(14), tick=False):
-            _set_offpeak_config(start=22, end=6)
+        with time_machine.travel(_tomorrow_at(14), tick=False), _offpeak_config(start=22, end=6):
             strategy, next_step, _ = _make_strategy()
             with pytest.raises(MessageRejected):
                 strategy.submit(_make_message())
@@ -144,8 +146,7 @@ class TestOffPeakSameStartEnd:
     """When start == end, never off-peak (disables processing)."""
 
     def test_always_rejects(self) -> None:
-        with time_machine.travel(_tomorrow_at(5), tick=False):
-            _set_offpeak_config(start=5, end=5)
+        with time_machine.travel(_tomorrow_at(5), tick=False), _offpeak_config(start=5, end=5):
             strategy, next_step, _ = _make_strategy()
             with pytest.raises(MessageRejected):
                 strategy.submit(_make_message())

--- a/tests/query/parser/validation/test_functions.py
+++ b/tests/query/parser/validation/test_functions.py
@@ -4,9 +4,9 @@ from collections.abc import Mapping, Sequence
 from unittest.mock import MagicMock
 
 import pytest
+from sentry_options.testing import override_options
 
 import snuba.query.parser.validation.functions as functions
-from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -89,7 +89,7 @@ def test_functions(
     entity_return.return_value = entity_validators
     events_entity = get_entity(EntityKey.EVENTS)
     cached = events_entity.get_function_call_validators
-    events_entity.get_function_call_validators = entity_return
+    events_entity.get_function_call_validators = entity_return  # type: ignore[method-assign]
     data_source = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
 
     expression = FunctionCall(
@@ -102,15 +102,15 @@ def test_functions(
             FunctionCallsValidator().validate(expression, data_source)
 
     # TODO: This should use fixture to do this
-    events_entity.get_function_call_validators = cached
+    events_entity.get_function_call_validators = cached  # type: ignore[method-assign]
     functions.default_validators = fn_cached
 
 
 @pytest.mark.parametrize("expression, should_raise", test_expressions[:1])
 @pytest.mark.redis_db
+@override_options("snuba", {"function-validator.enabled": True})
 def test_invalid_function_name(expression: FunctionCall, should_raise: bool) -> None:
     data_source = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
-    state.set_config("function-validator.enabled", True)
 
     with pytest.raises(InvalidExpressionException):
         FunctionCallsValidator().validate(expression, data_source)
@@ -118,9 +118,9 @@ def test_invalid_function_name(expression: FunctionCall, should_raise: bool) -> 
 
 @pytest.mark.parametrize("expression, should_raise", test_expressions)
 @pytest.mark.redis_db
+@override_options("snuba", {"function-validator.enabled": True})
 def test_allowed_functions_validator(expression: FunctionCall, should_raise: bool) -> None:
     data_source = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
-    state.set_config("function-validator.enabled", True)
 
     if should_raise:
         with pytest.raises(InvalidFunctionCall):

--- a/tests/query/processors/test_clickhouse_settings_override.py
+++ b/tests/query/processors/test_clickhouse_settings_override.py
@@ -2,8 +2,8 @@ from collections.abc import MutableMapping
 from typing import Any
 
 import pytest
+from sentry_options.testing import override_options
 
-from snuba import state
 from snuba.clickhouse.columns import ColumnSet, DateTime, String
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.query import Query
@@ -97,11 +97,11 @@ def test_per_query_settings() -> None:
 
 
 @pytest.mark.redis_db
+@override_options(
+    "snuba",
+    {"ignore_clickhouse_settings_override": "max_execution_time,timeout_overflow_mode"},
+)
 def test_ignore_clickhouse_settings_overrides() -> None:
-    state.set_config(
-        "ignore_clickhouse_settings_override",
-        "max_execution_time,timeout_overflow_mode",
-    )
     query = Query(
         Table(
             "discover",

--- a/tests/query/processors/test_mapping_optimizer.py
+++ b/tests/query/processors/test_mapping_optimizer.py
@@ -1,4 +1,5 @@
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.query.conditions import (
@@ -9,7 +10,6 @@ from snuba.query.conditions import (
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.physical.mapping_optimizer import MappingOptimizer
 from snuba.query.query_settings import HTTPQuerySettings
-from snuba.state import set_config
 from tests.query.processors.query_builders import (
     build_query,
     column,
@@ -381,11 +381,11 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("query, expected_condition", TEST_CASES)
 @pytest.mark.redis_db
+@override_options("snuba", {"tags_hash_map_enabled": True})
 def test_tags_hash_map(
     query: ClickhouseQuery,
     expected_condition: Expression,
 ) -> None:
-    set_config("tags_hash_map_enabled", 1)
     MappingOptimizer(
         column_name="tags",
         hash_map_name="_tags_hash_map",

--- a/tests/query/processors/test_uniq_in_select_and_having.py
+++ b/tests/query/processors/test_uniq_in_select_and_having.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.query.expressions import Column, FunctionCall, Literal
@@ -9,11 +10,10 @@ from snuba.query.processors.physical.uniq_in_select_and_having import (
     UniqInSelectAndHavingProcessor,
 )
 from snuba.query.query_settings import HTTPQuerySettings
-from snuba.state import set_config
 from tests.query.processors.query_builders import build_query
 
 
-def uniq_expression(alias: str = None, column_name: str = "user") -> FunctionCall:
+def uniq_expression(alias: str | None = None, column_name: str = "user") -> FunctionCall:
     return FunctionCall(
         None,
         "greater",
@@ -81,16 +81,16 @@ VALID_QUERY_CASES = [
 
 @pytest.mark.parametrize("input_query", deepcopy(INVALID_QUERY_CASES))
 @pytest.mark.redis_db
+@override_options("snuba", {"throw_on_uniq_select_and_having": True})
 def test_invalid_uniq_queries(input_query: ClickhouseQuery) -> None:
-    set_config("throw_on_uniq_select_and_having", True)
     with pytest.raises(MismatchedAggregationException):
         UniqInSelectAndHavingProcessor().process_query(input_query, HTTPQuerySettings())
 
 
 @pytest.mark.parametrize("input_query", deepcopy(VALID_QUERY_CASES))
 @pytest.mark.redis_db
+@override_options("snuba", {"throw_on_uniq_select_and_having": True})
 def test_valid_uniq_queries(input_query: ClickhouseQuery) -> None:
-    set_config("throw_on_uniq_select_and_having", True)
     og_query = deepcopy(input_query)
     UniqInSelectAndHavingProcessor().process_query(input_query, HTTPQuerySettings())
     # query should not change

--- a/tests/query/snql/test_query_column_validation.py
+++ b/tests/query/snql/test_query_column_validation.py
@@ -3,8 +3,8 @@ from collections.abc import Generator
 from typing import Any
 
 import pytest
+from sentry_options.testing import override_options
 
-from snuba import state
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
@@ -385,19 +385,17 @@ time_validation_tests = [
 
 @pytest.fixture(autouse=True)
 def set_configs(redis_db: None) -> Generator[None]:
-    old_max = state.get_config("max_days")
-    old_align = state.get_config("date_align_seconds")
-    state.set_config("max_days", 5)
-    state.set_config("date_align_seconds", 3600)
-    yield
-    state.set_config("max_days", old_max)
-    state.set_config("date_align_seconds", old_align)
+    with override_options("snuba", {"max_days": 5, "date_align_seconds": 3600}):
+        yield
 
 
 @pytest.mark.parametrize("query_body, expected_query", time_validation_tests)
 @pytest.mark.redis_db
 def test_entity_column_validation(
-    query_body: str, expected_query: LogicalQuery, set_configs: Any, monkeypatch
+    query_body: str,
+    expected_query: LogicalQuery,
+    set_configs: Any,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     events = get_dataset("events")
 

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -14,10 +14,10 @@ import sentry_sdk
 from redis import RedisError, ResponseError
 from redis.exceptions import ReadOnlyError
 from redis.exceptions import TimeoutError as RedisTimeoutError
+from sentry_options.testing import override_options
 from sentry_redis_tools.failover_redis import FailoverRedis
 
 from snuba.redis import RedisClientKey, get_redis_client
-from snuba.state import set_config
 from snuba.state.cache.abstract import Cache
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import ExceptionAwareCodec
@@ -110,8 +110,8 @@ def noop(value: int) -> None:
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"read_through_cache.short_circuit": True})
 def test_short_circuit(backend: Cache[bytes]) -> None:
-    set_config("read_through_cache.short_circuit", 1)
     key = "key"
     value = b"value"
     function = mock.MagicMock(return_value=value)

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -9,6 +9,7 @@ import pytest
 import rapidjson
 from confluent_kafka import Consumer
 from confluent_kafka.admin import AdminClient
+from sentry_options.testing import override_options
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba import settings
@@ -17,7 +18,6 @@ from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.lw_deletions.types import AttributeConditions
 from snuba.query.exceptions import InvalidQueryException
-from snuba.state import set_config
 from snuba.utils.manage_topics import create_topics
 from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic
@@ -98,12 +98,12 @@ def test_deletes_not_enabled_on_storage() -> None:
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"storage_deletes_enabled": False})
 def test_deletes_not_enabled_runtime_config() -> None:
     storage = get_writable_storage(StorageKey("search_issues"))
     conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
     attr_info = get_attribution_info()
 
-    set_config("storage_deletes_enabled", 0)
     with pytest.raises(DeletesNotEnabledError):
         delete_from_storage(storage, conditions, attr_info)
 
@@ -111,12 +111,12 @@ def test_deletes_not_enabled_runtime_config() -> None:
 @pytest.mark.redis_db
 @patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
 @patch("snuba.web.bulk_delete_query.produce_delete_query")
+@override_options("snuba", {"lw_deletes_killswitch": {"search_issues": "[1]"}})
 def test_deletes_killswitch(mock_produce_query: Mock, mock_enforce_rows: Mock) -> None:
     storage = get_writable_storage(StorageKey("search_issues"))
     conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
     attr_info = get_attribution_info()
 
-    set_config("lw_deletes_killswitch_search_issues", "[1]")
     delete_from_storage(storage, conditions, attr_info)
     mock_produce_query.assert_not_called()
 
@@ -269,37 +269,31 @@ def test_attribute_conditions_feature_flag_enabled() -> None:
     )
     attr_info = get_attribution_info()
 
-    # Enable the feature flag
-    set_config("permit_delete_by_attribute", 1)
+    # Mock out _enforce_max_rows to avoid needing actual data
+    with (
+        override_options("snuba", {"permit_delete_by_attribute": True}),
+        patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10),
+        patch("snuba.web.bulk_delete_query.produce_delete_query") as mock_produce,
+    ):
+        # Should process normally and produce a message
+        result = delete_from_storage(storage, conditions, attr_info, attribute_conditions)
 
-    try:
-        # Mock out _enforce_max_rows to avoid needing actual data
-        with (
-            patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10),
-            patch("snuba.web.bulk_delete_query.produce_delete_query") as mock_produce,
-        ):
-            # Should process normally and produce a message
-            result = delete_from_storage(storage, conditions, attr_info, attribute_conditions)
+        # Should have produced a message
+        assert mock_produce.call_count == 1
+        # Should return success results
+        assert result != {}
 
-            # Should have produced a message
-            assert mock_produce.call_count == 1
-            # Should return success results
-            assert result != {}
-
-            # Verify the message includes attribute_conditions
-            call_args = mock_produce.call_args[0][0]
-            assert "attribute_conditions" in call_args
-            assert call_args["attribute_conditions"] == {
-                "group_id": {
-                    "attr_key_name": "group_id",
-                    "attr_key_type": AttributeKey.TYPE_INT,
-                    "attr_values": [12345],
-                }
+        # Verify the message includes attribute_conditions
+        call_args = mock_produce.call_args[0][0]
+        assert "attribute_conditions" in call_args
+        assert call_args["attribute_conditions"] == {
+            "group_id": {
+                "attr_key_name": "group_id",
+                "attr_key_type": AttributeKey.TYPE_INT,
+                "attr_values": [12345],
             }
-            assert call_args["attribute_conditions_item_type"] == TRACE_ITEM_TYPE_OCCURRENCE
-    finally:
-        # Clean up: disable the feature flag
-        set_config("permit_delete_by_attribute", 0)
+        }
+        assert call_args["attribute_conditions_item_type"] == TRACE_ITEM_TYPE_OCCURRENCE
 
 
 @pytest.mark.redis_db
@@ -321,8 +315,7 @@ def test_eap_items_counts_each_table_against_its_readonly_replica() -> None:
     )
     attr_info = get_attribution_info()
 
-    set_config("permit_delete_by_attribute", 1)
-    try:
+    with override_options("snuba", {"permit_delete_by_attribute": True}):
         with (
             patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10) as mock_enforce,
             patch("snuba.web.bulk_delete_query.produce_delete_query"),
@@ -344,8 +337,6 @@ def test_eap_items_counts_each_table_against_its_readonly_replica() -> None:
             "eap_items_downsample_64_ro",
             "eap_items_downsample_512_ro",
         }
-    finally:
-        set_config("permit_delete_by_attribute", 0)
 
 
 def test_count_storage_key_mapping_without_readonly_storage_set() -> None:

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 from unittest import mock
 
 import pytest
+from sentry_options.testing import override_options
 
-from snuba import state
 from snuba.attribution.appid import AppID
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.formatter.query import format_query
@@ -194,8 +195,40 @@ test_data = [
 ]
 
 
+def _query_config_to_overrides(query_config: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate the legacy flat runtime-config keys used by these test cases
+    into the sentry-options dict shape _get_query_settings_from_config now reads.
+    Values are stringified to match the string-typed option dicts; the
+    per-prefix/per-referrer second level is JSON-encoded."""
+    base: dict[str, str] = {}
+    async_settings: dict[str, str] = {}
+    by_prefix: dict[str, dict[str, str]] = {}
+    by_referrer: dict[str, dict[str, str]] = {}
+    for key, value in query_config.items():
+        sval = str(value)
+        if key.startswith("query_settings/"):
+            base[key.split("/", 1)[1]] = sval
+        elif key.startswith("async_query_settings/"):
+            async_settings[key.split("/", 1)[1]] = sval
+        elif key.startswith("referrer/"):
+            _, ref, _, setting = key.split("/", 3)
+            by_referrer.setdefault(ref, {})[setting] = sval
+        else:
+            prefix, _, setting = key.split("/", 2)
+            by_prefix.setdefault(prefix, {})[setting] = sval
+    overrides: dict[str, Any] = {}
+    if base:
+        overrides["query_settings"] = base
+    if async_settings:
+        overrides["async_query_settings"] = async_settings
+    if by_prefix:
+        overrides["query_settings_by_prefix"] = {p: json.dumps(s) for p, s in by_prefix.items()}
+    if by_referrer:
+        overrides["query_settings_by_referrer"] = {r: json.dumps(s) for r, s in by_referrer.items()}
+    return overrides
+
+
 @pytest.mark.parametrize("query_config,expected,query_prefix,async_override,referrer", test_data)
-@pytest.mark.redis_db
 def test_query_settings_from_config(
     query_config: Mapping[str, Any],
     expected: MutableMapping[str, Any],
@@ -203,11 +236,11 @@ def test_query_settings_from_config(
     async_override: bool,
     referrer: str,
 ) -> None:
-    for k, v in query_config.items():
-        state.set_config(k, v)
-    assert (
-        _get_query_settings_from_config(query_prefix, async_override, referrer=referrer) == expected
-    )
+    with override_options("snuba", _query_config_to_overrides(query_config)):
+        result = _get_query_settings_from_config(query_prefix, async_override, referrer=referrer)
+    # Values come back as strings (the option dicts are string-typed); ClickHouse
+    # HTTP settings are strings on the wire regardless.
+    assert result == {k: str(v) for k, v in expected.items()}
 
 
 def _build_test_query(
@@ -402,8 +435,6 @@ def test_bypass_cache_referrer() -> None:
     query_metadata_list: list[ClickhouseQueryMetadata] = []
     stats: dict[str, Any] = {"clickhouse_table": "errors_local"}
 
-    state.set_config("enable_bypass_cache_referrers", 1)
-
     attribution_info = AttributionInfo(
         app_id=AppID(key="key"),
         tenant_ids={
@@ -419,6 +450,7 @@ def test_bypass_cache_referrer() -> None:
     # cache should not be used for "some_bypass_cache_referrer" so if the
     # bypass does not work, the test will try to use a bad cache
     with (
+        override_options("snuba", {"enable_bypass_cache_referrers": True}),
         mock.patch("snuba.settings.BYPASS_CACHE_REFERRERS", ["some_bypass_cache_referrer"]),
         mock.patch("snuba.web.db_query._get_cache_partition"),
     ):
@@ -472,8 +504,10 @@ def test_db_query_fail() -> None:
 
     assert len(query_metadata_list) == 1
     assert query_metadata_list[0].status.value == "error"
-    assert excinfo.value.extra["stats"] == stats
-    assert excinfo.value.extra["sql"] is not None
+    err = excinfo.value
+    assert isinstance(err, QueryException)
+    assert err.extra["stats"] == stats
+    assert err.extra["sql"] is not None
 
 
 class MockThrottleAllocationPolicy(AllocationPolicy):
@@ -714,14 +748,16 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
             },
         }
         # extra data contains policy failure information
+        err = excinfo.value
+        assert isinstance(err, QueryException)
         assert (
-            excinfo.value.extra["stats"]["quota_allowance"]["details"]["RejectAllocationPolicy"][
+            err.extra["stats"]["quota_allowance"]["details"]["RejectAllocationPolicy"][
                 "explanation"
             ]["reason"]
             == "policy rejects all queries"
         )
         assert query_metadata_list[0].request_status.status.value == "rate-limited"
-        cause = excinfo.value.__cause__
+        cause = err.__cause__
         assert isinstance(cause, AllocationPolicyViolations)
         assert "RejectAllocationPolicy" in cause.violations
         assert update_called, (
@@ -922,7 +958,9 @@ def test_allocation_policy_updates_quota() -> None:
     with pytest.raises(QueryException) as e:
         _run_query()
 
-    assert e.value.extra["stats"]["quota_allowance"] == {
+    err = e.value
+    assert isinstance(err, QueryException)
+    assert err.extra["stats"]["quota_allowance"] == {
         "summary": {
             "threads_used": 0,
             "is_successful": False,
@@ -958,7 +996,7 @@ def test_allocation_policy_updates_quota() -> None:
             },
         },
     }
-    cause = e.value.__cause__
+    cause = err.__cause__
     assert isinstance(cause, AllocationPolicyViolations)
     assert "CountQueryPolicy" in cause.violations
     assert "CountQueryPolicyDuplicate" not in cause.violations
@@ -1010,9 +1048,9 @@ def test_clickhouse_settings_applied_to_query() -> None:
 
 @pytest.mark.events_db
 @pytest.mark.redis_db
+@override_options("snuba", {"ignore_consistent_queries_sample_rate": {"events": 1.0}})
 def test_db_query_ignore_consistent() -> None:
     query, storage, attribution_info = _build_test_query("count(distinct(project_id))")
-    state.set_config("events_ignore_consistent_queries_sample_rate", 1)
 
     query_metadata_list: list[ClickhouseQueryMetadata] = []
     stats: dict[str, Any] = {}

--- a/tests/web/test_max_rows_enforcer.py
+++ b/tests/web/test_max_rows_enforcer.py
@@ -1,9 +1,10 @@
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from datetime import datetime
 from typing import Any
 from unittest import mock
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
@@ -15,7 +16,6 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.data_source.simple import Table
 from snuba.query.dsl import and_cond, column, equals, literal
 from snuba.query.exceptions import TooManyDeleteRowsException
-from snuba.state import set_config
 from snuba.web.delete_query import _enforce_max_rows
 from tests.base import BaseApiTest
 from tests.web.rpc.v1.test_utils import write_eap_item
@@ -44,8 +44,12 @@ class TestMaxRowsEnforcer(BaseApiTest):
             is_delete=True,
         )
 
+    @pytest.fixture(autouse=True)
+    def _short_circuit_cache(self) -> Generator[None]:
+        with override_options("snuba", {"read_through_cache.short_circuit": True}):
+            yield
+
     def _insert_event(self) -> None:
-        set_config("read_through_cache.short_circuit", 1)
         now = datetime.now().replace(minute=0, second=0, microsecond=0)
 
         write_eap_item(
@@ -87,7 +91,7 @@ class TestMaxRowsEnforcer(BaseApiTest):
             allowed_columns=["project_id", "organization_id"],
         ),
     )
+    @override_options("snuba", {"enforce_max_rows_to_delete": False})
     def test_bypass_enforce_max_rows(self, mock: mock.MagicMock) -> None:
-        set_config("enforce_max_rows_to_delete", 0)
         self._insert_event()
         _enforce_max_rows(self.query)


### PR DESCRIPTION
Superseded — the query-execution config migration was consolidated into #8118 (query-execution, cache & deletes) to keep the cross-cutting integration tests in a single PR. Closing in favor of #8118 + #8120. The Rust slice remains #8112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)