### PR TITLE
feat(gocd): Run distroless image in all SaaS regions

### DIFF
--- a/gocd/templates/bash/deploy-py.sh
+++ b/gocd/templates/bash/deploy-py.sh
@@ -2,10 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-IMAGE_TAG="${GO_REVISION_SNUBA_REPO}"
-if [ "${SENTRY_REGION}" = "s4s2" ] || [ "${SENTRY_REGION}" = "de" ]; then
-  IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
-fi
+IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
 
 /devinfra/scripts/get-cluster-credentials \
 && k8s-deploy \

--- a/gocd/templates/bash/deploy-rs.sh
+++ b/gocd/templates/bash/deploy-rs.sh
@@ -2,10 +2,7 @@
 
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 
-IMAGE_TAG="${GO_REVISION_SNUBA_REPO}"
-if [ "${SENTRY_REGION}" = "s4s2" ] || [ "${SENTRY_REGION}" = "de" ]; then
-  IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
-fi
+IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
 
 /devinfra/scripts/get-cluster-credentials \
 && k8s-deploy \


### PR DESCRIPTION
Set `IMAGE_TAG` to the `-distroless` variant unconditionally in `deploy-py.sh` and `deploy-rs.sh`, dropping the per-region gating that previously scoped it to `s4s2` and `de`. The distroless image has run in those two regions for three weeks with no issues, so all SaaS regions now deploy it.

The deploy gate already requires `"Build and push distroless production image"` to pass (added in #8090), so no region can deploy before the distroless image is published.

Single-tenant deploys (`deploy-st-py.sh`, `deploy-st.sh`) are intentionally left on the standard image and will move to distroless in a follow-up PR with their own bake window, since they've never run the distroless variant.

Note for oncall: distroless images have no shell, so `kubectl exec` debugging differs from the standard image — use the debug distroless variant from `image.yml` when needed.