### PR TITLE
feat(consumer): DLQ messages older than a per-storage threshold

### DIFF
--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -28,6 +28,7 @@ use crate::strategies::accountant::RecordCogs;
 use crate::strategies::blq_router::BLQRouter;
 use crate::strategies::clickhouse::writer_v2::{ClickhouseWriterStep, InsertFormat};
 use crate::strategies::commit_log::ProduceCommitLog;
+use crate::strategies::dlq_stale_messages::DlqStaleMessages;
 use crate::strategies::healthcheck::HealthCheck as SnubaHealthCheck;
 use crate::strategies::join_timeout::SetJoinTimeout;
 use crate::strategies::processor::{
@@ -309,6 +310,16 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                 tracing::info!("Not using a backlog-queue",);
                 Box::new(next_step)
             };
+
+        // Dead-letter messages older than a per-storage threshold. This is a
+        // no-op unless `consumer.dlq_stale_threshold_seconds` has a positive
+        // entry for this storage in sentry-options, so it's always safe to
+        // include. Placed ahead of everything else so stale messages are
+        // dropped before any processing work.
+        let next_step: Box<dyn ProcessingStrategy<KafkaPayload>> = Box::new(DlqStaleMessages::new(
+            next_step,
+            self.storage_config.name.clone(),
+        ));
 
         if let Some(path) = &self.health_check_file {
             {

--- a/rust_snuba/src/strategies/dlq_stale_messages.rs
+++ b/rust_snuba/src/strategies/dlq_stale_messages.rs
@@ -1,0 +1,247 @@
+//! # DLQ Stale Messages
+//!
+//! `DlqStaleMessages` is an arroyo strategy that dead-letters any message whose
+//! Kafka timestamp is older than a configurable, per-storage threshold. Fresh
+//! messages are forwarded untouched to the next step in the pipeline.
+//!
+//! Unlike [`crate::strategies::blq_router::BLQRouter`] — which drains a
+//! contiguous backlog of stale messages to a backlog-queue topic and flips back
+//! to forwarding once it catches up — this strategy makes an independent
+//! per-message decision. A stale message is reported to arroyo as an
+//! [`InvalidMessage`], and the `StreamProcessor`'s DLQ machinery produces the
+//! original raw payload to the storage's configured DLQ topic. If the storage
+//! has no DLQ configured, the message is skipped (arroyo logs and moves on).
+//!
+//! The threshold is read at submit time from sentry-options
+//! (`consumer.dlq_stale_threshold_seconds`, a dict keyed by storage name) so it
+//! can be tuned per storage without a restart. A storage with no entry (or a
+//! non-positive value) disables the behavior entirely, making this a
+//! pass-through by default.
+
+use std::time::Duration;
+
+use chrono::{TimeDelta, Utc};
+use sentry_arroyo::backends::kafka::types::KafkaPayload;
+use sentry_arroyo::counter;
+use sentry_arroyo::processing::strategies::{
+    CommitRequest, InvalidMessage, ProcessingStrategy, StrategyError, SubmitError,
+};
+use sentry_arroyo::types::{InnerMessage, Message};
+use sentry_options::options;
+
+const STALE_THRESHOLD_KEY: &str = "consumer.dlq_stale_threshold_seconds";
+
+pub struct DlqStaleMessages<Next> {
+    next_step: Next,
+    storage_name: String,
+}
+
+impl<Next> DlqStaleMessages<Next>
+where
+    Next: ProcessingStrategy<KafkaPayload> + 'static,
+{
+    pub fn new(next_step: Next, storage_name: String) -> Self {
+        Self {
+            next_step,
+            storage_name,
+        }
+    }
+
+    /// Messages older than this are dead-lettered. Read per-message from
+    /// sentry-options to allow runtime tuning. Returns `None` (disabled) when
+    /// the storage has no entry or the configured value is non-positive.
+    fn stale_threshold(&self) -> Option<TimeDelta> {
+        options("snuba")
+            .ok()
+            .and_then(|o| o.get(STALE_THRESHOLD_KEY).ok())
+            .and_then(|v| v.get(&self.storage_name).and_then(|n| n.as_i64()))
+            .filter(|&s| s > 0)
+            .map(TimeDelta::seconds)
+    }
+}
+
+impl<Next> ProcessingStrategy<KafkaPayload> for DlqStaleMessages<Next>
+where
+    Next: ProcessingStrategy<KafkaPayload> + 'static,
+{
+    fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
+        self.next_step.poll()
+    }
+
+    fn submit(&mut self, message: Message<KafkaPayload>) -> Result<(), SubmitError<KafkaPayload>> {
+        let Some(threshold) = self.stale_threshold() else {
+            return self.next_step.submit(message);
+        };
+
+        // A message without a timestamp can't be evaluated for staleness, so we
+        // forward it rather than dead-lettering it.
+        if let Some(msg_ts) = message.timestamp() {
+            if Utc::now().signed_duration_since(msg_ts) > threshold {
+                // Report the original message as invalid so the StreamProcessor
+                // produces it to the configured DLQ topic. Non-broker messages
+                // can't be dead-lettered (no partition/offset), so fall through.
+                if let InnerMessage::BrokerMessage(ref broker_msg) = message.inner_message {
+                    counter!(
+                        "dlq_stale_messages.dlqed",
+                        1,
+                        "storage" => self.storage_name.clone()
+                    );
+                    return Err(SubmitError::InvalidMessage(InvalidMessage::from(
+                        broker_msg,
+                    )));
+                }
+            }
+        }
+
+        self.next_step.submit(message)
+    }
+
+    fn terminate(&mut self) {
+        self.next_step.terminate();
+    }
+
+    fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, StrategyError> {
+        self.next_step.join(timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::DateTime;
+    use sentry_arroyo::processing::strategies::InvalidMessageReason;
+    use sentry_arroyo::types::{Partition, Topic};
+    use sentry_options::init_with_schemas;
+    use sentry_options::testing::override_options;
+    use serde_json::json;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    fn init_config() {
+        INIT.call_once(|| init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)]).unwrap());
+    }
+
+    struct MockStrategy {
+        submitted: Vec<Message<KafkaPayload>>,
+    }
+
+    impl MockStrategy {
+        fn new() -> Self {
+            Self { submitted: vec![] }
+        }
+    }
+
+    impl ProcessingStrategy<KafkaPayload> for MockStrategy {
+        fn poll(&mut self) -> Result<Option<CommitRequest>, StrategyError> {
+            Ok(None)
+        }
+
+        fn submit(
+            &mut self,
+            message: Message<KafkaPayload>,
+        ) -> Result<(), SubmitError<KafkaPayload>> {
+            self.submitted.push(message);
+            Ok(())
+        }
+
+        fn terminate(&mut self) {}
+
+        fn join(
+            &mut self,
+            _timeout: Option<Duration>,
+        ) -> Result<Option<CommitRequest>, StrategyError> {
+            Ok(None)
+        }
+    }
+
+    fn make_message(timestamp: DateTime<Utc>) -> Message<KafkaPayload> {
+        Message::new_broker_message(
+            KafkaPayload::new(None, None, Some(b"test".to_vec())),
+            Partition::new(Topic::new("test"), 0),
+            0,
+            timestamp,
+        )
+    }
+
+    #[test]
+    fn test_passthrough_when_unconfigured() {
+        // No entry for this storage -> disabled, everything forwards.
+        init_config();
+        let mut strategy = DlqStaleMessages::new(MockStrategy::new(), "some_storage".to_string());
+
+        strategy
+            .submit(make_message(Utc::now() - TimeDelta::hours(1)))
+            .unwrap();
+        strategy.submit(make_message(Utc::now())).unwrap();
+
+        assert_eq!(strategy.next_step.submitted.len(), 2);
+    }
+
+    #[test]
+    fn test_non_positive_threshold_disables() {
+        init_config();
+        let _guard = override_options(&[(
+            "snuba",
+            "consumer.dlq_stale_threshold_seconds",
+            json!({ "dlq_disabled_test": 0 }),
+        )])
+        .unwrap();
+        let mut strategy =
+            DlqStaleMessages::new(MockStrategy::new(), "dlq_disabled_test".to_string());
+
+        strategy
+            .submit(make_message(Utc::now() - TimeDelta::hours(1)))
+            .unwrap();
+
+        assert_eq!(strategy.next_step.submitted.len(), 1);
+    }
+
+    #[test]
+    fn test_stale_message_is_dlqed() {
+        init_config();
+        let _guard = override_options(&[(
+            "snuba",
+            "consumer.dlq_stale_threshold_seconds",
+            json!({ "dlq_stale_test": 10 }),
+        )])
+        .unwrap();
+        let mut strategy = DlqStaleMessages::new(MockStrategy::new(), "dlq_stale_test".to_string());
+
+        // Fresh message is forwarded.
+        strategy.submit(make_message(Utc::now())).unwrap();
+        assert_eq!(strategy.next_step.submitted.len(), 1);
+
+        // Stale message is reported as invalid (routed to DLQ by the processor).
+        let err = strategy
+            .submit(make_message(Utc::now() - TimeDelta::seconds(20)))
+            .unwrap_err();
+        match err {
+            SubmitError::InvalidMessage(invalid) => {
+                assert_eq!(invalid.offset, 0);
+                assert_eq!(invalid.reason, InvalidMessageReason::Invalid);
+            }
+            _ => panic!("expected InvalidMessage"),
+        }
+        // Stale message was not forwarded downstream.
+        assert_eq!(strategy.next_step.submitted.len(), 1);
+    }
+
+    #[test]
+    fn test_only_configured_storage_is_affected() {
+        // The option targets a different storage, so ours stays disabled.
+        init_config();
+        let _guard = override_options(&[(
+            "snuba",
+            "consumer.dlq_stale_threshold_seconds",
+            json!({ "other_storage": 10 }),
+        )])
+        .unwrap();
+        let mut strategy = DlqStaleMessages::new(MockStrategy::new(), "my_storage".to_string());
+
+        strategy
+            .submit(make_message(Utc::now() - TimeDelta::hours(1)))
+            .unwrap();
+
+        assert_eq!(strategy.next_step.submitted.len(), 1);
+    }
+}

