### PR TITLE
fix(rpc): distinguish false boolean attributes from missing

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -334,14 +334,16 @@ def add_existence_check_to_subscriptable_references(query: Query) -> None:
     query.transform_expressions(transform)
 
 
-def _contains_subscriptable_reference(exp: Expression) -> bool:
-    """True if ``exp`` contains a ``SubscriptableReference`` (a map lookup) — the
-    map-backed keys we route through ``_map_backed_operands``."""
+def _contains_map_lookup(exp: Expression) -> bool:
+    """True if ``exp`` contains one of the map lookup representations we route
+    through ``_map_backed_operands``."""
     found = False
 
     def visit(node: Expression) -> Expression:
         nonlocal found
-        if isinstance(node, SubscriptableReference):
+        if isinstance(node, SubscriptableReference) or (
+            isinstance(node, FunctionCall) and node.function_name == "arrayElement"
+        ):
             found = True
         return node
 
@@ -367,14 +369,14 @@ def _map_backed_operands(k: AttributeKey) -> tuple[Expression, Expression]:
     Callers build ``cmp(value, v)``, wrapped in ``and(exists, ...)`` only when the
     literal could be the column default (see ``_comparison_can_match_column_default``)
     — then ``exists``, not the value, distinguishes a missing key from a stored
-    empty value, since ``arrayElement`` reads both as the '' / 0 default. The
+    empty value, since ``arrayElement`` reads both as the '' / 0 / false default. The
     ``multiIf`` else is only reached when all keys are absent.
 
     Built without aliases: conditions don't need them, and an alias here would
     collide with the SELECT clause's existence ``if(...)`` for the same attribute
     (same alias, different expression). Only valid for map-backed keys
-    (string/int/float); booleans / normalized columns / arrays take the legacy
-    path, and SELECT keeps its own ``coalesce(...)`` representation untouched.
+    (string/int/float/bool); normalized columns and arrays take the legacy path,
+    and SELECT keeps its own ``coalesce(...)`` representation untouched.
     """
     col_name = PROTO_TYPE_TO_ATTRIBUTE_COLUMN[k.type]
     names = [k.name] + list(ATTRIBUTES_TO_COALESCE.get(k.name, ()))
@@ -446,11 +448,16 @@ def _scalar_value(v: AttributeValue) -> bool | str | int | float | None:
 def _comparison_can_match_column_default(
     attr_type: AttributeKey.Type.ValueType, v: AttributeValue, value_type: str
 ) -> bool:
-    """True if any compared literal is the column default ('' / 0), which an
+    """True if any compared literal is the column default ('' / 0 / false), which an
     absent key also reads as — so the existence guard is needed to avoid
     matching absent keys. When no literal is the default the guard is dropped (the
     simplest form). LIKE/NOT_LIKE always guard; null comparisons are separate."""
-    default: str | int = "" if attr_type == AttributeKey.Type.TYPE_STRING else 0
+    if attr_type == AttributeKey.Type.TYPE_STRING:
+        default: str | int | bool = ""
+    elif attr_type == AttributeKey.Type.TYPE_BOOLEAN:
+        default = False
+    else:
+        default = 0
     if value_type == "val_array":
         scalars: list[Any] = [_scalar_value(x) for x in v.val_array.values]
     elif value_type in ("val_str_array", "val_int_array", "val_float_array", "val_double_array"):
@@ -969,7 +976,7 @@ def trace_item_filters_to_expression(
                 return _typed_array_includes_scalar_expression(
                     k, v, item_filter.comparison_filter.ignore_case
                 )
-            if _contains_subscriptable_reference(k_expression):
+            if _contains_map_lookup(k_expression):
                 # Map-backed: NULL-free (exists, value) form (see _map_backed_operands).
                 value, exists = _map_backed_operands(k)
                 if v_is_null:  # `attr = null` <=> key absent
@@ -980,7 +987,7 @@ def trace_item_filters_to_expression(
                     else (value, v_expression)
                 )
                 cmp = f.equals(lhs, rhs)
-                # existence guard only needed when '' / 0 could match an absent key.
+                # Existence guard only needed when the default could match an absent key.
                 if _comparison_can_match_column_default(k.type, v, value_type):
                     return and_cond(exists, cmp)
                 return cmp
@@ -1001,7 +1008,7 @@ def trace_item_filters_to_expression(
                         k, v, item_filter.comparison_filter.ignore_case
                     )
                 )
