### PR TITLE
feat: add llm-proxy-cost-consumer to GoCD deploy

### DIFF
--- a/gocd/templates/bash/deploy-rs.sh
+++ b/gocd/templates/bash/deploy-rs.sh
@@ -15,6 +15,7 @@ IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
   --container-name="generic-metrics-counters-consumer" \
   --container-name="generic-metrics-distributions-consumer" \
   --container-name="generic-metrics-sets-consumer" \
+  --container-name="llm-proxy-cost-consumer" \
   --container-name="loadbalancer-outcomes-consumer" \
   --container-name="metrics-consumer" \
   --container-name="outcomes-billing-consumer" \


### PR DESCRIPTION
## Summary

- Add `llm-proxy-cost-consumer` to the `k8s-deploy` container list in `deploy-rs.sh` so it receives image updates on deploy
- Companion to [ops#22064](https://github.com/getsentry/ops/pull/22064) which adds the consumer deployment definition

## Test plan

- [ ] Verify GoCD deploy picks up the new consumer container on next snuba deploy