### PR TITLE
feat(admin): Cap admin HTTP requests with a web-layer timeout

### DIFF
--- a/snuba/admin/request_timeout.py
+++ b/snuba/admin/request_timeout.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import simplejson as json
+import structlog
+
+logger = structlog.get_logger().bind(module=__name__)
+
+StartResponse = Callable[..., Any]
+WSGIApp = Callable[[dict[str, Any], StartResponse], Iterable[bytes]]
+
+_TIMEOUT_BODY = json.dumps(
+    {"error": {"type": "timeout", "message": "Operation took too long"}}
+).encode("utf-8")
+
+
+class RequestTimeoutMiddleware:
+    """
+    WSGI middleware that caps the wall-clock duration of a single request.
+
+    The wrapped app runs in a worker thread; if it doesn't finish within
+    ``timeout_seconds`` we abandon it and return 504 Gateway Timeout to the
+    client. The abandoned thread keeps running to completion (WSGI has no way
+    to preempt it), but the underlying ClickHouse queries are themselves capped,
+    so it unwinds on its own shortly after.
+    """
+
+    def __init__(self, wsgi_app: WSGIApp, timeout_seconds: int) -> None:
+        self.wsgi_app = wsgi_app
+        self.timeout_seconds = timeout_seconds
+
+    def __call__(self, environ: dict[str, Any], start_response: StartResponse) -> Iterable[bytes]:
+        captured: dict[str, Any] = {}
+        error: dict[str, BaseException] = {}
+
+        def run() -> None:
+            def capture_start_response(
+                status: str,
+                headers: list[tuple[str, str]],
+                exc_info: Any = None,
+            ) -> Callable[[bytes], None]:
+                captured["status"] = status
+                captured["headers"] = headers
+                return lambda _: None
+
+            try:
+                app_iter = self.wsgi_app(environ, capture_start_response)
+                try:
+                    captured["body"] = b"".join(app_iter)
+                finally:
+                    close = getattr(app_iter, "close", None)
+                    if close is not None:
+                        close()
+            except BaseException as e:  # surfaced to the main thread below
+                error["error"] = e
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join(self.timeout_seconds)
+
+        if thread.is_alive():
+            logger.warning(
+                "admin request exceeded timeout",
+                path=environ.get("PATH_INFO"),
+                timeout_seconds=self.timeout_seconds,
+            )
+            start_response(
+                "408 REQUEST TIMEOUT",
+                [
+                    ("Content-Type", "application/json"),
+                    ("Content-Length", str(len(_TIMEOUT_BODY))),
+                ],
+            )
+            return [_TIMEOUT_BODY]
+
+        if "error" in error:
+            raise error["error"]
+
+        start_response(captured["status"], captured["headers"])
+        return [captured["body"]]

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -49,6 +49,7 @@ from snuba.admin.migrations_policies import (
     get_migration_group_policies,
 )
 from snuba.admin.production_queries.prod_queries import run_mql_query, run_snql_query
+from snuba.admin.request_timeout import RequestTimeoutMiddleware
 from snuba.admin.rpc.rpc_queries import validate_request_meta
 from snuba.admin.runtime_config import (
     ConfigChange,
@@ -107,6 +108,9 @@ from snuba.web.views import dataset_query
 logger = structlog.get_logger().bind(module=__name__)
 
 application = Flask(__name__, static_url_path="/static", static_folder="dist")
+application.wsgi_app = RequestTimeoutMiddleware(  # type: ignore[method-assign]
+    application.wsgi_app, settings.ADMIN_REQUEST_TIMEOUT_SECONDS
+)
 
 runner = Runner()
 audit_log = AuditLog()

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -57,6 +57,11 @@ ADMIN_ALLOWED_PROD_PROJECTS: Sequence[int] = []
 ADMIN_ALLOWED_ORG_IDS: Sequence[int] = []
 ADMIN_ROLES_REDIS_TTL = 600
 
+# Hard cap on how long a single admin HTTP request may take before the web
+# layer gives up and returns 504. ClickHouse queries are already capped at 25s;
+# this is a backstop for anything that outlives that.
+ADMIN_REQUEST_TIMEOUT_SECONDS = int(os.environ.get("ADMIN_REQUEST_TIMEOUT_SECONDS", 30))
+
 # All available regions where region is:
 # https://snuba-admin.<region>.getsentry.net/
 ADMIN_REGIONS: Sequence[str] = []


### PR DESCRIPTION
## What

Adds a hard cap on how long a single **snuba-admin** HTTP request may run at the web layer. Admin is served by Granian (WSGI), which — unlike gunicorn — exposes no per-request timeout, so this is enforced inside the admin Flask app itself and is therefore scoped to admin only.

## How

`RequestTimeoutMiddleware` (`snuba/admin/request_timeout.py`) wraps `application.wsgi_app`. It runs each request in a daemon worker thread and joins with a deadline:

- **On overrun** it returns `408 Request Timeout` with the same JSON error shape the other admin handlers use.
- **Otherwise** it passes the inner response (status/headers/body) through untouched, so existing error handlers — including the global exception handler — keep working.

Timeout is configurable via `ADMIN_REQUEST_TIMEOUT_SECONDS` (env var, default **30s**), set just above ClickHouse's existing 25s query cap so CH's own timeout fires first in the normal case and this stays a backstop.

### Known limitation

WSGI can't preempt a running thread, so on timeout the client gets its `408` immediately but the abandoned worker thread runs to completion. This is acceptable here because ClickHouse queries are themselves capped at 25s, so the thread unwinds on its own shortly after. The middleware **abandons** the request; it does not **kill** the underlying work.

## Potential alternative: `pebble`

If we ever want *true* termination (actually killing in-flight work rather than abandoning it), [`pebble`](https://pypi.org/project/pebble/) is the actively-maintained option — it runs work in a separate process that can be terminated on timeout. The tradeoff is that every request would have to pickle its args/results across a process boundary, which isn't worth it for a WSGI hot path given ClickHouse already self-caps. Noting it here for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
