### PR TITLE
fix(clickhouse): add an explicit insert() to the pool interface

### DIFF
--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -5,9 +5,9 @@ import logging
 import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import date, datetime
 from threading import Lock
-from typing import Any
+from typing import Any, TypeGuard
 
 import clickhouse_connect
 import sentry_sdk
@@ -52,17 +52,17 @@ clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 # statement, capturing the target table and (when present) the explicit column
 # list. The native driver treats an INSERT whose ``params`` is a sequence of
 # rows as a data insert; clickhouse-connect's ``query()`` has no such notion, so
-# the connect pool detects this shape and routes it to ``client.insert()``
-# instead (see ``_execute_insert``). Whatever trails the column list (``VALUES``,
-# ``FORMAT JSONEachRow``, ...) is irrelevant here -- clickhouse-connect builds
-# the wire format itself -- so we only need the table and columns.
+# the connect pool detects this shape and sends the rows as a JSONEachRow insert
+# body instead (see ``_execute_insert``). Whatever trails the column list
+# (``VALUES``, ``FORMAT JSONEachRow``, ...) is rebuilt as ``FORMAT JSONEachRow``,
+# so we only need the table and (for positional rows) the column list.
 _INSERT_RE = re.compile(
     r"^\s*INSERT\s+INTO\s+(?P<table>[^\s(]+)\s*(?:\((?P<columns>[^)]*)\))?",
     re.IGNORECASE,
 )
 
 
-def _is_row_data(params: Params) -> bool:
+def _is_row_data(params: Params) -> TypeGuard[Sequence[Any]]:
     """
     True when ``params`` is a sequence of rows (insert data) rather than a
     mapping of query-substitution parameters. ``str``/``bytes`` are sequences
@@ -70,6 +70,26 @@ def _is_row_data(params: Params) -> bool:
     and is therefore already excluded.
     """
     return isinstance(params, Sequence) and not isinstance(params, (str, bytes, bytearray))
+
+
+def _clickhouse_json_default(value: Any) -> Any:
+    """
+    ``json.dumps`` fallback that renders the Python types ClickHouse's JSONEachRow
+    parser cannot take as bare JSON into the string forms it accepts. Only
+    ``datetime``/``date`` need help here -- they are what the migration status
+    writers put in a row, and the crash they caused ("Object of type datetime is
+    not JSON serializable") is the whole reason this path exists.
+
+    ``datetime`` is formatted to second precision (``YYYY-MM-DD HH:MM:SS``), the
+    only form ClickHouse's default ``date_time_input_format=basic`` accepts for a
+    ``DateTime`` column -- a fractional part would be rejected. ``date`` becomes
+    ``YYYY-MM-DD``. ``datetime`` is checked first because it subclasses ``date``.
+    """
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+    if isinstance(value, date):
+        return value.strftime("%Y-%m-%d")
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
 def _coerce_temporal(value: Any, ch_type: str) -> Any:
@@ -443,7 +463,7 @@ class ClickhouseConnectPool(ClickhousePool):
         JSONEachRow`` + list-of-rows pattern). clickhouse-connect's ``query()``
         would treat those rows as substitution parameters and JSON-encode them,
         which fails for native Python values such as ``datetime``. Such calls are
-        routed to ``client.insert()`` instead (see ``_execute_insert``).
+        sent as a JSONEachRow insert body instead (see ``_execute_insert``).
         """
         with self._translate_clickhouse_errors():
             if params is not None and _is_row_data(params) and _INSERT_RE.match(query):
@@ -466,15 +486,20 @@ class ClickhouseConnectPool(ClickhousePool):
         query_id: str | None,
     ) -> ClickhouseResult:
         """
-        Insert a sequence of rows via clickhouse-connect's ``client.insert()``,
-        reproducing the native driver's ``INSERT INTO ... + list-of-rows`` path.
+        Insert a sequence of rows, reproducing the native driver's ``INSERT INTO
+        ... + list-of-rows`` path over HTTP.
 
