### PR TITLE
fix(clickhouse): recover empty-result meta and WITH TOTALS row on the connect driver

### DIFF
--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -58,81 +58,48 @@ clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 _WITH_TOTALS_RE = re.compile(r"\bWITH\s+TOTALS\b", re.IGNORECASE)
 
 
-def _split_type_args(type_args: str) -> list[str]:
-    """
-    Split the argument list of a parametric ClickHouse type (``Tuple(...)`` /
-    ``Map(...)``) on top-level commas, keeping nested parametric types intact
-    (e.g. ``UInt64, Array(String)`` -> ``["UInt64", "Array(String)"]``).
-    """
-    parts: list[str] = []
-    depth = 0
-    current = ""
-    for char in type_args:
-        if char in "([":
-            depth += 1
-            current += char
-        elif char in ")]":
-            depth -= 1
-            current += char
-        elif char == "," and depth == 0:
-            parts.append(current.strip())
-            current = ""
-        else:
-            current += char
-    if current.strip():
-        parts.append(current.strip())
-    return parts
-
-
 def _decode_json_value(value: Any, ch_type: str) -> Any:
     """
-    Decode a value from ClickHouse's JSONCompact output into the same Python type
-    the native (clickhouse-connect Native) result path yields, recursing through
-    the composite types. This lets the JSONCompact totals path (see
-    :meth:`ClickhouseConnectPool._execute_with_totals`) feed the reader values
-    that are indistinguishable from the native driver's.
+    Decode a value from ClickHouse's JSONCompact output into the Python type the
+    reader expects for the totals row (see
+    :meth:`ClickhouseConnectPool._execute_with_totals`).
 
-    Relies on the totals query running with ``output_format_json_quote_64bit_integers=0``
-    (64-bit ints as JSON numbers, not strings) and ``output_format_json_quote_denormals=1``
-    (``inf``/``nan`` as strings, not ``null``) so numeric values round-trip
-    exactly; see the settings applied in ``_execute_with_totals``.
+    Almost everything JSONCompact returns is already the right Python type and
+    passes through untouched -- numbers, strings, booleans, arrays, maps. Only a
+    few conversions are actually required:
+
+      * ``Date`` / ``DateTime`` -> ``date`` / ``datetime`` objects. The reader's
+        column-type transforms operate on objects (and re-emit Snuba's canonical
+        ISO string), so a raw JSON string would crash them / change the format.
+      * wide integers (``Int128/256``, ``UInt128/256``) -> ``int`` -- JSON
+        renders those as strings.
+      * ``Float`` -> ``float`` -- so ``inf``/``nan`` (emitted as strings, see the
+        settings in ``_execute_with_totals``) round-trip instead of staying str.
+      * ``Decimal`` -> ``Decimal`` -- to match the native driver's type.
+
+    ``Nullable`` / ``LowCardinality`` are unwrapped, and ``Array`` recurses, only
+    to reach one of the above. Every other type (``String``, ``UUID``, ``Bool``,
+    ``Tuple``, ``Map``, ...) is returned as-is: JSON already yields a value that
+    serializes identically to the native driver's.
     """
-    ch_type = ch_type.strip()
-    if ch_type.startswith("LowCardinality("):
-        return _decode_json_value(value, ch_type[len("LowCardinality(") : -1])
-    if ch_type.startswith("Nullable("):
-        if value is None:
-            return None
-        return _decode_json_value(value, ch_type[len("Nullable(") : -1])
     if value is None:
         return None
-    if ch_type.startswith("Array("):
-        inner = ch_type[len("Array(") : -1]
-        return [_decode_json_value(item, inner) for item in value]
-    if ch_type.startswith("Tuple("):
-        inner_types = _split_type_args(ch_type[len("Tuple(") : -1])
-        return tuple(
-            _decode_json_value(item, inner_types[index]) for index, item in enumerate(value)
-        )
-    if ch_type.startswith("Map("):
-        key_type, value_type = _split_type_args(ch_type[len("Map(") : -1])
-        return {
-            _decode_json_value(key, key_type): _decode_json_value(val, value_type)
-            for key, val in value.items()
-        }
+    inner = ch_type.strip()
+    while inner.startswith(("Nullable(", "LowCardinality(")):
+        inner = inner[inner.index("(") + 1 : -1]
+    if inner.startswith("Array("):
+        return [_decode_json_value(item, inner[len("Array(") : -1]) for item in value]
     # DateTime must be checked before the bare Date prefix.
-    if ch_type.startswith("DateTime"):  # DateTime, DateTime64, DateTime('UTC')
+    if inner.startswith("DateTime"):  # DateTime, DateTime64, DateTime('UTC')
         return datetime.fromisoformat(value) if isinstance(value, str) else value
-    if ch_type.startswith("Date"):  # Date, Date32
+    if inner.startswith("Date"):  # Date, Date32
         return date.fromisoformat(value) if isinstance(value, str) else value
-    if ch_type.startswith(("Int", "UInt")):  # incl. 128/256, which arrive as JSON strings
+    if inner.startswith(("Int", "UInt")):  # incl. 128/256, which arrive as JSON strings
         return int(value)
-    if ch_type.startswith(("Float", "BFloat")):
+    if inner.startswith(("Float", "BFloat")):
         return float(value)
-    if ch_type.startswith("Decimal"):
+    if inner.startswith("Decimal"):
         return Decimal(str(value))
-    # String / FixedString / UUID / Enum* / Bool / IPv4 / IPv6: JSON already
-    # yields the right Python type (or a str the reader's transforms accept).
     return value
 
 

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -71,12 +71,16 @@ def _coerce_temporal(value: Any, ch_type: str) -> Any:
     if not isinstance(value, str):
         return value
     _, inner = unwrap_nullable_type(ch_type)
-    # DateTime must be checked before the bare Date prefix.
-    if inner.startswith("DateTime"):  # DateTime, DateTime64, DateTime('UTC')
-        return datetime.fromisoformat(value)
-    if inner.startswith("Date"):  # Date, Date32
-        return date.fromisoformat(value)
-    return value
+    # Match on the base type name -- parameters stripped, so DateTime64(9) and
+    # DateTime('UTC') reduce to DateTime64 / DateTime -- so the exact type drives
+    # the conversion rather than a brittle prefix.
+    match inner.split("(", 1)[0]:
+        case "DateTime" | "DateTime64":
+            return datetime.fromisoformat(value)
+        case "Date" | "Date32":
+            return date.fromisoformat(value)
+        case _:
+            return value
 
 
 class ClickhouseConnectPool(ClickhousePool):
@@ -343,7 +347,7 @@ class ClickhouseConnectPool(ClickhousePool):
                 for row in payload.get("data", [])
             ]
             totals = payload.get("totals")
-            if totals is not None:
+            if totals:
                 results.append(
                     tuple(
                         _coerce_temporal(value, column_types[index])
@@ -365,9 +369,8 @@ class ClickhouseConnectPool(ClickhousePool):
         statistics = payload.get("statistics") or {}
 
         def _int(key: str) -> int:
-            value = statistics.get(key)
             try:
-                return int(value) if value is not None else 0
+                return int(statistics.get(key) or 0)
             except (TypeError, ValueError):
                 return 0
 

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -279,32 +279,24 @@ class ClickhouseConnectPool(ClickhousePool):
             )
         ]
 
-        # clickhouse-connect's Native/HTTP path diverges from the native (TCP)
-        # driver in two ways the driver-agnostic ClickhouseReader relies on. Both
-        # only surface against a real server (mocked-client unit tests miss them),
-        # and both are recoverable from the JSON output format:
+        # A ``GROUP BY ... WITH TOTALS`` query never carries the totals row over
+        # clickhouse-connect's Native/HTTP path: ClickHouse does not serialize
+        # totals into the Native HTTP output (they only travel over the native
+        # TCP protocol), so ``client.query()`` returns just the grouped rows. The
+        # driver-agnostic ClickhouseReader, like the native driver, expects the
+        # totals as the trailing result row. The totals are available from the
+        # JSON output format, so for a WITH TOTALS query we re-run it once with
+        # FORMAT JSON, type-coerce the totals row, and append it.
         #
-        #   * A query that matches no rows comes back with no column header at all
-        #     — ClickHouse emits a zero-byte Native body for an empty result — so
-        #     ``meta`` is empty. The native driver always reports the columns even
-        #     for an empty result, and Snuba callers reject a ``"meta": []``
-        #     response (e.g. Sentry asserts the returned columns match the query).
-        #
-        #   * A ``GROUP BY ... WITH TOTALS`` query never carries the totals row:
-        #     ClickHouse does not serialize totals into the Native HTTP output
-        #     (they only travel over the native TCP protocol), so clickhouse-
-        #     connect returns only the grouped rows. The reader expects the totals
-        #     as the trailing result row, exactly as the native driver appends it.
-        #
-        # When either applies, re-run the query once with FORMAT JSON to recover
-        # the column metadata and/or the totals row. This costs a second scan,
-        # but only for empty results and WITH TOTALS queries; the common
-        # (non-empty, no-totals) read path is untouched.
-        wants_totals = _WITH_TOTALS_RE.search(query) is not None
-        if not meta or wants_totals:
-            recovered_meta, totals = self._recover_meta_and_totals(
-                client, query, params, settings, wants_totals
-            )
+        # The other HTTP/native divergence -- an empty result set coming back
+        # with no column header at all (ClickHouse emits a zero-byte Native body
+        # for zero rows), which leaves ``meta`` empty -- is handled one layer up
+        # in snuba.web.db_query, which synthesizes the column metadata from the
+        # query itself instead of paying for a second scan here.
+        if _WITH_TOTALS_RE.search(query) is not None:
+            recovered_meta, totals = self._recover_meta_and_totals(client, query, params, settings)
+            # An empty WITH TOTALS result has no Native header either, so fall
+            # back to the JSON meta we just fetched (it carries the real types).
             if not meta:
                 meta = recovered_meta
             if totals is not None:
@@ -329,19 +321,18 @@ class ClickhouseConnectPool(ClickhousePool):
         query: str,
         params: Params,
         settings: Mapping[str, Any] | None,
-        want_totals: bool,
     ) -> tuple[list[tuple[str, str]], Mapping[str, Any] | None]:
         """
-        Re-run ``query`` with ``FORMAT JSON`` and return ``(meta, totals)``.
+        Re-run a ``WITH TOTALS`` ``query`` with ``FORMAT JSON`` and return
+        ``(meta, totals)``.
 
-        ``meta`` is the list of ``(name, type)`` column tuples (always present in
-        the JSON response, even for an empty result). ``totals`` is the raw totals
-        mapping (column name -> value) when ``want_totals`` and the response
-        carries a ``WITH TOTALS`` block, otherwise ``None``.
-
-        The JSON output format is the only one clickhouse-connect can read that
-        exposes both pieces; the Native/HTTP path the main query uses drops them.
-        Used by :meth:`_execute_once` to backfill what that path loses.
+        ``meta`` is the list of ``(name, type)`` column tuples (present in the
+        JSON response even when the result is empty); it backfills the column
+        metadata when the totals query itself matched zero rows. ``totals`` is
+        the raw totals mapping (column name -> value), or ``None`` if the
+        response carries no totals block. The JSON output format is the only one
+        clickhouse-connect can read that exposes the totals the Native/HTTP path
+        omits.
         """
         json_settings: dict[str, Any] = dict(settings) if settings else {}
         # UInt64/Int64 are emitted as quoted strings in JSON by default; turn that
@@ -355,7 +346,7 @@ class ClickhouseConnectPool(ClickhousePool):
         )
         payload = json.loads(raw)
         meta = [(column["name"], column["type"]) for column in payload.get("meta", [])]
-        totals = payload.get("totals") if want_totals else None
+        totals = payload.get("totals")
         return meta, totals
 
     @contextmanager

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -50,30 +50,16 @@ clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 
 def _coerce_temporal(value: Any, ch_type: str) -> Any:
     """
-    Convert a ``Date`` / ``DateTime`` value from ClickHouse's JSONCompact output
-    (a string) into a ``date`` / ``datetime`` object.
-
-    This is the only value conversion the JSONCompact totals path needs. The
-    reader's column-type transforms call ``date``/``datetime`` methods on these
-    values (re-emitting Snuba's canonical ISO string), so a raw JSON string would
-    crash them and change the output format -- Date/DateTime are the only types
-    that do. ``Nullable`` is unwrapped so ``Nullable(DateTime)`` is handled too,
-    mirroring the reader's own transform.
-
-    Every other type is left as ``json.loads`` decoded it. That is byte-identical
-    to the native driver once serialized (numbers, strings, bools, arrays, maps,
-    and -- via ``default=str`` -- UUID / IPv4 / IPv6 / Enum), with two harmless
-    exceptions: a whole-number ``Float`` total serializes as ``5`` rather than
-    ``5.0`` (numerically identical to any JSON consumer), and a ``Decimal``
-    decodes as a JSON number rather than the native driver's string. Totals are
-    dominated by integer counts, so this is not worth type-directed coercion.
+    Parse a ``Date``/``DateTime`` string from JSONCompact into a ``date``/``datetime``.
+    The reader's transforms call date/datetime methods on these and would crash on a
+    raw string; every other type already matches the native driver once serialized.
+    ``Nullable`` is unwrapped so ``Nullable(DateTime)`` is handled.
     """
     if not isinstance(value, str):
         return value
     _, inner = unwrap_nullable_type(ch_type)
-    # Match on the base type name -- parameters stripped, so DateTime64(9) and
-    # DateTime('UTC') reduce to DateTime64 / DateTime -- so the exact type drives
-    # the conversion rather than a brittle prefix.
+    # Match the base type name (params stripped) so DateTime64(9)/DateTime('UTC')
+    # reduce to DateTime64/DateTime.
     match inner.split("(", 1)[0]:
         case "DateTime" | "DateTime64":
             return datetime.fromisoformat(value)
@@ -297,28 +283,16 @@ class ClickhouseConnectPool(ClickhousePool):
         robust: bool = False,
     ) -> ClickhouseResult:
         """
-        Override of :meth:`ClickhousePool.execute_with_totals` for the HTTP driver.
-
-        clickhouse-connect's Native/HTTP output omits the ``WITH TOTALS`` row
-        entirely (totals only travel over the native TCP protocol), so the default
-        implementation -- which relies on that trailing row -- does not work here.
-        Instead, run the query once with ``FORMAT JSONCompact``, which returns the
-        data rows, the column metadata, and the totals row together, and append
-        the totals as the trailing result row (the shape the reader expects). Only
-        ``Date``/``DateTime`` values need coercing back to objects (see
-        :func:`_coerce_temporal`); ``json.loads`` yields every other type in a form
-        that serializes identically to the native driver.
-
-        One request, one scan. ``settings`` (timeouts, max_threads, readonly, ...)
-        are inherited; ``query_id`` is used as-is. ``capture_trace`` and ``robust``
-        are accepted for interface parity: the HTTP path cannot surface trace
-        output, and clickhouse-connect handles its own retries.
+        HTTP override of :meth:`ClickhousePool.execute_with_totals`. clickhouse-connect's
+        Native/HTTP output drops the ``WITH TOTALS`` row, so run the query once with
+        ``FORMAT JSONCompact`` (data + meta + totals together) and append the totals as
+        the trailing result row, the shape the reader expects. ``capture_trace``/``robust``
+        are accepted for interface parity but unused on this path.
         """
         with self._translate_clickhouse_errors():
             client = self._get_client()
             json_settings: dict[str, Any] = dict(settings) if settings else {}
-            # 64-bit ints as JSON numbers (not quoted strings) so they round-trip
-            # to the same Python ints the native driver yields.
+            # 64-bit ints as JSON numbers, matching the native driver's Python ints.
             json_settings["output_format_json_quote_64bit_integers"] = 0
             if query_id is not None:
                 json_settings["query_id"] = query_id
@@ -337,9 +311,7 @@ class ClickhouseConnectPool(ClickhousePool):
             meta = [(column["name"], column["type"]) for column in payload.get("meta", [])]
             column_types = [ch_type for _, ch_type in meta]
 
-            # JSONCompact returns each data row and the totals row as a positional
-            # array aligned to ``meta``, so values line up with the reader's
-            # positional indexing without any name-based lookup.
+            # Each data row and the totals row is a positional array aligned to meta.
             results: list[tuple[Any, ...]] = [
                 tuple(
                     _coerce_temporal(value, column_types[index]) for index, value in enumerate(row)
@@ -364,8 +336,8 @@ class ClickhouseConnectPool(ClickhousePool):
 
     @staticmethod
     def _profile_from_statistics(payload: Mapping[str, Any]) -> ClickhouseProfile:
-        # The JSON output formats include a ``statistics`` object carrying the same
-        # read counters the Native path reads from the X-ClickHouse-Summary header.
+        # JSON's ``statistics`` object carries the same read counters as the Native
+        # path's X-ClickHouse-Summary header.
         statistics = payload.get("statistics") or {}
 
         def _int(key: str) -> int:

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -302,11 +302,17 @@ class ClickhouseConnectPool(ClickhousePool):
             if not meta:
                 meta = recovered_meta
             if totals is not None:
-                # Order the totals values to match ``meta`` so the reader, which
-                # indexes rows positionally against ``meta``, lines them up the
-                # same way it does for the native driver's trailing totals row.
+                # Build the totals row from recovered_meta -- the JSON payload's
+                # own column list -- so the names used to read the ``totals`` dict
+                # are guaranteed to match its keys (both come from that same JSON
+                # response). Keying off the Native ``meta`` instead would risk a
+                # silent ``None`` if the two protocols ever named a column
+                # differently. recovered_meta is in the same column order as
+                # ``meta`` (both follow the SELECT list), so the row still aligns
+                # positionally with the meta the reader indexes against.
                 totals_row = tuple(
-                    _coerce_json_value(totals.get(name), ch_type) for name, ch_type in meta
+                    _coerce_json_value(totals.get(name), ch_type)
+                    for name, ch_type in recovered_meta
                 )
                 results = [*results, totals_row]
 

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import date, datetime
-from decimal import Decimal
 from threading import Lock
 from typing import Any
 
@@ -25,6 +23,7 @@ from snuba.clickhouse.native import (
     ClickhouseResult,
     Params,
 )
+from snuba.reader import unwrap_nullable_type
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger("snuba.clickhouse.connect")
@@ -48,63 +47,35 @@ DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
 # we tell clickhouse-connect to drop unrecognized settings instead of failing.
 clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 
-# Matches the ``WITH TOTALS`` clause the query formatter appends for
-# ``has_totals()`` queries (see snuba.clickhouse.formatter.query). clickhouse-
-# connect's Native/HTTP path never returns the totals row, so the connect pool
-# routes these queries through a single FORMAT JSONCompact request (which does
-# carry the totals) instead — see ClickhouseConnectPool._execute_with_totals.
-# A false positive (e.g. the literal text inside a string) is harmless: it just
-# takes the JSONCompact path, which returns the same rows without a totals block.
-_WITH_TOTALS_RE = re.compile(r"\bWITH\s+TOTALS\b", re.IGNORECASE)
 
-# Exact ClickHouse fixed-width integer type names. Matched precisely (not via a
-# ``startswith("Int")`` prefix) so ``Interval*`` types -- which also start with
-# "Int" -- are not mistaken for integers and forced through ``int()``.
-_INT_TYPE_RE = re.compile(r"^U?Int(?:8|16|32|64|128|256)$")
-
-
-def _decode_json_value(value: Any, ch_type: str) -> Any:
+def _coerce_temporal(value: Any, ch_type: str) -> Any:
     """
-    Decode a value from ClickHouse's JSONCompact output into the Python type the
-    reader expects for the totals row (see
-    :meth:`ClickhouseConnectPool._execute_with_totals`).
+    Convert a ``Date`` / ``DateTime`` value from ClickHouse's JSONCompact output
+    (a string) into a ``date`` / ``datetime`` object.
 
-    Almost everything JSONCompact returns is already the right Python type and
-    passes through untouched -- numbers, strings, booleans, arrays, maps. Only a
-    few conversions are actually required:
+    This is the only value conversion the JSONCompact totals path needs. The
+    reader's column-type transforms call ``date``/``datetime`` methods on these
+    values (re-emitting Snuba's canonical ISO string), so a raw JSON string would
+    crash them and change the output format -- Date/DateTime are the only types
+    that do. ``Nullable`` is unwrapped so ``Nullable(DateTime)`` is handled too,
+    mirroring the reader's own transform.
 
-      * ``Date`` / ``DateTime`` -> ``date`` / ``datetime`` objects. The reader's
-        column-type transforms operate on objects (and re-emit Snuba's canonical
-        ISO string), so a raw JSON string would crash them / change the format.
-      * wide integers (``Int128/256``, ``UInt128/256``) -> ``int`` -- JSON
-        renders those as strings.
-      * ``Float`` -> ``float`` -- so ``inf``/``nan`` (emitted as strings, see the
-        settings in ``_execute_with_totals``) round-trip instead of staying str.
-      * ``Decimal`` -> ``Decimal`` -- to match the native driver's type.
-
-    ``Nullable`` / ``LowCardinality`` are unwrapped, and ``Array`` recurses, only
-    to reach one of the above. Every other type (``String``, ``UUID``, ``Bool``,
-    ``Tuple``, ``Map``, ...) is returned as-is: JSON already yields a value that
-    serializes identically to the native driver's.
+    Every other type is left as ``json.loads`` decoded it. That is byte-identical
+    to the native driver once serialized (numbers, strings, bools, arrays, maps,
+    and -- via ``default=str`` -- UUID / IPv4 / IPv6 / Enum), with two harmless
+    exceptions: a whole-number ``Float`` total serializes as ``5`` rather than
+    ``5.0`` (numerically identical to any JSON consumer), and a ``Decimal``
+    decodes as a JSON number rather than the native driver's string. Totals are
+    dominated by integer counts, so this is not worth type-directed coercion.
     """
-    if value is None:
-        return None
-    inner = ch_type.strip()
-    while inner.startswith(("Nullable(", "LowCardinality(")):
-        inner = inner[inner.index("(") + 1 : -1]
-    if inner.startswith("Array("):
-        return [_decode_json_value(item, inner[len("Array(") : -1]) for item in value]
+    if not isinstance(value, str):
+        return value
+    _, inner = unwrap_nullable_type(ch_type)
     # DateTime must be checked before the bare Date prefix.
     if inner.startswith("DateTime"):  # DateTime, DateTime64, DateTime('UTC')
-        return datetime.fromisoformat(value) if isinstance(value, str) else value
+        return datetime.fromisoformat(value)
     if inner.startswith("Date"):  # Date, Date32
-        return date.fromisoformat(value) if isinstance(value, str) else value
-    if _INT_TYPE_RE.match(inner):  # incl. Int/UInt 128/256, which arrive as JSON strings
-        return int(value)
-    if inner.startswith(("Float", "BFloat")):
-        return float(value)
-    if inner.startswith("Decimal"):
-        return Decimal(str(value))
+        return date.fromisoformat(value)
     return value
 
 
@@ -249,19 +220,6 @@ class ClickhouseConnectPool(ClickhousePool):
         capture_trace: bool,
     ) -> ClickhouseResult:
         client = self._get_client()
-
-        # A ``GROUP BY ... WITH TOTALS`` query never carries the totals row over
-        # clickhouse-connect's Native/HTTP path: ClickHouse does not serialize
-        # totals into the Native HTTP output (they only travel over the native TCP
-        # protocol). FORMAT JSONCompact does carry them, so such queries take a
-        # dedicated single-request path (data + column metadata + totals in one
-        # response, one scan). It applies only to the reader path
-        # (``with_column_types``); the empty-result column metadata for non-totals
-        # queries is synthesized upstream in snuba.web.db_query instead of paying
-        # for a second scan here.
-        if with_column_types and _WITH_TOTALS_RE.search(query) is not None:
-            return self._execute_with_totals(client, query, params, query_id, settings)
-
         query_settings = self._build_query_settings(settings, query_id, capture_trace)
 
         with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
@@ -325,74 +283,80 @@ class ClickhouseConnectPool(ClickhousePool):
             trace_output="",
         )
 
