### PR TITLE
feat(allocation_policies): add org allowlist to bypass all rate limits

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -18,6 +18,7 @@ from snuba.configs.configuration import (
     logger,
 )
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.state import get_config as get_runtime_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.registered_class import import_submodules_in_directory
 from snuba.utils.serializable_exception import JsonSerializable, SerializableException
@@ -25,6 +26,13 @@ from snuba.web import QueryResult
 
 CAPMAN_PREFIX = "capman"
 CAPMAN_HASH = "capman"
+
+# Global runtime config (visible in the runtime config admin UI, NOT Capacity
+# Management) holding a comma-separated list of organization ids that are exempt
+# from ALL allocation policies (rate limits), e.g. "1,42,1337". It is global
+# rather than per-policy because it is meant to exempt an org from every policy
+# at once. See AllocationPolicy.is_rate_limit_bypassed.
+ORG_RATE_LIMIT_BYPASS_CONFIG = "organization_rate_limit_bypass_allowlist"
 
 IS_ACTIVE = "is_active"
 IS_ENFORCED = "is_enforced"
@@ -424,6 +432,27 @@ class AllocationPolicy(ConfigurableComponent, ABC):
     def is_cross_org_query(self, tenant_ids: dict[str, str | int]) -> bool:
         return bool(tenant_ids.get("cross_org_query", False))
 
+    def is_rate_limit_bypassed(self, tenant_ids: dict[str, str | int]) -> bool:
+        """Returns True if the query's organization is in the global rate limit
+        bypass allowlist. Orgs in this allowlist skip ALL allocation policies
+        entirely, in the same way an inactive policy is skipped.
+
+        The allowlist is a single global runtime config shared across every
+        policy (see ORG_RATE_LIMIT_BYPASS_CONFIG), since it is meant to exempt an
+        org from all rate limits at once. It is stored as a comma-separated list
+        of organization ids, e.g. "1,42,1337".
+        """
+        org_id = tenant_ids.get("organization_id")
+        if org_id is None:
+            return False
+        allowlist = get_runtime_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "")
+        if not allowlist:
+            return False
+        bypassed_orgs = {
+            part.strip() for part in str(allowlist).split(",") if part.strip()
+        }
+        return str(org_id) in bypassed_orgs
+
     @classmethod
     def from_kwargs(cls, **kwargs: str) -> AllocationPolicy:
         required_tenant_types = kwargs.pop("required_tenant_types", None)
@@ -457,7 +486,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
             for t, tid in tenant_ids.items():
                 span.set_data(f"tenant_ids.{t}", str(tid))
             try:
-                if not self.is_active:
+                if not self.is_active or self.is_rate_limit_bypassed(tenant_ids):
                     allowance = QuotaAllowance(
                         can_run=True,
                         max_threads=self.max_threads,
@@ -547,7 +576,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
         result_or_error: QueryResultOrError,
     ) -> None:
         try:
-            if not self.is_active:
+            if not self.is_active or self.is_rate_limit_bypassed(tenant_ids):
                 return None
             return self._update_quota_balance(tenant_ids, query_id, result_or_error)
         except InvalidTenantsForAllocationPolicy:

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -448,9 +448,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
         allowlist = get_runtime_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "")
         if not allowlist:
             return False
-        bypassed_orgs = {
-            part.strip() for part in str(allowlist).split(",") if part.strip()
-        }
+        bypassed_orgs = {part.strip() for part in str(allowlist).split(",") if part.strip()}
         return str(org_id) in bypassed_orgs
 
     @classmethod

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -445,8 +445,11 @@ class AllocationPolicy(ConfigurableComponent, ABC):
         org_id = tenant_ids.get("organization_id")
         if org_id is None:
             return False