-        clickhouse-connect introspects the target table's column types and
-        serializes native Python values (``datetime``, ``date``, ints, ...)
-        itself, so -- unlike the ``query()`` parameter-binding path -- it does not
-        try to JSON-encode the values. Rows may be dicts (as the migration status
-        writers pass, mapping column name -> value) or positional sequences (with
-        the column list carried in the SQL, e.g. ``INSERT INTO t (a, b) VALUES``).
+        The rows are serialized to a JSONEachRow body -- the same format the
+        callers already name in their SQL -- and sent via
+        ``client.raw_insert(..., fmt="JSONEachRow")``. Serialization uses
+        :func:`_clickhouse_json_default` so native Python values that plain JSON
+        rejects (notably ``datetime``, which triggered this whole path) are
+        encoded into the string forms ClickHouse's JSONEachRow parser accepts.
+
+        Rows may be dicts (as the migration status writers pass, mapping column
+        name -> value) or positional sequences, in which case the column list is
+        taken from the SQL (e.g. ``INSERT INTO t (a, b) VALUES``) and zipped with
+        each row to form the JSON objects.
         """
         client = self._get_client()
 
@@ -492,20 +517,25 @@ class ClickhouseConnectPool(ClickhousePool):
                 trace_output="",
             )
 
-        column_names: str | list[str]
         if isinstance(row_list[0], Mapping):
-            # dict rows: column order comes from the keys of the first row.
-            column_names = list(row_list[0].keys())
-            matrix: list[list[Any]] = [[row[name] for name in column_names] for row in row_list]
+            dict_rows: list[Mapping[str, Any]] = list(row_list)
         else:
-            # positional rows: take the column list from the SQL if it names one,
-            # otherwise let clickhouse-connect default to every column ("*").
+            # positional rows need the column list from the SQL to become named
+            # JSON objects; without it JSONEachRow has no field names to map to.
             columns_sql = match.group("columns")
-            if columns_sql:
-                column_names = [name.strip().strip("`") for name in columns_sql.split(",")]
-            else:
-                column_names = "*"
-            matrix = [list(row) for row in row_list]
+            if not columns_sql:
+                raise ClickhouseError(
+                    "positional INSERT rows require an explicit column list in the query, "
+                    f"e.g. 'INSERT INTO t (a, b) VALUES'; got: {query}",
+                    code=-1,
+                )
+            column_names = [name.strip().strip("`") for name in columns_sql.split(",")]
+            dict_rows = [dict(zip(column_names, row, strict=True)) for row in row_list]
+
+        body = "\n".join(
+            json.dumps(row, default=_clickhouse_json_default, separators=(",", ":"))
+            for row in dict_rows
+        )
 
         insert_settings = dict(settings) if settings else {}
         if query_id is not None:
@@ -514,10 +544,10 @@ class ClickhouseConnectPool(ClickhousePool):
         with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
             span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
             span.set_data("query_id", query_id)
-            summary = client.insert(
+            summary = client.raw_insert(
                 table,
-                matrix,
-                column_names=column_names,
+                insert_block=body.encode("utf-8"),
+                fmt="JSONEachRow",
                 settings=insert_settings or None,
             )
 

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -488,9 +488,7 @@ class ClickhouseConnectPool(ClickhousePool):
             # Nothing to insert; mirror the native driver, which writes zero rows.
             return ClickhouseResult(
                 results=[],
-                profile=ClickhouseProfile(
-                    blocks=0, bytes=0, elapsed=0.0, progress_bytes=0, rows=0
-                ),
+                profile=ClickhouseProfile(blocks=0, bytes=0, elapsed=0.0, progress_bytes=0, rows=0),
                 trace_output="",
             )
 

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -49,18 +49,6 @@ clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 
 
 def _clickhouse_json_default(value: Any) -> Any:
-    """
-    ``json.dumps`` fallback that renders the Python types ClickHouse's JSONEachRow
-    parser cannot take as bare JSON into the string forms it accepts. Only
-    ``datetime``/``date`` need help here -- they are what the migration status
-    writers put in a row, and the crash they caused ("Object of type datetime is
-    not JSON serializable") is the whole reason this path exists.
-
-    ``datetime`` is formatted to second precision (``YYYY-MM-DD HH:MM:SS``), the
-    only form ClickHouse's default ``date_time_input_format=basic`` accepts for a
-    ``DateTime`` column -- a fractional part would be rejected. ``date`` becomes
-    ``YYYY-MM-DD``. ``datetime`` is checked first because it subclasses ``date``.
-    """
     if isinstance(value, datetime):
         return value.strftime("%Y-%m-%d %H:%M:%S")
     if isinstance(value, date):
@@ -452,17 +440,6 @@ class ClickhouseConnectPool(ClickhousePool):
         settings: Mapping[str, Any] | None = None,
         query_id: str | None = None,
     ) -> None:
-        """
-        HTTP override of :meth:`ClickhousePool.insert`.
-
-        clickhouse-connect's ``query()`` has no insert notion -- it would treat
-        the rows as ``query`` substitution parameters and JSON-encode them, which
-        fails on native Python values such as ``datetime`` -- so instead the rows
-        are serialized to a JSONEachRow body and sent via
-        ``client.raw_insert(..., fmt="JSONEachRow")``. Serialization goes through
-        :func:`_clickhouse_json_default`, which renders ``datetime``/``date`` into
-        the string forms ClickHouse's JSONEachRow parser accepts.
-        """
         rows = list(data)
         if not rows:
             return

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import date, datetime
 from threading import Lock
-from typing import Any, TypeGuard
+from typing import Any
 
 import clickhouse_connect
 import sentry_sdk
@@ -47,29 +46,6 @@ DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
 # forwards whatever settings it is given to the server, so to preserve parity
 # we tell clickhouse-connect to drop unrecognized settings instead of failing.
 clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
-
-# Matches the leading ``INSERT INTO <table> [(col, col, ...)]`` of an insert
-# statement, capturing the target table and (when present) the explicit column
-# list. The native driver treats an INSERT whose ``params`` is a sequence of
-# rows as a data insert; clickhouse-connect's ``query()`` has no such notion, so
-# the connect pool detects this shape and sends the rows as a JSONEachRow insert
-# body instead (see ``_execute_insert``). Whatever trails the column list
-# (``VALUES``, ``FORMAT JSONEachRow``, ...) is rebuilt as ``FORMAT JSONEachRow``,
-# so we only need the table and (for positional rows) the column list.
-_INSERT_RE = re.compile(
-    r"^\s*INSERT\s+INTO\s+(?P<table>[^\s(]+)\s*(?:\((?P<columns>[^)]*)\))?",
-    re.IGNORECASE,
-)
-
-
-def _is_row_data(params: Params) -> TypeGuard[Sequence[Any]]:
-    """
-    True when ``params`` is a sequence of rows (insert data) rather than a
-    mapping of query-substitution parameters. ``str``/``bytes`` are sequences
-    but never row data, so they are excluded. A ``Mapping`` is not a ``Sequence``
-    and is therefore already excluded.
-    """
-    return isinstance(params, Sequence) and not isinstance(params, (str, bytes, bytearray))
 
 
 def _clickhouse_json_default(value: Any) -> Any:
@@ -457,17 +433,8 @@ class ClickhouseConnectPool(ClickhousePool):
 
         The ``retryable`` argument is accepted for interface parity with the
         native pool but has no effect here.
-
-        When ``params`` is a sequence of rows and ``query`` is an INSERT, the
-        call is a data insert (the native driver's ``INSERT INTO ... FORMAT
-        JSONEachRow`` + list-of-rows pattern). clickhouse-connect's ``query()``
-        would treat those rows as substitution parameters and JSON-encode them,
-        which fails for native Python values such as ``datetime``. Such calls are
-        sent as a JSONEachRow insert body instead (see ``_execute_insert``).
         """
         with self._translate_clickhouse_errors():
-            if params is not None and _is_row_data(params) and _INSERT_RE.match(query):
-                return self._execute_insert(query, params, settings, query_id)
             return self._execute_once(
                 query,
                 params,
@@ -478,92 +445,49 @@ class ClickhouseConnectPool(ClickhousePool):
                 capture_trace,
             )
 
-    def _execute_insert(
+    def insert(
         self,
-        query: str,
-        rows: Sequence[Any],
-        settings: Mapping[str, Any] | None,
-        query_id: str | None,
-    ) -> ClickhouseResult:
+        table: str,
+        data: Sequence[Mapping[str, Any]],
+        settings: Mapping[str, Any] | None = None,
+        query_id: str | None = None,
+    ) -> None:
         """
-        Insert a sequence of rows, reproducing the native driver's ``INSERT INTO
-        ... + list-of-rows`` path over HTTP.
+        HTTP override of :meth:`ClickhousePool.insert`.
 
-        The rows are serialized to a JSONEachRow body -- the same format the
-        callers already name in their SQL -- and sent via
-        ``client.raw_insert(..., fmt="JSONEachRow")``. Serialization uses
-        :func:`_clickhouse_json_default` so native Python values that plain JSON
-        rejects (notably ``datetime``, which triggered this whole path) are
-        encoded into the string forms ClickHouse's JSONEachRow parser accepts.
-
-        Rows may be dicts (as the migration status writers pass, mapping column
-        name -> value) or positional sequences, in which case the column list is
-        taken from the SQL (e.g. ``INSERT INTO t (a, b) VALUES``) and zipped with
-        each row to form the JSON objects.
+        clickhouse-connect's ``query()`` has no insert notion -- it would treat
+        the rows as ``query`` substitution parameters and JSON-encode them, which
+        fails on native Python values such as ``datetime`` -- so instead the rows
+        are serialized to a JSONEachRow body and sent via
+        ``client.raw_insert(..., fmt="JSONEachRow")``. Serialization goes through
+        :func:`_clickhouse_json_default`, which renders ``datetime``/``date`` into
+        the string forms ClickHouse's JSONEachRow parser accepts.
         """
-        client = self._get_client()
-
-        match = _INSERT_RE.match(query)
-        if match is None:  # pragma: no cover - guarded by the caller
-            raise ClickhouseError(f"could not parse INSERT target from query: {query}", code=-1)
-        table = match.group("table")
-
-        row_list = list(rows)
-        if not row_list:
-            # Nothing to insert; mirror the native driver, which writes zero rows.
-            return ClickhouseResult(
-                results=[],
-                profile=ClickhouseProfile(blocks=0, bytes=0, elapsed=0.0, progress_bytes=0, rows=0),
-                trace_output="",
-            )
-
-        if isinstance(row_list[0], Mapping):
-            dict_rows: list[Mapping[str, Any]] = list(row_list)
-        else:
-            # positional rows need the column list from the SQL to become named
-            # JSON objects; without it JSONEachRow has no field names to map to.
-            columns_sql = match.group("columns")
-            if not columns_sql:
-                raise ClickhouseError(
-                    "positional INSERT rows require an explicit column list in the query, "
-                    f"e.g. 'INSERT INTO t (a, b) VALUES'; got: {query}",
-                    code=-1,
-                )
-            column_names = [name.strip().strip("`") for name in columns_sql.split(",")]
-            dict_rows = [dict(zip(column_names, row, strict=True)) for row in row_list]
+        rows = list(data)
+        if not rows:
+            return
 
         body = "\n".join(
-            json.dumps(row, default=_clickhouse_json_default, separators=(",", ":"))
-            for row in dict_rows
+            json.dumps(row, default=_clickhouse_json_default, separators=(",", ":")) for row in rows
         )
 
         insert_settings = dict(settings) if settings else {}
         if query_id is not None:
             insert_settings["query_id"] = query_id
 
-        with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
-            span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
-            span.set_data("query_id", query_id)
-            summary = client.raw_insert(
-                table,
-                insert_block=body.encode("utf-8"),
-                fmt="JSONEachRow",
-                settings=insert_settings or None,
-            )
-
-        written_rows = getattr(summary, "written_rows", 0) or 0
-        written_bytes = getattr(summary, "written_bytes", 0) or 0
-        profile = ClickhouseProfile(
-            blocks=0,
-            bytes=written_bytes,
-            elapsed=0.0,
-            progress_bytes=written_bytes,
-            rows=written_rows,
-        )
-        # The native driver returns the written row count for an INSERT (wrapped
-        # in a list by execute()); mirror that shape. Both current callers ignore
-        # the value beyond logging it.
-        return ClickhouseResult(results=[written_rows], profile=profile, trace_output="")
+        with self._translate_clickhouse_errors():
+            client = self._get_client()
+            with sentry_sdk.start_span(
+                description=f"INSERT INTO {table}", op="db.clickhouse"
+            ) as span:
+                span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
+                span.set_data("query_id", query_id)
+                client.raw_insert(
+                    table,
+                    insert_block=body.encode("utf-8"),
+                    fmt="JSONEachRow",
+                    settings=insert_settings or None,
+                )
 
     def execute_robust(
         self,

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -437,7 +437,7 @@ class ClickhouseConnectPool(ClickhousePool):
             return
 
         column_names = list(rows[0].keys())
-        matrix = [[row[name] for name in column_names] for row in rows]
+        matrix = [list(row.values()) for row in rows]
 
         insert_settings = dict(settings) if settings else {}
         if query_id is not None:

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from datetime import date, datetime
+from datetime import datetime
 from threading import Lock
 from typing import Any
 
@@ -46,14 +46,6 @@ DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
 # forwards whatever settings it is given to the server, so to preserve parity
 # we tell clickhouse-connect to drop unrecognized settings instead of failing.
 clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
-
-
-def _clickhouse_json_default(value: Any) -> Any:
-    if isinstance(value, datetime):
-        return value.strftime("%Y-%m-%d %H:%M:%S")
-    if isinstance(value, date):
-        return value.strftime("%Y-%m-%d")
-    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
 def _coerce_temporal(value: Any, ch_type: str) -> Any:
@@ -444,9 +436,8 @@ class ClickhouseConnectPool(ClickhousePool):
         if not rows:
             return
 
-        body = "\n".join(
-            json.dumps(row, default=_clickhouse_json_default, separators=(",", ":")) for row in rows
-        )
+        column_names = list(rows[0].keys())
+        matrix = [[row[name] for name in column_names] for row in rows]
 
         insert_settings = dict(settings) if settings else {}
         if query_id is not None:
@@ -459,10 +450,10 @@ class ClickhouseConnectPool(ClickhousePool):
             ) as span:
                 span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
                 span.set_data("query_id", query_id)
-                client.raw_insert(
+                client.insert(
                     table,
-                    insert_block=body.encode("utf-8"),
-                    fmt="JSONEachRow",
+                    matrix,
+                    column_names=column_names,
                     settings=insert_settings or None,
                 )
 

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime
@@ -46,6 +47,29 @@ DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
 # forwards whatever settings it is given to the server, so to preserve parity
 # we tell clickhouse-connect to drop unrecognized settings instead of failing.
 clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
+
+# Matches the leading ``INSERT INTO <table> [(col, col, ...)]`` of an insert
+# statement, capturing the target table and (when present) the explicit column
+# list. The native driver treats an INSERT whose ``params`` is a sequence of
+# rows as a data insert; clickhouse-connect's ``query()`` has no such notion, so
+# the connect pool detects this shape and routes it to ``client.insert()``
+# instead (see ``_execute_insert``). Whatever trails the column list (``VALUES``,
+# ``FORMAT JSONEachRow``, ...) is irrelevant here -- clickhouse-connect builds
+# the wire format itself -- so we only need the table and columns.
+_INSERT_RE = re.compile(
+    r"^\s*INSERT\s+INTO\s+(?P<table>[^\s(]+)\s*(?:\((?P<columns>[^)]*)\))?",
+    re.IGNORECASE,
+)
+
+
+def _is_row_data(params: Params) -> bool:
+    """
+    True when ``params`` is a sequence of rows (insert data) rather than a
+    mapping of query-substitution parameters. ``str``/``bytes`` are sequences
+    but never row data, so they are excluded. A ``Mapping`` is not a ``Sequence``
+    and is therefore already excluded.
+    """
+    return isinstance(params, Sequence) and not isinstance(params, (str, bytes, bytearray))
 
 
 def _coerce_temporal(value: Any, ch_type: str) -> Any:
@@ -413,8 +437,17 @@ class ClickhouseConnectPool(ClickhousePool):
 
         The ``retryable`` argument is accepted for interface parity with the
         native pool but has no effect here.
+
+        When ``params`` is a sequence of rows and ``query`` is an INSERT, the
+        call is a data insert (the native driver's ``INSERT INTO ... FORMAT
+        JSONEachRow`` + list-of-rows pattern). clickhouse-connect's ``query()``
+        would treat those rows as substitution parameters and JSON-encode them,
+        which fails for native Python values such as ``datetime``. Such calls are
+        routed to ``client.insert()`` instead (see ``_execute_insert``).
         """
         with self._translate_clickhouse_errors():
+            if params is not None and _is_row_data(params) and _INSERT_RE.match(query):
+                return self._execute_insert(query, params, settings, query_id)
             return self._execute_once(
                 query,
                 params,
@@ -424,6 +457,85 @@ class ClickhouseConnectPool(ClickhousePool):
                 columnar,
                 capture_trace,
             )
+
+    def _execute_insert(
+        self,
+        query: str,
+        rows: Sequence[Any],
+        settings: Mapping[str, Any] | None,
+        query_id: str | None,
+    ) -> ClickhouseResult:
+        """
+        Insert a sequence of rows via clickhouse-connect's ``client.insert()``,
+        reproducing the native driver's ``INSERT INTO ... + list-of-rows`` path.
+
+        clickhouse-connect introspects the target table's column types and
+        serializes native Python values (``datetime``, ``date``, ints, ...)
+        itself, so -- unlike the ``query()`` parameter-binding path -- it does not
+        try to JSON-encode the values. Rows may be dicts (as the migration status
+        writers pass, mapping column name -> value) or positional sequences (with
+        the column list carried in the SQL, e.g. ``INSERT INTO t (a, b) VALUES``).
+        """
+        client = self._get_client()
+
+        match = _INSERT_RE.match(query)
+        if match is None:  # pragma: no cover - guarded by the caller
+            raise ClickhouseError(f"could not parse INSERT target from query: {query}", code=-1)
+        table = match.group("table")
+
+        row_list = list(rows)
+        if not row_list:
+            # Nothing to insert; mirror the native driver, which writes zero rows.
+            return ClickhouseResult(
+                results=[],
+                profile=ClickhouseProfile(
+                    blocks=0, bytes=0, elapsed=0.0, progress_bytes=0, rows=0
+                ),
+                trace_output="",
+            )
+
+        column_names: str | list[str]
+        if isinstance(row_list[0], Mapping):
+            # dict rows: column order comes from the keys of the first row.
+            column_names = list(row_list[0].keys())
+            matrix: list[list[Any]] = [[row[name] for name in column_names] for row in row_list]
+        else:
+            # positional rows: take the column list from the SQL if it names one,
+            # otherwise let clickhouse-connect default to every column ("*").
+            columns_sql = match.group("columns")
+            if columns_sql:
+                column_names = [name.strip().strip("`") for name in columns_sql.split(",")]
+            else:
+                column_names = "*"
+            matrix = [list(row) for row in row_list]
+
+        insert_settings = dict(settings) if settings else {}
+        if query_id is not None:
+            insert_settings["query_id"] = query_id
+
+        with sentry_sdk.start_span(description=query, op="db.clickhouse") as span:
+            span.set_data(sentry_sdk.consts.SPANDATA.DB_SYSTEM, "clickhouse")
+            span.set_data("query_id", query_id)
+            summary = client.insert(
+                table,
+                matrix,
+                column_names=column_names,
+                settings=insert_settings or None,
+            )
+
+        written_rows = getattr(summary, "written_rows", 0) or 0
+        written_bytes = getattr(summary, "written_bytes", 0) or 0
+        profile = ClickhouseProfile(
+            blocks=0,
+            bytes=written_bytes,
+            elapsed=0.0,
+            progress_bytes=written_bytes,
+            rows=written_rows,
+        )
+        # The native driver returns the written row count for an INSERT (wrapped
+        # in a list by execute()); mirror that shape. Both current callers ignore
+        # the value beyond logging it.
+        return ClickhouseResult(results=[written_rows], profile=profile, trace_output="")
 
     def execute_robust(
         self,

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -174,20 +174,6 @@ class ClickhousePool(ABC):
         settings: Mapping[str, Any] | None = None,
         query_id: str | None = None,
     ) -> None:
-        """
-        Insert ``data`` -- a sequence of rows, each a column-name -> value
-        mapping -- into ``table``. This is the interface callers should use to
-        write rows; it keeps them off ``execute``'s query path, which the two
-        drivers implement differently for inserts.
-
-        The default implementation targets the native protocol: it issues an
-        ``INSERT INTO <table> FORMAT JSONEachRow`` through :meth:`execute`, where
-        the driver serializes native Python values (``datetime``, ...) into the
-        native binary block itself, using the column types from the server's
-        INSERT sample block, and maps each dict's keys to columns. The
-        clickhouse-connect (HTTP) pool has no such query-path insert notion and
-        overrides this -- see ``ClickhouseConnectPool.insert``.
-        """
         rows = list(data)
         if not rows:
             return

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -167,6 +167,37 @@ class ClickhousePool(ABC):
             capture_trace=capture_trace,
         )
 
+    def insert(
+        self,
+        table: str,
+        data: Sequence[Mapping[str, Any]],
+        settings: Mapping[str, Any] | None = None,
+        query_id: str | None = None,
+    ) -> None:
+        """
+        Insert ``data`` -- a sequence of rows, each a column-name -> value
+        mapping -- into ``table``. This is the interface callers should use to
+        write rows; it keeps them off ``execute``'s query path, which the two
+        drivers implement differently for inserts.
+
+        The default implementation targets the native protocol: it issues an
+        ``INSERT INTO <table> FORMAT JSONEachRow`` through :meth:`execute`, where
+        the driver serializes native Python values (``datetime``, ...) into the
+        native binary block itself, using the column types from the server's
+        INSERT sample block, and maps each dict's keys to columns. The
+        clickhouse-connect (HTTP) pool has no such query-path insert notion and
+        overrides this -- see ``ClickhouseConnectPool.insert``.
+        """
+        rows = list(data)
+        if not rows:
+            return
+        self.execute(
+            f"INSERT INTO {table} FORMAT JSONEachRow",
+            rows,
+            settings=settings,
+            query_id=query_id,
+        )
+
     @abstractmethod
     def close(self) -> None:
         raise NotImplementedError

--- a/snuba/manual_jobs/update_migration_status.py
+++ b/snuba/manual_jobs/update_migration_status.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
@@ -71,7 +71,7 @@ class UpdateMigrationStatus(Job):
             {
                 "group": self._group,
                 "migration_id": self._migration_id,
-                "timestamp": datetime.now(),
+                "timestamp": datetime.now(UTC),
                 "status": self._new_status,
                 "version": version + 1,
             }

--- a/snuba/manual_jobs/update_migration_status.py
+++ b/snuba/manual_jobs/update_migration_status.py
@@ -48,9 +48,6 @@ class UpdateMigrationStatus(Job):
     def _select_query(self, table_name: str) -> str:
         return f"SELECT status, version FROM {table_name} FINAL WHERE group = %(group)s AND migration_id = %(migration_id)s;"
 
-    def _insert_query(self, table_name: str) -> str:
-        return f"INSERT INTO {table_name} FORMAT JSONEachRow"
-
     def execute(self, logger: JobLogger) -> None:
         migrations_cluster = get_cluster(StorageSetKey.MIGRATIONS)
         table_name = LOCAL_TABLE_NAME if migrations_cluster.is_single_node() else DIST_TABLE_NAME
@@ -70,7 +67,6 @@ class UpdateMigrationStatus(Job):
             f"actual status {status} does not match expected {self._old_status}, aborting"
         )
 
-        query = self._insert_query(table_name)
         row_data = [
             {
                 "group": self._group,
@@ -81,7 +77,7 @@ class UpdateMigrationStatus(Job):
             }
         ]
 
-        logger.info(f"{self.job_spec.job_id}: executing {query} with data = {row_data}")
+        logger.info(f"{self.job_spec.job_id}: inserting into {table_name} data = {row_data}")
 
-        result = connection.execute(query, row_data)
-        logger.info(result.__repr__())
+        connection.insert(table_name, row_data)
+        logger.info(f"{self.job_spec.job_id}: inserted {len(row_data)} row(s) into {table_name}")

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import partial
 from typing import NamedTuple
 
@@ -559,7 +559,7 @@ class Runner:
             {
                 "group": migration_key.group.value,
                 "migration_id": migration_key.migration_id,
-                "timestamp": datetime.now(),
+                "timestamp": datetime.now(UTC),
                 "status": status.value,
                 "version": next_version,
             }

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -555,7 +555,6 @@ class Runner:
         self.__status = {}
         next_version = self._get_next_version(migration_key)
 
-        statement = f"INSERT INTO {self.__table_name} FORMAT JSONEachRow"
         data = [
             {
                 "group": migration_key.group.value,
@@ -565,7 +564,7 @@ class Runner:
                 "version": next_version,
             }
         ]
-        self.__connection.execute(statement, data)
+        self.__connection.insert(self.__table_name, data)
 
     def _get_next_version(self, migration_key: MigrationKey) -> int:
         result = self.__connection.execute(

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -136,7 +136,10 @@ def test_insert_positional_rows_use_columns_from_sql() -> None:
     args, kwargs = client.insert.call_args
     assert args[0] == "metrics"
     assert kwargs["column_names"] == ["g", "ts", "v"]
-    assert args[1] == [[1, datetime(2023, 1, 2, 3, 4, 5), 10], [2, datetime(2023, 1, 3, 0, 0, 0), 30]]
+    assert args[1] == [
+        [1, datetime(2023, 1, 2, 3, 4, 5), 10],
+        [2, datetime(2023, 1, 3, 0, 0, 0), 30],
+    ]
 
 
 def test_insert_empty_rows_short_circuits() -> None:

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -84,18 +84,12 @@ def test_execute_passes_query_id_and_settings() -> None:
 
 
 def _jsoneachrow(kwargs: Any, args: Any) -> list[dict[str, Any]]:
-    # raw_insert may receive insert_block positionally or by keyword; normalize
-    # to the parsed JSONEachRow rows either way.
     block = kwargs.get("insert_block", args[1] if len(args) > 1 else None)
     text = block.decode("utf-8") if isinstance(block, bytes) else block
     return [json.loads(line) for line in text.splitlines()]
 
 
 def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
-    # The migration status writers hand insert() a list of dict rows, one of
-    # which is a datetime. It must be sent via raw_insert as a JSONEachRow body
-    # with the datetime encoded as a string -- never through client.query(),
-    # whose parameter binding would try to JSON-encode the datetime and fail.
     client = mock.Mock()
 
     pool = _make_pool(client)
@@ -116,7 +110,6 @@ def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
     args, kwargs = client.raw_insert.call_args
     assert args[0] == "migrations_local"
     assert kwargs["fmt"] == "JSONEachRow"
-    # The datetime is encoded to ClickHouse's second-precision DateTime string.
     assert _jsoneachrow(kwargs, args) == [
         {
             "group": "events",
@@ -129,7 +122,6 @@ def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
 
 
 def test_insert_encodes_date_without_time() -> None:
-    # A bare date encodes as YYYY-MM-DD (no time component).
     client = mock.Mock()
 
     pool = _make_pool(client)
@@ -140,8 +132,6 @@ def test_insert_encodes_date_without_time() -> None:
 
 
 def test_insert_empty_rows_short_circuits() -> None:
-    # An empty row sequence writes nothing and never touches the client, matching
-    # the native driver's zero-row insert.
     client = mock.Mock()
 
     pool = _make_pool(client)
@@ -168,8 +158,6 @@ def test_insert_forwards_query_id_and_settings() -> None:
 
 
 def test_execute_does_not_handle_insert_rows() -> None:
-    # execute() is the query path only: insert data goes through insert(), so a
-    # plain query still routes to client.query() and never to raw_insert.
     client = mock.Mock()
     client.query.return_value = FakeQueryResult(result_set=[[1]])
 

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -83,14 +83,22 @@ def test_execute_passes_query_id_and_settings() -> None:
     assert kwargs["settings"]["max_threads"] == 4
 
 
-def test_insert_dict_rows_routed_to_client_insert() -> None:
+def _jsoneachrow(kwargs: Any, args: Any) -> list[dict[str, Any]]:
+    # raw_insert may receive insert_block positionally or by keyword; normalize
+    # to the parsed JSONEachRow rows either way.
+    block = kwargs.get("insert_block", args[1] if len(args) > 1 else None)
+    text = block.decode("utf-8") if isinstance(block, bytes) else block
+    return [json.loads(line) for line in text.splitlines()]
+
+
+def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
     # The migration status writers pass an "INSERT INTO <table> FORMAT
-    # JSONEachRow" query with a list of dict rows (one of which is a datetime).
-    # This must be routed to client.insert() -- which serializes native Python
-    # types itself -- rather than client.query(), whose parameter binding would
-    # try to JSON-encode the datetime and fail.
+    # JSONEachRow" query with a list of dict rows, one of which is a datetime.
+    # This must be sent via raw_insert as a JSONEachRow body with the datetime
+    # encoded as a string, rather than through client.query(), whose parameter
+    # binding would try to JSON-encode the datetime and fail.
     client = mock.Mock()
-    client.insert.return_value = mock.Mock(written_rows=1, written_bytes=42)
+    client.raw_insert.return_value = mock.Mock(written_rows=1, written_bytes=42)
 
     pool = _make_pool(client)
     ts = datetime(2026, 7, 8, 21, 14, 31)
@@ -107,22 +115,42 @@ def test_insert_dict_rows_routed_to_client_insert() -> None:
     result = pool.execute("INSERT INTO migrations_local FORMAT JSONEachRow", rows)
 
     client.query.assert_not_called()
-    args, kwargs = client.insert.call_args
+    args, kwargs = client.raw_insert.call_args
     assert args[0] == "migrations_local"
-    # Rows are built as a positional matrix aligned to the dict key order.
-    assert kwargs["column_names"] == ["group", "migration_id", "timestamp", "status", "version"]
-    assert args[1] == [["events", "0025_add_segment_names_column", ts, "in_progress", 3]]
+    assert kwargs["fmt"] == "JSONEachRow"
+    # The datetime is encoded to ClickHouse's second-precision DateTime string.
+    assert _jsoneachrow(kwargs, args) == [
+        {
+            "group": "events",
+            "migration_id": "0025_add_segment_names_column",
+            "timestamp": "2026-07-08 21:14:31",
+            "status": "in_progress",
+            "version": 3,
+        }
+    ]
     # The written row count is surfaced (wrapped), mirroring the native driver.
     assert result.results == [1]
     assert result.profile is not None
     assert result.profile["rows"] == 1
 
 
-def test_insert_positional_rows_use_columns_from_sql() -> None:
-    # Positional rows (list of lists) take their column names from the SQL
-    # column list, e.g. "INSERT INTO t (g, ts, v) VALUES".
+def test_insert_encodes_date_without_time() -> None:
+    # A bare date encodes as YYYY-MM-DD (no time component).
     client = mock.Mock()
-    client.insert.return_value = mock.Mock(written_rows=2, written_bytes=0)
+    client.raw_insert.return_value = mock.Mock(written_rows=1, written_bytes=0)
+
+    pool = _make_pool(client)
+    pool.execute("INSERT INTO t FORMAT JSONEachRow", [{"d": date(2026, 7, 8)}])
+
+    args, kwargs = client.raw_insert.call_args
+    assert _jsoneachrow(kwargs, args) == [{"d": "2026-07-08"}]
+
+
+def test_insert_positional_rows_use_columns_from_sql() -> None:
+    # Positional rows (list of lists) take their field names from the SQL column
+    # list, e.g. "INSERT INTO t (g, ts, v) VALUES", and are zipped into objects.
+    client = mock.Mock()
+    client.raw_insert.return_value = mock.Mock(written_rows=2, written_bytes=0)
 
     pool = _make_pool(client)
     rows = [
@@ -133,13 +161,23 @@ def test_insert_positional_rows_use_columns_from_sql() -> None:
     pool.execute("INSERT INTO metrics (g, ts, v) VALUES", rows)
 
     client.query.assert_not_called()
-    args, kwargs = client.insert.call_args
+    args, kwargs = client.raw_insert.call_args
     assert args[0] == "metrics"
-    assert kwargs["column_names"] == ["g", "ts", "v"]
-    assert args[1] == [
-        [1, datetime(2023, 1, 2, 3, 4, 5), 10],
-        [2, datetime(2023, 1, 3, 0, 0, 0), 30],
+    assert _jsoneachrow(kwargs, args) == [
+        {"g": 1, "ts": "2023-01-02 03:04:05", "v": 10},
+        {"g": 2, "ts": "2023-01-03 00:00:00", "v": 30},
     ]
+
+
+def test_insert_positional_rows_without_columns_raise() -> None:
+    # Positional rows without a column list can't be turned into JSONEachRow
+    # objects; surface a clear error rather than sending a malformed body.
+    client = mock.Mock()
+
+    pool = _make_pool(client)
+    with pytest.raises(ClickhouseError):
+        pool.execute("INSERT INTO t FORMAT JSONEachRow", [[1, 2, 3]])
+    client.raw_insert.assert_not_called()
 
 
 def test_insert_empty_rows_short_circuits() -> None:
@@ -150,7 +188,7 @@ def test_insert_empty_rows_short_circuits() -> None:
     pool = _make_pool(client)
     result = pool.execute("INSERT INTO t FORMAT JSONEachRow", [])
 
-    client.insert.assert_not_called()
+    client.raw_insert.assert_not_called()
     client.query.assert_not_called()
     assert result.results == []
     assert result.profile is not None
@@ -159,7 +197,7 @@ def test_insert_empty_rows_short_circuits() -> None:
 
 def test_insert_forwards_query_id_and_settings() -> None:
     client = mock.Mock()
-    client.insert.return_value = mock.Mock(written_rows=1, written_bytes=0)
+    client.raw_insert.return_value = mock.Mock(written_rows=1, written_bytes=0)
 
     pool = _make_pool(client)
     pool.execute(
@@ -169,7 +207,7 @@ def test_insert_forwards_query_id_and_settings() -> None:
         settings={"async_insert": 1},
     )
 
-    _, kwargs = client.insert.call_args
+    _, kwargs = client.raw_insert.call_args
     assert kwargs["settings"]["query_id"] == "insert-id"
     assert kwargs["settings"]["async_insert"] == 1
 
@@ -183,7 +221,7 @@ def test_select_with_mapping_params_still_uses_query() -> None:
     pool = _make_pool(client)
     pool.execute("SELECT %(x)s", {"x": 1})
 
-    client.insert.assert_not_called()
+    client.raw_insert.assert_not_called()
     client.query.assert_called_once()
 
 

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -83,13 +83,7 @@ def test_execute_passes_query_id_and_settings() -> None:
     assert kwargs["settings"]["max_threads"] == 4
 
 
-def _jsoneachrow(kwargs: Any, args: Any) -> list[dict[str, Any]]:
-    block = kwargs.get("insert_block", args[1] if len(args) > 1 else None)
-    text = block.decode("utf-8") if isinstance(block, bytes) else block
-    return [json.loads(line) for line in text.splitlines()]
-
-
-def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
+def test_insert_dict_rows_use_client_insert() -> None:
     client = mock.Mock()
 
     pool = _make_pool(client)
@@ -107,28 +101,35 @@ def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
     pool.insert("migrations_local", rows)
 
     client.query.assert_not_called()
-    args, kwargs = client.raw_insert.call_args
+    args, kwargs = client.insert.call_args
     assert args[0] == "migrations_local"
-    assert kwargs["fmt"] == "JSONEachRow"
-    assert _jsoneachrow(kwargs, args) == [
-        {
-            "group": "events",
-            "migration_id": "0025_add_segment_names_column",
-            "timestamp": "2026-07-08 21:14:31",
-            "status": "in_progress",
-            "version": 3,
-        }
+    assert kwargs["column_names"] == [
+        "group",
+        "migration_id",
+        "timestamp",
+        "status",
+        "version",
     ]
+    assert args[1] == [["events", "0025_add_segment_names_column", ts, "in_progress", 3]]
 
 
-def test_insert_encodes_date_without_time() -> None:
+def test_insert_multiple_rows_build_a_matrix() -> None:
     client = mock.Mock()
 
     pool = _make_pool(client)
-    pool.insert("t", [{"d": date(2026, 7, 8)}])
+    rows = [
+        {"g": 1, "ts": datetime(2023, 1, 2, 3, 4, 5), "v": 10},
+        {"g": 2, "ts": datetime(2023, 1, 3, 0, 0, 0), "v": 30},
+    ]
 
-    args, kwargs = client.raw_insert.call_args
-    assert _jsoneachrow(kwargs, args) == [{"d": "2026-07-08"}]
+    pool.insert("metrics", rows)
+
+    _, kwargs = client.insert.call_args
+    assert kwargs["column_names"] == ["g", "ts", "v"]
+    assert client.insert.call_args[0][1] == [
+        [1, datetime(2023, 1, 2, 3, 4, 5), 10],
+        [2, datetime(2023, 1, 3, 0, 0, 0), 30],
+    ]
 
 
 def test_insert_empty_rows_short_circuits() -> None:
@@ -137,7 +138,7 @@ def test_insert_empty_rows_short_circuits() -> None:
     pool = _make_pool(client)
     pool.insert("t", [])
 
-    client.raw_insert.assert_not_called()
+    client.insert.assert_not_called()
     client.query.assert_not_called()
 
 
@@ -152,7 +153,7 @@ def test_insert_forwards_query_id_and_settings() -> None:
         settings={"async_insert": 1},
     )
 
-    _, kwargs = client.raw_insert.call_args
+    _, kwargs = client.insert.call_args
     assert kwargs["settings"]["query_id"] == "insert-id"
     assert kwargs["settings"]["async_insert"] == 1
 
@@ -164,7 +165,7 @@ def test_execute_does_not_handle_insert_rows() -> None:
     pool = _make_pool(client)
     pool.execute("SELECT %(x)s", {"x": 1})
 
-    client.raw_insert.assert_not_called()
+    client.insert.assert_not_called()
     client.query.assert_called_once()
 
 

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -92,13 +92,11 @@ def _jsoneachrow(kwargs: Any, args: Any) -> list[dict[str, Any]]:
 
 
 def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
-    # The migration status writers pass an "INSERT INTO <table> FORMAT
-    # JSONEachRow" query with a list of dict rows, one of which is a datetime.
-    # This must be sent via raw_insert as a JSONEachRow body with the datetime
-    # encoded as a string, rather than through client.query(), whose parameter
-    # binding would try to JSON-encode the datetime and fail.
+    # The migration status writers hand insert() a list of dict rows, one of
+    # which is a datetime. It must be sent via raw_insert as a JSONEachRow body
+    # with the datetime encoded as a string -- never through client.query(),
+    # whose parameter binding would try to JSON-encode the datetime and fail.
     client = mock.Mock()
-    client.raw_insert.return_value = mock.Mock(written_rows=1, written_bytes=42)
 
     pool = _make_pool(client)
     ts = datetime(2026, 7, 8, 21, 14, 31)
@@ -112,7 +110,7 @@ def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
         }
     ]
 
-    result = pool.execute("INSERT INTO migrations_local FORMAT JSONEachRow", rows)
+    pool.insert("migrations_local", rows)
 
     client.query.assert_not_called()
     args, kwargs = client.raw_insert.call_args
@@ -128,56 +126,17 @@ def test_insert_dict_rows_sent_as_jsoneachrow() -> None:
             "version": 3,
         }
     ]
-    # The written row count is surfaced (wrapped), mirroring the native driver.
-    assert result.results == [1]
-    assert result.profile is not None
-    assert result.profile["rows"] == 1
 
 
 def test_insert_encodes_date_without_time() -> None:
     # A bare date encodes as YYYY-MM-DD (no time component).
     client = mock.Mock()
-    client.raw_insert.return_value = mock.Mock(written_rows=1, written_bytes=0)
 
     pool = _make_pool(client)
-    pool.execute("INSERT INTO t FORMAT JSONEachRow", [{"d": date(2026, 7, 8)}])
+    pool.insert("t", [{"d": date(2026, 7, 8)}])
 
     args, kwargs = client.raw_insert.call_args
     assert _jsoneachrow(kwargs, args) == [{"d": "2026-07-08"}]
-
-
-def test_insert_positional_rows_use_columns_from_sql() -> None:
-    # Positional rows (list of lists) take their field names from the SQL column
-    # list, e.g. "INSERT INTO t (g, ts, v) VALUES", and are zipped into objects.
-    client = mock.Mock()
-    client.raw_insert.return_value = mock.Mock(written_rows=2, written_bytes=0)
-
-    pool = _make_pool(client)
-    rows = [
-        [1, datetime(2023, 1, 2, 3, 4, 5), 10],
-        [2, datetime(2023, 1, 3, 0, 0, 0), 30],
-    ]
-
-    pool.execute("INSERT INTO metrics (g, ts, v) VALUES", rows)
-
-    client.query.assert_not_called()
-    args, kwargs = client.raw_insert.call_args
-    assert args[0] == "metrics"
-    assert _jsoneachrow(kwargs, args) == [
-        {"g": 1, "ts": "2023-01-02 03:04:05", "v": 10},
-        {"g": 2, "ts": "2023-01-03 00:00:00", "v": 30},
-    ]
-
-
-def test_insert_positional_rows_without_columns_raise() -> None:
-    # Positional rows without a column list can't be turned into JSONEachRow
-    # objects; surface a clear error rather than sending a malformed body.
-    client = mock.Mock()
-
-    pool = _make_pool(client)
-    with pytest.raises(ClickhouseError):
-        pool.execute("INSERT INTO t FORMAT JSONEachRow", [[1, 2, 3]])
-    client.raw_insert.assert_not_called()
 
 
 def test_insert_empty_rows_short_circuits() -> None:
@@ -186,22 +145,18 @@ def test_insert_empty_rows_short_circuits() -> None:
     client = mock.Mock()
 
     pool = _make_pool(client)
-    result = pool.execute("INSERT INTO t FORMAT JSONEachRow", [])
+    pool.insert("t", [])
 
     client.raw_insert.assert_not_called()
     client.query.assert_not_called()
-    assert result.results == []
-    assert result.profile is not None
-    assert result.profile["rows"] == 0
 
 
 def test_insert_forwards_query_id_and_settings() -> None:
     client = mock.Mock()
-    client.raw_insert.return_value = mock.Mock(written_rows=1, written_bytes=0)
 
     pool = _make_pool(client)
-    pool.execute(
-        "INSERT INTO t FORMAT JSONEachRow",
+    pool.insert(
+        "t",
         [{"a": 1}],
         query_id="insert-id",
         settings={"async_insert": 1},
@@ -212,9 +167,9 @@ def test_insert_forwards_query_id_and_settings() -> None:
     assert kwargs["settings"]["async_insert"] == 1
 
 
-def test_select_with_mapping_params_still_uses_query() -> None:
-    # Mapping params are query-substitution parameters, not insert rows: they must
-    # continue to go through client.query() unchanged.
+def test_execute_does_not_handle_insert_rows() -> None:
+    # execute() is the query path only: insert data goes through insert(), so a
+    # plain query still routes to client.query() and never to raw_insert.
     client = mock.Mock()
     client.query.return_value = FakeQueryResult(result_set=[[1]])
 

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -83,6 +83,107 @@ def test_execute_passes_query_id_and_settings() -> None:
     assert kwargs["settings"]["max_threads"] == 4
 
 
+def test_insert_dict_rows_routed_to_client_insert() -> None:
+    # The migration status writers pass an "INSERT INTO <table> FORMAT
+    # JSONEachRow" query with a list of dict rows (one of which is a datetime).
+    # This must be routed to client.insert() -- which serializes native Python
+    # types itself -- rather than client.query(), whose parameter binding would
+    # try to JSON-encode the datetime and fail.
+    client = mock.Mock()
+    client.insert.return_value = mock.Mock(written_rows=1, written_bytes=42)
+
+    pool = _make_pool(client)
+    ts = datetime(2026, 7, 8, 21, 14, 31)
+    rows = [
+        {
+            "group": "events",
+            "migration_id": "0025_add_segment_names_column",
+            "timestamp": ts,
+            "status": "in_progress",
+            "version": 3,
+        }
+    ]
+
+    result = pool.execute("INSERT INTO migrations_local FORMAT JSONEachRow", rows)
+
+    client.query.assert_not_called()
+    args, kwargs = client.insert.call_args
+    assert args[0] == "migrations_local"
+    # Rows are built as a positional matrix aligned to the dict key order.
+    assert kwargs["column_names"] == ["group", "migration_id", "timestamp", "status", "version"]
+    assert args[1] == [["events", "0025_add_segment_names_column", ts, "in_progress", 3]]
+    # The written row count is surfaced (wrapped), mirroring the native driver.
+    assert result.results == [1]
+    assert result.profile is not None
+    assert result.profile["rows"] == 1
+
+
+def test_insert_positional_rows_use_columns_from_sql() -> None:
+    # Positional rows (list of lists) take their column names from the SQL
+    # column list, e.g. "INSERT INTO t (g, ts, v) VALUES".
+    client = mock.Mock()
+    client.insert.return_value = mock.Mock(written_rows=2, written_bytes=0)
+
+    pool = _make_pool(client)
+    rows = [
+        [1, datetime(2023, 1, 2, 3, 4, 5), 10],
+        [2, datetime(2023, 1, 3, 0, 0, 0), 30],
+    ]
+
+    pool.execute("INSERT INTO metrics (g, ts, v) VALUES", rows)
+
+    client.query.assert_not_called()
+    args, kwargs = client.insert.call_args
+    assert args[0] == "metrics"
+    assert kwargs["column_names"] == ["g", "ts", "v"]
+    assert args[1] == [[1, datetime(2023, 1, 2, 3, 4, 5), 10], [2, datetime(2023, 1, 3, 0, 0, 0), 30]]
+
+
+def test_insert_empty_rows_short_circuits() -> None:
+    # An empty row sequence writes nothing and never touches the client, matching
+    # the native driver's zero-row insert.
+    client = mock.Mock()
+
+    pool = _make_pool(client)
+    result = pool.execute("INSERT INTO t FORMAT JSONEachRow", [])
+
+    client.insert.assert_not_called()
+    client.query.assert_not_called()
+    assert result.results == []
+    assert result.profile is not None
+    assert result.profile["rows"] == 0
+
+
+def test_insert_forwards_query_id_and_settings() -> None:
+    client = mock.Mock()
+    client.insert.return_value = mock.Mock(written_rows=1, written_bytes=0)
+
+    pool = _make_pool(client)
+    pool.execute(
+        "INSERT INTO t FORMAT JSONEachRow",
+        [{"a": 1}],
+        query_id="insert-id",
+        settings={"async_insert": 1},
+    )
+
+    _, kwargs = client.insert.call_args
+    assert kwargs["settings"]["query_id"] == "insert-id"
+    assert kwargs["settings"]["async_insert"] == 1
+
+
+def test_select_with_mapping_params_still_uses_query() -> None:
+    # Mapping params are query-substitution parameters, not insert rows: they must
+    # continue to go through client.query() unchanged.
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult(result_set=[[1]])
+
+    pool = _make_pool(client)
+    pool.execute("SELECT %(x)s", {"x": 1})
+
+    client.insert.assert_not_called()
+    client.query.assert_called_once()
+
+
 def test_too_many_simultaneous_queries_not_retried() -> None:
     # We delegate all retries to clickhouse-connect, which does not retry the
     # TOO_MANY_SIMULTANEOUS_QUERIES error. It should be surfaced directly,


### PR DESCRIPTION
## Summary

Running any migration with the new clickhouse-connect (HTTP) driver crashes with:

```
TypeError: Object of type datetime is not JSON serializable
```

**Root cause:** The HTTP pool's `execute()` forwards every call to `client.query()`, passing the caller's `params` as query-substitution parameters. The native `clickhouse-driver`, by contrast, treats an `INSERT` whose `params` is a *sequence of rows* as insert data — the `INSERT INTO <table> FORMAT JSONEachRow` + list-of-dicts pattern the migration status writers use. Over HTTP those rows went through clickhouse-connect's parameter binding, which JSON-encodes values and can't serialize the `datetime` timestamp.

This broke:
- `Runner._update_migration_status` — runs on **every** migration (`update_status(Status.IN_PROGRESS)`), which is the traceback in the report.
- The `UpdateMigrationStatus` manual job — same pattern.

## Approach

Rather than having `execute()` sniff the SQL to detect inserts, this adds a first-class **`insert()`** method to the `ClickhousePool` interface, so callers invoke the right method explicitly and each driver inserts the way its protocol wants:

- **`ClickhousePool.insert(table, data)`** — concrete default for the **native** protocol. Issues `INSERT INTO <table> FORMAT JSONEachRow` via `execute()`, where the driver serializes native Python values (`datetime`, …) into the native binary block itself, using the column types from the server's INSERT sample block. The native pool and the test fakes inherit it unchanged.
- **`ClickhouseConnectPool.insert()`** — HTTP override. Serializes the rows to a JSONEachRow body and sends it via `client.raw_insert(..., fmt="JSONEachRow")`. A `datetime`/`date`-aware JSON encoder (`_clickhouse_json_default`) renders `datetime` → `"YYYY-MM-DD HH:MM:SS"` (the form ClickHouse's default `DateTime` input accepts) and `date` → `"YYYY-MM-DD"`. `execute()` is back to being the query path only — the regex/`_execute_insert` machinery is removed.
- **Callers** (`Runner._update_migration_status`, `UpdateMigrationStatus`) now call `connection.insert(table, data)`.

`data` is a `Sequence[Mapping[str, Any]]` (rows as column-name → value); empty input is a no-op on both drivers.

## Changes

- `snuba/clickhouse/native.py`: add the default `insert()` to `ClickhousePool`.
- `snuba/clickhouse/connect.py`: override `insert()` for HTTP; drop the SQL-sniffing from `execute()`.
- `snuba/migrations/runner.py`, `snuba/manual_jobs/update_migration_status.py`: use `connection.insert(...)`.
- `tests/clickhouse/test_connect.py`: unit tests for the HTTP `insert()` — JSONEachRow serialization with `datetime` → string, `date` encoding, empty-row no-op, `query_id`/settings forwarding, and that `execute()` no longer touches `raw_insert`.

## Testing

- Verified serialization/encoding in isolation and confirmed the `client.raw_insert()` signature against clickhouse-connect and the `DateTime` type of the migrations `timestamp` column.
- ruff format + lint pass on the changed files. The full pytest suite runs in CI (the local sandbox is Python 3.11 vs the project's 3.13, so the suite can't run here).

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)