-    def _execute_with_totals(
+    def execute_with_totals(
         self,
-        client: Client,
         query: str,
-        params: Params,
-        query_id: str | None,
-        settings: Mapping[str, Any] | None,
+        params: Params = None,
+        query_id: str | None = None,
+        settings: Mapping[str, Any] | None = None,
+        capture_trace: bool = False,
+        robust: bool = False,
     ) -> ClickhouseResult:
         """
-        Execute a ``GROUP BY ... WITH TOTALS`` query in a single request using
-        ``FORMAT JSONCompact``, which returns the data rows, the column metadata,
-        and the totals row together — unlike the Native/HTTP output, which omits
-        totals entirely. Values are decoded (see :func:`_decode_json_value`) into
-        the same Python types the native driver yields, and the totals row is
-        appended as the trailing result row so the driver-agnostic reader splits
-        it off exactly as it does for the native driver.
+        Override of :meth:`ClickhousePool.execute_with_totals` for the HTTP driver.
 
-        This costs no extra scan: the single JSONCompact request replaces both the
-        Native query and any separate totals fetch. ``settings`` (the query's
-        functional settings: timeouts, max_threads, readonly, ...) are inherited,
-        and ``query_id`` is used as-is (there is only one query, so no derived id
-        is needed).
+        clickhouse-connect's Native/HTTP output omits the ``WITH TOTALS`` row
+        entirely (totals only travel over the native TCP protocol), so the default
+        implementation -- which relies on that trailing row -- does not work here.
+        Instead, run the query once with ``FORMAT JSONCompact``, which returns the
+        data rows, the column metadata, and the totals row together, and append
+        the totals as the trailing result row (the shape the reader expects). Only
+        ``Date``/``DateTime`` values need coercing back to objects (see
+        :func:`_coerce_temporal`); ``json.loads`` yields every other type in a form
+        that serializes identically to the native driver.
+
+        One request, one scan. ``settings`` (timeouts, max_threads, readonly, ...)
+        are inherited; ``query_id`` is used as-is. ``capture_trace`` and ``robust``
+        are accepted for interface parity: the HTTP path cannot surface trace
+        output, and clickhouse-connect handles its own retries.
         """
-        json_settings: dict[str, Any] = dict(settings) if settings else {}
-        # Round-trip numerics to the exact Python types the native driver yields:
-        # 64-bit ints as JSON numbers (not quoted strings), and inf/nan as
-        # "inf"/"nan" strings (JSON's default renders non-finite floats as null).
-        json_settings["output_format_json_quote_64bit_integers"] = 0
-        json_settings["output_format_json_quote_denormals"] = 1
-        if query_id is not None:
-            json_settings["query_id"] = query_id
+        with self._translate_clickhouse_errors():
+            client = self._get_client()
+            json_settings: dict[str, Any] = dict(settings) if settings else {}
+            # 64-bit ints as JSON numbers (not quoted strings) so they round-trip
+            # to the same Python ints the native driver yields.
+            json_settings["output_format_json_quote_64bit_integers"] = 0
+            if query_id is not None:
+                json_settings["query_id"] = query_id
 
-        with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
-            span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
-            span.set_data("query_id", query_id)
-            raw = client.raw_query(
-                query,
-                parameters=params if params else None,
-                settings=json_settings,
-                fmt="JSONCompact",
-            )
-
-        payload = json.loads(raw)
-        meta = [(column["name"], column["type"]) for column in payload.get("meta", [])]
-        column_types = [ch_type for _, ch_type in meta]
-
-        # JSONCompact returns each data row and the totals row as a positional
-        # array aligned to ``meta``, so values line up with the reader's
-        # positional indexing without any name-based lookup.
-        results: list[tuple[Any, ...]] = [
-            tuple(_decode_json_value(value, column_types[index]) for index, value in enumerate(row))
-            for row in payload.get("data", [])
-        ]
-        totals = payload.get("totals")
-        if totals is not None:
-            results.append(
-                tuple(
-                    _decode_json_value(value, column_types[index])
-                    for index, value in enumerate(totals)
+            with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
+                span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
+                span.set_data("query_id", query_id)
+                raw = client.raw_query(
+                    query,
+                    parameters=params if params else None,
+                    settings=json_settings,
+                    fmt="JSONCompact",
                 )
-            )
 
-        return ClickhouseResult(
-            results=results,
-            meta=meta,
-            profile=self._profile_from_statistics(payload),
-            trace_output="",
-        )
+            payload = json.loads(raw)
+            meta = [(column["name"], column["type"]) for column in payload.get("meta", [])]
+            column_types = [ch_type for _, ch_type in meta]
+
+            # JSONCompact returns each data row and the totals row as a positional
+            # array aligned to ``meta``, so values line up with the reader's
+            # positional indexing without any name-based lookup.
+            results: list[tuple[Any, ...]] = [
+                tuple(
+                    _coerce_temporal(value, column_types[index]) for index, value in enumerate(row)
+                )
+                for row in payload.get("data", [])
+            ]
+            totals = payload.get("totals")
+            if totals is not None:
+                results.append(
+                    tuple(
+                        _coerce_temporal(value, column_types[index])
+                        for index, value in enumerate(totals)
+                    )
+                )
+
+            return ClickhouseResult(
+                results=results,
+                meta=meta,
+                profile=self._profile_from_statistics(payload),
+                trace_output="",
+            )
 
     @staticmethod
     def _profile_from_statistics(payload: Mapping[str, Any]) -> ClickhouseProfile:

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -6,6 +6,7 @@ import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import date, datetime
+from decimal import Decimal
 from threading import Lock
 from typing import Any
 
@@ -24,7 +25,6 @@ from snuba.clickhouse.native import (
     ClickhouseResult,
     Params,
 )
-from snuba.reader import unwrap_nullable_type
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger("snuba.clickhouse.connect")
@@ -51,34 +51,88 @@ clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 # Matches the ``WITH TOTALS`` clause the query formatter appends for
 # ``has_totals()`` queries (see snuba.clickhouse.formatter.query). clickhouse-
 # connect's Native/HTTP path never returns the totals row, so the connect pool
-# detects the clause to recover the totals via a secondary JSON query. A false
-# positive (e.g. the literal text inside a string) is harmless: the recovery
-# only appends a row if the JSON response actually carries a ``totals`` block.
+# routes these queries through a single FORMAT JSONCompact request (which does
+# carry the totals) instead — see ClickhouseConnectPool._execute_with_totals.
+# A false positive (e.g. the literal text inside a string) is harmless: it just
+# takes the JSONCompact path, which returns the same rows without a totals block.
 _WITH_TOTALS_RE = re.compile(r"\bWITH\s+TOTALS\b", re.IGNORECASE)
 
 
-def _coerce_json_value(value: Any, ch_type: str) -> Any:
+def _split_type_args(type_args: str) -> list[str]:
     """
-    Convert a scalar parsed from ClickHouse's JSON output into the Python type
-    the native result path would have produced. Only ``Date``/``DateTime``
-    columns need this: the JSON format renders them as strings, but the reader's
-    column-type transforms (and the native driver) expect ``date``/``datetime``
-    objects. Numbers already arrive as numbers (we disable 64-bit-int quoting),
-    UUIDs are stringified by the reader regardless, and every other type is
-    returned unchanged.
+    Split the argument list of a parametric ClickHouse type (``Tuple(...)`` /
+    ``Map(...)``) on top-level commas, keeping nested parametric types intact
+    (e.g. ``UInt64, Array(String)`` -> ``["UInt64", "Array(String)"]``).
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for char in type_args:
+        if char in "([":
+            depth += 1
+            current += char
+        elif char in ")]":
+            depth -= 1
+            current += char
+        elif char == "," and depth == 0:
+            parts.append(current.strip())
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        parts.append(current.strip())
+    return parts
 
-    This is applied to the recovered ``WITH TOTALS`` row so its values are
-    indistinguishable from the equivalent native-driver row downstream.
+
+def _decode_json_value(value: Any, ch_type: str) -> Any:
     """
-    if not isinstance(value, str):
-        return value
-    _, inner = unwrap_nullable_type(ch_type)
-    # Order matters: DateTime / DateTime64 must be checked before the bare Date
-    # prefix so they are not misclassified as a date.
-    if inner.startswith("DateTime"):
-        return datetime.fromisoformat(value)
-    if inner.startswith("Date"):
-        return date.fromisoformat(value)
+    Decode a value from ClickHouse's JSONCompact output into the same Python type
+    the native (clickhouse-connect Native) result path yields, recursing through
+    the composite types. This lets the JSONCompact totals path (see
+    :meth:`ClickhouseConnectPool._execute_with_totals`) feed the reader values
+    that are indistinguishable from the native driver's.
+
+    Relies on the totals query running with ``output_format_json_quote_64bit_integers=0``
+    (64-bit ints as JSON numbers, not strings) and ``output_format_json_quote_denormals=1``
+    (``inf``/``nan`` as strings, not ``null``) so numeric values round-trip
+    exactly; see the settings applied in ``_execute_with_totals``.
+    """
+    ch_type = ch_type.strip()
+    if ch_type.startswith("LowCardinality("):
+        return _decode_json_value(value, ch_type[len("LowCardinality(") : -1])
+    if ch_type.startswith("Nullable("):
+        if value is None:
+            return None
+        return _decode_json_value(value, ch_type[len("Nullable(") : -1])
+    if value is None:
+        return None
+    if ch_type.startswith("Array("):
+        inner = ch_type[len("Array(") : -1]
+        return [_decode_json_value(item, inner) for item in value]
+    if ch_type.startswith("Tuple("):
+        inner_types = _split_type_args(ch_type[len("Tuple(") : -1])
+        return tuple(
+            _decode_json_value(item, inner_types[index]) for index, item in enumerate(value)
+        )
+    if ch_type.startswith("Map("):
+        key_type, value_type = _split_type_args(ch_type[len("Map(") : -1])
+        return {
+            _decode_json_value(key, key_type): _decode_json_value(val, value_type)
+            for key, val in value.items()
+        }
+    # DateTime must be checked before the bare Date prefix.
+    if ch_type.startswith("DateTime"):  # DateTime, DateTime64, DateTime('UTC')
+        return datetime.fromisoformat(value) if isinstance(value, str) else value
+    if ch_type.startswith("Date"):  # Date, Date32
+        return date.fromisoformat(value) if isinstance(value, str) else value
+    if ch_type.startswith(("Int", "UInt")):  # incl. 128/256, which arrive as JSON strings
+        return int(value)
+    if ch_type.startswith(("Float", "BFloat")):
+        return float(value)
+    if ch_type.startswith("Decimal"):
+        return Decimal(str(value))
+    # String / FixedString / UUID / Enum* / Bool / IPv4 / IPv6: JSON already
+    # yields the right Python type (or a str the reader's transforms accept).
     return value
 
 
@@ -223,6 +277,19 @@ class ClickhouseConnectPool(ClickhousePool):
         capture_trace: bool,
     ) -> ClickhouseResult:
         client = self._get_client()
+
+        # A ``GROUP BY ... WITH TOTALS`` query never carries the totals row over
+        # clickhouse-connect's Native/HTTP path: ClickHouse does not serialize
+        # totals into the Native HTTP output (they only travel over the native TCP
+        # protocol). FORMAT JSONCompact does carry them, so such queries take a
+        # dedicated single-request path (data + column metadata + totals in one
+        # response, one scan). It applies only to the reader path
+        # (``with_column_types``); the empty-result column metadata for non-totals
+        # queries is synthesized upstream in snuba.web.db_query instead of paying
+        # for a second scan here.
+        if with_column_types and _WITH_TOTALS_RE.search(query) is not None:
+            return self._execute_with_totals(client, query, params, query_id, settings)
+
         query_settings = self._build_query_settings(settings, query_id, capture_trace)
 
         with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
@@ -279,43 +346,6 @@ class ClickhouseConnectPool(ClickhousePool):
             )
         ]
 
-        # A ``GROUP BY ... WITH TOTALS`` query never carries the totals row over
-        # clickhouse-connect's Native/HTTP path: ClickHouse does not serialize
-        # totals into the Native HTTP output (they only travel over the native
-        # TCP protocol), so ``client.query()`` returns just the grouped rows. The
-        # driver-agnostic ClickhouseReader, like the native driver, expects the
-        # totals as the trailing result row. The totals are available from the
-        # JSON output format, so for a WITH TOTALS query we re-run it once with
-        # FORMAT JSON, type-coerce the totals row, and append it.
-        #
-        # The other HTTP/native divergence -- an empty result set coming back
-        # with no column header at all (ClickHouse emits a zero-byte Native body
-        # for zero rows), which leaves ``meta`` empty -- is handled one layer up
-        # in snuba.web.db_query, which synthesizes the column metadata from the
-        # query itself instead of paying for a second scan here.
-        if _WITH_TOTALS_RE.search(query) is not None:
-            recovered_meta, totals = self._recover_meta_and_totals(
-                client, query, params, settings, query_id
-            )
-            # An empty WITH TOTALS result has no Native header either, so fall
-            # back to the JSON meta we just fetched (it carries the real types).
-            if not meta:
-                meta = recovered_meta
-            if totals is not None:
-                # Build the totals row from recovered_meta -- the JSON payload's
-                # own column list -- so the names used to read the ``totals`` dict
-                # are guaranteed to match its keys (both come from that same JSON
-                # response). Keying off the Native ``meta`` instead would risk a
-                # silent ``None`` if the two protocols ever named a column
-                # differently. recovered_meta is in the same column order as
-                # ``meta`` (both follow the SELECT list), so the row still aligns
-                # positionally with the meta the reader indexes against.
-                totals_row = tuple(
-                    _coerce_json_value(totals.get(name), ch_type)
-                    for name, ch_type in recovered_meta
-                )
-                results = [*results, totals_row]
-
         return ClickhouseResult(
             results=results,
             meta=meta,
@@ -323,52 +353,101 @@ class ClickhouseConnectPool(ClickhousePool):
             trace_output="",
         )
 
-    def _recover_meta_and_totals(
+    def _execute_with_totals(
         self,
         client: Client,
         query: str,
         params: Params,
-        settings: Mapping[str, Any] | None,
         query_id: str | None,
-    ) -> tuple[list[tuple[str, str]], Mapping[str, Any] | None]:
+        settings: Mapping[str, Any] | None,
+    ) -> ClickhouseResult:
         """
-        Re-run a ``WITH TOTALS`` ``query`` with ``FORMAT JSON`` and return
-        ``(meta, totals)``.
+        Execute a ``GROUP BY ... WITH TOTALS`` query in a single request using
+        ``FORMAT JSONCompact``, which returns the data rows, the column metadata,
+        and the totals row together — unlike the Native/HTTP output, which omits
+        totals entirely. Values are decoded (see :func:`_decode_json_value`) into
+        the same Python types the native driver yields, and the totals row is
+        appended as the trailing result row so the driver-agnostic reader splits
+        it off exactly as it does for the native driver.
 
-        ``meta`` is the list of ``(name, type)`` column tuples (present in the
-        JSON response even when the result is empty); it backfills the column
-        metadata when the totals query itself matched zero rows. ``totals`` is
-        the raw totals mapping (column name -> value), or ``None`` if the
-        response carries no totals block. The JSON output format is the only one
-        clickhouse-connect can read that exposes the totals the Native/HTTP path
-        omits.
-
-        ``settings`` is the primary query's settings, which already carries every
-        functional runtime setting (timeouts, max_threads, readonly, ...); the
-        recovery query inherits all of them. ``query_id`` is the primary query's
-        id, used to derive a distinct-but-correlated id for this recovery query.
+        This costs no extra scan: the single JSONCompact request replaces both the
+        Native query and any separate totals fetch. ``settings`` (the query's
+        functional settings: timeouts, max_threads, readonly, ...) are inherited,
+        and ``query_id`` is used as-is (there is only one query, so no derived id
+        is needed).
         """
         json_settings: dict[str, Any] = dict(settings) if settings else {}
-        # UInt64/Int64 are emitted as quoted strings in JSON by default; turn that
-        # off so numeric values come back as numbers, matching the native driver.
+        # Round-trip numerics to the exact Python types the native driver yields:
+        # 64-bit ints as JSON numbers (not quoted strings), and inf/nan as
+        # "inf"/"nan" strings (JSON's default renders non-finite floats as null).
         json_settings["output_format_json_quote_64bit_integers"] = 0
-        # Tag the recovery query with an id derived from the primary one's so the
-        # two are correlatable in ClickHouse's query_log without sharing an id
-        # (which would make them indistinguishable). send_logs_level is
-        # intentionally not propagated: the HTTP path cannot surface trace output
-        # regardless (see _build_query_settings), so it would be pure overhead.
+        json_settings["output_format_json_quote_denormals"] = 1
         if query_id is not None:
-            json_settings["query_id"] = f"{query_id}_totals"
-        raw = client.raw_query(
-            query,
-            parameters=params if params else None,
-            settings=json_settings,
-            fmt="JSON",
-        )
+            json_settings["query_id"] = query_id
+
+        with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
+            span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
+            span.set_data("query_id", query_id)
+            raw = client.raw_query(
+                query,
+                parameters=params if params else None,
+                settings=json_settings,
+                fmt="JSONCompact",
+            )
+
         payload = json.loads(raw)
         meta = [(column["name"], column["type"]) for column in payload.get("meta", [])]
+        column_types = [ch_type for _, ch_type in meta]
+
+        # JSONCompact returns each data row and the totals row as a positional
+        # array aligned to ``meta``, so values line up with the reader's
+        # positional indexing without any name-based lookup.
+        results: list[tuple[Any, ...]] = [
+            tuple(_decode_json_value(value, column_types[index]) for index, value in enumerate(row))
+            for row in payload.get("data", [])
+        ]
         totals = payload.get("totals")
-        return meta, totals
+        if totals is not None:
+            results.append(
+                tuple(
+                    _decode_json_value(value, column_types[index])
+                    for index, value in enumerate(totals)
+                )
+            )
+
+        return ClickhouseResult(
+            results=results,
+            meta=meta,
+            profile=self._profile_from_statistics(payload),
+            trace_output="",
+        )
+
+    @staticmethod
+    def _profile_from_statistics(payload: Mapping[str, Any]) -> ClickhouseProfile:
+        # The JSON output formats include a ``statistics`` object carrying the same
+        # read counters the Native path reads from the X-ClickHouse-Summary header.
+        statistics = payload.get("statistics") or {}
+
+        def _int(key: str) -> int:
+            value = statistics.get(key)
+            try:
+                return int(value) if value is not None else 0
+            except (TypeError, ValueError):
+                return 0
+
+        try:
+            elapsed = float(statistics.get("elapsed") or 0.0)
+        except (TypeError, ValueError):
+            elapsed = 0.0
+
+        read_bytes = _int("bytes_read")
+        return ClickhouseProfile(
+            blocks=0,
+            bytes=read_bytes,
+            elapsed=elapsed,
+            progress_bytes=read_bytes,
+            rows=_int("rows_read"),
+        )
 
     @contextmanager
     def _translate_clickhouse_errors(self) -> Iterator[None]:

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -294,7 +294,9 @@ class ClickhouseConnectPool(ClickhousePool):
         # in snuba.web.db_query, which synthesizes the column metadata from the
         # query itself instead of paying for a second scan here.
         if _WITH_TOTALS_RE.search(query) is not None:
-            recovered_meta, totals = self._recover_meta_and_totals(client, query, params, settings)
+            recovered_meta, totals = self._recover_meta_and_totals(
+                client, query, params, settings, query_id
+            )
             # An empty WITH TOTALS result has no Native header either, so fall
             # back to the JSON meta we just fetched (it carries the real types).
             if not meta:
@@ -321,6 +323,7 @@ class ClickhouseConnectPool(ClickhousePool):
         query: str,
         params: Params,
         settings: Mapping[str, Any] | None,
+        query_id: str | None,
     ) -> tuple[list[tuple[str, str]], Mapping[str, Any] | None]:
         """
         Re-run a ``WITH TOTALS`` ``query`` with ``FORMAT JSON`` and return
@@ -333,11 +336,23 @@ class ClickhouseConnectPool(ClickhousePool):
         response carries no totals block. The JSON output format is the only one
         clickhouse-connect can read that exposes the totals the Native/HTTP path
         omits.
+
+        ``settings`` is the primary query's settings, which already carries every
+        functional runtime setting (timeouts, max_threads, readonly, ...); the
+        recovery query inherits all of them. ``query_id`` is the primary query's
+        id, used to derive a distinct-but-correlated id for this recovery query.
         """
         json_settings: dict[str, Any] = dict(settings) if settings else {}
         # UInt64/Int64 are emitted as quoted strings in JSON by default; turn that
         # off so numeric values come back as numbers, matching the native driver.
         json_settings["output_format_json_quote_64bit_integers"] = 0
+        # Tag the recovery query with an id derived from the primary one's so the
+        # two are correlatable in ClickHouse's query_log without sharing an id
+        # (which would make them indistinguishable). send_logs_level is
+        # intentionally not propagated: the HTTP path cannot surface trace output
+        # regardless (see _build_query_settings), so it would be pure overhead.
+        if query_id is not None:
+            json_settings["query_id"] = f"{query_id}_totals"
         raw = client.raw_query(
             query,
             parameters=params if params else None,

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import logging
+import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from datetime import date, datetime
 from threading import Lock
 from typing import Any
 
@@ -21,6 +24,7 @@ from snuba.clickhouse.native import (
     ClickhouseResult,
     Params,
 )
+from snuba.reader import unwrap_nullable_type
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger("snuba.clickhouse.connect")
@@ -43,6 +47,39 @@ DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
 # forwards whatever settings it is given to the server, so to preserve parity
 # we tell clickhouse-connect to drop unrecognized settings instead of failing.
 clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
+
+# Matches the ``WITH TOTALS`` clause the query formatter appends for
+# ``has_totals()`` queries (see snuba.clickhouse.formatter.query). clickhouse-
+# connect's Native/HTTP path never returns the totals row, so the connect pool
+# detects the clause to recover the totals via a secondary JSON query. A false
+# positive (e.g. the literal text inside a string) is harmless: the recovery
+# only appends a row if the JSON response actually carries a ``totals`` block.
+_WITH_TOTALS_RE = re.compile(r"\bWITH\s+TOTALS\b", re.IGNORECASE)
+
+
+def _coerce_json_value(value: Any, ch_type: str) -> Any:
+    """
+    Convert a scalar parsed from ClickHouse's JSON output into the Python type
+    the native result path would have produced. Only ``Date``/``DateTime``
+    columns need this: the JSON format renders them as strings, but the reader's
+    column-type transforms (and the native driver) expect ``date``/``datetime``
+    objects. Numbers already arrive as numbers (we disable 64-bit-int quoting),
+    UUIDs are stringified by the reader regardless, and every other type is
+    returned unchanged.
+
+    This is applied to the recovered ``WITH TOTALS`` row so its values are
+    indistinguishable from the equivalent native-driver row downstream.
+    """
+    if not isinstance(value, str):
+        return value
+    _, inner = unwrap_nullable_type(ch_type)
+    # Order matters: DateTime / DateTime64 must be checked before the bare Date
+    # prefix so they are not misclassified as a date.
+    if inner.startswith("DateTime"):
+        return datetime.fromisoformat(value)
+    if inner.startswith("Date"):
+        return date.fromisoformat(value)
+    return value
 
 
 class ClickhouseConnectPool(ClickhousePool):
@@ -228,25 +265,98 @@ class ClickhouseConnectPool(ClickhousePool):
         # for capturing the server's send_logs_level output (it only parses the
         # X-ClickHouse-Summary header for the profile above). This is a known,
         # accepted limitation of the HTTP path — see _build_query_settings.
-        if with_column_types:
-            meta = [
-                (name, column_type.name)
-                for name, column_type in zip(
-                    query_result.column_names, query_result.column_types, strict=True
-                )
-            ]
+        if not with_column_types:
             return ClickhouseResult(
                 results=results,
-                meta=meta,
                 profile=profile_data,
                 trace_output="",
             )
 
+        meta: list[tuple[str, str]] = [
+            (name, column_type.name)
+            for name, column_type in zip(
+                query_result.column_names, query_result.column_types, strict=True
+            )
+        ]
+
+        # clickhouse-connect's Native/HTTP path diverges from the native (TCP)
+        # driver in two ways the driver-agnostic ClickhouseReader relies on. Both
+        # only surface against a real server (mocked-client unit tests miss them),
+        # and both are recoverable from the JSON output format:
+        #
+        #   * A query that matches no rows comes back with no column header at all
+        #     — ClickHouse emits a zero-byte Native body for an empty result — so
+        #     ``meta`` is empty. The native driver always reports the columns even
+        #     for an empty result, and Snuba callers reject a ``"meta": []``
+        #     response (e.g. Sentry asserts the returned columns match the query).
+        #
+        #   * A ``GROUP BY ... WITH TOTALS`` query never carries the totals row:
+        #     ClickHouse does not serialize totals into the Native HTTP output
+        #     (they only travel over the native TCP protocol), so clickhouse-
+        #     connect returns only the grouped rows. The reader expects the totals
+        #     as the trailing result row, exactly as the native driver appends it.
+        #
+        # When either applies, re-run the query once with FORMAT JSON to recover
+        # the column metadata and/or the totals row. This costs a second scan,
+        # but only for empty results and WITH TOTALS queries; the common
+        # (non-empty, no-totals) read path is untouched.
+        wants_totals = _WITH_TOTALS_RE.search(query) is not None
+        if not meta or wants_totals:
+            recovered_meta, totals = self._recover_meta_and_totals(
+                client, query, params, settings, wants_totals
+            )
+            if not meta:
+                meta = recovered_meta
+            if totals is not None:
+                # Order the totals values to match ``meta`` so the reader, which
+                # indexes rows positionally against ``meta``, lines them up the
+                # same way it does for the native driver's trailing totals row.
+                totals_row = tuple(
+                    _coerce_json_value(totals.get(name), ch_type) for name, ch_type in meta
+                )
+                results = [*results, totals_row]
+
         return ClickhouseResult(
             results=results,
+            meta=meta,
             profile=profile_data,
             trace_output="",
         )
+
+    def _recover_meta_and_totals(
+        self,
+        client: Client,
+        query: str,
+        params: Params,
+        settings: Mapping[str, Any] | None,
+        want_totals: bool,
+    ) -> tuple[list[tuple[str, str]], Mapping[str, Any] | None]:
+        """
+        Re-run ``query`` with ``FORMAT JSON`` and return ``(meta, totals)``.
+
+        ``meta`` is the list of ``(name, type)`` column tuples (always present in
+        the JSON response, even for an empty result). ``totals`` is the raw totals
+        mapping (column name -> value) when ``want_totals`` and the response
+        carries a ``WITH TOTALS`` block, otherwise ``None``.
+
+        The JSON output format is the only one clickhouse-connect can read that
+        exposes both pieces; the Native/HTTP path the main query uses drops them.
+        Used by :meth:`_execute_once` to backfill what that path loses.
+        """
+        json_settings: dict[str, Any] = dict(settings) if settings else {}
+        # UInt64/Int64 are emitted as quoted strings in JSON by default; turn that
+        # off so numeric values come back as numbers, matching the native driver.
+        json_settings["output_format_json_quote_64bit_integers"] = 0
+        raw = client.raw_query(
+            query,
+            parameters=params if params else None,
+            settings=json_settings,
+            fmt="JSON",
+        )
+        payload = json.loads(raw)
+        meta = [(column["name"], column["type"]) for column in payload.get("meta", [])]
+        totals = payload.get("totals") if want_totals else None
+        return meta, totals
 
     @contextmanager
     def _translate_clickhouse_errors(self) -> Iterator[None]:

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from datetime import date, datetime
+from datetime import datetime
 from threading import Lock
 from typing import Any
 
@@ -50,23 +50,18 @@ clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 
 def _coerce_temporal(value: Any, ch_type: str) -> Any:
     """
-    Parse a ``Date``/``DateTime`` string from JSONCompact into a ``date``/``datetime``.
-    The reader's transforms call date/datetime methods on these and would crash on a
-    raw string; every other type already matches the native driver once serialized.
-    ``Nullable`` is unwrapped so ``Nullable(DateTime)`` is handled.
+    Parse a ``Date``/``DateTime`` string from JSONCompact into the ``date``/``datetime``
+    object the reader's transforms expect -- they call date/datetime methods on it and
+    would crash on a raw string. Other types (and non-strings) pass through unchanged.
     """
     if not isinstance(value, str):
         return value
     _, inner = unwrap_nullable_type(ch_type)
-    # Match the base type name (params stripped) so DateTime64(9)/DateTime('UTC')
-    # reduce to DateTime64/DateTime.
-    match inner.split("(", 1)[0]:
-        case "DateTime" | "DateTime64":
-            return datetime.fromisoformat(value)
-        case "Date" | "Date32":
-            return date.fromisoformat(value)
-        case _:
-            return value
+    if not inner.startswith("Date"):  # Date, Date32, DateTime, DateTime64
+        return value
+    parsed = datetime.fromisoformat(value)
+    # DateTime/DateTime64 keep the time; Date/Date32 want a bare date.
+    return parsed if inner.startswith("DateTime") else parsed.date()
 
 
 class ClickhouseConnectPool(ClickhousePool):
@@ -388,6 +383,10 @@ class ClickhouseConnectPool(ClickhousePool):
             # pool likewise wraps the whole clickhouse_driver errors.Error family
             # into ClickhouseError, preserving the server error code when present.
             raise ClickhouseError(str(e), code=getattr(e, "code", None) or -1) from e
+        except json.JSONDecodeError as e:
+            # A malformed body on the JSONCompact totals path (truncation, a proxy
+            # error page) surfaces as ClickhouseError, like the native driver does.
+            raise ClickhouseError(f"invalid JSON response: {e}", code=-1) from e
 
     def execute(
         self,

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -57,6 +57,11 @@ clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 # takes the JSONCompact path, which returns the same rows without a totals block.
 _WITH_TOTALS_RE = re.compile(r"\bWITH\s+TOTALS\b", re.IGNORECASE)
 
+# Exact ClickHouse fixed-width integer type names. Matched precisely (not via a
+# ``startswith("Int")`` prefix) so ``Interval*`` types -- which also start with
+# "Int" -- are not mistaken for integers and forced through ``int()``.
+_INT_TYPE_RE = re.compile(r"^U?Int(?:8|16|32|64|128|256)$")
+
 
 def _decode_json_value(value: Any, ch_type: str) -> Any:
     """
@@ -94,7 +99,7 @@ def _decode_json_value(value: Any, ch_type: str) -> Any:
         return datetime.fromisoformat(value) if isinstance(value, str) else value
     if inner.startswith("Date"):  # Date, Date32
         return date.fromisoformat(value) if isinstance(value, str) else value
-    if inner.startswith(("Int", "UInt")):  # incl. 128/256, which arrive as JSON strings
+    if _INT_TYPE_RE.match(inner):  # incl. Int/UInt 128/256, which arrive as JSON strings
         return int(value)
     if inner.startswith(("Float", "BFloat")):
         return float(value)

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -143,18 +143,11 @@ class ClickhousePool(ABC):
         robust: bool = False,
     ) -> ClickhouseResult:
         """
-        Run a ``WITH TOTALS`` query and return a result whose trailing row is the
-        totals row (the shape :class:`ClickhouseReader` expects).
-
-        This gets its own entry point because the drivers surface totals
-        differently. The native protocol streams the totals block back as the
-        trailing result row, so a plain :meth:`execute` already produces the right
-        shape and the default implementation just delegates to it. The
-        clickhouse-connect (HTTP) pool cannot — its Native/HTTP output drops the
-        totals block entirely — so it overrides this method to refetch them via
-        ``FORMAT JSONCompact`` (see ``ClickhouseConnectPool.execute_with_totals``).
-        Callers that issue ``WITH TOTALS`` must use this method rather than
-        ``execute`` so they work on either driver.
+        Run a ``WITH TOTALS`` query, returning the totals as the trailing result row
+        (the shape :class:`ClickhouseReader` expects). The native protocol already
+        streams it there, so this default just delegates to :meth:`execute`; the
+        clickhouse-connect pool overrides it (its output drops the totals block).
+        Callers must use this rather than ``execute`` so both drivers work.
         """
         execute = self.execute_robust if robust else self.execute
         return execute(
@@ -543,10 +536,8 @@ class ClickhouseReader(Reader):
 
         new_result: Result = {}
         if with_totals:
-            # The driver is expected to return the totals as the trailing result
-            # row: the native pool appends it from the protocol, and the
-            # clickhouse-connect pool re-fetches it via JSON (the Native/HTTP
-            # output omits it). An empty result here means that row went missing.
+            # Both pools return the totals as the trailing row (see
+            # ClickhousePool.execute_with_totals); an empty result means it went missing.
             assert len(data) > 0, "WITH TOTALS query returned no rows (missing totals row)"
             totals = data.pop(-1)
             new_result = {
@@ -584,9 +575,8 @@ class ClickhouseReader(Reader):
             query_id = settings.pop("query_id")
 
         if with_totals:
-            # Totals travel differently on each driver (a trailing protocol row on
-            # native, a dropped block that must be refetched over HTTP), so route
-            # through the dedicated entry point that both pools implement.
+            # Totals travel differently per driver, so route through the entry
+            # point both pools implement (see ClickhousePool.execute_with_totals).
             result = self.__client.execute_with_totals(
                 query.get_sql(),
                 query_id=query_id,

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -510,7 +510,11 @@ class ClickhouseReader(Reader):
 
         new_result: Result = {}
         if with_totals:
-            assert len(data) > 0
+            # The driver is expected to return the totals as the trailing result
+            # row: the native pool appends it from the protocol, and the
+            # clickhouse-connect pool re-fetches it via JSON (the Native/HTTP
+            # output omits it). An empty result here means that row went missing.
+            assert len(data) > 0, "WITH TOTALS query returned no rows (missing totals row)"
             totals = data.pop(-1)
             new_result = {
                 "data": data,

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -133,6 +133,39 @@ class ClickhousePool(ABC):
         """
         return self.execute(query, with_column_types=True)
 
+    def execute_with_totals(
+        self,
+        query: str,
+        params: Params = None,
+        query_id: str | None = None,
+        settings: Mapping[str, Any] | None = None,
+        capture_trace: bool = False,
+        robust: bool = False,
+    ) -> ClickhouseResult:
+        """
+        Run a ``WITH TOTALS`` query and return a result whose trailing row is the
+        totals row (the shape :class:`ClickhouseReader` expects).
+
+        This gets its own entry point because the drivers surface totals
+        differently. The native protocol streams the totals block back as the
+        trailing result row, so a plain :meth:`execute` already produces the right
+        shape and the default implementation just delegates to it. The
+        clickhouse-connect (HTTP) pool cannot — its Native/HTTP output drops the
+        totals block entirely — so it overrides this method to refetch them via
+        ``FORMAT JSONCompact`` (see ``ClickhouseConnectPool.execute_with_totals``).
+        Callers that issue ``WITH TOTALS`` must use this method rather than
+        ``execute`` so they work on either driver.
+        """
+        execute = self.execute_robust if robust else self.execute
+        return execute(
+            query,
+            params=params,
+            with_column_types=True,
+            query_id=query_id,
+            settings=settings,
+            capture_trace=capture_trace,
+        )
+
     @abstractmethod
     def close(self) -> None:
         raise NotImplementedError
@@ -550,15 +583,25 @@ class ClickhouseReader(Reader):
         if "query_id" in settings:
             query_id = settings.pop("query_id")
 
-        execute_func = self.__client.execute_robust if robust is True else self.__client.execute
-
-        return self.__transform_result(
-            execute_func(
+        if with_totals:
+            # Totals travel differently on each driver (a trailing protocol row on
+            # native, a dropped block that must be refetched over HTTP), so route
+            # through the dedicated entry point that both pools implement.
+            result = self.__client.execute_with_totals(
+                query.get_sql(),
+                query_id=query_id,
+                settings=settings,
+                capture_trace=capture_trace,
+                robust=robust,
+            )
+        else:
+            execute_func = self.__client.execute_robust if robust is True else self.__client.execute
+            result = execute_func(
                 query.get_sql(),
                 with_column_types=True,
                 query_id=query_id,
                 settings=settings,
                 capture_trace=capture_trace,
-            ),
-            with_totals=with_totals,
-        )
+            )
+
+        return self.__transform_result(result, with_totals=with_totals)

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -595,7 +595,7 @@ class ClickhouseReader(Reader):
                 robust=robust,
             )
         else:
-            execute_func = self.__client.execute_robust if robust is True else self.__client.execute
+            execute_func = self.__client.execute_robust if robust else self.__client.execute
             result = execute_func(
                 query.get_sql(),
                 with_column_types=True,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -196,14 +196,16 @@ def execute_query(
     if not result["meta"]:
         synthesized_meta: list[Column] = []
         for index, selected in enumerate(clickhouse_query.get_selected_columns()):
-            # The result column name is the expression's alias -- that is what the
-            # formatter emits as ``... AS <alias>`` and what ClickHouse echoes
-            # back. SelectedExpression.name mirrors it but is nullable, so fall
-            # back to the expression alias, and finally to the same
-            # ``_invalid_alias_{index}`` placeholder Query.get_columns() uses --
-            # so a column is never dropped, keeping meta aligned one-to-one with
-            # the result columns.
-            name = selected.name or selected.expression.alias or f"_invalid_alias_{index}"
+            # The result column name is the expression's SQL alias: that is what
+            # the formatter emits as ``... AS <alias>`` and what ClickHouse echoes
+            # back in the column header (i.e. exactly what the native driver
+            # reports, which this synthesis must match). SelectedExpression.name is
+            # Snuba's logical name -- it usually equals the alias but can differ
+            # (e.g. MQL rollup: name ``time`` vs alias ``events.time``), so it is
+            # only a fallback. Finally fall back to the same
+            # ``_invalid_alias_{index}`` placeholder Query.get_columns() uses, so a
+            # column is never dropped and meta stays aligned with the result.
+            name = selected.expression.alias or selected.name or f"_invalid_alias_{index}"
             synthesized_meta.append({"name": name, "type": ""})
         result["meta"] = synthesized_meta
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -48,7 +48,7 @@ from snuba.querylog.query_metadata import (
     get_query_status_from_error_codes,
     get_request_status,
 )
-from snuba.reader import Reader, Result
+from snuba.reader import Column, Reader, Result
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.state.cache.abstract import Cache, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import (
@@ -184,6 +184,21 @@ def execute_query(
         with_totals=clickhouse_query.has_totals(),
         robust=robust,
     )
+
+    # The clickhouse-connect (HTTP) reader returns no column metadata for an
+    # empty result set: ClickHouse emits a zero-byte Native body for a query
+    # that matches no rows, so there is no header to read (the native driver
+    # always reports the columns). Rather than issue a second query to recover
+    # them, synthesize the column names from the query we just ran -- they are
+    # the selected-column aliases, which is exactly how the result columns are
+    # named. Types are left blank: an empty result has no values to coerce, and
+    # consumers of an empty result rely only on the column names.
+    if not result["meta"]:
+        synthesized_meta: list[Column] = []
+        for selected in clickhouse_query.get_selected_columns():
+            if selected.name is not None:
+                synthesized_meta.append({"name": selected.name, "type": ""})
+        result["meta"] = synthesized_meta
 
     timer.mark("execute")
     stats.update(

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -195,15 +195,16 @@ def execute_query(
     # consumers of an empty result rely only on the column names.
     if not result["meta"]:
         synthesized_meta: list[Column] = []
-        for selected in clickhouse_query.get_selected_columns():
+        for index, selected in enumerate(clickhouse_query.get_selected_columns()):
             # The result column name is the expression's alias -- that is what the
             # formatter emits as ``... AS <alias>`` and what ClickHouse echoes
             # back. SelectedExpression.name mirrors it but is nullable, so fall
-            # back to the expression alias rather than dropping a column (which
-            # would desync meta from the actual result columns).
-            name = selected.name or selected.expression.alias
-            if name is not None:
-                synthesized_meta.append({"name": name, "type": ""})
+            # back to the expression alias, and finally to the same
+            # ``_invalid_alias_{index}`` placeholder Query.get_columns() uses --
+            # so a column is never dropped, keeping meta aligned one-to-one with
+            # the result columns.
+            name = selected.name or selected.expression.alias or f"_invalid_alias_{index}"
+            synthesized_meta.append({"name": name, "type": ""})
         result["meta"] = synthesized_meta
 
     timer.mark("execute")

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -202,10 +202,17 @@ def execute_query(
             # reports, which this synthesis must match). SelectedExpression.name is
             # Snuba's logical name -- it usually equals the alias but can differ
             # (e.g. MQL rollup: name ``time`` vs alias ``events.time``), so it is
-            # only a fallback. Finally fall back to the same
-            # ``_invalid_alias_{index}`` placeholder Query.get_columns() uses, so a
-            # column is never dropped and meta stays aligned with the result.
-            name = selected.expression.alias or selected.name or f"_invalid_alias_{index}"
+            # only a fallback. If neither is set, a bare column is echoed by its
+            # own name (``SELECT project_id`` -> column ``project_id``), so use
+            # that. Finally fall back to the same ``_invalid_alias_{index}``
+            # placeholder Query.get_columns() uses, so a column is never dropped
+            # and meta stays aligned with the result.
+            name = (
+                selected.expression.alias
+                or selected.name
+                or getattr(selected.expression, "column_name", None)
+                or f"_invalid_alias_{index}"
+            )
             synthesized_meta.append({"name": name, "type": ""})
         result["meta"] = synthesized_meta
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -185,28 +185,18 @@ def execute_query(
         robust=robust,
     )
 
-    # The clickhouse-connect (HTTP) reader returns no column metadata for an
-    # empty result set: ClickHouse emits a zero-byte Native body for a query
-    # that matches no rows, so there is no header to read (the native driver
-    # always reports the columns). Rather than issue a second query to recover
-    # them, synthesize the column names from the query we just ran -- they are
-    # the selected-column aliases, which is exactly how the result columns are
-    # named. Types are left blank: an empty result has no values to coerce, and
-    # consumers of an empty result rely only on the column names.
+    # The clickhouse-connect (HTTP) reader returns empty meta for a zero-row result
+    # (ClickHouse sends a zero-byte Native body, so there's no column header; the
+    # native driver always reports columns). Synthesize the names from the query we
+    # just ran instead of paying for a second scan; types are left blank (an empty
+    # result has no values to coerce).
     if not result["meta"]:
         synthesized_meta: list[Column] = []
         for index, selected in enumerate(clickhouse_query.get_selected_columns()):
-            # The result column name is the expression's SQL alias: that is what
-            # the formatter emits as ``... AS <alias>`` and what ClickHouse echoes
-            # back in the column header (i.e. exactly what the native driver
-            # reports, which this synthesis must match). SelectedExpression.name is
-            # Snuba's logical name -- it usually equals the alias but can differ
-            # (e.g. MQL rollup: name ``time`` vs alias ``events.time``), so it is
-            # only a fallback. If neither is set, a bare column is echoed by its
-            # own name (``SELECT project_id`` -> column ``project_id``), so use
-            # that. Finally fall back to the same ``_invalid_alias_{index}``
-            # placeholder Query.get_columns() uses, so a column is never dropped
-            # and meta stays aligned with the result.
+            # ClickHouse names the column by its SQL alias (matching the native
+            # driver), so prefer that; fall back to the logical name (can differ,
+            # e.g. MQL ``time`` vs ``events.time``), then a bare column's own name,
+            # then the ``_invalid_alias_{index}`` placeholder Query.get_columns() uses.
             name = (
                 selected.expression.alias
                 or selected.name

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -196,8 +196,14 @@ def execute_query(
     if not result["meta"]:
         synthesized_meta: list[Column] = []
         for selected in clickhouse_query.get_selected_columns():
-            if selected.name is not None:
-                synthesized_meta.append({"name": selected.name, "type": ""})
+            # The result column name is the expression's alias -- that is what the
+            # formatter emits as ``... AS <alias>`` and what ClickHouse echoes
+            # back. SelectedExpression.name mirrors it but is nullable, so fall
+            # back to the expression alias rather than dropping a column (which
+            # would desync meta from the actual result columns).
+            name = selected.name or selected.expression.alias
+            if name is not None:
+                synthesized_meta.append({"name": name, "type": ""})
         result["meta"] = synthesized_meta
 
     timer.mark("execute")

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -788,15 +788,23 @@ def test_connect_driver_matches_native_for_totals_and_empty_results() -> None:
         assert http_empty["meta"] == []
         assert {c["name"] for c in native_empty["meta"]} == {"g", "s"}
 
-        # 3) WITH TOTALS matching zero rows still yields a totals row. Over the
-        #    HTTP driver this used to leave the reader with no rows, firing the
-        #    totals assertion -> "SnubaError (No error message)".
+        # 3) WITH TOTALS matching zero rows still yields a totals row on BOTH
+        #    drivers. Over the HTTP driver this used to leave the reader with no
+        #    rows, firing the totals assertion -> "SnubaError (No error message)".
+        #    The native driver streams the totals block over the TCP protocol even
+        #    when no data rows match, so the reader's `assert len(data) > 0` holds
+        #    there too -- asserting the native side pins that behavior, so a
+        #    clickhouse-driver change that dropped the empty totals block would
+        #    fail here rather than in production.
         empty_totals_sql = (
             f"SELECT g, sum(v) AS s FROM {table} WHERE g = 999 GROUP BY g WITH TOTALS"
         )
+        native_empty_totals = run(native_pool, empty_totals_sql, True)
         http_empty_totals = run(connect_pool, empty_totals_sql, True)
+        assert native_empty_totals["data"] == []
+        assert native_empty_totals["totals"]["s"] == 0
         assert http_empty_totals["data"] == []
-        assert http_empty_totals["totals"]["s"] == 0
+        assert http_empty_totals["totals"] == native_empty_totals["totals"]
         assert {c["name"] for c in http_empty_totals["meta"]} == {"g", "s"}
     finally:
         try:

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -249,13 +249,9 @@ def test_clickhouse_reader_wraps_connect_pool() -> None:
 
 
 def test_with_totals_via_single_jsoncompact_request() -> None:
-    # clickhouse-connect's Native/HTTP path never returns the WITH TOTALS row
-    # (ClickHouse omits totals from the Native HTTP output). The connect pool runs
-    # WITH TOTALS queries through a single FORMAT JSONCompact request -- which
-    # returns data + meta + totals together -- and appends the totals as the
-    # trailing result row, the contract the driver-agnostic ClickhouseReader
-    # expects (the same one the native driver satisfies). The Native query() path
-    # is not used for these queries, so there is no second scan.
+    # WITH TOTALS runs through a single FORMAT JSONCompact request (data + meta +
+    # totals), appending the totals as the trailing row the reader expects -- the
+    # Native query() path is untouched, so there is no second scan.
     from snuba.clickhouse.native import ClickhouseReader
 
     class FakeFormattedQuery:
@@ -294,9 +290,7 @@ def test_with_totals_via_single_jsoncompact_request() -> None:
 
 
 def test_totals_jsoncompact_uses_original_query_id_and_inherits_settings() -> None:
-    # The single JSONCompact request carries the query's own id -- there is only
-    # one query, so no derived id is needed -- and inherits every functional
-    # runtime setting from the query.
+    # The single JSONCompact request uses the query's own id and inherits its settings.
     client = mock.Mock()
     client.raw_query.return_value = json.dumps(
         {
@@ -320,11 +314,8 @@ def test_totals_jsoncompact_uses_original_query_id_and_inherits_settings() -> No
 
 
 def test_totals_jsoncompact_decodes_value_types() -> None:
-    # Values from JSONCompact are decoded into the same Python types the native
-    # driver yields, so the reader's transforms and downstream serialization
-    # behave identically for both drivers. Covers the tricky cases: DateTime
-    # (string -> datetime, so the reader's transform can ISO-format it rather than
-    # crash on a str), Array (passed through), and Nullable (null -> None / value).
+    # JSONCompact values decode to the types the native driver yields. Covers DateTime
+    # (string -> datetime so the reader can ISO-format it), Array, and Nullable.
     from snuba.clickhouse.native import ClickhouseReader
 
     class FakeFormattedQuery:
@@ -362,12 +353,8 @@ def test_totals_jsoncompact_decodes_value_types() -> None:
 
 
 def test_coerce_temporal_only_touches_date_and_datetime() -> None:
-    # _coerce_temporal is the single value conversion the JSONCompact totals path
-    # applies: Date/DateTime strings become date/datetime objects (so the reader's
-    # column transforms can ISO-format them instead of crashing on a str -- those
-    # are the only types whose transforms would crash), and it unwraps Nullable so
-    # Nullable(DateTime) is handled too. Every other type -- including the ints and
-    # floats json.loads returns -- must pass through untouched.
+    # Date/DateTime strings become objects (else the reader's transforms crash on a
+    # str); Nullable is unwrapped; every other type passes through untouched.
     from snuba.clickhouse.connect import _coerce_temporal
 
     assert _coerce_temporal("2023-01-02 03:04:05", "DateTime") == datetime(2023, 1, 2, 3, 4, 5)
@@ -375,33 +362,24 @@ def test_coerce_temporal_only_touches_date_and_datetime() -> None:
         2023, 1, 2, 3, 4, 5
     )
     assert _coerce_temporal("2023-01-02", "Date") == date(2023, 1, 2)
-    # Parametrized precision variants reduce to the same base type (the match is on
-    # the base name, not a prefix), so DateTime64/Date32 are handled too.
+    # Parametrized variants reduce to the base type (DateTime64(9), Date32).
     assert _coerce_temporal("2023-01-02 03:04:05.123456789", "DateTime64(9)") == datetime(
         2023, 1, 2, 3, 4, 5, 123456
     )
     assert _coerce_temporal("2023-01-02", "Date32") == date(2023, 1, 2)
-    # Nullable is unwrapped, mirroring the reader's own transform.
     assert _coerce_temporal("2023-01-02 03:04:05", "Nullable(DateTime)") == datetime(
         2023, 1, 2, 3, 4, 5
     )
-    # Non-temporal values (and None) are returned verbatim, whatever the type. A
-    # whole-number Float that JSON emitted as an int stays an int here (the
-    # accepted, numerically-identical 5-vs-5.0 divergence).
+    # Non-temporal values and non-strings (incl. None) pass through untouched.
     assert _coerce_temporal(5, "UInt64") == 5
     assert _coerce_temporal(1.5, "Float64") == 1.5
     assert _coerce_temporal(None, "Nullable(DateTime)") is None
-    # A non-string under a Date/DateTime type is left alone (defensive).
     assert _coerce_temporal(0, "DateTime") == 0
 
 
 def test_empty_non_totals_result_does_not_refetch() -> None:
-    # An empty, non-WITH-TOTALS result comes back from the Native/HTTP path with
-    # no column header (ClickHouse emits a zero-byte Native body for zero rows),
-    # so meta is empty. The driver does NOT pay for a second query to recover it:
-    # the column metadata for an empty result is synthesized one layer up, in
-    # snuba.web.db_query, from the query's own columns (see
-    # test_db_query.test_empty_result_meta_synthesized_from_query).
+    # An empty result yields empty meta (zero-byte Native body) and no second query;
+    # the meta is synthesized upstream in db_query, not refetched here.
     client = mock.Mock()
     client.query.return_value = FakeQueryResult(result_set=[], column_names=(), column_types=())
 
@@ -417,10 +395,8 @@ def test_empty_non_totals_result_does_not_refetch() -> None:
 
 
 def test_empty_with_totals_returns_meta_and_totals_via_jsoncompact() -> None:
-    # A WITH TOTALS query that matches zero rows loses both its column header and
-    # its totals row over the Native/HTTP path. The single JSONCompact request
-    # still carries the column metadata and the totals row, so the connect pool
-    # returns them (and never touches the Native query() path).
+    # A zero-row WITH TOTALS loses its header and totals row over Native/HTTP, but
+    # the JSONCompact request still carries both.
     client = mock.Mock()
     client.raw_query.return_value = json.dumps(
         {
@@ -642,10 +618,8 @@ def test_native_pool_execute_explain_delegates_to_execute() -> None:
 
 
 def test_native_pool_execute_with_totals_delegates_to_execute() -> None:
-    # The ClickhousePool default (used by the native driver) runs WITH TOTALS
-    # through the normal execute() path: the native protocol streams the totals
-    # back as the trailing result row, so a plain execute() already yields the
-    # shape the reader expects. Only the connect pool overrides this.
+    # The native default runs WITH TOTALS through execute() -- the protocol already
+    # streams the totals as the trailing row. Only the connect pool overrides this.
     from snuba.clickhouse.native import ClickhouseNativePool, ClickhouseResult
 
     pool = ClickhouseNativePool("host", 9000, "user", "pw", "db")
@@ -685,10 +659,8 @@ def test_native_pool_execute_with_totals_robust_uses_execute_robust() -> None:
 
 
 def test_reader_routes_with_totals_through_execute_with_totals() -> None:
-    # The reader sends WITH TOTALS queries through the pool's execute_with_totals
-    # entry point (not plain execute), forwarding robust, so each driver can
-    # handle totals its own way. This pins the driver-agnostic wiring both pools
-    # rely on.
+    # The reader routes WITH TOTALS through execute_with_totals (not plain execute),
+    # forwarding robust, so each driver handles totals its own way.
     from snuba.clickhouse.native import ClickhouseReader, ClickhouseResult
 
     class FakeFormattedQuery:
@@ -719,13 +691,10 @@ def test_reader_routes_with_totals_through_execute_with_totals() -> None:
 
 @pytest.mark.clickhouse_db
 def test_connect_driver_matches_native_for_totals_and_empty_results() -> None:
-    # End-to-end against a real ClickHouse: the clickhouse-connect (HTTP) pool
-    # must produce the same ClickhouseReader output as the native pool for the
-    # two query shapes that broke when the HTTP driver was first enabled --
-    # GROUP BY ... WITH TOTALS, and queries that match zero rows. Mocked unit
-    # tests cannot catch these regressions because they hinge on how a real
-    # server serializes the Native/HTTP response (an empty body for zero rows,
-    # and no totals block at all).
+    # End-to-end vs a real ClickHouse: the connect (HTTP) pool must produce the same
+    # reader output as the native pool for the two shapes that broke when the HTTP
+    # driver was enabled -- WITH TOTALS and zero-row queries. Mocked tests can't catch
+    # these; they hinge on the real server's Native/HTTP serialization.
     from snuba import settings
     from snuba.clickhouse.native import ClickhouseNativePool, ClickhouseReader
 
@@ -780,13 +749,9 @@ def test_connect_driver_matches_native_for_totals_and_empty_results() -> None:
         assert http["totals"]["s"] == 40  # sum(v) over all rows
         assert {c["name"] for c in http["meta"]} == {"g", "ts", "s"}
 
-        # 2) A query matching zero rows: the native driver still reports its
-        #    columns, while the connect driver returns empty meta at the reader
-        #    level (ClickHouse sends a zero-byte Native body for zero rows). The
-        #    column metadata for this case is synthesized one layer up, in
-        #    db_query, from the query's own columns -- see
-        #    test_db_query.test_empty_result_meta_synthesized_from_query -- so no
-        #    second scan is paid here. This pins the driver-level divergence.
+        # 2) Zero-row query: native still reports its columns, connect returns empty
+        #    meta (zero-byte Native body); meta is synthesized in db_query, not
+        #    refetched. Pins the driver-level divergence.
         empty_sql = f"SELECT g, sum(v) AS s FROM {table} WHERE g = 999 GROUP BY g"
         native_empty = run(native_pool, empty_sql, False)
         http_empty = run(connect_pool, empty_sql, False)
@@ -794,14 +759,9 @@ def test_connect_driver_matches_native_for_totals_and_empty_results() -> None:
         assert http_empty["meta"] == []
         assert {c["name"] for c in native_empty["meta"]} == {"g", "s"}
 
-        # 3) WITH TOTALS matching zero rows still yields a totals row on BOTH
-        #    drivers. Over the HTTP driver this used to leave the reader with no
-        #    rows, firing the totals assertion -> "SnubaError (No error message)".
-        #    The native driver streams the totals block over the TCP protocol even
-        #    when no data rows match, so the reader's `assert len(data) > 0` holds
-        #    there too -- asserting the native side pins that behavior, so a
-        #    clickhouse-driver change that dropped the empty totals block would
-        #    fail here rather than in production.
+        # 3) Zero-row WITH TOTALS still yields a totals row on both drivers -- the
+        #    case that fired the reader's assertion -> "SnubaError" over HTTP.
+        #    Asserting the native side pins that its protocol keeps the empty totals row.
         empty_totals_sql = (
             f"SELECT g, sum(v) AS s FROM {table} WHERE g = 999 GROUP BY g WITH TOTALS"
         )

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -301,23 +301,15 @@ def test_with_totals_refetched_via_json_over_http() -> None:
     assert kwargs["settings"]["output_format_json_quote_64bit_integers"] == 0
 
 
-def test_empty_result_recovers_column_meta_via_json() -> None:
-    # A query that matches no rows comes back from the Native/HTTP path with no
-    # column header at all (ClickHouse emits a zero-byte Native body for an empty
-    # result), so column_names/meta are empty. The pool recovers the column
-    # metadata from a FORMAT JSON query. Without this Snuba returns "meta": [],
-    # and Sentry's column validation fails with "expected (...), got set()".
+def test_empty_non_totals_result_does_not_refetch() -> None:
+    # An empty, non-WITH-TOTALS result comes back from the Native/HTTP path with
+    # no column header (ClickHouse emits a zero-byte Native body for zero rows),
+    # so meta is empty. The driver does NOT pay for a second query to recover it:
+    # the column metadata for an empty result is synthesized one layer up, in
+    # snuba.web.db_query, from the query's own columns (see
+    # test_db_query.test_empty_result_meta_synthesized_from_query).
     client = mock.Mock()
     client.query.return_value = FakeQueryResult(result_set=[], column_names=(), column_types=())
-    client.raw_query.return_value = json.dumps(
-        {
-            "meta": [
-                {"name": "flags_key", "type": "String"},
-                {"name": "count", "type": "UInt64"},
-            ],
-            "data": [],
-        }
-    ).encode()
 
     pool = _make_pool(client)
     result = pool.execute(
@@ -326,12 +318,38 @@ def test_empty_result_recovers_column_meta_via_json() -> None:
     )
 
     assert result.results == []
-    assert result.meta == [("flags_key", "String"), ("count", "UInt64")]
+    assert result.meta == []
+    client.raw_query.assert_not_called()
+
+
+def test_empty_with_totals_recovers_meta_and_totals_via_json() -> None:
+    # A WITH TOTALS query that matches zero rows loses both its column header and
+    # its totals row over the Native/HTTP path. The JSON re-fetch (which only
+    # fires for WITH TOTALS) recovers the column metadata and the totals row.
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(result_set=[], column_names=(), column_types=())
+    client.raw_query.return_value = json.dumps(
+        {
+            "meta": [{"name": "g", "type": "UInt64"}, {"name": "s", "type": "UInt64"}],
+            "data": [],
+            "totals": {"g": 0, "s": 0},
+        }
+    ).encode()
+
+    pool = _make_pool(client)
+    # The trailing totals row is appended to results; the reader pops it off.
+    result = pool.execute(
+        "SELECT g, sum(v) AS s FROM t WHERE g = 999 GROUP BY g WITH TOTALS",
+        with_column_types=True,
+    )
+
+    assert result.meta == [("g", "UInt64"), ("s", "UInt64")]
+    assert result.results == [(0, 0)]
 
 
 def test_non_empty_non_totals_query_does_not_refetch() -> None:
-    # The common read path (rows present, no WITH TOTALS) must not pay for the
-    # second JSON scan -- only empty results and WITH TOTALS queries do.
+    # The common read path (rows present, no WITH TOTALS) must not pay for a
+    # second JSON scan -- only WITH TOTALS queries do.
     client = mock.Mock()
     client.query.return_value = FakeQueryResult(
         result_set=[[1, 2]],
@@ -630,13 +648,18 @@ def test_connect_driver_matches_native_for_totals_and_empty_results() -> None:
         assert http["totals"]["s"] == 40  # sum(v) over all rows
         assert {c["name"] for c in http["meta"]} == {"g", "ts", "s"}
 
-        # 2) A query matching zero rows must still report its columns. Over the
-        #    HTTP driver this used to return "meta": [] -> Sentry "got set()".
+        # 2) A query matching zero rows: the native driver still reports its
+        #    columns, while the connect driver returns empty meta at the reader
+        #    level (ClickHouse sends a zero-byte Native body for zero rows). The
+        #    column metadata for this case is synthesized one layer up, in
+        #    db_query, from the query's own columns -- see
+        #    test_db_query.test_empty_result_meta_synthesized_from_query -- so no
+        #    second scan is paid here. This pins the driver-level divergence.
         empty_sql = f"SELECT g, sum(v) AS s FROM {table} WHERE g = 999 GROUP BY g"
         native_empty = run(native_pool, empty_sql, False)
         http_empty = run(connect_pool, empty_sql, False)
         assert http_empty["data"] == []
-        assert {c["name"] for c in http_empty["meta"]} == {"g", "s"}
+        assert http_empty["meta"] == []
         assert {c["name"] for c in native_empty["meta"]} == {"g", "s"}
 
         # 3) WITH TOTALS matching zero rows still yields a totals row. Over the

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -248,14 +248,14 @@ def test_clickhouse_reader_wraps_connect_pool() -> None:
     assert isinstance(reader, ClickhouseReader)
 
 
-def test_with_totals_refetched_via_json_over_http() -> None:
-    # clickhouse-connect's Native/HTTP path never returns the WITH TOTALS row:
-    # ClickHouse does not serialize totals into the Native HTTP output, so
-    # client.query() yields only the grouped rows. The connect pool therefore
-    # re-fetches the totals with a FORMAT JSON query and appends them as the
-    # trailing result row -- the contract the driver-agnostic ClickhouseReader
-    # expects, the same one the native driver satisfies by appending the totals
-    # row it receives over the native protocol.
+def test_with_totals_via_single_jsoncompact_request() -> None:
+    # clickhouse-connect's Native/HTTP path never returns the WITH TOTALS row
+    # (ClickHouse omits totals from the Native HTTP output). The connect pool runs
+    # WITH TOTALS queries through a single FORMAT JSONCompact request -- which
+    # returns data + meta + totals together -- and appends the totals as the
+    # trailing result row, the contract the driver-agnostic ClickhouseReader
+    # expects (the same one the native driver satisfies). The Native query() path
+    # is not used for these queries, so there is no second scan.
     from snuba.clickhouse.native import ClickhouseReader
 
     class FakeFormattedQuery:
@@ -263,24 +263,15 @@ def test_with_totals_refetched_via_json_over_http() -> None:
             return "SELECT project_id, count() FROM t GROUP BY project_id WITH TOTALS"
 
     client = mock.Mock()
-    # The Native path returns only the grouped rows -- no totals row.
-    client.query.return_value = FakeQueryResult(
-        result_set=[[1, 10], [2, 20]],
-        column_names=("project_id", "count()"),
-        column_types=(FakeColumnType("UInt64"), FakeColumnType("UInt64")),
-    )
-    # The JSON re-fetch is the only place the totals are available.
+    # JSONCompact returns each row (and the totals row) as a positional array.
     client.raw_query.return_value = json.dumps(
         {
             "meta": [
                 {"name": "project_id", "type": "UInt64"},
                 {"name": "count()", "type": "UInt64"},
             ],
-            "data": [
-                {"project_id": 1, "count()": 10},
-                {"project_id": 2, "count()": 20},
-            ],
-            "totals": {"project_id": 0, "count()": 30},
+            "data": [[1, 10], [2, 20]],
+            "totals": [0, 30],
         }
     ).encode()
 
@@ -289,34 +280,30 @@ def test_with_totals_refetched_via_json_over_http() -> None:
 
     result = reader.execute(cast(FormattedQuery, FakeFormattedQuery()), with_totals=True)
 
-    # The re-fetched totals row is split out as totals; only the real rows remain.
+    # The trailing totals row is split out as totals; only the real rows remain.
     assert result["data"] == [
         {"project_id": 1, "count()": 10},
         {"project_id": 2, "count()": 20},
     ]
     assert result["totals"] == {"project_id": 0, "count()": 30}
-    # Totals come from the JSON output format, not the Native query path.
+    # Single request via JSONCompact; the Native query() path is never used.
+    client.query.assert_not_called()
     _, kwargs = client.raw_query.call_args
-    assert kwargs["fmt"] == "JSON"
+    assert kwargs["fmt"] == "JSONCompact"
     assert kwargs["settings"]["output_format_json_quote_64bit_integers"] == 0
+    assert kwargs["settings"]["output_format_json_quote_denormals"] == 1
 
 
-def test_totals_refetch_uses_correlated_query_id_and_inherits_settings() -> None:
-    # The WITH TOTALS recovery query carries an id derived from the primary
-    # query's id -- so the two correlate in ClickHouse's query_log -- without
-    # reusing it (which would make them indistinguishable). Every other runtime
-    # setting is inherited from the primary query.
+def test_totals_jsoncompact_uses_original_query_id_and_inherits_settings() -> None:
+    # The single JSONCompact request carries the query's own id -- there is only
+    # one query, so no derived id is needed -- and inherits every functional
+    # runtime setting from the query.
     client = mock.Mock()
-    client.query.return_value = FakeQueryResult(
-        result_set=[[1, 10]],
-        column_names=("g", "s"),
-        column_types=(FakeColumnType("UInt64"), FakeColumnType("UInt64")),
-    )
     client.raw_query.return_value = json.dumps(
         {
             "meta": [{"name": "g", "type": "UInt64"}, {"name": "s", "type": "UInt64"}],
-            "data": [{"g": 1, "s": 10}],
-            "totals": {"g": 0, "s": 10},
+            "data": [[1, 10]],
+            "totals": [0, 10],
         }
     ).encode()
 
@@ -329,38 +316,35 @@ def test_totals_refetch_uses_correlated_query_id_and_inherits_settings() -> None
     )
 
     _, kwargs = client.raw_query.call_args
-    # Correlated but distinct id, and the primary query's functional settings.
-    assert kwargs["settings"]["query_id"] == "abc-123_totals"
+    assert kwargs["fmt"] == "JSONCompact"
+    assert kwargs["settings"]["query_id"] == "abc-123"
     assert kwargs["settings"]["max_execution_time"] == 30
 
 
-def test_totals_row_sourced_from_json_payload_columns() -> None:
-    # The totals row is built from the JSON payload's own column list, so its
-    # values are read with keys guaranteed to match the JSON totals dict -- they
-    # can never be silently None'd by a Native-vs-JSON column-name difference.
-    # Column names are format-independent in practice; here the Native names are
-    # deliberately made to differ from the JSON names to prove the totals values
-    # still come through (aligned positionally to the returned meta).
+def test_totals_jsoncompact_decodes_value_types() -> None:
+    # Values from JSONCompact are decoded into the same Python types the native
+    # driver yields, so the reader's transforms and downstream serialization
+    # behave identically for both drivers. Covers the tricky cases: DateTime
+    # (string -> datetime, so the reader's transform can ISO-format it rather than
+    # crash on a str), Array (recursed), and Nullable (null -> None / value).
     from snuba.clickhouse.native import ClickhouseReader
 
     class FakeFormattedQuery:
         def get_sql(self) -> str:
-            return "SELECT a, sum(v) AS b FROM t GROUP BY a WITH TOTALS"
+            return "SELECT g, ts, cnt, arr, opt FROM t GROUP BY g WITH TOTALS"
 
     client = mock.Mock()
-    # Native result reports column names ("a", "b").
-    client.query.return_value = FakeQueryResult(
-        result_set=[[1, 10]],
-        column_names=("a", "b"),
-        column_types=(FakeColumnType("UInt64"), FakeColumnType("UInt64")),
-    )
-    # JSON payload uses different names ("x", "y"); the totals must be recovered
-    # from those, not looked up by the Native names (which would yield None).
     client.raw_query.return_value = json.dumps(
         {
-            "meta": [{"name": "x", "type": "UInt64"}, {"name": "y", "type": "UInt64"}],
-            "data": [{"x": 1, "y": 10}],
-            "totals": {"x": 0, "y": 10},
+            "meta": [
+                {"name": "g", "type": "UInt64"},
+                {"name": "ts", "type": "DateTime"},
+                {"name": "cnt", "type": "UInt64"},
+                {"name": "arr", "type": "Array(UInt64)"},
+                {"name": "opt", "type": "Nullable(UInt64)"},
+            ],
+            "data": [[1, "2023-01-02 03:04:05", 10, [1, 2], None]],
+            "totals": [0, "1970-01-01 00:00:00", 10, [1, 2], 5],
         }
     ).encode()
 
@@ -368,10 +352,15 @@ def test_totals_row_sourced_from_json_payload_columns() -> None:
     reader = ClickhouseReader(cache_partition_id=None, client=pool, query_settings_prefix=None)
     result = reader.execute(cast(FormattedQuery, FakeFormattedQuery()), with_totals=True)
 
-    # Returned meta keeps the Native names; the totals values come from the JSON
-    # payload, aligned positionally -> b=10, a=0 (never None, None).
-    assert result["data"] == [{"a": 1, "b": 10}]
-    assert result["totals"] == {"a": 0, "b": 10}
+    row = result["data"][0]
+    # DateTime string -> datetime -> ISO string via the reader's transform.
+    assert row["ts"] == "2023-01-02T03:04:05+00:00"
+    assert row["arr"] == [1, 2]
+    assert row["opt"] is None
+    totals = result["totals"]
+    assert totals["ts"] == "1970-01-01T00:00:00+00:00"
+    assert totals["cnt"] == 10
+    assert totals["opt"] == 5
 
 
 def test_empty_non_totals_result_does_not_refetch() -> None:
@@ -395,17 +384,17 @@ def test_empty_non_totals_result_does_not_refetch() -> None:
     client.raw_query.assert_not_called()
 
 
-def test_empty_with_totals_recovers_meta_and_totals_via_json() -> None:
+def test_empty_with_totals_returns_meta_and_totals_via_jsoncompact() -> None:
     # A WITH TOTALS query that matches zero rows loses both its column header and
-    # its totals row over the Native/HTTP path. The JSON re-fetch (which only
-    # fires for WITH TOTALS) recovers the column metadata and the totals row.
+    # its totals row over the Native/HTTP path. The single JSONCompact request
+    # still carries the column metadata and the totals row, so the connect pool
+    # returns them (and never touches the Native query() path).
     client = mock.Mock()
-    client.query.return_value = FakeQueryResult(result_set=[], column_names=(), column_types=())
     client.raw_query.return_value = json.dumps(
         {
             "meta": [{"name": "g", "type": "UInt64"}, {"name": "s", "type": "UInt64"}],
             "data": [],
-            "totals": {"g": 0, "s": 0},
+            "totals": [0, 0],
         }
     ).encode()
 
@@ -418,6 +407,7 @@ def test_empty_with_totals_recovers_meta_and_totals_via_json() -> None:
 
     assert result.meta == [("g", "UInt64"), ("s", "UInt64")]
     assert result.results == [(0, 0)]
+    client.query.assert_not_called()
 
 
 def test_non_empty_non_totals_query_does_not_refetch() -> None:
@@ -435,44 +425,6 @@ def test_non_empty_non_totals_query_does_not_refetch() -> None:
 
     assert result.meta == [("a", "UInt8"), ("b", "UInt8")]
     client.raw_query.assert_not_called()
-
-
-def test_recovered_totals_datetime_is_typed_like_native() -> None:
-    # The totals row recovered from JSON has Date/DateTime values as strings; the
-    # pool coerces them to date/datetime objects so they are indistinguishable
-    # from the native driver's values and survive the reader's type transforms
-    # (which would otherwise crash calling datetime methods on a str).
-    from snuba.clickhouse.native import ClickhouseReader
-
-    class FakeFormattedQuery:
-        def get_sql(self) -> str:
-            return "SELECT ts, count() FROM t GROUP BY ts WITH TOTALS"
-
-    client = mock.Mock()
-    client.query.return_value = FakeQueryResult(
-        result_set=[[datetime(2023, 1, 2, 3, 4, 5), 10]],
-        column_names=("ts", "count()"),
-        column_types=(FakeColumnType("DateTime"), FakeColumnType("UInt64")),
-    )
-    client.raw_query.return_value = json.dumps(
-        {
-            "meta": [
-                {"name": "ts", "type": "DateTime"},
-                {"name": "count()", "type": "UInt64"},
-            ],
-            "data": [{"ts": "2023-01-02 03:04:05", "count()": 10}],
-            "totals": {"ts": "1970-01-01 00:00:00", "count()": 10},
-        }
-    ).encode()
-
-    pool = _make_pool(client)
-    reader = ClickhouseReader(cache_partition_id=None, client=pool, query_settings_prefix=None)
-    result = reader.execute(cast(FormattedQuery, FakeFormattedQuery()), with_totals=True)
-
-    # The DateTime totals value (a JSON string) is coerced to a datetime, then
-    # transformed to an ISO string -- exactly like the data row.
-    assert result["data"][0]["ts"] == "2023-01-02T03:04:05+00:00"
-    assert result["totals"]["ts"] == "1970-01-01T00:00:00+00:00"
 
 
 def test_connect_type_names_drive_reader_transforms() -> None:

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -1,3 +1,6 @@
+import json
+import uuid
+from datetime import datetime
 from typing import Any, cast
 from unittest import mock
 
@@ -245,13 +248,14 @@ def test_clickhouse_reader_wraps_connect_pool() -> None:
     assert isinstance(reader, ClickhouseReader)
 
 
-def test_with_totals_handled_over_http() -> None:
-    # WITH TOTALS works on the HTTP driver through clickhouse-connect's own
-    # parsing: its Native-format reader concatenates every response block,
-    # including the trailing totals block, into result_set, so the totals row
-    # arrives last — exactly what the driver-agnostic ClickhouseReader expects
-    # when it pops the last row as "totals". No native-driver-specific handling
-    # is involved.
+def test_with_totals_refetched_via_json_over_http() -> None:
+    # clickhouse-connect's Native/HTTP path never returns the WITH TOTALS row:
+    # ClickHouse does not serialize totals into the Native HTTP output, so
+    # client.query() yields only the grouped rows. The connect pool therefore
+    # re-fetches the totals with a FORMAT JSON query and appends them as the
+    # trailing result row -- the contract the driver-agnostic ClickhouseReader
+    # expects, the same one the native driver satisfies by appending the totals
+    # row it receives over the native protocol.
     from snuba.clickhouse.native import ClickhouseReader
 
     class FakeFormattedQuery:
@@ -259,25 +263,125 @@ def test_with_totals_handled_over_http() -> None:
             return "SELECT project_id, count() FROM t GROUP BY project_id WITH TOTALS"
 
     client = mock.Mock()
-    # Two data rows followed by the totals row, the way clickhouse-connect
-    # surfaces a WITH TOTALS response over HTTP.
+    # The Native path returns only the grouped rows -- no totals row.
     client.query.return_value = FakeQueryResult(
-        result_set=[[1, 10], [2, 20], [0, 30]],
+        result_set=[[1, 10], [2, 20]],
         column_names=("project_id", "count()"),
         column_types=(FakeColumnType("UInt64"), FakeColumnType("UInt64")),
     )
+    # The JSON re-fetch is the only place the totals are available.
+    client.raw_query.return_value = json.dumps(
+        {
+            "meta": [
+                {"name": "project_id", "type": "UInt64"},
+                {"name": "count()", "type": "UInt64"},
+            ],
+            "data": [
+                {"project_id": 1, "count()": 10},
+                {"project_id": 2, "count()": 20},
+            ],
+            "totals": {"project_id": 0, "count()": 30},
+        }
+    ).encode()
 
     pool = _make_pool(client)
     reader = ClickhouseReader(cache_partition_id=None, client=pool, query_settings_prefix=None)
 
     result = reader.execute(cast(FormattedQuery, FakeFormattedQuery()), with_totals=True)
 
-    # The trailing row is split out as totals; only the real rows remain in data.
+    # The re-fetched totals row is split out as totals; only the real rows remain.
     assert result["data"] == [
         {"project_id": 1, "count()": 10},
         {"project_id": 2, "count()": 20},
     ]
     assert result["totals"] == {"project_id": 0, "count()": 30}
+    # Totals come from the JSON output format, not the Native query path.
+    _, kwargs = client.raw_query.call_args
+    assert kwargs["fmt"] == "JSON"
+    assert kwargs["settings"]["output_format_json_quote_64bit_integers"] == 0
+
+
+def test_empty_result_recovers_column_meta_via_json() -> None:
+    # A query that matches no rows comes back from the Native/HTTP path with no
+    # column header at all (ClickHouse emits a zero-byte Native body for an empty
+    # result), so column_names/meta are empty. The pool recovers the column
+    # metadata from a FORMAT JSON query. Without this Snuba returns "meta": [],
+    # and Sentry's column validation fails with "expected (...), got set()".
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(result_set=[], column_names=(), column_types=())
+    client.raw_query.return_value = json.dumps(
+        {
+            "meta": [
+                {"name": "flags_key", "type": "String"},
+                {"name": "count", "type": "UInt64"},
+            ],
+            "data": [],
+        }
+    ).encode()
+
+    pool = _make_pool(client)
+    result = pool.execute(
+        "SELECT flags_key, count() AS count FROM t GROUP BY flags_key",
+        with_column_types=True,
+    )
+
+    assert result.results == []
+    assert result.meta == [("flags_key", "String"), ("count", "UInt64")]
+
+
+def test_non_empty_non_totals_query_does_not_refetch() -> None:
+    # The common read path (rows present, no WITH TOTALS) must not pay for the
+    # second JSON scan -- only empty results and WITH TOTALS queries do.
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(
+        result_set=[[1, 2]],
+        column_names=("a", "b"),
+        column_types=(FakeColumnType("UInt8"), FakeColumnType("UInt8")),
+    )
+
+    pool = _make_pool(client)
+    result = pool.execute("SELECT a, b FROM t", with_column_types=True)
+
+    assert result.meta == [("a", "UInt8"), ("b", "UInt8")]
+    client.raw_query.assert_not_called()
+
+
+def test_recovered_totals_datetime_is_typed_like_native() -> None:
+    # The totals row recovered from JSON has Date/DateTime values as strings; the
+    # pool coerces them to date/datetime objects so they are indistinguishable
+    # from the native driver's values and survive the reader's type transforms
+    # (which would otherwise crash calling datetime methods on a str).
+    from snuba.clickhouse.native import ClickhouseReader
+
+    class FakeFormattedQuery:
+        def get_sql(self) -> str:
+            return "SELECT ts, count() FROM t GROUP BY ts WITH TOTALS"
+
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(
+        result_set=[[datetime(2023, 1, 2, 3, 4, 5), 10]],
+        column_names=("ts", "count()"),
+        column_types=(FakeColumnType("DateTime"), FakeColumnType("UInt64")),
+    )
+    client.raw_query.return_value = json.dumps(
+        {
+            "meta": [
+                {"name": "ts", "type": "DateTime"},
+                {"name": "count()", "type": "UInt64"},
+            ],
+            "data": [{"ts": "2023-01-02 03:04:05", "count()": 10}],
+            "totals": {"ts": "1970-01-01 00:00:00", "count()": 10},
+        }
+    ).encode()
+
+    pool = _make_pool(client)
+    reader = ClickhouseReader(cache_partition_id=None, client=pool, query_settings_prefix=None)
+    result = reader.execute(cast(FormattedQuery, FakeFormattedQuery()), with_totals=True)
+
+    # The DateTime totals value (a JSON string) is coerced to a datetime, then
+    # transformed to an ISO string -- exactly like the data row.
+    assert result["data"][0]["ts"] == "2023-01-02T03:04:05+00:00"
+    assert result["totals"]["ts"] == "1970-01-01T00:00:00+00:00"
 
 
 def test_connect_type_names_drive_reader_transforms() -> None:
@@ -461,3 +565,93 @@ def test_native_pool_execute_explain_delegates_to_execute() -> None:
 
     execute.assert_called_once_with("EXPLAIN AST SELECT 1", with_column_types=True)
     assert out is sentinel
+
+
+@pytest.mark.clickhouse_db
+def test_connect_driver_matches_native_for_totals_and_empty_results() -> None:
+    # End-to-end against a real ClickHouse: the clickhouse-connect (HTTP) pool
+    # must produce the same ClickhouseReader output as the native pool for the
+    # two query shapes that broke when the HTTP driver was first enabled --
+    # GROUP BY ... WITH TOTALS, and queries that match zero rows. Mocked unit
+    # tests cannot catch these regressions because they hinge on how a real
+    # server serializes the Native/HTTP response (an empty body for zero rows,
+    # and no totals block at all).
+    from snuba import settings
+    from snuba.clickhouse.native import ClickhouseNativePool, ClickhouseReader
+
+    conf = settings.CLUSTERS[0]
+    native_pool = ClickhouseNativePool(
+        conf["host"], conf["port"], conf["user"], conf["password"], conf["database"]
+    )
+    connect_pool = ClickhouseConnectPool(
+        conf["host"],
+        conf["user"],
+        conf["password"],
+        conf["database"],
+        http_port=conf["http_port"],
+    )
+
+    # Unique table name so parallel (xdist) workers don't collide.
+    table = f"test_connect_totals_parity_{uuid.uuid4().hex[:8]}"
+
+    class FakeFormattedQuery:
+        def __init__(self, sql: str) -> None:
+            self._sql = sql
+
+        def get_sql(self) -> str:
+            return self._sql
+
+    def run(pool: Any, sql: str, with_totals: bool) -> Any:
+        reader = ClickhouseReader(cache_partition_id=None, client=pool, query_settings_prefix=None)
+        return reader.execute(
+            cast(FormattedQuery, FakeFormattedQuery(sql)), with_totals=with_totals
+        )
+
+    try:
+        native_pool.execute(f"DROP TABLE IF EXISTS {table}")
+        native_pool.execute(
+            f"CREATE TABLE {table} (g UInt64, ts DateTime, v UInt64) ENGINE = Memory"
+        )
+        native_pool.execute(
+            f"INSERT INTO {table} (g, ts, v) VALUES",
+            [
+                [1, datetime(2023, 1, 2, 3, 4, 5), 10],
+                [2, datetime(2023, 1, 3, 0, 0, 0), 30],
+            ],
+        )
+
+        # 1) WITH TOTALS over a DateTime group: data and totals (including the
+        #    coerced totals datetime) must match the native driver exactly.
+        totals_sql = f"SELECT g, ts, sum(v) AS s FROM {table} GROUP BY g, ts WITH TOTALS ORDER BY g"
+        native = run(native_pool, totals_sql, True)
+        http = run(connect_pool, totals_sql, True)
+        assert http["data"] == native["data"]
+        assert http["totals"] == native["totals"]
+        assert http["totals"]["s"] == 40  # sum(v) over all rows
+        assert {c["name"] for c in http["meta"]} == {"g", "ts", "s"}
+
+        # 2) A query matching zero rows must still report its columns. Over the
+        #    HTTP driver this used to return "meta": [] -> Sentry "got set()".
+        empty_sql = f"SELECT g, sum(v) AS s FROM {table} WHERE g = 999 GROUP BY g"
+        native_empty = run(native_pool, empty_sql, False)
+        http_empty = run(connect_pool, empty_sql, False)
+        assert http_empty["data"] == []
+        assert {c["name"] for c in http_empty["meta"]} == {"g", "s"}
+        assert {c["name"] for c in native_empty["meta"]} == {"g", "s"}
+
+        # 3) WITH TOTALS matching zero rows still yields a totals row. Over the
+        #    HTTP driver this used to leave the reader with no rows, firing the
+        #    totals assertion -> "SnubaError (No error message)".
+        empty_totals_sql = (
+            f"SELECT g, sum(v) AS s FROM {table} WHERE g = 999 GROUP BY g WITH TOTALS"
+        )
+        http_empty_totals = run(connect_pool, empty_totals_sql, True)
+        assert http_empty_totals["data"] == []
+        assert http_empty_totals["totals"]["s"] == 0
+        assert {c["name"] for c in http_empty_totals["meta"]} == {"g", "s"}
+    finally:
+        try:
+            native_pool.execute(f"DROP TABLE IF EXISTS {table}")
+        finally:
+            native_pool.close()
+            connect_pool.close()

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -375,6 +375,12 @@ def test_coerce_temporal_only_touches_date_and_datetime() -> None:
         2023, 1, 2, 3, 4, 5
     )
     assert _coerce_temporal("2023-01-02", "Date") == date(2023, 1, 2)
+    # Parametrized precision variants reduce to the same base type (the match is on
+    # the base name, not a prefix), so DateTime64/Date32 are handled too.
+    assert _coerce_temporal("2023-01-02 03:04:05.123456789", "DateTime64(9)") == datetime(
+        2023, 1, 2, 3, 4, 5, 123456
+    )
+    assert _coerce_temporal("2023-01-02", "Date32") == date(2023, 1, 2)
     # Nullable is unwrapped, mirroring the reader's own transform.
     assert _coerce_temporal("2023-01-02 03:04:05", "Nullable(DateTime)") == datetime(
         2023, 1, 2, 3, 4, 5

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -363,6 +363,23 @@ def test_totals_jsoncompact_decodes_value_types() -> None:
     assert totals["opt"] == 5
 
 
+def test_decode_json_value_matches_ints_but_not_intervals() -> None:
+    # The integer branch matches Int/UInt fixed-width types exactly (wide ones
+    # arrive as JSON strings), but must NOT match Interval* types -- which also
+    # start with "Int" -- or they'd be forced through int() and could raise.
+    from snuba.clickhouse.connect import _decode_json_value
+
+    # Fixed-width ints (incl. wide ones sent as strings) become int.
+    assert _decode_json_value(5, "UInt64") == 5
+    assert (
+        _decode_json_value("170141183460469231731687303715884105727", "Int128")
+        == 170141183460469231731687303715884105727
+    )
+    # Interval* passes through untouched (never int()'d), whatever ClickHouse emits.
+    assert _decode_json_value(7, "IntervalDay") == 7
+    assert _decode_json_value("P7D", "IntervalDay") == "P7D"
+
+
 def test_empty_non_totals_result_does_not_refetch() -> None:
     # An empty, non-WITH-TOTALS result comes back from the Native/HTTP path with
     # no column header (ClickHouse emits a zero-byte Native body for zero rows),

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -301,6 +301,39 @@ def test_with_totals_refetched_via_json_over_http() -> None:
     assert kwargs["settings"]["output_format_json_quote_64bit_integers"] == 0
 
 
+def test_totals_refetch_uses_correlated_query_id_and_inherits_settings() -> None:
+    # The WITH TOTALS recovery query carries an id derived from the primary
+    # query's id -- so the two correlate in ClickHouse's query_log -- without
+    # reusing it (which would make them indistinguishable). Every other runtime
+    # setting is inherited from the primary query.
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(
+        result_set=[[1, 10]],
+        column_names=("g", "s"),
+        column_types=(FakeColumnType("UInt64"), FakeColumnType("UInt64")),
+    )
+    client.raw_query.return_value = json.dumps(
+        {
+            "meta": [{"name": "g", "type": "UInt64"}, {"name": "s", "type": "UInt64"}],
+            "data": [{"g": 1, "s": 10}],
+            "totals": {"g": 0, "s": 10},
+        }
+    ).encode()
+
+    pool = _make_pool(client)
+    pool.execute(
+        "SELECT g, sum(v) AS s FROM t GROUP BY g WITH TOTALS",
+        with_column_types=True,
+        query_id="abc-123",
+        settings={"max_execution_time": 30},
+    )
+
+    _, kwargs = client.raw_query.call_args
+    # Correlated but distinct id, and the primary query's functional settings.
+    assert kwargs["settings"]["query_id"] == "abc-123_totals"
+    assert kwargs["settings"]["max_execution_time"] == 30
+
+
 def test_empty_non_totals_result_does_not_refetch() -> None:
     # An empty, non-WITH-TOTALS result comes back from the Native/HTTP path with
     # no column header (ClickHouse emits a zero-byte Native body for zero rows),

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, cast
 from unittest import mock
 
@@ -291,7 +291,6 @@ def test_with_totals_via_single_jsoncompact_request() -> None:
     _, kwargs = client.raw_query.call_args
     assert kwargs["fmt"] == "JSONCompact"
     assert kwargs["settings"]["output_format_json_quote_64bit_integers"] == 0
-    assert kwargs["settings"]["output_format_json_quote_denormals"] == 1
 
 
 def test_totals_jsoncompact_uses_original_query_id_and_inherits_settings() -> None:
@@ -308,9 +307,8 @@ def test_totals_jsoncompact_uses_original_query_id_and_inherits_settings() -> No
     ).encode()
 
     pool = _make_pool(client)
-    pool.execute(
+    pool.execute_with_totals(
         "SELECT g, sum(v) AS s FROM t GROUP BY g WITH TOTALS",
-        with_column_types=True,
         query_id="abc-123",
         settings={"max_execution_time": 30},
     )
@@ -326,7 +324,7 @@ def test_totals_jsoncompact_decodes_value_types() -> None:
     # driver yields, so the reader's transforms and downstream serialization
     # behave identically for both drivers. Covers the tricky cases: DateTime
     # (string -> datetime, so the reader's transform can ISO-format it rather than
-    # crash on a str), Array (recursed), and Nullable (null -> None / value).
+    # crash on a str), Array (passed through), and Nullable (null -> None / value).
     from snuba.clickhouse.native import ClickhouseReader
 
     class FakeFormattedQuery:
@@ -363,21 +361,32 @@ def test_totals_jsoncompact_decodes_value_types() -> None:
     assert totals["opt"] == 5
 
 
-def test_decode_json_value_matches_ints_but_not_intervals() -> None:
-    # The integer branch matches Int/UInt fixed-width types exactly (wide ones
-    # arrive as JSON strings), but must NOT match Interval* types -- which also
-    # start with "Int" -- or they'd be forced through int() and could raise.
-    from snuba.clickhouse.connect import _decode_json_value
+def test_coerce_temporal_only_touches_date_and_datetime() -> None:
+    # _coerce_temporal is the single value conversion the JSONCompact totals path
+    # applies: Date/DateTime strings become date/datetime objects (so the reader's
+    # column transforms can ISO-format them instead of crashing on a str -- those
+    # are the only types whose transforms would crash), and it unwraps Nullable so
+    # Nullable(DateTime) is handled too. Every other type -- including the ints and
+    # floats json.loads returns -- must pass through untouched.
+    from snuba.clickhouse.connect import _coerce_temporal
 
-    # Fixed-width ints (incl. wide ones sent as strings) become int.
-    assert _decode_json_value(5, "UInt64") == 5
-    assert (
-        _decode_json_value("170141183460469231731687303715884105727", "Int128")
-        == 170141183460469231731687303715884105727
+    assert _coerce_temporal("2023-01-02 03:04:05", "DateTime") == datetime(2023, 1, 2, 3, 4, 5)
+    assert _coerce_temporal("2023-01-02 03:04:05", "DateTime('UTC')") == datetime(
+        2023, 1, 2, 3, 4, 5
     )
-    # Interval* passes through untouched (never int()'d), whatever ClickHouse emits.
-    assert _decode_json_value(7, "IntervalDay") == 7
-    assert _decode_json_value("P7D", "IntervalDay") == "P7D"
+    assert _coerce_temporal("2023-01-02", "Date") == date(2023, 1, 2)
+    # Nullable is unwrapped, mirroring the reader's own transform.
+    assert _coerce_temporal("2023-01-02 03:04:05", "Nullable(DateTime)") == datetime(
+        2023, 1, 2, 3, 4, 5
+    )
+    # Non-temporal values (and None) are returned verbatim, whatever the type. A
+    # whole-number Float that JSON emitted as an int stays an int here (the
+    # accepted, numerically-identical 5-vs-5.0 divergence).
+    assert _coerce_temporal(5, "UInt64") == 5
+    assert _coerce_temporal(1.5, "Float64") == 1.5
+    assert _coerce_temporal(None, "Nullable(DateTime)") is None
+    # A non-string under a Date/DateTime type is left alone (defensive).
+    assert _coerce_temporal(0, "DateTime") == 0
 
 
 def test_empty_non_totals_result_does_not_refetch() -> None:
@@ -417,9 +426,8 @@ def test_empty_with_totals_returns_meta_and_totals_via_jsoncompact() -> None:
 
     pool = _make_pool(client)
     # The trailing totals row is appended to results; the reader pops it off.
-    result = pool.execute(
+    result = pool.execute_with_totals(
         "SELECT g, sum(v) AS s FROM t WHERE g = 999 GROUP BY g WITH TOTALS",
-        with_column_types=True,
     )
 
     assert result.meta == [("g", "UInt64"), ("s", "UInt64")]
@@ -625,6 +633,82 @@ def test_native_pool_execute_explain_delegates_to_execute() -> None:
 
     execute.assert_called_once_with("EXPLAIN AST SELECT 1", with_column_types=True)
     assert out is sentinel
+
+
+def test_native_pool_execute_with_totals_delegates_to_execute() -> None:
+    # The ClickhousePool default (used by the native driver) runs WITH TOTALS
+    # through the normal execute() path: the native protocol streams the totals
+    # back as the trailing result row, so a plain execute() already yields the
+    # shape the reader expects. Only the connect pool overrides this.
+    from snuba.clickhouse.native import ClickhouseNativePool, ClickhouseResult
+
+    pool = ClickhouseNativePool("host", 9000, "user", "pw", "db")
+    sentinel = ClickhouseResult(results=[(1, 10), (0, 10)])
+    with mock.patch.object(pool, "execute", return_value=sentinel) as execute:
+        out = pool.execute_with_totals(
+            "SELECT g, sum(v) FROM t GROUP BY g WITH TOTALS",
+            query_id="qid",
+            settings={"max_threads": 4},
+        )
+
+    execute.assert_called_once_with(
+        "SELECT g, sum(v) FROM t GROUP BY g WITH TOTALS",
+        params=None,
+        with_column_types=True,
+        query_id="qid",
+        settings={"max_threads": 4},
+        capture_trace=False,
+    )
+    assert out is sentinel
+
+
+def test_native_pool_execute_with_totals_robust_uses_execute_robust() -> None:
+    # robust=True must route through execute_robust (the retrying path), matching
+    # how the reader forwards robust for WITH TOTALS queries.
+    from snuba.clickhouse.native import ClickhouseNativePool, ClickhouseResult
+
+    pool = ClickhouseNativePool("host", 9000, "user", "pw", "db")
+    sentinel = ClickhouseResult(results=[(1, 10), (0, 10)])
+    with mock.patch.object(pool, "execute_robust", return_value=sentinel) as execute_robust:
+        out = pool.execute_with_totals(
+            "SELECT g, sum(v) FROM t GROUP BY g WITH TOTALS", robust=True
+        )
+
+    execute_robust.assert_called_once()
+    assert out is sentinel
+
+
+def test_reader_routes_with_totals_through_execute_with_totals() -> None:
+    # The reader sends WITH TOTALS queries through the pool's execute_with_totals
+    # entry point (not plain execute), forwarding robust, so each driver can
+    # handle totals its own way. This pins the driver-agnostic wiring both pools
+    # rely on.
+    from snuba.clickhouse.native import ClickhouseReader, ClickhouseResult
+
+    class FakeFormattedQuery:
+        def get_sql(self) -> str:
+            return "SELECT g, sum(v) AS s FROM t GROUP BY g WITH TOTALS"
+
+    pool = mock.Mock()
+    pool.execute_with_totals.return_value = ClickhouseResult(
+        results=[(1, 10), (0, 10)],
+        meta=[("g", "UInt64"), ("s", "UInt64")],
+    )
+
+    reader = ClickhouseReader(cache_partition_id=None, client=pool, query_settings_prefix=None)
+    result = reader.execute(
+        cast(FormattedQuery, FakeFormattedQuery()), with_totals=True, robust=True
+    )
+
+    pool.execute_with_totals.assert_called_once()
+    _, kwargs = pool.execute_with_totals.call_args
+    assert kwargs["robust"] is True
+    # The non-totals path (plain execute / execute_robust) is not taken.
+    pool.execute.assert_not_called()
+    pool.execute_robust.assert_not_called()
+    # The trailing totals row is split out; only the real rows remain as data.
+    assert result["data"] == [{"g": 1, "s": 10}]
+    assert result["totals"] == {"g": 0, "s": 10}
 
 
 @pytest.mark.clickhouse_db

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -132,6 +132,17 @@ def test_generic_clickhouse_error_wrapped() -> None:
     assert client.query.call_count == 1
 
 
+def test_totals_malformed_json_wrapped() -> None:
+    # A non-JSON totals response (truncation, a proxy error page) surfaces as a
+    # ClickhouseError rather than leaking a raw JSONDecodeError.
+    client = mock.Mock()
+    client.raw_query.return_value = b"<html>502 Bad Gateway</html>"
+
+    pool = _make_pool(client)
+    with pytest.raises(ClickhouseError):
+        pool.execute_with_totals("SELECT g, sum(v) FROM t GROUP BY g WITH TOTALS")
+
+
 def test_timeouts_are_passed_through() -> None:
     import clickhouse_connect
 

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -334,6 +334,46 @@ def test_totals_refetch_uses_correlated_query_id_and_inherits_settings() -> None
     assert kwargs["settings"]["max_execution_time"] == 30
 
 
+def test_totals_row_sourced_from_json_payload_columns() -> None:
+    # The totals row is built from the JSON payload's own column list, so its
+    # values are read with keys guaranteed to match the JSON totals dict -- they
+    # can never be silently None'd by a Native-vs-JSON column-name difference.
+    # Column names are format-independent in practice; here the Native names are
+    # deliberately made to differ from the JSON names to prove the totals values
+    # still come through (aligned positionally to the returned meta).
+    from snuba.clickhouse.native import ClickhouseReader
+
+    class FakeFormattedQuery:
+        def get_sql(self) -> str:
+            return "SELECT a, sum(v) AS b FROM t GROUP BY a WITH TOTALS"
+
+    client = mock.Mock()
+    # Native result reports column names ("a", "b").
+    client.query.return_value = FakeQueryResult(
+        result_set=[[1, 10]],
+        column_names=("a", "b"),
+        column_types=(FakeColumnType("UInt64"), FakeColumnType("UInt64")),
+    )
+    # JSON payload uses different names ("x", "y"); the totals must be recovered
+    # from those, not looked up by the Native names (which would yield None).
+    client.raw_query.return_value = json.dumps(
+        {
+            "meta": [{"name": "x", "type": "UInt64"}, {"name": "y", "type": "UInt64"}],
+            "data": [{"x": 1, "y": 10}],
+            "totals": {"x": 0, "y": 10},
+        }
+    ).encode()
+
+    pool = _make_pool(client)
+    reader = ClickhouseReader(cache_partition_id=None, client=pool, query_settings_prefix=None)
+    result = reader.execute(cast(FormattedQuery, FakeFormattedQuery()), with_totals=True)
+
+    # Returned meta keeps the Native names; the totals values come from the JSON
+    # payload, aligned positionally -> b=10, a=0 (never None, None).
+    assert result["data"] == [{"a": 1, "b": 10}]
+    assert result["totals"] == {"a": 0, "b": 10}
+
+
 def test_empty_non_totals_result_does_not_refetch() -> None:
     # An empty, non-WITH-TOTALS result comes back from the Native/HTTP path with
     # no column header (ClickHouse emits a zero-byte Native body for zero rows),

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -328,6 +328,48 @@ def test_empty_result_meta_falls_back_to_expression_alias() -> None:
     assert stats["result_cols"] == 1
 
 
+def test_empty_result_meta_placeholder_when_name_and_alias_missing() -> None:
+    # If a selected column has neither a name nor an expression alias, synthesis
+    # must still emit a column (never silently drop one, which would desync meta
+    # from the result), using the same `_invalid_alias_{index}` placeholder that
+    # Query.get_columns() falls back to.
+    from snuba.query import SelectedExpression
+    from snuba.query.expressions import Column as ColumnExpr
+    from snuba.reader import Reader, Result
+
+    query, _storage, _attribution_info = _build_test_query("count(distinct(project_id))")
+    query.set_ast_selected_columns(
+        [
+            SelectedExpression(
+                name=None,
+                expression=ColumnExpr(alias=None, table_name=None, column_name="project_id"),
+            )
+        ]
+    )
+
+    class _EmptyMetaReader(Reader):
+        def __init__(self) -> None:
+            super().__init__(cache_partition_id=None, query_settings_prefix=None)
+
+        def execute(self, *args: Any, **kwargs: Any) -> Result:
+            return {"data": [], "meta": [], "profile": None, "trace_output": ""}
+
+    stats: dict[str, Any] = {}
+    result = execute_query(
+        clickhouse_query=query,
+        query_settings=HTTPQuerySettings(),
+        formatted_query=format_query(query),
+        reader=_EmptyMetaReader(),
+        timer=Timer("test"),
+        stats=stats,
+        clickhouse_query_settings={},
+        robust=False,
+    )
+
+    assert result["meta"] == [{"name": "_invalid_alias_0", "type": ""}]
+    assert stats["result_cols"] == 1
+
+
 @pytest.mark.events_db
 @pytest.mark.redis_db
 def test_db_record_bytes_scanned() -> None:

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -246,12 +246,9 @@ def _build_test_query(
 
 
 def test_empty_result_meta_synthesized_from_query() -> None:
-    # The clickhouse-connect (HTTP) reader returns no column metadata for a
-    # zero-row result (ClickHouse emits a zero-byte Native body), leaving
-    # result["meta"] empty. execute_query synthesizes the columns from the query
-    # itself -- avoiding a second scan -- so callers that validate the returned
-    # columns (e.g. Sentry, which otherwise fails with "got set()") still see
-    # them. The native driver reports columns directly, so this is a no-op there.
+    # The connect (HTTP) reader returns empty meta for a zero-row result; execute_query
+    # synthesizes the columns from the query (no second scan) so callers that validate
+    # columns (Sentry, else "got set()") still see them. No-op on the native driver.
     from snuba.reader import Reader, Result
 
     query, _storage, _attribution_info = _build_test_query("count(distinct(project_id))")
@@ -283,11 +280,8 @@ def test_empty_result_meta_synthesized_from_query() -> None:
 
 
 def test_empty_result_meta_falls_back_to_expression_alias() -> None:
-    # SelectedExpression.name is nullable, but the actual result column name is
-    # the expression's alias (what the formatter emits and ClickHouse echoes
-    # back). When name is None, synthesis must fall back to the alias rather than
-    # dropping the column -- otherwise meta would be missing columns and
-    # downstream column-count/name validation would fail.
+    # SelectedExpression.name is nullable; the result column name is the expression's
+    # alias. When name is None, synthesis falls back to the alias, not dropping the column.
     from snuba.query import SelectedExpression
     from snuba.query.expressions import Column as ColumnExpr
     from snuba.reader import Reader, Result
@@ -329,9 +323,8 @@ def test_empty_result_meta_falls_back_to_expression_alias() -> None:
 
 
 def test_empty_result_meta_uses_column_name_for_bare_column() -> None:
-    # A bare column with neither a SelectedExpression.name nor an alias is echoed
-    # by ClickHouse under its own column name (SELECT project_id -> "project_id"),
-    # so synthesis uses the column name rather than a placeholder.
+    # A bare column with no name/alias is echoed under its own column name
+    # (SELECT project_id -> "project_id"), so synthesis uses that, not a placeholder.
     from snuba.query import SelectedExpression
     from snuba.query.expressions import Column as ColumnExpr
     from snuba.reader import Reader, Result
@@ -367,9 +360,8 @@ def test_empty_result_meta_uses_column_name_for_bare_column() -> None:
 
 
 def test_empty_result_meta_placeholder_for_unnamed_non_column() -> None:
-    # A non-column expression with no name and no alias has nothing to derive a
-    # name from, so synthesis must still emit a column (never silently drop one)
-    # using the same `_invalid_alias_{index}` placeholder Query.get_columns() uses.
+    # A non-column expression with no name/alias still emits a column (never dropped),
+    # using the `_invalid_alias_{index}` placeholder Query.get_columns() uses.
     from snuba.query import SelectedExpression
     from snuba.query.expressions import FunctionCall
     from snuba.reader import Reader, Result
@@ -400,10 +392,8 @@ def test_empty_result_meta_placeholder_for_unnamed_non_column() -> None:
 
 
 def test_empty_result_meta_prefers_alias_over_name() -> None:
-    # ClickHouse echoes the formatted SQL alias as the result column name, not
-    # SelectedExpression.name. When they differ (e.g. MQL rollup: name "time" vs
-    # alias "events.time"), synthesis must use the alias so the meta matches the
-    # actual result columns and passes downstream column validation.
+    # ClickHouse names the column by the SQL alias, not SelectedExpression.name. When
+    # they differ (MQL: name "time" vs alias "events.time"), synthesis uses the alias.
     from snuba.query import SelectedExpression
     from snuba.query.expressions import Column as ColumnExpr
     from snuba.reader import Reader, Result

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -39,6 +39,7 @@ from snuba.web.db_query import (
     _apply_allocation_policies_quota,
     _get_query_settings_from_config,
     db_query,
+    execute_query,
 )
 
 test_data = [
@@ -242,6 +243,43 @@ def _build_test_query(
             parent_api=None,
         ),
     )
+
+
+def test_empty_result_meta_synthesized_from_query() -> None:
+    # The clickhouse-connect (HTTP) reader returns no column metadata for a
+    # zero-row result (ClickHouse emits a zero-byte Native body), leaving
+    # result["meta"] empty. execute_query synthesizes the columns from the query
+    # itself -- avoiding a second scan -- so callers that validate the returned
+    # columns (e.g. Sentry, which otherwise fails with "got set()") still see
+    # them. The native driver reports columns directly, so this is a no-op there.
+    from snuba.reader import Reader, Result
+
+    query, _storage, _attribution_info = _build_test_query("count(distinct(project_id))")
+
+    class _EmptyMetaReader(Reader):
+        def __init__(self) -> None:
+            super().__init__(cache_partition_id=None, query_settings_prefix=None)
+
+        def execute(self, *args: Any, **kwargs: Any) -> Result:
+            # Mirror what the connect pool returns for an empty result set.
+            return {"data": [], "meta": [], "profile": None, "trace_output": ""}
+
+    stats: dict[str, Any] = {}
+    result = execute_query(
+        clickhouse_query=query,
+        query_settings=HTTPQuerySettings(),
+        formatted_query=format_query(query),
+        reader=_EmptyMetaReader(),
+        timer=Timer("test"),
+        stats=stats,
+        clickhouse_query_settings={},
+        robust=False,
+    )
+
+    assert result["data"] == []
+    # The single selected column ("some_alias") is recovered from the query.
+    assert result["meta"] == [{"name": "some_alias", "type": ""}]
+    assert stats["result_cols"] == 1
 
 
 @pytest.mark.events_db

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -370,6 +370,48 @@ def test_empty_result_meta_placeholder_when_name_and_alias_missing() -> None:
     assert stats["result_cols"] == 1
 
 
+def test_empty_result_meta_prefers_alias_over_name() -> None:
+    # ClickHouse echoes the formatted SQL alias as the result column name, not
+    # SelectedExpression.name. When they differ (e.g. MQL rollup: name "time" vs
+    # alias "events.time"), synthesis must use the alias so the meta matches the
+    # actual result columns and passes downstream column validation.
+    from snuba.query import SelectedExpression
+    from snuba.query.expressions import Column as ColumnExpr
+    from snuba.reader import Reader, Result
+
+    query, _storage, _attribution_info = _build_test_query("count(distinct(project_id))")
+    query.set_ast_selected_columns(
+        [
+            SelectedExpression(
+                name="time",
+                expression=ColumnExpr(alias="events.time", table_name="events", column_name="time"),
+            )
+        ]
+    )
+
+    class _EmptyMetaReader(Reader):
+        def __init__(self) -> None:
+            super().__init__(cache_partition_id=None, query_settings_prefix=None)
+
+        def execute(self, *args: Any, **kwargs: Any) -> Result:
+            return {"data": [], "meta": [], "profile": None, "trace_output": ""}
+
+    stats: dict[str, Any] = {}
+    result = execute_query(
+        clickhouse_query=query,
+        query_settings=HTTPQuerySettings(),
+        formatted_query=format_query(query),
+        reader=_EmptyMetaReader(),
+        timer=Timer("test"),
+        stats=stats,
+        clickhouse_query_settings={},
+        robust=False,
+    )
+
+    # Alias wins over the differing name -- matches what ClickHouse would return.
+    assert result["meta"] == [{"name": "events.time", "type": ""}]
+
+
 @pytest.mark.events_db
 @pytest.mark.redis_db
 def test_db_record_bytes_scanned() -> None:

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -282,6 +282,52 @@ def test_empty_result_meta_synthesized_from_query() -> None:
     assert stats["result_cols"] == 1
 
 
+def test_empty_result_meta_falls_back_to_expression_alias() -> None:
+    # SelectedExpression.name is nullable, but the actual result column name is
+    # the expression's alias (what the formatter emits and ClickHouse echoes
+    # back). When name is None, synthesis must fall back to the alias rather than
+    # dropping the column -- otherwise meta would be missing columns and
+    # downstream column-count/name validation would fail.
+    from snuba.query import SelectedExpression
+    from snuba.query.expressions import Column as ColumnExpr
+    from snuba.reader import Reader, Result
+
+    query, _storage, _attribution_info = _build_test_query("count(distinct(project_id))")
+    query.set_ast_selected_columns(
+        [
+            SelectedExpression(
+                name=None,
+                expression=ColumnExpr(
+                    alias="aliased_col", table_name=None, column_name="project_id"
+                ),
+            )
+        ]
+    )
+
+    class _EmptyMetaReader(Reader):
+        def __init__(self) -> None:
+            super().__init__(cache_partition_id=None, query_settings_prefix=None)
+
+        def execute(self, *args: Any, **kwargs: Any) -> Result:
+            return {"data": [], "meta": [], "profile": None, "trace_output": ""}
+
+    stats: dict[str, Any] = {}
+    result = execute_query(
+        clickhouse_query=query,
+        query_settings=HTTPQuerySettings(),
+        formatted_query=format_query(query),
+        reader=_EmptyMetaReader(),
+        timer=Timer("test"),
+        stats=stats,
+        clickhouse_query_settings={},
+        robust=False,
+    )
+
+    # Recovered from the expression alias even though name is None.
+    assert result["meta"] == [{"name": "aliased_col", "type": ""}]
+    assert stats["result_cols"] == 1
+
+
 @pytest.mark.events_db
 @pytest.mark.redis_db
 def test_db_record_bytes_scanned() -> None:

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -328,11 +328,10 @@ def test_empty_result_meta_falls_back_to_expression_alias() -> None:
     assert stats["result_cols"] == 1
 
 
-def test_empty_result_meta_placeholder_when_name_and_alias_missing() -> None:
-    # If a selected column has neither a name nor an expression alias, synthesis
-    # must still emit a column (never silently drop one, which would desync meta
-    # from the result), using the same `_invalid_alias_{index}` placeholder that
-    # Query.get_columns() falls back to.
+def test_empty_result_meta_uses_column_name_for_bare_column() -> None:
+    # A bare column with neither a SelectedExpression.name nor an alias is echoed
+    # by ClickHouse under its own column name (SELECT project_id -> "project_id"),
+    # so synthesis uses the column name rather than a placeholder.
     from snuba.query import SelectedExpression
     from snuba.query.expressions import Column as ColumnExpr
     from snuba.reader import Reader, Result
@@ -354,20 +353,50 @@ def test_empty_result_meta_placeholder_when_name_and_alias_missing() -> None:
         def execute(self, *args: Any, **kwargs: Any) -> Result:
             return {"data": [], "meta": [], "profile": None, "trace_output": ""}
 
-    stats: dict[str, Any] = {}
     result = execute_query(
         clickhouse_query=query,
         query_settings=HTTPQuerySettings(),
         formatted_query=format_query(query),
         reader=_EmptyMetaReader(),
         timer=Timer("test"),
-        stats=stats,
+        stats={},
         clickhouse_query_settings={},
         robust=False,
     )
+    assert result["meta"] == [{"name": "project_id", "type": ""}]
 
+
+def test_empty_result_meta_placeholder_for_unnamed_non_column() -> None:
+    # A non-column expression with no name and no alias has nothing to derive a
+    # name from, so synthesis must still emit a column (never silently drop one)
+    # using the same `_invalid_alias_{index}` placeholder Query.get_columns() uses.
+    from snuba.query import SelectedExpression
+    from snuba.query.expressions import FunctionCall
+    from snuba.reader import Reader, Result
+
+    query, _storage, _attribution_info = _build_test_query("count(distinct(project_id))")
+    query.set_ast_selected_columns(
+        [SelectedExpression(name=None, expression=FunctionCall(None, "now", ()))]
+    )
+
+    class _EmptyMetaReader(Reader):
+        def __init__(self) -> None:
+            super().__init__(cache_partition_id=None, query_settings_prefix=None)
+
+        def execute(self, *args: Any, **kwargs: Any) -> Result:
+            return {"data": [], "meta": [], "profile": None, "trace_output": ""}
+
+    result = execute_query(
+        clickhouse_query=query,
+        query_settings=HTTPQuerySettings(),
+        formatted_query=format_query(query),
+        reader=_EmptyMetaReader(),
+        timer=Timer("test"),
+        stats={},
+        clickhouse_query_settings={},
+        robust=False,
+    )
     assert result["meta"] == [{"name": "_invalid_alias_0", "type": ""}]
-    assert stats["result_cols"] == 1
 
 
 def test_empty_result_meta_prefers_alias_over_name() -> None:


### PR DESCRIPTION
## Description

Enabling the clickhouse-connect (HTTP) read driver in production surfaced a wave of errors on the Sentry side (`AssertionError: expected (...), got set()` and empty-message `SnubaError`s). They trace to two ways the HTTP/Native read path diverges from the native (TCP) driver — both of which the driver-agnostic `ClickhouseReader` silently relies on, and both of which only appear against a real server (so the existing mocked unit tests missed them).

### Root causes

1. **Zero-row queries lose their column metadata.** ClickHouse&#39;s HTTP `FORMAT Native` output for a query that matches no rows is a **zero-byte body** (verified against a real server), so `clickhouse-connect` returns empty `column_names`. The connect pool then built an empty `meta`, Snuba returned `&#34;meta&#34;: []`, and Sentry&#39;s column-validation assertion failed with `expected (...), got set()`. The native driver always reports the columns even for an empty result.

2. **`GROUP BY ... WITH TOTALS` drops the totals row.** ClickHouse does not serialize totals into the Native HTTP output (they only travel over the native TCP protocol), so `client.query()` returns only the grouped rows ([clickhouse-connect#632](https://github.com/ClickHouse/clickhouse-connect/issues/632)). The reader expects the totals as the trailing result row (as the native driver appends it), so:
   - a totals query matching **zero rows** tripped the reader&#39;s `assert len(data) &gt; 0` → empty-message `SnubaError`;
   - a totals query with **rows present** silently popped a real data row and mislabeled it as the totals.

### Fix

Each divergence is addressed at the layer that owns it, with **no second scan** and no matching on SQL text:

- **Empty-result meta** is synthesized one layer up, in `snuba.web.db_query`, from the query&#39;s own selected columns (alias → name → bare column name) when the driver returns an empty `meta`. This costs nothing — the column list is already in hand — and covers every empty result, not just totals ones.

- **`WITH TOTALS`** now flows through a dedicated `execute_with_totals` method on the `ClickhousePool` interface, implemented by both drivers:
  - the **native** pool&#39;s default delegates to `execute()`, since the protocol already streams the totals as the trailing result row;
  - the **clickhouse-connect** pool overrides it to run the query once with `FORMAT JSONCompact`, which returns the data rows, the column metadata, and the totals row together, and appends the totals as the trailing row — the exact shape the reader expects.

  `ClickhouseReader.execute` calls this entry point whenever `with_totals` is set, so both drivers are handled identically without sniffing the query text.

The common non-empty, no-totals read path is untouched (plain `client.query()`, no extra request). The reader&#39;s previously bare totals assertion also gets a descriptive message.

### A note on value types

Values from `JSONCompact` are read with `json.loads`; only `Date`/`DateTime` are coerced back to objects, because the reader&#39;s column transforms call `date`/`datetime` methods on them and would crash on a raw string. Every other type serializes identically to the native driver once Snuba encodes the response with `default=str` (numbers, strings, bools, arrays, maps, and `UUID`/`IPv4`/`IPv6`/`Enum`), with two harmless exceptions: a whole-number `Float` total renders as `5` rather than `5.0`, and a `Decimal` as a JSON number rather than the native driver&#39;s string — both numerically identical to any JSON consumer. Totals are dominated by integer counts, so no type-directed coercion is warranted. This was verified column-by-column against a real server (16 representative column types, incl. `Int128`, `IPv4/6`, `Tuple`, `Array(DateTime)`, `Nullable`).

Out of scope: the admin cardinality analyzer issues `WITH TOTALS` through `execute()` directly (not the reader), so on the HTTP driver it does not get the totals summary row — unchanged from `master`, where the connect driver has no totals handling at all.

### Tests

- New mocked unit tests: the `execute_with_totals` JSONCompact path (single request, query-id/settings inheritance, empty-totals), the native pool&#39;s default delegation (incl. `robust`), the reader routing `with_totals` through the new entry point, and the `Date`/`DateTime` coercion.
- Existing `snuba.web.db_query` tests cover the empty-result meta synthesis (alias/name/bare-column precedence).
- A real-ClickHouse integration test (`@pytest.mark.clickhouse_db`) asserting connect/native parity for `WITH TOTALS`, zero-row, and zero-row-`WITH TOTALS` queries.

Verified end-to-end against a real ClickHouse server (the CI Altinity 25.3 image); `mypy` and `ruff` clean.

### Legal Boilerplate

Look, I get it. The entity doing business as &#34;Sentry&#34; was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here&#39;s the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry&#39;s choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQ2NuQ2WiFcrBdFhm2t8fC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQ2NuQ2WiFcrBdFhm2t8fC)_