### PR TITLE
fix(rpc): keep trace_id bare in cross-item subqueries so the bloom filter index is used

### DIFF
--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -36,7 +36,7 @@ from snuba.query.dsl import (
     literals_array,
     or_cond,
 )
-from snuba.query.expressions import DangerousRawSQL, Expression
+from snuba.query.expressions import Expression
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.request import Request as SnubaRequest
@@ -57,6 +57,7 @@ from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.resolvers.common.cross_item_queries import (
     convert_trace_filters_to_trace_item_filter_with_type,
     get_trace_ids_sql_for_cross_item_query,
+    trace_id_in_subquery_condition,
 )
 
 _DEFAULT_ROW_LIMIT = 10_000
@@ -847,23 +848,19 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
             sample=None,
         )
 
-        # Use DangerousRawSQL to embed the subquery instead of materializing trace IDs
+        # Embed the subquery as a bare `trace_id IN (...)` predicate so the bf_trace_id
+        # bloom-filter index is used (UUIDColumnProcessor would otherwise wrap the column
+        # and defeat the index — see trace_id_in_subquery_condition).
         if item_type:
             condition = base_conditions_and(
                 request.meta,
-                in_cond(
-                    column("trace_id"),
-                    DangerousRawSQL(None, f"({trace_ids_sql})"),
-                ),
+                trace_id_in_subquery_condition(trace_ids_sql),
                 f.equals(column("item_type"), item_type),
             )
         else:
             condition = base_conditions_and(
                 request.meta,
-                in_cond(
-                    column("trace_id"),
-                    DangerousRawSQL(None, f"({trace_ids_sql})"),
-                ),
+                trace_id_in_subquery_condition(trace_ids_sql),
             )
 
         query = Query(

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -33,8 +33,8 @@ from snuba.downsampled_storage_tiers import Tier
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import column, in_cond, literal
-from snuba.query.expressions import DangerousRawSQL, Expression
+from snuba.query.dsl import column, literal
+from snuba.query.expressions import Expression
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
@@ -68,6 +68,7 @@ from snuba.web.rpc.v1.resolvers.common.aggregation import (
 )
 from snuba.web.rpc.v1.resolvers.common.cross_item_queries import (
     get_trace_ids_sql_for_cross_item_query,
+    trace_id_in_subquery_condition,
 )
 from snuba.web.rpc.v1.resolvers.common.formula_reliability import (
     FormulaReliabilityCalculator,
@@ -383,12 +384,7 @@ def build_query(
         trace_ids_sql, _ = get_trace_ids_sql_for_cross_item_query(
             request, request.meta, list(request.trace_filters), sampling_tier, timer
         )
-        additional_conditions.append(
-            in_cond(
-                column("trace_id"),
-                DangerousRawSQL(None, f"({trace_ids_sql})"),
-            )
-        )
+        additional_conditions.append(trace_id_in_subquery_condition(trace_ids_sql))
 
     res = Query(
         from_clause=entity,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -40,13 +40,12 @@ from snuba.protos.common import (
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
-from snuba.query.dsl import and_cond, if_cond, in_cond, literal, literals_array, or_cond
+from snuba.query.dsl import and_cond, if_cond, literal, literals_array, or_cond
 from snuba.query.dsl import column as snuba_column
 from snuba.query.expressions import (
     Column as ColumnExpr,
 )
 from snuba.query.expressions import (
-    DangerousRawSQL,
     Expression,
     FunctionCall,
     SubscriptableReference,
@@ -90,6 +89,7 @@ from snuba.web.rpc.v1.resolvers.common.aggregation import (
 )
 from snuba.web.rpc.v1.resolvers.common.cross_item_queries import (
     get_trace_ids_sql_for_cross_item_query,
+    trace_id_in_subquery_condition,
 )
 from snuba.web.rpc.v1.resolvers.common.trace_item_table import convert_results
 
@@ -649,9 +649,7 @@ def build_query(
         trace_ids_sql, _ = get_trace_ids_sql_for_cross_item_query(
             request, request.meta, list(request.trace_filters), sampling_tier, timer
         )
-        additional_conditions.append(
-            in_cond(snuba_column("trace_id"), DangerousRawSQL(None, f"({trace_ids_sql})"))
-        )
+        additional_conditions.append(trace_id_in_subquery_condition(trace_ids_sql))
     if time_window is not None:
         additional_conditions.append(
             timestamp_in_range_condition(

--- a/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
+++ b/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
@@ -19,6 +19,7 @@ from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import and_cond, column, or_cond
+from snuba.query.expressions import DangerousRawSQL
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
@@ -36,6 +37,23 @@ from snuba.web.rpc.common.common import (
 # 50 million trace ids * 16 bytes per id = a limit of 1gigabyte memory usage per cross item query
 # most queries do not hit this number this is just an upper bound
 _TRACE_LIMIT = 50_000_000
+
+
+def trace_id_in_subquery_condition(trace_ids_sql: str) -> DangerousRawSQL:
+    """Build a ``trace_id IN (<subquery>)`` predicate as raw SQL.
+
+    The ``trace_id`` column must stay *bare* for the ``bf_trace_id`` bloom-filter skip
+    index to prune granules. ``UUIDColumnProcessor`` only keeps ``trace_id`` bare for
+    ``=``/``IN`` comparisons against literal values; it does not recognize an
+    ``IN (subquery)`` term, so it would otherwise wrap the column in
+    ``replaceAll(toString(trace_id), '-', '')``, defeating the index. Emitting the whole
+    predicate as ``DangerousRawSQL`` bypasses that rewrite so the column reads bare.
+
+    The subquery built by :func:`get_trace_ids_sql_for_cross_item_query` projects
+    ``trace_id`` as a real ``UUID`` (it is not wrapped in the dash-stripping expression),
+    so the ``IN`` set matches the column type.
+    """
+    return DangerousRawSQL(None, f"trace_id IN ({trace_ids_sql})")
 
 
 def convert_trace_filters_to_trace_item_filter_with_type(
@@ -129,7 +147,12 @@ def get_trace_ids_sql_for_cross_item_query(
         selected_columns=[
             SelectedExpression(
                 name="trace_id",
-                expression=column("trace_id"),
+                # Project (and group by) trace_id bare via DangerousRawSQL so it is not
+                # rewritten to replaceAll(toString(trace_id), '-', '') by
+                # UUIDColumnProcessor. This keeps the subquery output a real UUID, which
+                # is what the outer `trace_id IN (...)` predicate compares against (see
+                # trace_id_in_subquery_condition).
+                expression=DangerousRawSQL(None, "trace_id"),
             )
         ],
         condition=base_conditions_and(
@@ -139,7 +162,7 @@ def get_trace_ids_sql_for_cross_item_query(
         groupby=[
             column("organization_id"),
             column("project_id"),
-            column("trace_id"),
+            DangerousRawSQL(None, "trace_id"),
         ],
         having=trace_item_filters_and_expression,
         order_by=[

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -380,9 +380,7 @@ def test_raw_sql_in_subquery_predicate_keeps_column_bare() -> None:
             DangerousRawSQL(None, f"({subquery})"),
         )
     )
-    UUIDColumnProcessor({"column1", "column2"}).process_query(
-        wrapped_query, HTTPQuerySettings()
-    )
+    UUIDColumnProcessor({"column1", "column2"}).process_query(wrapped_query, HTTPQuerySettings())
     wrapped_condition = wrapped_query.get_condition()
     assert wrapped_condition is not None
     formatted = wrapped_condition.accept(ClickhouseExpressionFormatter())

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -13,7 +13,13 @@ from snuba.query.conditions import (
     binary_condition,
 )
 from snuba.query.data_source.simple import Table
-from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.expressions import (
+    Column,
+    DangerousRawSQL,
+    Expression,
+    FunctionCall,
+    Literal,
+)
 from snuba.query.processors.physical.type_converters import ColumnTypeError
 from snuba.query.processors.physical.uuid_column_processor import UUIDColumnProcessor
 from snuba.query.query_settings import HTTPQuerySettings
@@ -336,3 +342,65 @@ def test_invalid_uuid(unprocessed: Expression) -> None:
         UUIDColumnProcessor({"column1", "column2"}).process_query(
             unprocessed_query, HTTPQuerySettings()
         )
+
+
+def _query_with_condition(condition: Expression) -> Query:
+    return Query(
+        Table("transactions", ColumnSet([]), storage_key=StorageKey("dontmatter")),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=condition,
+    )
+
+
+def test_raw_sql_in_subquery_predicate_keeps_column_bare() -> None:
+    """A ``column IN (<subquery>)`` predicate emitted as ``DangerousRawSQL`` must survive
+    ``UUIDColumnProcessor`` untouched, so the bare column can use its bloom-filter skip
+    index.
+
+    The processor only keeps a UUID column bare for ``=``/``IN`` comparisons against
+    literal values. An ``in(column, <subquery>)`` term (the RHS is not a literal
+    array/tuple) is not recognized, so the processor falls back to wrapping the column in
+    ``replaceAll(toString(column), '-', '')`` -- which defeats the index. RPC cross-item
+    queries therefore build the whole predicate as raw SQL (see
+    ``cross_item_queries.trace_id_in_subquery_condition``).
+    """
+    subquery = "SELECT column1 FROM transactions"
+
+    # Fixed form: the entire predicate is raw SQL, so column1 stays bare and untouched.
+    raw_predicate = DangerousRawSQL(None, f"column1 IN ({subquery})")
+    raw_query = _query_with_condition(raw_predicate)
+    UUIDColumnProcessor({"column1", "column2"}).process_query(raw_query, HTTPQuerySettings())
+    assert raw_query.get_condition() == raw_predicate
+
+    # Regression guard: the previous form wraps column1, hiding it from the skip index.
+    wrapped_query = _query_with_condition(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column(None, None, "column1"),
+            DangerousRawSQL(None, f"({subquery})"),
+        )
+    )
+    UUIDColumnProcessor({"column1", "column2"}).process_query(
+        wrapped_query, HTTPQuerySettings()
+    )
+    wrapped_condition = wrapped_query.get_condition()
+    assert wrapped_condition is not None
+    formatted = wrapped_condition.accept(ClickhouseExpressionFormatter())
+    assert "replaceAll(toString(column1)" in formatted
+
+
+def test_raw_sql_select_column_is_not_rewritten() -> None:
+    """A ``DangerousRawSQL`` projection (used by the cross-item trace-id subquery so it
+    emits a real ``UUID`` instead of ``replaceAll(toString(trace_id), '-', '')``) must be
+    left untouched by ``UUIDColumnProcessor``."""
+    query = Query(
+        Table("transactions", ColumnSet([]), storage_key=StorageKey("dontmatter")),
+        selected_columns=[
+            SelectedExpression("column1", DangerousRawSQL(None, "column1")),
+        ],
+        condition=None,
+    )
+    UUIDColumnProcessor({"column1", "column2"}).process_query(query, HTTPQuerySettings())
+    assert query.get_selected_columns() == [
+        SelectedExpression("column1", DangerousRawSQL(None, "column1"))
+    ]


### PR DESCRIPTION
Cross-item RPC queries filter the main query by a subquery of matching trace IDs: `trace_id IN (<subquery>)`. The `bf_trace_id` bloom-filter skip index on the `trace_id` UUID column only prunes granules when the column reads **bare** — these call sites were unintentionally hiding it from the index.

### Root cause

`UUIDColumnProcessor` keeps a `trace_id` column bare (index-friendly) only for `=`/`IN` comparisons against literal values. It does **not** recognize an `IN (subquery)` term, so it fell back to wrapping the column in `replaceAll(toString(trace_id), '-', '')`, which the index cannot use. The cross-item subquery itself also projected/grouped `trace_id` through that same dash-stripping rewrite, so both sides of the comparison were function-wrapped strings rather than UUIDs.

Affected call sites (all in the cross-item-query path):
- `endpoint_get_traces._get_metadata_for_traces_with_subquery`
- `resolver_trace_item_table.build_query`
- `resolver_time_series.build_query`

Simple `EQ` / `IN`-literal-array `trace_id` filters elsewhere are already index-friendly and are unchanged.

### Fix

- Added `trace_id_in_subquery_condition(trace_ids_sql)` which builds the whole `trace_id IN (<subquery>)` predicate as `DangerousRawSQL`, so the outer column stays bare and is eligible for the bloom-filter index. This mirrors the existing `SubqueryFilterOptimizer` pattern, whose documented purpose is exactly to let the bloom-filter index prune granules via `key_column IN (subquery)`.
- Projected and grouped the subquery's `trace_id` bare (via `DangerousRawSQL`) in `get_trace_ids_sql_for_cross_item_query`, so it emits a real `UUID` that matches the outer column's type (instead of dash-stripped hex, which `toUUID`/`CAST` would reject).
- Updated the three call sites to use the helper and removed now-unused imports.

### Verification

- New unit tests in `test_uuid_column_processor.py` assert that:
  - a `DangerousRawSQL` `column IN (<subquery>)` predicate survives `UUIDColumnProcessor` untouched (column stays bare), while the previous `in(col, DangerousRawSQL(subquery))` form gets wrapped in `replaceAll(toString(...))` — a regression guard.
  - a `DangerousRawSQL` projection is not rewritten by the processor.
- Rendered the actual cross-item SQL in `dry_run` mode and confirmed both the subquery projection and the outer predicate now use bare `trace_id`:

  ```
  trace_id IN (SELECT trace_id FROM eap_items_1_local WHERE ... GROUP BY organization_id, project_id, trace_id ...)
  ```

  Previously this was `replaceAll(toString(trace_id), '-', '') IN (SELECT replaceAll(toString(trace_id), '-', '') ...)`.
- The existing `clickhouse_db` cross-item integration tests exercise these paths end-to-end.

<!-- Describe your PR here. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJsCjzicTRwE39Vc4TEvu9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJsCjzicTRwE39Vc4TEvu9)_