### PR TITLE
ref(cache): Stop capturing non-actionable redis errors to Sentry

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -40,9 +40,14 @@ class FuzzyMatchException:
 
 
 DONT_CAPTURE_ERRORS = (
-    # if you need to track this error, see datadog metric snuba.read_through_cache.redis_cache_set_error
+    # These errors are not actionable: they reflect transient redis/infra conditions
+    # rather than bugs in Snuba, so we don't send them to Sentry. They are still
+    # tracked via the datadog metrics snuba.read_through_cache.redis_cache_get_error
+    # and snuba.read_through_cache.redis_cache_set_error.
     FuzzyMatchException(ResponseError, "OOM command not allowed under OOM prevention."),
     FuzzyMatchException(RedisTimeoutError),
+    # Redis connection errors, e.g. "Connection reset by peer" (SNUBA-BQ6, SNUBA-B53).
+    FuzzyMatchException(ConnectionError),
 )
 
 

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -40,13 +40,9 @@ class FuzzyMatchException:
 
 
 DONT_CAPTURE_ERRORS = (
-    # These errors are not actionable: they reflect transient redis/infra conditions
-    # rather than bugs in Snuba, so we don't send them to Sentry. They are still
-    # tracked via the datadog metrics snuba.read_through_cache.redis_cache_get_error
-    # and snuba.read_through_cache.redis_cache_set_error.
+    # if you need to track these errors, see datadog metrics snuba.read_through_cache.redis_cache_get_error and redis_cache_set_error
     FuzzyMatchException(ResponseError, "OOM command not allowed under OOM prevention."),
     FuzzyMatchException(RedisTimeoutError),
-    # Redis connection errors, e.g. "Connection reset by peer" (SNUBA-BQ6, SNUBA-B53).
     FuzzyMatchException(ConnectionError),
 )
 

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -12,7 +12,7 @@ import pytest
 import rapidjson
 import sentry_sdk
 from redis import RedisError, ResponseError
-from redis.exceptions import ReadOnlyError
+from redis.exceptions import ConnectionError, ReadOnlyError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from sentry_options.testing import override_options
 from sentry_redis_tools.failover_redis import FailoverRedis
@@ -262,7 +262,12 @@ def test_set_fails_open(backend: Cache[bytes]) -> None:
 
 @pytest.mark.redis_db
 @pytest.mark.parametrize(
-    "error", [ResponseError("OOM command not allowed under OOM prevention."), RedisTimeoutError()]
+    "error",
+    [
+        ResponseError("OOM command not allowed under OOM prevention."),
+        RedisTimeoutError(),
+        ConnectionError("Error while reading from redis : (104, 'Connection reset by peer')"),
+    ],
 )
 def test_dont_record_expected_errors(backend: Cache[bytes], error: Exception) -> None:
     with (


### PR DESCRIPTION
Redis connection errors (e.g. `ConnectionError: ... (104, 'Connection reset by peer')`) raised on the read-through cache get/set path in `snuba/state/cache/redis/backend.py` are transient redis/infra conditions rather than bugs in Snuba. They are **already tracked** via the `snuba.read_through_cache.redis_cache_get_error` and `snuba.read_through_cache.redis_cache_set_error` metrics, but they were **also** being captured to Sentry as non-actionable noise:

- **SNUBA-BQ6** — `ConnectionError` on cache `get` (`api.metrics.totals`)
- **SNUBA-B53** — `ConnectionError` on cache `set` (`deletions.group`), ~4k occurrences

This adds redis `ConnectionError` to the existing `DONT_CAPTURE_ERRORS` tuple, alongside the OOM `ResponseError` and `RedisTimeoutError` that are already handled the same way. The result: these redis errors continue to be counted by the metrics (so they remain visible/alertable in Datadog) but are no longer sent to Sentry.

### Changes
- `snuba/state/cache/redis/backend.py`: add `FuzzyMatchException(ConnectionError)` to `DONT_CAPTURE_ERRORS`; clarify the accompanying comment to mention both the get and set metrics.
- `tests/state/test_cache.py`: extend `test_dont_record_expected_errors` to cover `ConnectionError`.

Note: the redis-backed test suite requires redis + full deps, which aren't available in the authoring environment; both files compile and the change mirrors the already-tested mechanism for the other two error types.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017vg4SqEP72pq7ARJLYD2QB)_