### PR TITLE
fix(rpc): boolean attribute SELECT returns empty (not false) for items missing the attribute

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -319,29 +319,12 @@ def _typed_null_for_map_column(column_name: str) -> Expression:
     return literal(None)
 
 
-# Scalar attribute maps that are NOT hash-bucketed, so a projection reads them as a plain
-# ``arrayElement`` rather than a ``SubscriptableReference``. The bucketed string/int/float
-# maps read as ``SubscriptableReference`` and are guarded by the first branch of the transform
-# below; these escape that branch and are matched by ``_non_bucketed_scalar_map_read`` instead.
-# Today only the bool map is non-bucketed — a future non-bucketed scalar type is covered by
-# adding its column here (and a NULL type to ``_MAP_COLUMN_NULL_TYPE``). Deriving the match
-# from this set rather than hardcoding a single type is what keeps the guard from silently
-# missing a type again (getsentry/sentry#119735 was exactly such a miss for booleans).
 _NON_BUCKETED_SCALAR_ATTRIBUTE_MAP_COLUMNS: frozenset[str] = frozenset(
     {PROTO_TYPE_TO_ATTRIBUTE_COLUMN[AttributeKey.Type.TYPE_BOOLEAN]}
 )
 
 
 def _non_bucketed_scalar_map_read(exp: Expression) -> tuple[Column, Expression] | None:
-    """``(map_column, key)`` if ``exp`` is a projection read of a non-bucketed scalar map,
-    ``cast(arrayElement(<non-bucketed map>, <key>), 'Nullable(...)')`` — else ``None``.
-
-    A projection read of such a map is always this cast+``arrayElement`` shape (see
-    ``_generate_subscriptable_reference``); a bare ``arrayElement`` (the WHERE-clause map
-    operands in ``_map_backed_operands``, and typed-array reads) is intentionally not matched,
-    so this never touches a filter/condition read. ``arrayElement`` returns the column
-    default for a missing key (``false`` for ``Bool``), so without the guard the transform
-    adds, the attribute rendered as that default instead of empty."""
     if not (isinstance(exp, FunctionCall) and exp.function_name == "cast" and exp.parameters):
         return None
     inner = exp.parameters[0]
@@ -361,15 +344,6 @@ def _non_bucketed_scalar_map_read(exp: Expression) -> tuple[Column, Expression] 
 
 
 def add_existence_check_to_subscriptable_references(query: Query) -> None:
-    """Guard every projection read of a custom (map-backed) attribute so a missing key reads
-    as NULL, not the column default. The two branches cover the two map storage layouts:
-    bucketed maps read as ``SubscriptableReference`` (string/int/float), non-bucketed maps as
-    ``cast(arrayElement(...))`` (bool). Both are rewritten to ``if(has(mapKeys(col), key),
-    <read>, NULL)``. Keying the second branch off ``_NON_BUCKETED_SCALAR_ATTRIBUTE_MAP_COLUMNS``
-    (rather than a single hardcoded type) means a new non-bucketed type is covered by that set
-    alone, so the guard can't silently miss a type as it did for booleans
-    (getsentry/sentry#119735 follow-up)."""
-
     def transform(exp: Expression) -> Expression:
         if isinstance(exp, SubscriptableReference):
             return FunctionCall(

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -343,7 +343,7 @@ def _non_bucketed_scalar_map_read(exp: Expression) -> tuple[Column, Expression] 
     return None
 
 
-def add_existence_check_to_subscriptable_references(query: Query) -> None:
+def add_existence_check_to_map_attribute_reads(query: Query) -> None:
     def transform(exp: Expression) -> Expression:
         if isinstance(exp, SubscriptableReference):
             return FunctionCall(

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -319,18 +319,29 @@ def _typed_null_for_map_column(column_name: str) -> Expression:
     return literal(None)
 
 
-def _boolean_map_read(exp: Expression) -> tuple[Column, Expression] | None:
-    """Return ``(map_column, key)`` if ``exp`` is a boolean-attribute SELECT read
-    ``cast(arrayElement(attributes_bool, <key>), 'Nullable(Boolean)')``, else ``None``.
+# Scalar attribute maps that are NOT hash-bucketed, so a projection reads them as a plain
+# ``arrayElement`` rather than a ``SubscriptableReference``. The bucketed string/int/float
+# maps read as ``SubscriptableReference`` and are guarded by the first branch of the transform
+# below; these escape that branch and are matched by ``_non_bucketed_scalar_map_read`` instead.
+# Today only the bool map is non-bucketed — a future non-bucketed scalar type is covered by
+# adding its column here (and a NULL type to ``_MAP_COLUMN_NULL_TYPE``). Deriving the match
+# from this set rather than hardcoding a single type is what keeps the guard from silently
+# missing a type again (getsentry/sentry#119735 was exactly such a miss for booleans).
+_NON_BUCKETED_SCALAR_ATTRIBUTE_MAP_COLUMNS: frozenset[str] = frozenset(
+    {PROTO_TYPE_TO_ATTRIBUTE_COLUMN[AttributeKey.Type.TYPE_BOOLEAN]}
+)
 
-    Booleans live in a Map column with no hash buckets, so
-    ``_generate_subscriptable_reference`` emits ``arrayElement`` directly rather than a
-    ``SubscriptableReference``. The existence check below only rewrites
-    ``SubscriptableReference`` reads, so booleans slipped through — and ``arrayElement``
-    reads a missing key as the ``Bool`` default (``false``). A boolean attribute therefore
-    showed as ``false`` for items that don't have it, instead of an empty value
-    (getsentry/sentry#119735 follow-up)."""
-    bool_column = PROTO_TYPE_TO_ATTRIBUTE_COLUMN[AttributeKey.Type.TYPE_BOOLEAN]
+
+def _non_bucketed_scalar_map_read(exp: Expression) -> tuple[Column, Expression] | None:
+    """``(map_column, key)`` if ``exp`` is a projection read of a non-bucketed scalar map,
+    ``cast(arrayElement(<non-bucketed map>, <key>), 'Nullable(...)')`` — else ``None``.
+
+    A projection read of such a map is always this cast+``arrayElement`` shape (see
+    ``_generate_subscriptable_reference``); a bare ``arrayElement`` (the WHERE-clause map
+    operands in ``_map_backed_operands``, and typed-array reads) is intentionally not matched,
+    so this never touches a filter/condition read. ``arrayElement`` returns the column
+    default for a missing key (``false`` for ``Bool``), so without the guard the transform
+    adds, the attribute rendered as that default instead of empty."""
     if not (isinstance(exp, FunctionCall) and exp.function_name == "cast" and exp.parameters):
         return None
     inner = exp.parameters[0]
@@ -341,12 +352,24 @@ def _boolean_map_read(exp: Expression) -> tuple[Column, Expression] | None:
     ):
         return None
     array_arg, key_arg = inner.parameters
-    if isinstance(array_arg, Column) and array_arg.column_name == bool_column:
+    if (
+        isinstance(array_arg, Column)
+        and array_arg.column_name in _NON_BUCKETED_SCALAR_ATTRIBUTE_MAP_COLUMNS
+    ):
         return array_arg, key_arg
     return None
 
 
 def add_existence_check_to_subscriptable_references(query: Query) -> None:
+    """Guard every projection read of a custom (map-backed) attribute so a missing key reads
+    as NULL, not the column default. The two branches cover the two map storage layouts:
+    bucketed maps read as ``SubscriptableReference`` (string/int/float), non-bucketed maps as
+    ``cast(arrayElement(...))`` (bool). Both are rewritten to ``if(has(mapKeys(col), key),
+    <read>, NULL)``. Keying the second branch off ``_NON_BUCKETED_SCALAR_ATTRIBUTE_MAP_COLUMNS``
+    (rather than a single hardcoded type) means a new non-bucketed type is covered by that set
+    alone, so the guard can't silently miss a type as it did for booleans
+    (getsentry/sentry#119735 follow-up)."""
+
     def transform(exp: Expression) -> Expression:
         if isinstance(exp, SubscriptableReference):
             return FunctionCall(
@@ -359,12 +382,9 @@ def add_existence_check_to_subscriptable_references(query: Query) -> None:
                 ),
             )
 
