### PR TITLE
fix(admin): Add a global exception handler that repackages all thrown errors as JSON

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -14,6 +14,7 @@ import structlog
 from flask import Flask, Response, g, jsonify, make_response, request
 from google.protobuf.json_format import MessageToDict, Parse
 from structlog.contextvars import bind_contextvars, clear_contextvars
+from werkzeug.exceptions import HTTPException
 
 from snuba import settings, state
 from snuba.admin.audit_log.action import AuditLogAction
@@ -128,6 +129,22 @@ def handle_invalid_dataset(exception: InvalidDatasetError) -> Response:
     return Response(
         json.dumps(data, sort_keys=True, indent=4),
         404,
+        {"Content-Type": "application/json"},
+    )
+
+
+# passthrough needed so that we don't turn these into 500s
+@application.errorhandler(HTTPException)
+def handle_http_exception(exception: HTTPException) -> HTTPException:
+    return exception
+
+
+@application.errorhandler(Exception)
+def handle_uncaught_exception(exception: Exception) -> Response:
+    logger.error(exception, exc_info=True)
+    return Response(
+        json.dumps({"error": {"type": "unknown", "message": str(exception)}}),
+        500,
         {"Content-Type": "application/json"},
     )
 

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -1482,3 +1482,25 @@ def test_list_rpc_endpoints(admin_api: FlaskClient) -> None:
     registered_endpoints = {tuple(name.split("__")) for name in RPCEndpoint.all_names()}
     response_endpoints = {tuple(endpoint) for endpoint in endpoint_names}
     assert response_endpoints == registered_endpoints
+
+
+@pytest.mark.redis_db
+def test_uncaught_exception_returns_json_500(admin_api: FlaskClient) -> None:
+    # The /tools endpoint has no try/except; make its handler raise an
+    # unexpected error and confirm the global handler repackages it as JSON.
+    with mock.patch(
+        "snuba.admin.views.get_user_allowed_tools",
+        side_effect=RuntimeError("boom"),
+    ):
+        response = admin_api.get("/tools")
+
+    assert response.status_code == 500
+    assert response.headers["Content-Type"] == "application/json"
+    assert json.loads(response.data) == {"error": {"type": "unknown", "message": "boom"}}
+
+
+@pytest.mark.redis_db
+def test_http_exception_passes_through(admin_api: FlaskClient) -> None:
+    # The catch-all must not swallow werkzeug HTTPExceptions into a 500.
+    response = admin_api.get("/this_route_does_not_exist")
+    assert response.status_code == 404


### PR DESCRIPTION
## Background

Snuba admin has no global exception handler.  Which means when there is an unknown exception raised it falls back to werkzeug's handler (which returns a HTML response).

In this PR we add a handler for an `Exception`, and a passthrough for `HTTPException` so that we always capture and report on any exception.

I've opted to keep this change only on the `admin` routes for now.  The `web` routes don't have a global fallback either, but they seem better covered.

## Testing

- `pytest tests/admin/test_api.py`
- Spawn snuba admin locally and run the following curl (it should fail with a JSON decode error due to a missing Content-Type header)
```
curl -XPOST http://127.0.0.1:1219/clickhouse_trace_query \
-d '{"storage": "errors", "sql": "SELECT sleepEachRow(1) FROM numbers(30) SETTINGS max_block_size = 1", "gather_profile_events": false}'
```


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