--- a/rust_snuba/src/strategies/mod.rs
+++ b/rust_snuba/src/strategies/mod.rs
@@ -3,6 +3,7 @@ pub mod accountant;
 pub mod blq_router;
 pub mod clickhouse;
 pub mod commit_log;
+pub mod dlq_stale_messages;
 pub mod healthcheck;
 pub mod join_timeout;
 pub mod noop;

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -27,6 +27,14 @@
       "default": 120,
       "description": "BLQ hysteresis in seconds. Once routing stale, keep routing messages at least (stale_threshold - static_friction) old. Set to 0 to disable friction."
     },
+    "consumer.dlq_stale_threshold_seconds": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "default": {},
+      "description": "Dict mapping storage name to a staleness threshold in seconds. A consumer dead-letters any message whose Kafka timestamp is older than its storage's threshold (routing the original payload to that storage's configured DLQ topic). Storages with no entry, or a non-positive value, are unaffected."
+    },
     "eap_items_drop_invalid_timestamps": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
Adds a `DlqStaleMessages` arroyo strategy that dead-letters any consumed message whose Kafka timestamp is older than a configurable, per-storage threshold. Fresh messages are forwarded untouched. The strategy is wired into the front of every consumer pipeline built by `ConsumerStrategyFactoryV2`.

