### PR TITLE
feat(eap): Enable block number/offset columns on eap_items tables

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0062_eap_items_enable_block_number_columns.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0062_eap_items_enable_block_number_columns.py
@@ -1,0 +1,49 @@
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+
+# Mirrors the sampling weights used by the eap_items downsample tables.
+sampling_weights = [8, 8**2, 8**3]
+
+
+def _local_tables() -> list[str]:
+    prefixes = ["eap_items_1"] + [
+        f"eap_items_1_downsample_{sampling_weight}" for sampling_weight in sampling_weights
+    ]
+    return [f"{prefix}_local" for prefix in prefixes]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> list[SqlOperation]:
+        # enable_block_number_column / enable_block_offset_column are MergeTree
+        # per-table settings, so they only apply to the local tables.
+        return [
+            operations.ModifyTableSettings(
+                storage_set=storage_set,
+                table_name=table_name,
+                settings={
+                    "enable_block_number_column": 1,
+                    "enable_block_offset_column": 1,
+                },
+                target=OperationTarget.LOCAL,
+            )
+            for table_name in _local_tables()
+        ]
+
+    def backwards_ops(self) -> list[SqlOperation]:
+        return [
+            operations.ModifyTableSettings(
+                storage_set=storage_set,
+                table_name=table_name,
+                settings={
+                    "enable_block_number_column": 0,
+                    "enable_block_offset_column": 0,
+                },
+                target=OperationTarget.LOCAL,
+            )
+            for table_name in _local_tables()
+        ]


### PR DESCRIPTION
Purpose: allow us to do lightweight update deletes on EAP

Adds migration 0062, which runs `ALTER TABLE ... MODIFY SETTING` to set `enable_block_number_column = 1` and `enable_block_offset_column = 1` on the eap_items local MergeTree tables:

- `eap_items_1_local`
- `eap_items_1_downsample_8_local`
- `eap_items_1_downsample_64_local`
- `eap_items_1_downsample_512_local`

These are MergeTree per-table settings, so the migration targets `OperationTarget.LOCAL` only — the Distributed `_dist`/`_dist_ro` tables don't carry these settings and are left untouched. This mirrors how the existing `events/0017_errors_add_indexes` migration applies `ModifyTableSettings`.

The migration is non-blocking since `MODIFY SETTING` is a metadata-only change. `backwards_ops` resets both settings to `0` (the ClickHouse default).