### PR TITLE
fix(clickhouse): Use default HTTP port for direct connections to cluster nodes

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -519,16 +519,19 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         )
 
     def __get_cluster_nodes(self, cluster_name: str) -> Sequence[ClickhouseNode]:
-        # system.clusters only reports the native port; every node in the
-        # cluster shares the cluster's configured HTTP port, so stamp it on each
-        # discovered node so it is self-describing for the HTTP driver.
+        # system.clusters only reports the native port. The cluster's configured
+        # HTTP port is an Envoy intercept port that only fronts the cluster
+        # endpoint (the query node); individual nodes discovered here are
+        # addressed directly, bypassing Envoy, and serve HTTP on the well-known
+        # default port. Stamp that on each node so the HTTP driver connects to a
+        # port the node actually listens on.
         return [
             ClickhouseNode(
                 host_name=host[0],
                 native_port=host[1],
                 shard=host[2],
                 replica=host[3],
-                http_port=self.__http_port,
+                http_port=DEFAULT_CLICKHOUSE_HTTP_PORT,
             )
             for host in self.get_query_connection(ClickhouseClientSettings.INTERNAL)
             .execute(

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -203,6 +203,40 @@ def test_get_local_nodes() -> None:
 
 
 @pytest.mark.clickhouse_db
+def test_discovered_nodes_use_default_http_port() -> None:
+    # The cluster's configured http_port is an Envoy intercept port that only
+    # fronts the cluster endpoint (query node). Nodes discovered via
+    # system.clusters are addressed directly (bypassing Envoy) and must carry
+    # the well-known default HTTP port instead.
+    envoy_http_port = 8158
+    distributed_cluster = cluster.ClickhouseCluster(
+        "host_query",
+        9000,
+        "default",
+        "",
+        "default",
+        envoy_http_port,
+        False,
+        None,
+        False,
+        {"events"},
+        False,
+        cluster_name="clickhouse_hosts",
+        distributed_cluster_name="dist_hosts",
+    )
+
+    with patch.object(ClickhouseNativePool, "execute") as execute:
+        execute.return_value = ClickhouseResult([("host_1", 9000, 1, 1), ("host_2", 9000, 2, 1)])
+        local_nodes = distributed_cluster.get_local_nodes()
+
+    # The cluster endpoint keeps the Envoy intercept port ...
+    assert distributed_cluster.get_http_port() == envoy_http_port
+    # ... but directly-addressed nodes use the default HTTP port.
+    assert len(local_nodes) == 2
+    assert all(node.http_port == cluster.DEFAULT_CLICKHOUSE_HTTP_PORT for node in local_nodes)
+
+
+@pytest.mark.clickhouse_db
 def test_cache_connections() -> None:
     cluster_1 = cluster.ClickhouseCluster(
         "127.0.0.1",


### PR DESCRIPTION
## Root cause

Since the clickhouse-connect (HTTP) driver was added (#8060), code that connects to individual cluster nodes does so over HTTP on the port stamped onto each node by `ClickhouseCluster.__get_cluster_nodes`. That port was the cluster's **configured `http_port`** — which in production is an **Envoy intercept port** that only fronts the cluster *endpoint* (the query node).

Nodes discovered via `system.clusters` are addressed **directly**, bypassing Envoy, and don't serve HTTP on that intercept port. So once the HTTP driver was enabled, `snuba migrations migrate` → `check_for_inactive_replicas` → `get_node_connection(MIGRATE, node)` tried to connect over HTTP on the Envoy port (`8158`) of an individual replica and got `Connection refused`, crashing the migration ([SNUBA-BDZ](https://sentry.sentry.io/issues/7588156898/)).

Only paths that connect to nodes **directly** (e.g. `check_for_inactive_replicas`, `get_column_states`) were affected. The read path goes through the query node / Envoy and was unaffected — consistent with the driver rollout being scoped to the read path.

## Fix

Stamp the well-known default ClickHouse HTTP port (`DEFAULT_CLICKHOUSE_HTTP_PORT`) on directly-addressed nodes in `__get_cluster_nodes`, so the HTTP driver connects to a port the node actually listens on. The query node keeps the configured (Envoy) `http_port`, since that is the correct address for the cluster endpoint.

## Changes
- `snuba/clusters/cluster.py`: `__get_cluster_nodes` stamps `DEFAULT_CLICKHOUSE_HTTP_PORT` on discovered nodes instead of the cluster's configured (Envoy) `http_port`.
- `tests/clusters/test_cluster.py`: add `test_discovered_nodes_use_default_http_port`, verifying discovered nodes carry the default HTTP port while the cluster endpoint keeps the configured port.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjxxGZNhvfFVtBQEr1KkRT