### PR TITLE
fix(migrations): serialize datetime as ISO string for new drivers

### DIFF
--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -243,8 +243,7 @@ class ClickhouseConnectPool(ClickhousePool):
             and not isinstance(params, (str, bytes, Mapping))
             and "FORMAT JSONEachRow" in query
         ):
-            safe = self._make_json_safe(params)
-            body = "\n".join(json.dumps(row) for row in safe)
+            body = "\n".join(json.dumps(self._make_json_safe(row)) for row in params)
             query = f"{query}\n{body}"
             params = None
         else:

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -194,6 +194,31 @@ class ClickhouseConnectPool(ClickhousePool):
             query_settings["send_logs_level"] = "trace"
         return query_settings or None
 
+    @staticmethod
+    def _make_json_safe(params: Params) -> Params:
+        """Convert datetime objects in params so they survive json.dumps.
+
+        The clickhouse-connect driver serialises bind parameters via
+        ``json.dumps``, which raises on bare ``datetime`` objects.  The
+        native driver handles them transparently via its binary protocol,
+        so callers (e.g. the migration runner) pass ``datetime`` values
+        directly.  This shim keeps that contract working on the HTTP path.
+        """
+        if params is None:
+            return None
+        if isinstance(params, Mapping):
+            return {k: v.isoformat() if isinstance(v, datetime) else v for k, v in params.items()}
+        if isinstance(params, Sequence):
+            return [
+                ClickhouseConnectPool._make_json_safe(item)
+                if isinstance(item, (dict, list))
+                else item.isoformat()
+                if isinstance(item, datetime)
+                else item
+                for item in params
+            ]
+        return params
+
     def _execute_once(
         self,
         query: str,
@@ -206,6 +231,7 @@ class ClickhouseConnectPool(ClickhousePool):
     ) -> ClickhouseResult:
         client = self._get_client()
         query_settings = self._build_query_settings(settings, query_id, capture_trace)
+        params = self._make_json_safe(params)
 
         with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
             span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -231,7 +231,24 @@ class ClickhouseConnectPool(ClickhousePool):
     ) -> ClickhouseResult:
         client = self._get_client()
         query_settings = self._build_query_settings(settings, query_id, capture_trace)
-        params = self._make_json_safe(params)
+
+        # The native driver treats INSERT … FORMAT JSONEachRow specially:
+        # the data list is serialised as JSON lines in the request body.
+        # clickhouse-connect's query() instead interprets ``parameters``
+        # as %-style bind params, which fails.  Inline the rows into the
+        # query string so they reach ClickHouse as the FORMAT body.
+        if (
+            params
+            and isinstance(params, Sequence)
+            and not isinstance(params, (str, bytes, Mapping))
+            and "FORMAT JSONEachRow" in query
+        ):
+            safe = self._make_json_safe(params)
+            body = "\n".join(json.dumps(row) for row in safe)
+            query = f"{query}\n{body}"
+            params = None
+        else:
+            params = self._make_json_safe(params)
 
         with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
             span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -560,7 +560,7 @@ class Runner:
             {
                 "group": migration_key.group.value,
                 "migration_id": migration_key.migration_id,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(),
                 "status": status.value,
                 "version": next_version,
             }

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -560,7 +560,7 @@ class Runner:
             {
                 "group": migration_key.group.value,
                 "migration_id": migration_key.migration_id,
-                "timestamp": datetime.now(),
+                "timestamp": datetime.now().isoformat(),
                 "status": status.value,
                 "version": next_version,
             }

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -709,6 +709,56 @@ def test_reader_routes_with_totals_through_execute_with_totals() -> None:
     assert result["totals"] == {"g": 0, "s": 10}
 
 
