### PR TITLE
fix(options): Add schema copy step to dockerfile for python library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,9 @@ ENV LD_PRELOAD=/usr/src/snuba/libjemalloc.so.2 \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-# set default path for sentry options values
+# set up sentry options schemas and default path.
+# schemas must be on disk at SENTRY_OPTIONS_DIR for the python client's init()
+COPY sentry-options/schemas /etc/sentry-options/schemas
 ENV SENTRY_OPTIONS_DIR=/etc/sentry-options
 
 USER snuba
@@ -167,6 +169,7 @@ FROM ghcr.io/getsentry/dhi/python:3.13-debian13 AS application-distroless
 
 COPY --from=distroless_prep /.venv /.venv
 COPY --from=distroless_prep /usr/src/snuba /usr/src/snuba
+COPY --from=distroless_prep /etc/sentry-options /etc/sentry-options
 COPY --from=distroless_prep /usr/lib/*/libjemalloc.so.2 /usr/lib/libjemalloc.so.2
 COPY --from=distroless_prep /etc/passwd /etc/passwd
 COPY --from=distroless_prep /etc/group /etc/group
@@ -191,6 +194,7 @@ FROM ghcr.io/getsentry/dhi/python:3.13-debian13-dev AS application-distroless-de
 
 COPY --from=distroless_prep /.venv /.venv
 COPY --from=distroless_prep /usr/src/snuba /usr/src/snuba
+COPY --from=distroless_prep /etc/sentry-options /etc/sentry-options
 COPY --from=distroless_prep /usr/lib/*/libjemalloc.so.2 /usr/lib/libjemalloc.so.2
 COPY --from=distroless_prep /etc/passwd /etc/passwd
 COPY --from=distroless_prep /etc/group /etc/group


### PR DESCRIPTION
the sentry-options rust library directly passed the schemas in with ` init_with_schemas(&[("snuba", crate::SNUBA_SCHEMA)])`.  however, the python library has no such API, and we need to copy the schemas over into the correct directory in the dockerfile.

this pr adds the copy.