### PR TITLE
fix(export): Bind trace_id filter to the raw column in ExportTraceItems

### DIFF
--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -273,7 +273,11 @@ def _build_query(
         ),
         SelectedExpression(
             "trace_id",
-            column("trace_id", alias="trace_id"),
+            expression=(
+                attribute_key_to_expression(
+                    AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING)
+                )
+            ),
         ),
         SelectedExpression("organization_id", column("organization_id", alias="organization_id")),
         SelectedExpression("project_id", column("project_id", alias="project_id")),
@@ -342,6 +346,7 @@ def _build_query(
     item_type_filter = []
     if meta.trace_item_type != TraceItemType.TRACE_ITEM_TYPE_UNSPECIFIED:
         item_type_filter.append(f.equals(column("item_type"), literal(meta.trace_item_type)))
+
     query = Query(
         from_clause=entity,
         selected_columns=selected_columns,
@@ -545,9 +550,10 @@ class EndpointExportTraceItems(RPCEndpoint[ExportTraceItemsRequest, ExportTraceI
             limit = default_page_size
 
         page_token = ExportTraceItemsPageToken.from_protobuf(in_msg.page_token)
+        snuba_request = _build_snuba_request(in_msg, self.routing_decision, limit, page_token)
         results = run_query(
             dataset=PluggableDataset(name="eap", all_entities=[]),
-            request=_build_snuba_request(in_msg, self.routing_decision, limit, page_token),
+            request=snuba_request,
             timer=self._timer,
         )
 

--- a/tests/web/rpc/v1/test_endpoint_export_trace_items.py
+++ b/tests/web/rpc/v1/test_endpoint_export_trace_items.py
@@ -228,6 +228,53 @@ class TestExportTraceItems(BaseApiTest):
         assert len(response.trace_items) == 2
         assert all(i.attributes["color"].string_value == filter_color for i in response.trace_items)
 
+    def test_with_trace_id_filter(self, setup_teardown: Any) -> None:
+        """
+        Some columns require special handling.  sentry.trace_id is one of them.
+        """
+        filter_trace_id = uuid.uuid4().hex
+        items = [
+            gen_item_message(
+                start_timestamp=BASE_TIME,
+                trace_id=trace_id,
+            )
+            for trace_id in [
+                filter_trace_id,
+                *[uuid.uuid4().hex for _ in range(10)],
+                filter_trace_id,
+            ]
+        ]
+        write_raw_unprocessed_events(get_writable_storage(StorageKey("eap_items")), items)
+
+        message = ExportTraceItemsRequest(
+            meta=RequestMeta(
+                project_ids=[1],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=Timestamp(seconds=int(BASE_TIME.timestamp())),
+                end_timestamp=Timestamp(
+                    seconds=int((BASE_TIME + timedelta(seconds=1)).timestamp())
+                ),
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                request_id=_REQUEST_ID,
+            ),
+            filter=TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(
+                        type=AttributeKey.TYPE_STRING,
+                        name="sentry.trace_id",
+                    ),
+                    op=ComparisonFilter.OP_EQUALS,
+                    value=AttributeValue(val_str=filter_trace_id),
+                ),
+            ),
+        )
+        response = EndpointExportTraceItems().execute(message)
+
+        assert len(response.trace_items) == 2
+        assert all(i.trace_id == filter_trace_id for i in response.trace_items)
+
     def test_pagination_with_filter(self, eap: Any, monkeypatch: Any) -> None:
         # Capture the SQL of every page so we can also assert at the SQL level that
         # keyset pagination stays anchored to the same total ordering as the ORDER BY.


### PR DESCRIPTION
## fix(eap): Bind trace_id filter to the raw column in ExportTraceItems

### Summary

There was a missed case in #8152 where filtering an `ExportTraceItemsRequest` on the first-class column `sentry.trace_id` returned **zero rows**, even when matching items existed.

Linear: https://linear.app/getsentry/issue/EAP-604/add-filtering-to-logs-export-requests

### Root cause

`_build_query` selected trace_id as `column("trace_id", alias="trace_id")` — giving the SELECT expression an alias with the **same name as the raw column**. The `eap_items` storage runs `UUIDColumnProcessor`, which rewrites that SELECT expression to `replaceAll(toString(trace_id), '-', '')` (the dash-stripped 32-char hex).

The trace_id filter, meanwhile, lowers to `equals(trace_id, '<canonical-dashed-uuid>')`. Because ClickHouse resolves a `WHERE` identifier to a same-named SELECT alias by default (`prefer_column_name_to_alias = 0`), the `trace_id` in the predicate bound to the **aliased, dash-stripped expression** rather than the raw `UUID` column. The comparison then pitted `1b60787e2c07…` (no dashes) against `1b60787e-2c07-…` (dashed) — never equal — so every trace_id filter matched nothing.

This only affected `trace_id`, not the other first-class columns, because it requires two conditions together:

1. the select alias collides with the raw column name
2.  a query processor rewrites that column's select expression so the alias value diverges from the raw column.
 
 - `organization_id`/`project_id`/`item_type`/`sampling_*` satisfy (1) but are read verbatim, so the alias equals the column and shadowing is a no-op.
 - `item_id` is transformed but is selected under a distinct alias (`sentry.item_id_TYPE_STRING`), so it never collides
 - `trace_id` was the only column hitting both, and was missing the same de-aliasing treatment as `item_id`.

### Fix

Build the trace_id select via `attribute_key_to_expression(AttributeKey(name="sentry.trace_id", ...))`, the same path `item_id` already uses. This gives the select a distinct alias (`sentry.trace_id_TYPE_STRING`), so nothing shadows the raw `trace_id` column and the filter predicate binds to the actual UUID column.

### Tests

Added `test_with_trace_id_filter`, which writes spans sharing a target trace_id alongside spans with other trace_ids and asserts the `sentry.trace_id` filter returns exactly the matching items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
