### PR TITLE
Stop writing to the attributes_array column in the EAP consumer

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -415,14 +415,6 @@ macro_rules! seq_attrs {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq)]
-enum EAPValue {
-    String(String),
-    Bool(bool),
-    Int(i64),
-    Double(f64),
-}
-
 seq_attrs! {
 #[derive(Debug, Default, Serialize)]
 struct AttributeMap {
@@ -432,13 +424,12 @@ struct AttributeMap {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     attributes_int: HashMap<String, i64>,
 
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    attributes_array: HashMap<String, Vec<EAPValue>>,
-
     // Typed map columns for array-valued attributes (migration 0059). Arrays are
-    // double-written here, alongside the legacy `attributes_array` JSON column, on
-    // both the JSON and RowBinary paths so the read path can filter/aggregate on
-    // values and enumerate keys via `mapKeys(...)` like the scalar attribute maps.
+    // written to these `Map(String, Array(T))` columns on both the JSON and
+    // RowBinary paths so the read path can filter/aggregate on values and
+    // enumerate keys via `mapKeys(...)` like the scalar attribute maps. A
+    // homogeneous array (the common case) lands in a single typed column; mixed
+    // arrays are split across columns by element type.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     attributes_array_string: HashMap<String, Vec<String>>,
 
@@ -498,40 +489,33 @@ impl AttributeMap {
 
     pub fn insert_array(&mut self, k: String, v: ArrayValue) {
         // Each element is appended to its typed `Map(String, Array(T))` column as
-        // it is read, and also to the legacy `attributes_array` JSON column. A
-        // homogeneous array (the common case) lands in a single typed column;
-        // mixed arrays are split across columns by element type.
-        let mut values: Vec<EAPValue> = Vec::default();
-
+        // it is read. A homogeneous array (the common case) lands in a single
+        // typed column; mixed arrays are split across columns by element type.
         for value in v.values {
             match value.value {
                 Some(Value::StringValue(string)) => {
                     self.attributes_array_string
                         .entry(k.clone())
                         .or_default()
-                        .push(string.clone());
-                    values.push(EAPValue::String(string));
+                        .push(string);
                 }
                 Some(Value::DoubleValue(double)) => {
                     self.attributes_array_float
                         .entry(k.clone())
                         .or_default()
                         .push(double);
-                    values.push(EAPValue::Double(double));
                 }
                 Some(Value::IntValue(int)) => {
                     self.attributes_array_int
                         .entry(k.clone())
                         .or_default()
                         .push(int);
-                    values.push(EAPValue::Int(int));
                 }
                 Some(Value::BoolValue(bool)) => {
                     self.attributes_array_bool
                         .entry(k.clone())
                         .or_default()
                         .push(bool);
-                    values.push(EAPValue::Bool(bool));
                 }
                 Some(Value::BytesValue(_)) => (),
                 Some(Value::KvlistValue(_)) => (),
@@ -539,8 +523,6 @@ impl AttributeMap {
                 None => (),
             }
         }
-
-        self.attributes_array.insert(k, values);
     }
 }
 
@@ -575,8 +557,6 @@ pub struct EAPItemRow {
     attributes_string_~N: Vec<(String, String)>,
     attributes_float_~N: Vec<(String, f64)>,
     )*
-
-    attributes_array: String,
 
     attributes_array_string: Vec<(String, Vec<String>)>,
     attributes_array_int: Vec<(String, Vec<i64>)>,
@@ -624,7 +604,6 @@ impl EAPItemRow {
         concat!("attributes_string_", stringify!(N)),
         concat!("attributes_float_", stringify!(N)),
         )*
-        "attributes_array",
         "attributes_array_string",
         "attributes_array_int",
         "attributes_array_float",
@@ -638,8 +617,6 @@ impl TryFrom<EAPItem> for EAPItemRow {
 
     #[allow(clippy::needless_return)]
     fn try_from(item: EAPItem) -> Result<Self, Self::Error> {
-        let attributes_array = serde_json::to_string(&item.attributes.attributes_array)?;
-
         // `return` is needed because `seq_attrs!` expands with a trailing semicolon,
         // which makes the struct expression a statement rather than a tail expression.
         seq_attrs! {
@@ -665,7 +642,6 @@ impl TryFrom<EAPItem> for EAPItemRow {
                 attributes_string_~N: item.attributes.attributes_string_~N.into_iter().collect(),
                 attributes_float_~N: item.attributes.attributes_float_~N.into_iter().collect(),
                 )*
-                attributes_array,
                 attributes_array_string: item
                     .attributes
                     .attributes_array_string
@@ -913,10 +889,10 @@ mod tests {
             eap_item
                 .unwrap()
                 .attributes
-                .attributes_array
+                .attributes_array_int
                 .get("arrays")
                 .unwrap()[0],
-            EAPValue::Int(1234567890)
+            1234567890
         );
     }
 
@@ -1108,9 +1084,8 @@ mod tests {
     fn test_column_names_match_struct_layout() {
         let names = EAPItemRow::COLUMN_NAMES;
         // 14 scalars (incl. session_id + ai_conversation_id) + indexed_name +
-        // attributes_bool + attributes_int + 80 buckets + attributes_array +
-        // 4 typed array maps
-        assert_eq!(names.len(), 102);
+        // attributes_bool + attributes_int + 80 buckets + 4 typed array maps
+        assert_eq!(names.len(), 101);
         assert_eq!(names[0], "organization_id");
         assert_eq!(names[4], "trace_id");
         assert_eq!(names[5], "session_id");
@@ -1128,12 +1103,11 @@ mod tests {
         assert_eq!(names[19], "attributes_string_1");
         assert_eq!(names[95], "attributes_string_39");
         assert_eq!(names[96], "attributes_float_39");
-        assert_eq!(names[97], "attributes_array");
-        // Typed array map columns follow the JSON column.
-        assert_eq!(names[98], "attributes_array_string");
-        assert_eq!(names[99], "attributes_array_int");
-        assert_eq!(names[100], "attributes_array_float");
-        assert_eq!(names[101], "attributes_array_bool");
+        // Typed array map columns follow the attribute buckets.
+        assert_eq!(names[97], "attributes_array_string");
+        assert_eq!(names[98], "attributes_array_int");
+        assert_eq!(names[99], "attributes_array_float");
+        assert_eq!(names[100], "attributes_array_bool");
     }
 
     #[test]
@@ -1453,11 +1427,7 @@ mod tests {
             .iter()
             .any(|(k, v)| k == "my_bool" && *v));
 
-        // Array attributes are serialized as JSON string in the attributes_array column
-        assert!(row.attributes_array.contains("my_array"));
-        assert!(row.attributes_array.contains("elem"));
-
-        // ...and double-written to the typed `attributes_array_string` column.
+        // Array attributes are written to the typed `attributes_array_string` column.
         assert!(row
             .attributes_array_string
             .iter()
@@ -1465,7 +1435,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_typed_columns_double_write() {
+    fn test_array_typed_columns() {
         let item_id = Uuid::new_v4();
         let mut trace_item = generate_trace_item(item_id);
 
@@ -1541,10 +1511,6 @@ mod tests {
         // Typed maps are not cross-populated across element types.
         assert_eq!(attrs.attributes_array_int.get("strs"), None);
         assert_eq!(attrs.attributes_array_bool.get("ints"), None);
-
-        // The legacy JSON column is still populated (double write).
-        assert!(attrs.attributes_array.contains_key("strs"));
-        assert!(attrs.attributes_array.contains_key("ints"));
     }
 
     #[test]
@@ -1895,19 +1861,7 @@ mod tests {
             "float_attr mismatch in JSON"
         );
 
-        // Compare attributes_array
-        // In JSON: serialized as {"array_attr": [{"String": "a"}, {"Int": 1}]}
-        // In RowBinary: serialized as a JSON string in the attributes_array field
-        if let Some(json_arrays) = json_row.get("attributes_array") {
-            let rb_arrays: serde_json::Value =
-                serde_json::from_str(&rb_row.attributes_array).unwrap_or_default();
-            assert_eq!(
-                json_arrays, &rb_arrays,
-                "attributes_array mismatch between JSON and RowBinary"
-            );
-        }
-
-        // Compare the typed array columns. Both paths double-write them, and
+        // Compare the typed array columns. Both paths write them, and
         // array_attr = [String "a", Int 1] splits across the string and int maps.
         let json_arr_string: HashMap<String, Vec<String>> = json_row
             .get("attributes_array_string")


### PR DESCRIPTION
Array-valued attributes are already written to the typed `Map(String, Array(T))` columns (`attributes_array_string` / `_int` / `_float` / `_bool`) added in migration 0059, which the read path uses for filtering, aggregation, and key enumeration via `mapKeys(...)`. The legacy `attributes_array` JSON column is no longer needed on the write path.

This PR removes the `attributes_array` column from the EAP consumer processor:

- Drop the `attributes_array` field from the `AttributeMap` and `EAPItemRow` structs.
- Remove `"attributes_array"` from `EAPItemRow::COLUMN_NAMES`, so it is excluded from the explicit RowBinary insert column list.
- Stop serializing it in `TryFrom<EAPItem>`; `insert_array` now only populates the typed columns.
- Remove the now-unused `EAPValue` enum.
- Update unit tests to assert against the typed columns instead of the JSON column.

The physical `attributes_array` column is intentionally left in the ClickHouse schema (migrations and storage YAML are unchanged). Because it is excluded from the explicit insert column list, ClickHouse fills it with its default value on every insert. Removing the column itself would be a separate migration.

### Testing

`cargo check --lib` and the `eap_items` unit tests pass. The only failing test is `test_row_binary_clickhouse_insert`, which requires a live ClickHouse instance and fails here with connection-refused (unrelated to this change); its generated insert column list correctly skips `attributes_array`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuSMmqtpjLyDRuq4yY3LuX)_