-            if _contains_subscriptable_reference(k_expression):
+            if _contains_map_lookup(k_expression):
                 # Negation of OP_EQUALS; an absent key is "not equal".
                 value, exists = _map_backed_operands(k)
                 if v_is_null:  # `attr != null` <=> key present
@@ -1033,7 +1040,7 @@ def trace_item_filters_to_expression(
                     "the LIKE comparison is only supported on string and array keys"
                 )
             comparison_function = f.ilike if item_filter.comparison_filter.ignore_case else f.like
-            if _contains_subscriptable_reference(k_expression):
+            if _contains_map_lookup(k_expression):
                 value, exists = _map_backed_operands(k)
                 return and_cond(exists, comparison_function(value, v_expression))
             return comparison_function(k_expression, v_expression)
@@ -1048,7 +1055,7 @@ def trace_item_filters_to_expression(
                 raise BadSnubaRPCRequestException(
                     "the NOT LIKE comparison is only supported on string and array keys"
                 )
-            if _contains_subscriptable_reference(k_expression):
+            if _contains_map_lookup(k_expression):
                 # Negation of OP_LIKE; an absent key is "not like".
                 like_fn = f.ilike if item_filter.comparison_filter.ignore_case else f.like
                 value, exists = _map_backed_operands(k)
@@ -1086,7 +1093,7 @@ def trace_item_filters_to_expression(
             # note: v_expression must be an array
             # we redefine the way in works for nulls
             # now null in ['hi', null] is true
-            if _contains_subscriptable_reference(k_expression):
+            if _contains_map_lookup(k_expression):
                 # Map-backed: keep the existence if(...) out of in() (see helper).
                 return _analyzer_safe_in_expression(
                     k,
@@ -1121,7 +1128,7 @@ def trace_item_filters_to_expression(
             # note: v_expression must be an array
             # we redefine the way not in works for nulls
             # now null not in ['hi'] is true
-            if _contains_subscriptable_reference(k_expression):
+            if _contains_map_lookup(k_expression):
                 # Map-backed: keep the existence if(...) out of in() (see helper).
                 return _analyzer_safe_in_expression(
                     k,
@@ -1262,6 +1269,14 @@ def get_field_existence_expression(field: Expression) -> Expression:
         if isinstance(base, Column) and base.column_name in TYPED_ARRAY_MAP_COLUMNS:
             return f.notEmpty(field)
         return map_key_exists(field.parameters[0], field.parameters[1])
+
+    if (
+        isinstance(field, FunctionCall)
+        and field.function_name == "cast"
+        and isinstance(field.parameters[0], FunctionCall)
+        and field.parameters[0].function_name == "arrayElement"
+    ):
+        return get_field_existence_expression(field.parameters[0])
 
     if isinstance(field, FunctionCall) and field.function_name in ("arrayMap", "arrayConcat"):
         # Array attributes return empty arrays (not NULL) for missing keys, so notEmpty

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -486,6 +486,48 @@ class TestExistsFilterCoalesced:
         assert expr.function_name == "has"
 
 
+class TestBooleanAttributeFilters:
+    @staticmethod
+    def _comparison(value: bool) -> TraceItemFilter:
+        return TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="custom.flag"),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_bool=value),
+            )
+        )
+
+    def test_equals_false_checks_key_exists(self) -> None:
+        expr = trace_item_filters_to_expression(
+            self._comparison(False), attribute_key_to_expression
+        )
+
+        assert isinstance(expr, FunctionCall)
+        assert expr.function_name == "and"
+        assert {"has", "mapKeys", "equals", "arrayElement"} <= _collect_function_names(expr)
+
+    def test_equals_true_does_not_need_existence_check(self) -> None:
+        expr = trace_item_filters_to_expression(self._comparison(True), attribute_key_to_expression)
+
+        assert isinstance(expr, FunctionCall)
+        assert expr.function_name == "equals"
+        assert "mapKeys" not in _collect_function_names(expr)
+
+    def test_exists_checks_boolean_map_key(self) -> None:
+        expr = trace_item_filters_to_expression(
+            TraceItemFilter(
+                exists_filter=ExistsFilter(
+                    key=AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="custom.flag")
+                )
+            ),
+            attribute_key_to_expression,
+        )
+
+        assert isinstance(expr, FunctionCall)
+        assert expr.function_name == "has"
+        assert _collect_column_names(expr) == {"attributes_bool"}
+
+
 class TestSentryTimestampFilter:
     """Range filters on `sentry.timestamp` must target the raw DateTime `timestamp`
     column (index- and partition-prunable) rather than CAST(timestamp, 'Float64')."""