-        allowlist = get_runtime_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "")
-        if not allowlist:
+        # Use `is None` rather than a falsy check: runtime config coerces types,
+        # so a lone org id of `0` would be stored as the integer 0 and a `not
+        # allowlist` check would wrongly treat it as unset.
+        allowlist = get_runtime_config(ORG_RATE_LIMIT_BYPASS_CONFIG)
+        if allowlist is None:
             return False
         bypassed_orgs = {part.strip() for part in str(allowlist).split(",") if part.strip()}
         return str(org_id) in bypassed_orgs

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -442,6 +442,8 @@ class AllocationPolicy(ConfigurableComponent, ABC):
         org from all rate limits at once. It is stored as a comma-separated list
         of organization ids, e.g. "1,42,1337".
         """
+        if not tenant_ids:
+            return False
         org_id = tenant_ids.get("organization_id")
         if org_id is None:
             return False

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -595,9 +595,7 @@ def test_org_rate_limit_bypass_no_org_id() -> None:
     )
     set_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "123")
     # tenant_ids without an organization_id should never be bypassed.
-    assert not reject_policy.get_quota_allowance(
-        {"referrer": "some_referrer"}, "deadbeef"
-    ).can_run
+    assert not reject_policy.get_quota_allowance({"referrer": "some_referrer"}, "deadbeef").can_run
 
 
 @pytest.mark.redis_db

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -599,6 +599,21 @@ def test_org_rate_limit_bypass_no_org_id() -> None:
 
 
 @pytest.mark.redis_db
+def test_org_rate_limit_bypass_zero_org_id() -> None:
+    # A lone org id of 0 is coerced to the integer 0 by runtime config; make
+    # sure it is still honored (i.e. not treated as an unset allowlist).
+    reject_policy = RejectingEverythingAllocationPolicy(
+        StorageKey("some_storage"),
+        [],
+        {"is_active": 1, "is_enforced": 1},
+    )
+    set_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "0")
+    assert reject_policy.get_quota_allowance(
+        {"organization_id": 0, "referrer": "some_referrer"}, "deadbeef"
+    ).can_run
+
+
+@pytest.mark.redis_db
 def test_configs_with_delimiter_values() -> None:
     # test that configs with dots can be stored and read
     policy = SomeParametrizedConfigPolicy(StorageKey("something"), [], {})

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -12,6 +12,7 @@ from snuba.query.allocation_policies import (
     MAX_THRESHOLD,
     NO_SUGGESTION,
     NO_UNITS,
+    ORG_RATE_LIMIT_BYPASS_CONFIG,
     AllocationPolicy,
     AllocationPolicyConfig,
     InvalidTenantsForAllocationPolicy,
@@ -522,6 +523,81 @@ def test_is_not_enforced() -> None:
     assert throttled_metrics[0].tags["policy_class"] == "ThrottleEverythingAllocationPolicy"
     assert throttled_metrics[0].tags["is_enforced"] == "True"
     assert throttled_metrics[1].tags["is_enforced"] == "False"
+
+
+@pytest.mark.redis_db
+def test_org_rate_limit_bypass_allowlist() -> None:
+    MAX_THREADS = 100
+    reject_policy = RejectingEverythingAllocationPolicy(
+        StorageKey("some_storage"),
+        [],
+        {"is_active": 1, "is_enforced": 1, "max_threads": MAX_THREADS},
+    )
+    allowlisted_tenant: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    other_tenant: dict[str, int | str] = {
+        "organization_id": 999,
+        "referrer": "some_referrer",
+    }
+
+    # By default the org is rejected by the (enforced) policy.
+    assert not reject_policy.get_quota_allowance(allowlisted_tenant, "deadbeef").can_run
+
+    # Add the org to the global bypass allowlist.
+    set_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "123,456")
+
+    # Allowlisted org bypasses the policy entirely (passes through with full threads).
+    allowance = reject_policy.get_quota_allowance(allowlisted_tenant, "deadbeef")
+    assert allowance.can_run
+    assert allowance.max_threads == MAX_THREADS
+
+    # An org not in the allowlist is still rejected.
+    assert not reject_policy.get_quota_allowance(other_tenant, "deadbeef").can_run
+
+
+@pytest.mark.redis_db
+def test_org_rate_limit_bypass_skips_update_quota_balance() -> None:
+    # BadlyWrittenAllocationPolicy raises in both _get_quota_allowance and
+    # _update_quota_balance, so a successful call proves those private methods
+    # were never invoked (i.e. the org bypassed the policy).
+    policy = BadlyWrittenAllocationPolicy(
+        StorageKey("some_storage"),
+        [],
+        {"is_active": 1, "is_enforced": 1},
+    )
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    result_or_error = QueryResultOrError(
+        query_result=QueryResult(
+            result={"profile": {"bytes": 420}},
+            extra={"stats": {}, "sql": "", "experiments": {}},
+        ),
+        error=None,
+    )
+
+    set_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "123")
+
+    # Neither the buggy _get_quota_allowance nor _update_quota_balance is reached.
+    assert policy.get_quota_allowance(tenant_ids, "deadbeef").can_run
+    policy.update_quota_balance(tenant_ids, "deadbeef", result_or_error)
+
+
+@pytest.mark.redis_db
+def test_org_rate_limit_bypass_no_org_id() -> None:
+    reject_policy = RejectingEverythingAllocationPolicy(
+        StorageKey("some_storage"),
+        [],
+        {"is_active": 1, "is_enforced": 1},
+    )
+    set_config(ORG_RATE_LIMIT_BYPASS_CONFIG, "123")
+    # tenant_ids without an organization_id should never be bypassed.
+    assert not reject_policy.get_quota_allowance(
+        {"referrer": "some_referrer"}, "deadbeef"
+    ).can_run
 
 
 @pytest.mark.redis_db


### PR DESCRIPTION
Adds a way to maintain an allowlist of organizations that bypass **all** allocation policies (rate limits) at once.

### What

- New global runtime config **`organization_rate_limit_bypass_allowlist`** — a comma-separated list of organization ids (e.g. `"1,42,1337"`).
- Any org in this list skips every allocation policy entirely, the same way an inactive policy is skipped (query passes through with full `max_threads`, unlimited bytes).

### How

- The check lives in the base `AllocationPolicy` (`snuba/query/allocation_policies/__init__.py`) via a new `is_rate_limit_bypassed(tenant_ids)` helper, gated on `tenant_ids["organization_id"]`.
- It's applied at the single choke point every policy flows through:
  - `get_quota_allowance` — alongside the existing `is_active` check, returning a passthrough allowance.
  - `update_quota_balance` — alongside the same check, so bypassed orgs don't corrupt policy bookkeeping (e.g. the concurrent-limit policy removing a query it never recorded).
- Because both the legacy pipeline and the RPC/storage-routing pipeline call `get_quota_allowance`, this covers every policy (concurrent rate limit, bytes-scanned, referrer guard rail, cross-org, …) across both paths with one edit.

### Why a global config

It's a single global runtime config (visible in the runtime config admin UI) rather than a per-policy Capacity Management config, so one edit exempts an org from **all** rate limits at once instead of having to set an override on each policy individually. Operators maintain the list from the existing runtime config admin UI.

### Notes / scope

- This covers allocation policies (the rate limits). Capacity-based *routing strategy selection* (`RoutingStrategySelector`) is a separate path and is intentionally not changed here — this PR is about bypassing rate limits, not forcing a routing tier.
- Failure modes are unchanged: the helper is dead-simple string comparison and the surrounding methods already fail open on exceptions. An empty/unset allowlist is a no-op.

### Tests

Added to `tests/query/allocation_policies/test_allocation_policy_base.py`:
- Allowlisted org bypasses a reject-everything policy; non-allowlisted org is still rejected.
- `update_quota_balance` is skipped for a bypassed org (proven via a policy that raises in its private methods).
- tenant_ids without an `organization_id` are never bypassed.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjLqLCQ38BrNp1TKckiNex)_