### PR TITLE
fix(clickhouse): enforce 25s max_execution_time on TRACING profile

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -73,9 +73,7 @@ class ClickhouseClientSettings(Enum):
     )
     DELETE = ClickhouseClientSettingsType({"mutations_sync": 1}, None)
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
-    QUERY = ClickhouseClientSettingsType(
-        {"max_execution_time": _DEFAULT_USER_FACING_TIMEOUT}, _DEFAULT_USER_FACING_TIMEOUT
-    )
+    QUERY = ClickhouseClientSettingsType({}, _DEFAULT_USER_FACING_TIMEOUT)
     TRACING = ClickhouseClientSettingsType(
         {"readonly": 2, "max_execution_time": _DEFAULT_USER_FACING_TIMEOUT},
         _DEFAULT_USER_FACING_TIMEOUT,

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -35,6 +35,11 @@ logger = structlog.get_logger().bind(module=__name__)
 # tools) that only know a node's native address and have no cluster config to
 # read an http_port from.
 DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
+# User-facing read queries get a 25s timeout, leaving headroom under a ~30s
+# frontend request budget to still return a response. Migrations, DDL and
+# other long-running operations keep their own (default or longer) timeouts
+# above/below.
+_DEFAULT_USER_FACING_TIMEOUT = 25
 
 
 class ClickhouseClientSettingsType(NamedTuple):
@@ -68,11 +73,13 @@ class ClickhouseClientSettings(Enum):
     )
     DELETE = ClickhouseClientSettingsType({"mutations_sync": 1}, None)
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
-    # User-facing read queries get a 25s timeout, leaving headroom under a ~30s
-    # frontend request budget to still return a response. Migrations, DDL and
-    # other long-running operations keep their own (default or longer) timeouts
-    # above/below.
-    QUERY = ClickhouseClientSettingsType({}, 25)
+    QUERY = ClickhouseClientSettingsType(
+        {"max_execution_time": _DEFAULT_USER_FACING_TIMEOUT}, _DEFAULT_USER_FACING_TIMEOUT
+    )
+    TRACING = ClickhouseClientSettingsType(
+        {"readonly": 2, "max_execution_time": _DEFAULT_USER_FACING_TIMEOUT},
+        _DEFAULT_USER_FACING_TIMEOUT,
+    )
     # Internal/maintenance queries that are NOT user-facing reads and must not
     # inherit QUERY's 25s cap: cluster topology discovery (system.clusters),
     # storage-routing load lookups, delete-throttling system-table checks, the
@@ -80,7 +87,6 @@ class ClickhouseClientSettings(Enum):
     # so they stay unbounded (their behavior before QUERY got a read timeout).
     INTERNAL = ClickhouseClientSettingsType({}, None)
     QUERYLOG = ClickhouseClientSettingsType({}, None)
-    TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(
         {
             # Replacing existing rows requires reconstructing the entire tuple

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -6,6 +6,7 @@ import pytest
 from snuba.clickhouse.connect import ClickhouseConnectPool
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
+from snuba.clusters.cluster import ClickhouseClientSettings
 
 # Error code returned by ClickHouse when the maximum number of simultaneous
 # queries has been exceeded.
@@ -183,9 +184,19 @@ def test_send_receive_timeout_unbounded_when_profile_has_none() -> None:
 def test_read_query_client_settings_use_25s_timeout() -> None:
     # Read queries (the QUERY profile) get a 25s timeout on both drivers, leaving
     # headroom under the frontend request budget.
-    from snuba.clusters.cluster import ClickhouseClientSettings
 
-    assert ClickhouseClientSettings.QUERY.value.timeout == 25
+    settings = ClickhouseClientSettings.QUERY.value
+    assert settings.settings == {"max_execution_time": 25}
+    assert settings.timeout == 25
+
+
+def test_tracing_client_settings_use_25s_timeout() -> None:
+    # Tracing queries (the TRACING profile) get a 25s timeout on both drivers, leaving
+    # headroom under the frontend request budget.
+
+    settings = ClickhouseClientSettings.TRACING.value
+    assert settings.settings == {"readonly": 2, "max_execution_time": 25}
+    assert ClickhouseClientSettings.TRACING.value.timeout == 25
 
 
 def test_internal_profile_is_unbounded() -> None:
@@ -193,8 +204,6 @@ def test_internal_profile_is_unbounded() -> None:
     # (topology discovery, routing load lookups, delete throttling checks, the
     # span-export job, table copies). They use the INTERNAL profile, which stays
     # unbounded so long-running operations aren't capped at 30s.
-    from snuba.clusters.cluster import ClickhouseClientSettings
-
     assert ClickhouseClientSettings.INTERNAL.value.timeout is None
 
 

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -186,7 +186,7 @@ def test_read_query_client_settings_use_25s_timeout() -> None:
     # headroom under the frontend request budget.
 
     settings = ClickhouseClientSettings.QUERY.value
-    assert settings.settings == {"max_execution_time": 25}
+    assert settings.settings == {}
     assert settings.timeout == 25
 
 

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -196,7 +196,7 @@ def test_tracing_client_settings_use_25s_timeout() -> None:
 
     settings = ClickhouseClientSettings.TRACING.value
     assert settings.settings == {"readonly": 2, "max_execution_time": 25}
-    assert ClickhouseClientSettings.TRACING.value.timeout == 25
+    assert settings.timeout == 25
 
 
 def test_internal_profile_is_unbounded() -> None:


### PR DESCRIPTION
## Summary

Enforce the 25s user-facing read timeout **server-side** in ClickHouse, and extend the same cap to the admin tracing path, which was previously unbounded.

The `TRACING` profile (used by the admin `clickhouse_trace_query` tool) had no timeout at all either in the client side, or the server side. This tightens both.

On a timeout this endpoints still return a 400, not a 429.

## Changes

- **Extract the magic number** into a named constant `_DEFAULT_USER_FACING_TIMEOUT = 25`, with the rationale comment attached to it.
- **`TRACING`** goes from unbounded (`{"readonly": 2}`, `timeout=None`) to the same 25s treatment as `QUERY` (`{"readonly": 2, "max_execution_time": 25}`, `timeout=25`). This bounds admin trace queries, which run raw SQL directly against a query node and bypass the storage query-processor pipeline (so they never picked up a storage-level `max_execution_time`).


## Testing

- `test_read_query_client_settings_use_25s_timeout` updated to assert both the settings dict (`{}`) as well.
- Added `test_tracing_client_settings_use_25s_timeout` asserting `{"readonly": 2, "max_execution_time": 25}` and `timeout == 25`.
- Ran `snuba admin` locally and verified that a slow `clickhouse_trace_query` will now error out. 
```
curl  -v -XPOST -H'Content-Type: application/json' http://127.0.0.1:1219/clickhouse_trace_query -d '{"storage": "errors", "sql": "SELECT sleepEachRow(1) FROM numbers(30) SETTINGS max_block_size = 1", "gather_profile_events": false}' 
```

Run:

```
pytest tests/clickhouse/test_connect.py
```


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.