+def test_make_json_safe_converts_datetimes() -> None:
+    result = ClickhouseConnectPool._make_json_safe(
+        [
+            {
+                "group": "replays",
+                "migration_id": "0025_add_segment_names_column",
+                "timestamp": datetime(2026, 7, 9, 17, 38, 34),
+                "status": "in_progress",
+                "version": 1,
+            }
+        ]
+    )
+    assert isinstance(result, list)
+    row = result[0]
+    assert row["timestamp"] == "2026-07-09T17:38:34"
+    assert row["group"] == "replays"
+    assert row["version"] == 1
+    json.dumps(result)
+
+
+def test_make_json_safe_converts_dict_params() -> None:
+    result = ClickhouseConnectPool._make_json_safe({"ts": datetime(2026, 1, 1), "name": "test"})
+    assert isinstance(result, dict)
+    assert result["ts"] == "2026-01-01T00:00:00"
+    assert result["name"] == "test"
+    json.dumps(result)
+
+
+def test_make_json_safe_passthrough() -> None:
+    assert ClickhouseConnectPool._make_json_safe(None) is None
+    assert ClickhouseConnectPool._make_json_safe({"a": 1}) == {"a": 1}
+    assert ClickhouseConnectPool._make_json_safe([1, "two", 3]) == [1, "two", 3]
+
+
+def test_execute_makes_datetime_params_json_safe() -> None:
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(result_set=[])
+
+    pool = _make_pool(client)
+    pool.execute(
+        "INSERT INTO t FORMAT JSONEachRow",
+        params=[{"ts": datetime(2026, 7, 9, 12, 0, 0), "v": 1}],
+    )
+
+    _, kwargs = client.query.call_args
+    params = kwargs["parameters"]
+    assert params[0]["ts"] == "2026-07-09T12:00:00"
+    assert params[0]["v"] == 1
+
+
 @pytest.mark.clickhouse_db
 def test_connect_driver_matches_native_for_totals_and_empty_results() -> None:
     # End-to-end vs a real ClickHouse: the connect (HTTP) pool must produce the same

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -743,7 +743,7 @@ def test_make_json_safe_passthrough() -> None:
     assert ClickhouseConnectPool._make_json_safe([1, "two", 3]) == [1, "two", 3]
 
 
-def test_execute_makes_datetime_params_json_safe() -> None:
+def test_execute_inlines_json_each_row_data() -> None:
     client = mock.Mock()
     client.query.return_value = FakeQueryResult(result_set=[])
 
@@ -753,10 +753,26 @@ def test_execute_makes_datetime_params_json_safe() -> None:
         params=[{"ts": datetime(2026, 7, 9, 12, 0, 0), "v": 1}],
     )
 
+    args, kwargs = client.query.call_args
+    query = args[0]
+    assert kwargs["parameters"] is None
+    assert '"ts": "2026-07-09T12:00:00"' in query
+    assert '"v": 1' in query
+    assert query.startswith("INSERT INTO t FORMAT JSONEachRow\n")
+
+
+def test_execute_non_insert_passes_params_through() -> None:
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(result_set=[])
+
+    pool = _make_pool(client)
+    pool.execute(
+        "SELECT * FROM t WHERE group = %(group)s",
+        params={"group": "events"},
+    )
+
     _, kwargs = client.query.call_args
-    params = kwargs["parameters"]
-    assert params[0]["ts"] == "2026-07-09T12:00:00"
-    assert params[0]["v"] == 1
+    assert kwargs["parameters"] == {"group": "events"}
 
 
 @pytest.mark.clickhouse_db

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -423,6 +423,23 @@ def test_version() -> None:
 
 
 @pytest.mark.custom_clickhouse_db
+def test_update_migration_status_with_connect_driver() -> None:
+    """_update_migration_status passes datetime.now() in an INSERT FORMAT
+    JSONEachRow query. The clickhouse-connect HTTP driver serialises
+    parameters via json.dumps, which cannot handle bare datetime objects.
+    This test ensures the connect driver path works end-to-end."""
+    with patch("snuba.clusters.cluster.use_clickhouse_connect_driver", return_value=True):
+        runner = Runner()
+        runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"), force=True)
+        migration_key = MigrationKey(MigrationGroup.EVENTS, "test")
+        runner._update_migration_status(migration_key, Status.IN_PROGRESS)
+        status, ts = runner.get_status(migration_key)
+        assert status == Status.IN_PROGRESS
+        assert isinstance(ts, datetime)
+        assert runner._get_next_version(migration_key) == 2
+
+
+@pytest.mark.custom_clickhouse_db
 def test_no_schema_differences() -> None:
     settings.ENABLE_DEV_FEATURES = True
     importlib.reload(factory)


### PR DESCRIPTION
The migration runner passes datetime.now() as a parameter in INSERT FORMAT JSONEachRow queries to record migration status. The native ClickHouse driver handles datetime serialization via its binary protocol, but the clickhouse-connect HTTP driver passes parameters through json.dumps which cannot serialize Python datetime objects.

This causes all migrations to fail with 'TypeError: Object of type datetime is not JSON serializable' in regions where the use_clickhouse_connect_driver flag is enabled.

Convert to .isoformat() which is JSON-serializable and parsed correctly by ClickHouse's DateTime type.

Fixes SENTRY-5RCC

---

🤖: Claude diagnosed and fixed this.