## Why

We want a way to shed a backlog of very old messages without processing them — e.g. when a consumer falls far behind and the stale data is no longer worth writing. Rather than dropping silently, stale messages are routed to the storage's existing DLQ topic so they remain recoverable/inspectable.

## How it routes to the DLQ

The strategy returns `SubmitError::InvalidMessage { partition, offset, reason: Invalid }` for stale messages. The `StreamProcessor` already has a `dlq_policy` configured from each storage's `dlq_topic`; on `InvalidMessage` it looks up the original raw payload in its DLQ buffer by `(partition, offset)` and produces it to the DLQ topic. This is the same mechanism the message processor uses for invalid payloads, so no new wiring in `consumer.rs` was needed.

## Config

New per-storage sentry-option `consumer.dlq_stale_threshold_seconds` — a dict keyed by storage name mapping to a threshold in seconds. Read at submit time so it can be tuned without a restart. Off by default: a storage with no entry (or a non-positive value) is a pure pass-through, so this is safe to merge disabled-everywhere and enable for `eap_items` (or any storage) at runtime.

## Notes for reviewers

- **Generic, not eap_items-only.** The per-storage option gives the same targeting for free, so the strategy applies to all storages rather than being scoped to the eap-items processor.
- **Kafka timestamp, not event timestamp.** Staleness is measured against `message.timestamp()` (Kafka produce time), independent of the existing `eap_items_dlq_grace_period_min` feature, which uses the payload event timestamp plus weekly-partition logic.
- **Placement / interaction with BLQRouter.** It sits just inside the health check, ahead of `BLQRouter`. Both are off by default; if both were enabled for the same storage they would conflict, since `blq_topic` and `dlq_topic` are the same topic.
- **No DLQ configured = drop.** If a storage without a `dlq_topic` enables the option, stale messages are skipped (arroyo logs "No DLQ policy configured") rather than produced anywhere — consistent with existing `InvalidMessage` handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)