@@ -1171,6 +1213,7 @@ class TestEmptyVsAbsentComparison:
     # Custom attribute names not present in gen_item_message's default set
     # (which injects e.g. status="ok"), so we fully control present/empty/absent.
     ATTR = "test.empty_vs_absent.status"
+    BOOL_ATTR = "test.empty_vs_absent.flag"
     BATCH_ATTR = "test.empty_vs_absent.batch"
 
     @pytest.fixture(autouse=True)
@@ -1188,6 +1231,7 @@ class TestEmptyVsAbsentComparison:
                 attributes={
                     self.BATCH_ATTR: batch,
                     self.ATTR: AnyValue(string_value="ok"),
+                    self.BOOL_ATTR: AnyValue(bool_value=True),
                     "color": AnyValue(string_value="red"),
                 },
             ),
@@ -1196,6 +1240,7 @@ class TestEmptyVsAbsentComparison:
                 attributes={
                     self.BATCH_ATTR: batch,
                     self.ATTR: AnyValue(string_value=""),
+                    self.BOOL_ATTR: AnyValue(bool_value=False),
                     "color": AnyValue(string_value="blue"),
                 },
             ),
@@ -1214,10 +1259,19 @@ class TestEmptyVsAbsentComparison:
         self,
         op: ComparisonFilter.Op.ValueType,
         *,
-        value: str | None = None,
+        value: str | bool | None = None,
         is_null: bool = False,
+        attribute_name: str = ATTR,
+        attribute_type: AttributeKey.Type.ValueType = AttributeKey.TYPE_STRING,
     ) -> list[str]:
-        av = AttributeValue(val_null=True) if is_null else AttributeValue(val_str=value or "")
+        if is_null:
+            av = AttributeValue(val_null=True)
+        elif attribute_type == AttributeKey.TYPE_BOOLEAN:
+            assert isinstance(value, bool)
+            av = AttributeValue(val_bool=value)
+        else:
+            assert isinstance(value, (str, type(None)))
+            av = AttributeValue(val_str=value or "")
         filt = TraceItemFilter(
             and_filter=AndFilter(
                 filters=[
@@ -1230,7 +1284,7 @@ class TestEmptyVsAbsentComparison:
                     ),
                     TraceItemFilter(
                         comparison_filter=ComparisonFilter(
-                            key=AttributeKey(type=AttributeKey.TYPE_STRING, name=self.ATTR),
+                            key=AttributeKey(type=attribute_type, name=attribute_name),
                             op=op,
                             value=av,
                         )
@@ -1291,6 +1345,14 @@ class TestEmptyVsAbsentComparison:
     def test_not_like_wildcard_matches_only_absent(self) -> None:
         # Present rows all `like '%'`, so only the absent key survives NOT LIKE.
         assert self._execute(ComparisonFilter.OP_NOT_LIKE, value="%") == ["green"]
+
+    def test_boolean_equals_false_excludes_absent(self) -> None:
+        assert self._execute(
+            ComparisonFilter.OP_EQUALS,
+            value=False,
+            attribute_name=self.BOOL_ATTR,
+            attribute_type=AttributeKey.TYPE_BOOLEAN,
+        ) == ["blue"]
 
 
 class TestAnyAttributeFilterOption:


### PR DESCRIPTION
## Summary

- recognize boolean `arrayElement` expressions as map-backed RPC attributes
- guard comparisons against the missing-key default when filtering for `false`
- make boolean `ExistsFilter` check map-key presence
- add expression and end-to-end coverage for true, false, and missing attributes

## Tests

- `uv run pytest tests/web/rpc/test_common.py`
- `uv run pytest tests/web/rpc/v1/test_trace_item_attribute_values_v1.py`
- `uv run pytest tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py`
- `uv run ruff check snuba/web/rpc/common/common.py tests/web/rpc/test_common.py`
- `uv run mypy snuba/web/rpc/common/common.py tests/web/rpc/test_common.py`