-        # Booleans read via arrayElement (not a SubscriptableReference), so they need the
-        # same existence guard applied explicitly — otherwise a missing key reads as the
-        # `false` default instead of NULL (getsentry/sentry#119735 follow-up).
-        bool_read = _boolean_map_read(exp)
-        if bool_read is not None:
-            map_column, key = bool_read
+        non_bucketed_read = _non_bucketed_scalar_map_read(exp)
+        if non_bucketed_read is not None:
+            map_column, key = non_bucketed_read
             return FunctionCall(
                 alias=exp.alias,
                 function_name="if",
@@ -378,60 +398,6 @@ def add_existence_check_to_subscriptable_references(query: Query) -> None:
         return exp
 
     query.transform_expressions(transform)
-
-
-def _projection_existence_check(read: Expression) -> Expression:
-    """Existence check for a map-backed SELECT read, treating a ``cast`` as transparent and a
-    ``coalesce`` (deprecated-attribute fan-out) as "exists if any branch does". The leaf
-    cases (``SubscriptableReference`` for bucketed maps, ``arrayElement`` for the bool map)
-    are delegated to ``get_field_existence_expression`` so there's a single source of truth
-    for "does this key exist". The cast/coalesce unwrapping is what makes it type-agnostic:
-    int/bool wrap their read in a cast, and deprecated attributes wrap it in a coalesce."""
-    if isinstance(read, FunctionCall) and read.function_name == "cast" and read.parameters:
-        return _projection_existence_check(read.parameters[0])
-    if isinstance(read, FunctionCall) and read.function_name == "coalesce":
-        return combine_or_conditions([_projection_existence_check(p) for p in read.parameters])
-    return get_field_existence_expression(read)
-
-
-def attribute_key_to_projection_expression(attr_key: AttributeKey) -> Expression:
-    """PROTOTYPE — type-driven SELECT read of a custom attribute, guarded so a missing key
-    reads as NULL for *every* scalar type uniformly.
-
-    This is the generic replacement for ``add_existence_check_to_subscriptable_references``.
-    That pass enumerates per-type AST *shapes* — a ``SubscriptableReference`` for the
-    bucketed string/int/float maps, ``cast(arrayElement(...))`` for the non-bucketed bool map
-    — so a type whose read has a novel shape silently escapes the guard (exactly how booleans
-    regressed; see getsentry/sentry#119735 and its follow-up). Here the guard is derived from
-    the attribute's *type* (``_is_map_backed_key`` + the type→ClickHouse-type map), so a new
-    attribute type is covered the moment it's added to those maps — no new shape to teach a
-    matcher.
-
-    Why this can't just be a smarter version of the post-hoc transform: that pass runs over
-    the whole query, and SELECT and WHERE reads share shapes (a WHERE int read is also
-    ``cast(arrayElement(attributes_float, ...))``). A shape matcher general enough to catch
-    every SELECT read would also catch WHERE reads, and wrapping those in ``if(exists, v,
-    NULL)`` re-introduces the analyzer "Not found column ... in block" bug that
-    ``_map_backed_operands`` avoids. Building the guard at SELECT-construction time — where we
-    know the position is a projection — sidesteps that entirely.
-
-    Projection-only, therefore: it emits ``if(exists, value, NULL)``. Normalized columns,
-    ``attr_key`` and array attributes are returned unchanged (real columns / their own
-    empty-array semantics).
-
-    NOT YET WIRED IN. Adopting it means routing every projection read (SELECT columns,
-    group_by, order_by, aggregation inputs) through this builder and dropping the post-hoc
-    transform — a change that needs the full ClickHouse e2e suite to validate, so it's left
-    as a follow-up. Proven in isolation by ``TestProjectionExpressionExistenceGuard``.
-    """
-    read = attribute_key_to_expression(attr_key)
-    if not _is_map_backed_key(attr_key):
-        return read
-
-    alias = read.alias
-    read = replace(read, alias=None)
-    typed_null = f.cast(literal(None), f"Nullable({PROTO_TYPE_TO_CLICKHOUSE_TYPE[attr_key.type]})")
-    return FunctionCall(alias, "if", (_projection_existence_check(read), read, typed_null))
 
 
 def _is_map_backed_key(k: AttributeKey) -> bool:

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -380,6 +380,60 @@ def add_existence_check_to_subscriptable_references(query: Query) -> None:
     query.transform_expressions(transform)
 
 
+def _projection_existence_check(read: Expression) -> Expression:
+    """Existence check for a map-backed SELECT read, treating a ``cast`` as transparent and a
+    ``coalesce`` (deprecated-attribute fan-out) as "exists if any branch does". The leaf
+    cases (``SubscriptableReference`` for bucketed maps, ``arrayElement`` for the bool map)
+    are delegated to ``get_field_existence_expression`` so there's a single source of truth
+    for "does this key exist". The cast/coalesce unwrapping is what makes it type-agnostic:
+    int/bool wrap their read in a cast, and deprecated attributes wrap it in a coalesce."""
+    if isinstance(read, FunctionCall) and read.function_name == "cast" and read.parameters:
+        return _projection_existence_check(read.parameters[0])
+    if isinstance(read, FunctionCall) and read.function_name == "coalesce":
+        return combine_or_conditions([_projection_existence_check(p) for p in read.parameters])
+    return get_field_existence_expression(read)
+
+
+def attribute_key_to_projection_expression(attr_key: AttributeKey) -> Expression:
+    """PROTOTYPE — type-driven SELECT read of a custom attribute, guarded so a missing key
+    reads as NULL for *every* scalar type uniformly.
+
+    This is the generic replacement for ``add_existence_check_to_subscriptable_references``.
+    That pass enumerates per-type AST *shapes* — a ``SubscriptableReference`` for the
+    bucketed string/int/float maps, ``cast(arrayElement(...))`` for the non-bucketed bool map
+    — so a type whose read has a novel shape silently escapes the guard (exactly how booleans
+    regressed; see getsentry/sentry#119735 and its follow-up). Here the guard is derived from
+    the attribute's *type* (``_is_map_backed_key`` + the type→ClickHouse-type map), so a new
+    attribute type is covered the moment it's added to those maps — no new shape to teach a
+    matcher.
+
+    Why this can't just be a smarter version of the post-hoc transform: that pass runs over
+    the whole query, and SELECT and WHERE reads share shapes (a WHERE int read is also
+    ``cast(arrayElement(attributes_float, ...))``). A shape matcher general enough to catch
+    every SELECT read would also catch WHERE reads, and wrapping those in ``if(exists, v,
+    NULL)`` re-introduces the analyzer "Not found column ... in block" bug that
+    ``_map_backed_operands`` avoids. Building the guard at SELECT-construction time — where we
+    know the position is a projection — sidesteps that entirely.
+
+    Projection-only, therefore: it emits ``if(exists, value, NULL)``. Normalized columns,
+    ``attr_key`` and array attributes are returned unchanged (real columns / their own
+    empty-array semantics).
+
+    NOT YET WIRED IN. Adopting it means routing every projection read (SELECT columns,
+    group_by, order_by, aggregation inputs) through this builder and dropping the post-hoc
+    transform — a change that needs the full ClickHouse e2e suite to validate, so it's left
+    as a follow-up. Proven in isolation by ``TestProjectionExpressionExistenceGuard``.
+    """
+    read = attribute_key_to_expression(attr_key)
+    if not _is_map_backed_key(attr_key):
+        return read
+
+    alias = read.alias
+    read = replace(read, alias=None)
+    typed_null = f.cast(literal(None), f"Nullable({PROTO_TYPE_TO_CLICKHOUSE_TYPE[attr_key.type]})")
+    return FunctionCall(alias, "if", (_projection_existence_check(read), read, typed_null))
+
+
 def _is_map_backed_key(k: AttributeKey) -> bool:
     """True when ``k`` is a custom attribute stored in an ``attributes_*`` map column, so
     its filters take the ``(value, exists)`` path (see ``_map_backed_operands``). Excludes

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -1,5 +1,6 @@
 import math
 from collections.abc import Callable, Iterable
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, TypeVar
 
@@ -307,6 +308,7 @@ def dedupe_and_conditions(query: Query) -> None:
 _MAP_COLUMN_NULL_TYPE = {
     "attributes_string": "Nullable(String)",
     "attributes_float": "Nullable(Float64)",
+    "attributes_bool": "Nullable(Boolean)",
 }
 
 
@@ -317,20 +319,63 @@ def _typed_null_for_map_column(column_name: str) -> Expression:
     return literal(None)
 
 
+def _boolean_map_read(exp: Expression) -> tuple[Column, Expression] | None:
+    """Return ``(map_column, key)`` if ``exp`` is a boolean-attribute SELECT read
+    ``cast(arrayElement(attributes_bool, <key>), 'Nullable(Boolean)')``, else ``None``.
+
+    Booleans live in a Map column with no hash buckets, so
+    ``_generate_subscriptable_reference`` emits ``arrayElement`` directly rather than a
+    ``SubscriptableReference``. The existence check below only rewrites
+    ``SubscriptableReference`` reads, so booleans slipped through — and ``arrayElement``
+    reads a missing key as the ``Bool`` default (``false``). A boolean attribute therefore
+    showed as ``false`` for items that don't have it, instead of an empty value
+    (getsentry/sentry#119735 follow-up)."""
+    bool_column = PROTO_TYPE_TO_ATTRIBUTE_COLUMN[AttributeKey.Type.TYPE_BOOLEAN]
+    if not (isinstance(exp, FunctionCall) and exp.function_name == "cast" and exp.parameters):
+        return None
+    inner = exp.parameters[0]
+    if not (
+        isinstance(inner, FunctionCall)
+        and inner.function_name == "arrayElement"
+        and len(inner.parameters) == 2
+    ):
+        return None
+    array_arg, key_arg = inner.parameters
+    if isinstance(array_arg, Column) and array_arg.column_name == bool_column:
+        return array_arg, key_arg
+    return None
+
+
 def add_existence_check_to_subscriptable_references(query: Query) -> None:
     def transform(exp: Expression) -> Expression:
-        if not isinstance(exp, SubscriptableReference):
-            return exp
+        if isinstance(exp, SubscriptableReference):
+            return FunctionCall(
+                alias=exp.alias,
+                function_name="if",
+                parameters=(
+                    map_key_exists(exp.column, exp.key),
+                    SubscriptableReference(None, exp.column, exp.key),
+                    _typed_null_for_map_column(exp.column.column_name),
+                ),
+            )
 
-        return FunctionCall(
-            alias=exp.alias,
-            function_name="if",
-            parameters=(
-                map_key_exists(exp.column, exp.key),
-                SubscriptableReference(None, exp.column, exp.key),
-                _typed_null_for_map_column(exp.column.column_name),
-            ),
-        )
+        # Booleans read via arrayElement (not a SubscriptableReference), so they need the
+        # same existence guard applied explicitly — otherwise a missing key reads as the
+        # `false` default instead of NULL (getsentry/sentry#119735 follow-up).
+        bool_read = _boolean_map_read(exp)
+        if bool_read is not None:
+            map_column, key = bool_read
+            return FunctionCall(
+                alias=exp.alias,
+                function_name="if",
+                parameters=(
+                    map_key_exists(map_column, key),
+                    replace(exp, alias=None),
+                    _typed_null_for_map_column(map_column.column_name),
+                ),
+            )
+
+        return exp
 
     query.transform_expressions(transform)
 

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -28,7 +28,7 @@ from snuba.web.query import run_query
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.common import (
     BUCKET_COUNT,
-    add_existence_check_to_subscriptable_references,
+    add_existence_check_to_map_attribute_reads,
     attribute_key_to_expression,
     base_conditions_and,
     merge_typed_array_maps,
@@ -110,7 +110,7 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
         limit=1,
     )
     treeify_or_and_conditions(res)
-    add_existence_check_to_subscriptable_references(res)
+    add_existence_check_to_map_attribute_reads(res)
     return res
 
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -41,7 +41,7 @@ from snuba.state.sentry_options import get_option
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import run_query
 from snuba.web.rpc.common.common import (
-    add_existence_check_to_subscriptable_references,
+    add_existence_check_to_map_attribute_reads,
     attribute_key_to_expression,
     base_conditions_and,
     trace_item_filters_to_expression,
@@ -437,7 +437,7 @@ def build_query(
         order_by=[OrderBy(expression=column("time_slot"), direction=OrderByDirection.ASC)],
     )
     treeify_or_and_conditions(res)
-    add_existence_check_to_subscriptable_references(res)
+    add_existence_check_to_map_attribute_reads(res)
     return res
 
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -58,7 +58,7 @@ from snuba.request import Request as SnubaRequest
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import run_query
 from snuba.web.rpc.common.common import (
-    add_existence_check_to_subscriptable_references,
+    add_existence_check_to_map_attribute_reads,
     attribute_key_to_expression,
     base_conditions_and,
     get_field_existence_expression,
@@ -689,7 +689,7 @@ def build_query(
     )
     treeify_or_and_conditions(res)
     _apply_virtual_columns(res, request.virtual_column_contexts)
-    add_existence_check_to_subscriptable_references(res)
+    add_existence_check_to_map_attribute_reads(res)
     return res
 
 

--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -27,7 +27,7 @@ from snuba.request import Request as SnubaRequest
 from snuba.web.query import run_query
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.common import (
-    add_existence_check_to_subscriptable_references,
+    add_existence_check_to_map_attribute_reads,
     attribute_key_to_expression,
     base_conditions_and,
     treeify_or_and_conditions,
@@ -135,7 +135,7 @@ def _build_query(
         limit=10000,
     )
     treeify_or_and_conditions(inner_query)
-    add_existence_check_to_subscriptable_references(inner_query)
+    add_existence_check_to_map_attribute_reads(inner_query)
     res = CompositeQuery(
         from_clause=inner_query,
         selected_columns=[

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -56,6 +56,7 @@ from snuba.web.rpc.common.common import (
     _comparison_can_match_column_default,
     add_existence_check_to_subscriptable_references,
     attribute_key_to_expression,
+    attribute_key_to_projection_expression,
     dedupe_and_conditions,
     next_monday,
     prev_monday,
@@ -794,9 +795,10 @@ class TestAnalyzerSafeFilters:
 
 
 class TestBooleanAttributeFilters:
-    """Booleans are map-backed, so ``attr:false`` needs an existence guard — otherwise a
-    missing key reads as the ``false`` default and matches items lacking the attribute
-    (getsentry/sentry#119735).
+    """Booleans are map-backed, so they need an existence guard — otherwise a missing key
+    reads as the ``false`` default. In a filter (``attr:false``) that wrongly matches items
+    lacking the attribute; in a SELECT it wrongly renders as ``false`` instead of empty
+    (getsentry/sentry#119735 and its follow-up).
     """
 
     @staticmethod
@@ -849,14 +851,40 @@ class TestBooleanAttributeFilters:
         columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
         assert columns == {"attributes_bool"}
 
+    def _bool_select_after_transform(self, name: str = "hasCodeTag") -> Expression:
+        key = AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name=name)
+        query = Query(
+            from_clause=None,
+            selected_columns=[SelectedExpression(name, attribute_key_to_expression(key))],
+        )
+        add_existence_check_to_subscriptable_references(query)
+        return query.get_selected_columns()[0].expression
 
-class TestBooleanAttributeExistenceCheckInSelect:
-    """A boolean read in the SELECT clause is ``arrayElement(attributes_bool, key)`` (the
-    bool Map has no hash buckets, so it's not a ``SubscriptableReference``). Without an
-    explicit existence guard, ``arrayElement`` returns the ``false`` default for a missing
-    key, so the attribute rendered as ``false`` for items lacking it instead of an empty
-    value. ``add_existence_check_to_subscriptable_references`` must wrap it in
-    ``if(has(mapKeys(...)), value, NULL)`` (getsentry/sentry#119735 follow-up).
+    def test_select_guards_missing_key_as_null(self) -> None:
+        # In a SELECT a bool read is cast(arrayElement(attributes_bool, key)), not a
+        # SubscriptableReference, so add_existence_check_to_subscriptable_references must
+        # guard it too — otherwise a missing key renders as the `false` default instead of
+        # empty (getsentry/sentry#119735 follow-up).
+        expr = self._bool_select_after_transform()
+        # if(has(mapKeys(attributes_bool), 'hasCodeTag'), value, cast(NULL, ...))
+        assert isinstance(expr, FunctionCall) and expr.function_name == "if"
+        assert {"if", "has", "mapKeys", "arrayElement"} <= self._fn_names(expr)
+        _, value, otherwise = expr.parameters
+        assert isinstance(otherwise, FunctionCall) and otherwise.function_name == "cast"
+        assert otherwise.parameters[0] == Literal(None, None)  # typed NULL, not false
+        columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
+        assert columns == {"attributes_bool"}
+        # alias moves to the outer if(...); the inner value must not carry it (a duplicate
+        # alias would collide in the SELECT clause).
+        assert expr.alias == "hasCodeTag_TYPE_BOOLEAN"
+        assert value.alias is None
+
+
+class TestProjectionExpressionExistenceGuard:
+    """[Prototype] ``attribute_key_to_projection_expression`` derives the missing-key -> NULL
+    guard from the attribute *type*, so every scalar map type is guarded uniformly — unlike
+    the per-type shape matching in ``add_existence_check_to_subscriptable_references`` that
+    booleans slipped through. Normalized (real) columns are returned unguarded.
     """
 
     @staticmethod
@@ -873,52 +901,33 @@ class TestBooleanAttributeExistenceCheckInSelect:
     def _fn_names(self, expr: Expression) -> set[str]:
         return {n.function_name for n in self._walk(expr) if isinstance(n, FunctionCall)}
 
-    def _select_after_transform(self, key: AttributeKey) -> Expression:
-        expr = attribute_key_to_expression(key)
-        query = Query(
-            from_clause=None,
-            selected_columns=[SelectedExpression(key.name, expr)],
-        )
-        add_existence_check_to_subscriptable_references(query)
-        return query.get_selected_columns()[0].expression
-
-    def test_boolean_select_is_guarded_with_null_default(self) -> None:
-        expr = self._select_after_transform(
-            AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="hasCodeTag")
-        )
-        # if(has(mapKeys(attributes_bool), 'hasCodeTag'), <value>, cast(NULL, ...))
-        assert isinstance(expr, FunctionCall) and expr.function_name == "if"
-        assert {"if", "has", "mapKeys", "arrayElement"} <= self._fn_names(expr)
-        condition, value, otherwise = expr.parameters
-        assert isinstance(condition, FunctionCall) and condition.function_name == "has"
-        # the else branch is a typed NULL, so a missing key reads as empty, not false.
-        assert isinstance(otherwise, FunctionCall) and otherwise.function_name == "cast"
-        assert otherwise.parameters[0] == Literal(None, None)
-
-    def test_boolean_select_reads_attributes_bool(self) -> None:
-        expr = self._select_after_transform(
-            AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="hasCodeTag")
-        )
-        columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
-        assert columns == {"attributes_bool"}
-
-    def test_boolean_select_keeps_column_alias(self) -> None:
-        key = AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="hasCodeTag")
-        expr = self._select_after_transform(key)
-        # alias moves to the outer if(...); the inner cast must not carry it (a duplicate
-        # alias would collide in the SELECT clause).
-        assert isinstance(expr, FunctionCall)
-        assert expr.alias == "hasCodeTag_TYPE_BOOLEAN"
-        _, value, _ = expr.parameters
-        assert value.alias is None
-
-    def test_string_select_still_guarded(self) -> None:
-        # regression: strings resolve to a SubscriptableReference and keep their guard.
-        expr = self._select_after_transform(
-            AttributeKey(type=AttributeKey.Type.TYPE_STRING, name="some.tag")
-        )
+    @pytest.mark.parametrize(
+        "attr_type,column",
+        [
+            (AttributeKey.Type.TYPE_STRING, "attributes_string"),
+            (AttributeKey.Type.TYPE_INT, "attributes_float"),
+            (AttributeKey.Type.TYPE_FLOAT, "attributes_float"),
+            (AttributeKey.Type.TYPE_DOUBLE, "attributes_float"),
+            (AttributeKey.Type.TYPE_BOOLEAN, "attributes_bool"),
+        ],
+    )
+    def test_scalar_types_are_guarded_uniformly(
+        self, attr_type: "AttributeKey.Type.ValueType", column: str
+    ) -> None:
+        expr = attribute_key_to_projection_expression(AttributeKey(type=attr_type, name="myattr"))
+        # if(has(mapKeys(<col>), 'myattr'), value, cast(NULL, ...)) for every scalar type.
         assert isinstance(expr, FunctionCall) and expr.function_name == "if"
         assert {"if", "has", "mapKeys"} <= self._fn_names(expr)
+        columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
+        assert columns == {column}
+
+    def test_normalized_column_is_not_guarded(self) -> None:
+        # a real column (not a map lookup) is returned as-is, no existence guard.
+        expr = attribute_key_to_projection_expression(
+            AttributeKey(type=AttributeKey.Type.TYPE_STRING, name="sentry.trace_id")
+        )
+        assert not (isinstance(expr, FunctionCall) and expr.function_name == "if")
+        assert "mapKeys" not in self._fn_names(expr)
 
 
 class TestNormalizedColumnsNotMapBacked:

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -54,7 +54,7 @@ from snuba.query.logical import Query
 from snuba.web.rpc.common.common import (
     _any_attribute_filter_to_expression,
     _comparison_can_match_column_default,
-    add_existence_check_to_subscriptable_references,
+    add_existence_check_to_map_attribute_reads,
     attribute_key_to_expression,
     dedupe_and_conditions,
     next_monday,
@@ -856,7 +856,7 @@ class TestBooleanAttributeFilters:
             from_clause=None,
             selected_columns=[SelectedExpression(name, attribute_key_to_expression(key))],
         )
-        add_existence_check_to_subscriptable_references(query)
+        add_existence_check_to_map_attribute_reads(query)
         return query.get_selected_columns()[0].expression
 
     def test_select_guards_missing_key_as_null(self) -> None:

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -56,7 +56,6 @@ from snuba.web.rpc.common.common import (
     _comparison_can_match_column_default,
     add_existence_check_to_subscriptable_references,
     attribute_key_to_expression,
-    attribute_key_to_projection_expression,
     dedupe_and_conditions,
     next_monday,
     prev_monday,
@@ -878,56 +877,6 @@ class TestBooleanAttributeFilters:
         # alias would collide in the SELECT clause).
         assert expr.alias == "hasCodeTag_TYPE_BOOLEAN"
         assert value.alias is None
-
-
-class TestProjectionExpressionExistenceGuard:
-    """[Prototype] ``attribute_key_to_projection_expression`` derives the missing-key -> NULL
-    guard from the attribute *type*, so every scalar map type is guarded uniformly — unlike
-    the per-type shape matching in ``add_existence_check_to_subscriptable_references`` that
-    booleans slipped through. Normalized (real) columns are returned unguarded.
-    """
-
-    @staticmethod
-    def _walk(expr: Expression) -> list[Expression]:
-        nodes: list[Expression] = []
-
-        def visit(node: Expression) -> Expression:
-            nodes.append(node)
-            return node
-
-        expr.transform(visit)
-        return nodes
-
-    def _fn_names(self, expr: Expression) -> set[str]:
-        return {n.function_name for n in self._walk(expr) if isinstance(n, FunctionCall)}
-
-    @pytest.mark.parametrize(
-        "attr_type,column",
-        [
-            (AttributeKey.Type.TYPE_STRING, "attributes_string"),
-            (AttributeKey.Type.TYPE_INT, "attributes_float"),
-            (AttributeKey.Type.TYPE_FLOAT, "attributes_float"),
-            (AttributeKey.Type.TYPE_DOUBLE, "attributes_float"),
-            (AttributeKey.Type.TYPE_BOOLEAN, "attributes_bool"),
-        ],
-    )
-    def test_scalar_types_are_guarded_uniformly(
-        self, attr_type: "AttributeKey.Type.ValueType", column: str
-    ) -> None:
-        expr = attribute_key_to_projection_expression(AttributeKey(type=attr_type, name="myattr"))
-        # if(has(mapKeys(<col>), 'myattr'), value, cast(NULL, ...)) for every scalar type.
-        assert isinstance(expr, FunctionCall) and expr.function_name == "if"
-        assert {"if", "has", "mapKeys"} <= self._fn_names(expr)
-        columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
-        assert columns == {column}
-
-    def test_normalized_column_is_not_guarded(self) -> None:
-        # a real column (not a map lookup) is returned as-is, no existence guard.
-        expr = attribute_key_to_projection_expression(
-            AttributeKey(type=AttributeKey.Type.TYPE_STRING, name="sentry.trace_id")
-        )
-        assert not (isinstance(expr, FunctionCall) and expr.function_name == "if")
-        assert "mapKeys" not in self._fn_names(expr)
 
 
 class TestNormalizedColumnsNotMapBacked:

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -37,6 +37,7 @@ from snuba.protos.common import (
     MalformedAttributeException,
     type_array_to_membership_array_expression_from_typed_columns,
 )
+from snuba.query import SelectedExpression
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import and_cond, column
 from snuba.query.expressions import (
@@ -53,6 +54,7 @@ from snuba.query.logical import Query
 from snuba.web.rpc.common.common import (
     _any_attribute_filter_to_expression,
     _comparison_can_match_column_default,
+    add_existence_check_to_subscriptable_references,
     attribute_key_to_expression,
     dedupe_and_conditions,
     next_monday,
@@ -846,6 +848,76 @@ class TestBooleanAttributeFilters:
         expr = self._build(ComparisonFilter.OP_EQUALS, value=AttributeValue(val_bool=False))
         columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
         assert columns == {"attributes_bool"}
+
+
+class TestBooleanAttributeExistenceCheckInSelect:
+    """A boolean read in the SELECT clause is ``arrayElement(attributes_bool, key)`` (the
+    bool Map has no hash buckets, so it's not a ``SubscriptableReference``). Without an
+    explicit existence guard, ``arrayElement`` returns the ``false`` default for a missing
+    key, so the attribute rendered as ``false`` for items lacking it instead of an empty
+    value. ``add_existence_check_to_subscriptable_references`` must wrap it in
+    ``if(has(mapKeys(...)), value, NULL)`` (getsentry/sentry#119735 follow-up).
+    """
+
+    @staticmethod
+    def _walk(expr: Expression) -> list[Expression]:
+        nodes: list[Expression] = []
+
+        def visit(node: Expression) -> Expression:
+            nodes.append(node)
+            return node
+
+        expr.transform(visit)
+        return nodes
+
+    def _fn_names(self, expr: Expression) -> set[str]:
+        return {n.function_name for n in self._walk(expr) if isinstance(n, FunctionCall)}
+
+    def _select_after_transform(self, key: AttributeKey) -> Expression:
+        expr = attribute_key_to_expression(key)
+        query = Query(
+            from_clause=None,
+            selected_columns=[SelectedExpression(key.name, expr)],
+        )
+        add_existence_check_to_subscriptable_references(query)
+        return query.get_selected_columns()[0].expression
+
+    def test_boolean_select_is_guarded_with_null_default(self) -> None:
+        expr = self._select_after_transform(
+            AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="hasCodeTag")
+        )
+        # if(has(mapKeys(attributes_bool), 'hasCodeTag'), <value>, cast(NULL, ...))
+        assert isinstance(expr, FunctionCall) and expr.function_name == "if"
+        assert {"if", "has", "mapKeys", "arrayElement"} <= self._fn_names(expr)
+        condition, value, otherwise = expr.parameters
+        assert isinstance(condition, FunctionCall) and condition.function_name == "has"
+        # the else branch is a typed NULL, so a missing key reads as empty, not false.
+        assert isinstance(otherwise, FunctionCall) and otherwise.function_name == "cast"
+        assert otherwise.parameters[0] == Literal(None, None)
+
+    def test_boolean_select_reads_attributes_bool(self) -> None:
+        expr = self._select_after_transform(
+            AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="hasCodeTag")
+        )
+        columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
+        assert columns == {"attributes_bool"}
+
+    def test_boolean_select_keeps_column_alias(self) -> None:
+        key = AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="hasCodeTag")
+        expr = self._select_after_transform(key)
+        # alias moves to the outer if(...); the inner cast must not carry it (a duplicate
+        # alias would collide in the SELECT clause).
+        assert expr.alias == "hasCodeTag_TYPE_BOOLEAN"
+        _, value, _ = expr.parameters
+        assert value.alias is None
+
+    def test_string_select_still_guarded(self) -> None:
+        # regression: strings resolve to a SubscriptableReference and keep their guard.
+        expr = self._select_after_transform(
+            AttributeKey(type=AttributeKey.Type.TYPE_STRING, name="some.tag")
+        )
+        assert isinstance(expr, FunctionCall) and expr.function_name == "if"
+        assert {"if", "has", "mapKeys"} <= self._fn_names(expr)
 
 
 class TestNormalizedColumnsNotMapBacked:

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -907,6 +907,7 @@ class TestBooleanAttributeExistenceCheckInSelect:
         expr = self._select_after_transform(key)
         # alias moves to the outer if(...); the inner cast must not carry it (a duplicate
         # alias would collide in the SELECT clause).
+        assert isinstance(expr, FunctionCall)
         assert expr.alias == "hasCodeTag_TYPE_BOOLEAN"
         _, value, _ = expr.parameters
         assert value.alias is None

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -860,21 +860,14 @@ class TestBooleanAttributeFilters:
         return query.get_selected_columns()[0].expression
 
     def test_select_guards_missing_key_as_null(self) -> None:
-        # In a SELECT a bool read is cast(arrayElement(attributes_bool, key)), not a
-        # SubscriptableReference, so add_existence_check_to_subscriptable_references must
-        # guard it too — otherwise a missing key renders as the `false` default instead of
-        # empty (getsentry/sentry#119735 follow-up).
         expr = self._bool_select_after_transform()
-        # if(has(mapKeys(attributes_bool), 'hasCodeTag'), value, cast(NULL, ...))
         assert isinstance(expr, FunctionCall) and expr.function_name == "if"
         assert {"if", "has", "mapKeys", "arrayElement"} <= self._fn_names(expr)
         _, value, otherwise = expr.parameters
         assert isinstance(otherwise, FunctionCall) and otherwise.function_name == "cast"
-        assert otherwise.parameters[0] == Literal(None, None)  # typed NULL, not false
+        assert otherwise.parameters[0] == Literal(None, None)
         columns = {n.column_name for n in self._walk(expr) if isinstance(n, ColumnExpr)}
         assert columns == {"attributes_bool"}
-        # alias moves to the outer if(...); the inner value must not carry it (a duplicate
-        # alias would collide in the SELECT clause).
         assert expr.alias == "hasCodeTag_TYPE_BOOLEAN"
         assert value.alias is None
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
@@ -202,9 +202,6 @@ class TestBooleanAttributeFilteringForLogs(BaseApiTest):
         assert returned == list(range(10, 20))
 
     def test_select_absent_attribute_is_null_not_false(self, setup_bool_logs_in_db: Any) -> None:
-        # Selecting the attribute (rather than filtering on it) must return an empty (NULL)
-        # value for items lacking it, not the `false` default (getsentry/sentry#119735
-        # follow-up).
         message = TraceItemTableRequest(
             meta=RequestMeta(
                 project_ids=[1, 2, 3],
@@ -236,12 +233,11 @@ class TestBooleanAttributeFilteringForLogs(BaseApiTest):
         response = EndpointTraceItemTable().execute(message)
         by_label = {v.attribute_name: v for v in response.column_values}
         int_values = [v.val_int for v in by_label["int_tag"].results]
-        # int_tag drives the row order, so zip pairs each row's int with its bool value.
         by_int = dict(zip(int_values, by_label["hasCodeTag"].results, strict=True))
 
-        for i in range(10):  # stored false -> explicit false, not NULL
+        for i in range(10):
             assert by_int[i].WhichOneof("value") == "val_bool" and by_int[i].val_bool is False
-        for i in range(10, 20):  # stored true
+        for i in range(10, 20):
             assert by_int[i].WhichOneof("value") == "val_bool" and by_int[i].val_bool is True
-        for i in range(20, 30):  # absent -> NULL/empty, NOT false
+        for i in range(20, 30):
             assert by_int[i].is_null is True and by_int[i].WhichOneof("value") != "val_bool"

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
@@ -200,3 +200,64 @@ class TestBooleanAttributeFilteringForLogs(BaseApiTest):
         (values,) = response.column_values
         returned = sorted(v.val_int for v in values.results)
         assert returned == list(range(10, 20))
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
+class TestBooleanAttributeSelectForLogs(BaseApiTest):
+    """Selecting a boolean attribute must return an empty (NULL) value for items that don't
+    have it, not ``false``. Booleans read via ``arrayElement``, which yields the ``false``
+    default for a missing key unless an existence guard is added (getsentry/sentry#119735
+    follow-up)."""
+
+    def _select_hascodetag(self) -> TraceItemTableResponse:
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                request_id="be3123b3-2e5d-4eb9-bb48-f38eaa9e8480",
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+            ),
+            columns=[
+                Column(
+                    key=AttributeKey(type=AttributeKey.Type.TYPE_INT, name="int_tag"),
+                    label="int_tag",
+                ),
+                Column(
+                    key=AttributeKey(type=AttributeKey.Type.TYPE_BOOLEAN, name="hasCodeTag"),
+                    label="hasCodeTag",
+                ),
+            ],
+            order_by=[
+                TraceItemTableRequest.OrderBy(
+                    column=Column(key=AttributeKey(type=AttributeKey.TYPE_INT, name="int_tag"))
+                )
+            ],
+            limit=50,
+        )
+        return EndpointTraceItemTable().execute(message)
+
+    def test_absent_boolean_is_null_not_false(self, setup_bool_logs_in_db: Any) -> None:
+        response = self._select_hascodetag()
+        by_label = {v.attribute_name: v for v in response.column_values}
+        int_values = [v.val_int for v in by_label["int_tag"].results]
+        bool_results = by_label["hasCodeTag"].results
+        # int_tag drives the row order, so zip pairs each row's int with its bool value.
+        by_int = dict(zip(int_values, bool_results, strict=True))
+
+        # 0-9: attribute stored false -> an explicit false value (not NULL).
+        for i in range(10):
+            assert by_int[i].WhichOneof("value") == "val_bool"
+            assert by_int[i].val_bool is False
+        # 10-19: attribute stored true.
+        for i in range(10, 20):
+            assert by_int[i].WhichOneof("value") == "val_bool"
+            assert by_int[i].val_bool is True
+        # 20-29: attribute absent -> NULL/empty, NOT false.
+        for i in range(20, 30):
+            assert by_int[i].is_null is True
+            assert by_int[i].WhichOneof("value") != "val_bool"

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_logs.py
@@ -201,16 +201,10 @@ class TestBooleanAttributeFilteringForLogs(BaseApiTest):
         returned = sorted(v.val_int for v in values.results)
         assert returned == list(range(10, 20))
 
-
-@pytest.mark.eap
-@pytest.mark.redis_db
-class TestBooleanAttributeSelectForLogs(BaseApiTest):
-    """Selecting a boolean attribute must return an empty (NULL) value for items that don't
-    have it, not ``false``. Booleans read via ``arrayElement``, which yields the ``false``
-    default for a missing key unless an existence guard is added (getsentry/sentry#119735
-    follow-up)."""
-
-    def _select_hascodetag(self) -> TraceItemTableResponse:
+    def test_select_absent_attribute_is_null_not_false(self, setup_bool_logs_in_db: Any) -> None:
+        # Selecting the attribute (rather than filtering on it) must return an empty (NULL)
+        # value for items lacking it, not the `false` default (getsentry/sentry#119735
+        # follow-up).
         message = TraceItemTableRequest(
             meta=RequestMeta(
                 project_ids=[1, 2, 3],
@@ -239,25 +233,15 @@ class TestBooleanAttributeSelectForLogs(BaseApiTest):
             ],
             limit=50,
         )
-        return EndpointTraceItemTable().execute(message)
-
-    def test_absent_boolean_is_null_not_false(self, setup_bool_logs_in_db: Any) -> None:
-        response = self._select_hascodetag()
+        response = EndpointTraceItemTable().execute(message)
         by_label = {v.attribute_name: v for v in response.column_values}
         int_values = [v.val_int for v in by_label["int_tag"].results]
-        bool_results = by_label["hasCodeTag"].results
         # int_tag drives the row order, so zip pairs each row's int with its bool value.
-        by_int = dict(zip(int_values, bool_results, strict=True))
+        by_int = dict(zip(int_values, by_label["hasCodeTag"].results, strict=True))
 
-        # 0-9: attribute stored false -> an explicit false value (not NULL).
-        for i in range(10):
-            assert by_int[i].WhichOneof("value") == "val_bool"
-            assert by_int[i].val_bool is False
-        # 10-19: attribute stored true.
-        for i in range(10, 20):
-            assert by_int[i].WhichOneof("value") == "val_bool"
-            assert by_int[i].val_bool is True
-        # 20-29: attribute absent -> NULL/empty, NOT false.
-        for i in range(20, 30):
-            assert by_int[i].is_null is True
-            assert by_int[i].WhichOneof("value") != "val_bool"
+        for i in range(10):  # stored false -> explicit false, not NULL
+            assert by_int[i].WhichOneof("value") == "val_bool" and by_int[i].val_bool is False
+        for i in range(10, 20):  # stored true
+            assert by_int[i].WhichOneof("value") == "val_bool" and by_int[i].val_bool is True
+        for i in range(20, 30):  # absent -> NULL/empty, NOT false
+            assert by_int[i].is_null is True and by_int[i].WhichOneof("value") != "val_bool"


### PR DESCRIPTION
Follow-up to #8191.

That PR fixed boolean attribute **filtering** — `hasCodeTag:false` no longer matches items that don't have the attribute. But **selecting** a boolean attribute for display still showed `false` for items missing it, instead of an empty field. (Reported: "the search is fixed … but the table still shows the attribute as false for logs that do not have it instead of an empty field.")

### Root cause

`add_existence_check_to_subscriptable_references` wraps map reads in `if(has(mapKeys(...)), value, NULL)` so a missing key reads as NULL — but it only rewrote `SubscriptableReference` nodes. Booleans live in a `Map` with no hash buckets, so they read as `cast(arrayElement(attributes_bool, key), 'Nullable(Boolean)')` rather than a `SubscriptableReference`, slipped past the guard, and `arrayElement` returns the `Bool` default (`false`) for a missing key.

### Fix — a generic existence guard (not a per-type patch)

Rather than special-casing booleans, the guard now keys off the two map **storage layouts** instead of the attribute's type:

* **bucketed maps** (string/int/float) read as `SubscriptableReference` — first branch (unchanged).
* **non-bucketed maps** read as `cast(arrayElement(...))` — matched via a named `_NON_BUCKETED_SCALAR_ATTRIBUTE_MAP_COLUMNS` set (bool today).

Both are rewritten to `if(has(mapKeys(col), key), <read>, NULL)`. A new non-bucketed scalar type is covered by adding its column to that set (plus a NULL type to `_MAP_COLUMN_NULL_TYPE`) — so the guard can't silently miss a type the way it missed booleans.

The matcher requires the `cast`+`arrayElement` shape, so it only ever matches **projection** reads. Bare `arrayElement` — the WHERE-clause map operands built by `_map_backed_operands`, and typed-array reads — is never touched, so the #8191 filter fix is preserved and no NULL is introduced into a WHERE `in(...)` (the analyzer "Not found column … in block" bug). Verified directly: `hasCodeTag:false` still generates `and(has(mapKeys(attributes_bool), 'hasCodeTag'), equals(arrayElement(attributes_bool, 'hasCodeTag'), false))` unchanged.

### Why not a fully type-driven, build-time guard

A build-time guard (guarding at SELECT construction, keyed purely off the attribute type, dropping the post-hoc pass) would be even more general. But `attribute_key_to_expression` is a shared read builder threaded through the whole aggregation engine for **both** projection and filter reads — including conditions *inside* conditional aggregates, where a guarded NULL re-triggers the analyzer bug. Splitting projection-vs-filter construction across that surface needs the full ClickHouse e2e suite to validate, so it's left as a dedicated follow-up rather than done blind here.

### Tests

* `tests/web/rpc/test_common.py::TestBooleanAttributeFilters::test_select_guards_missing_key_as_null` — the transform wraps a boolean SELECT read in `if(has(mapKeys(...)), value, NULL)`, reads `attributes_bool`, uses a typed-NULL else, and moves the alias to the outer `if` (no SELECT-clause collision).
* `tests/web/rpc/v1/.../test_endpoint_trace_item_table_logs.py::TestBooleanAttributeFilteringForLogs::test_select_absent_attribute_is_null_not_false` — end-to-end against ClickHouse (reusing the three-group fixture from #8191): selecting `hasCodeTag` returns an explicit value for the stored-`false`/`true` groups and NULL (not `false`) for the absent group.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)