### PR TITLE
feat(admin): Exempt ai_conversation_id column from query scrubbing

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -34,6 +34,14 @@ class InvalidStorageError(SerializableException):
 
 
 def is_scrub_exempt_column(col_name: str | None) -> bool:
+    """Return whether a column is exempt from result scrubbing.
+
+    Scrubbing is deny-by-default: trace query results are scrubbed unless a
+    value is obviously safe (number, datetime, UUID, hex) or its column appears
+    here. This exemption list is maintained separately, by hand, so that adding
+    a column is a deliberate act -- we never want to accidentally unscrub a
+    column that may carry sensitive data.
+    """
     return col_name in {"ai_conversation_id"}
 
 

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -377,12 +377,17 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
     # `expr AS x` lands in columns_aliases_names, ARRAY JOIN aliases in
     # tables_aliases, and ClickHouse's `WITH <expr> AS <alias>` is in neither.
     #
+    # Also `SELECT a b FROM c` doesn't have an `as` keyword.  So need to check
+    # if the next token is a valid alias instead of relying on that.
+    #
     # So we walk the token stream and reject whenever the
     # token right after an AS is an exempt column name.
     invalid_aliases = sorted(
         t.next_token.value
         for t in parsed.tokens
-        if t.is_as_keyword and t.next_token and is_scrub_exempt_column(t.next_token.value)
+        if t.next_token
+        and (t.is_as_keyword or t.next_token.is_a_valid_alias)
+        and is_scrub_exempt_column(t.next_token.value)
     )
     if invalid_aliases:
         raise InvalidCustomQuery(

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -368,10 +368,22 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
     if parsed.query_type != QueryType.SELECT:
         raise InvalidCustomQuery("Only SELECT queries are allowed")
 
-    # we need to unscrub some specific values.  Currently we do it by column name.  Don't allow queries that alias those names.
-    # ARRAY JOIN aliases are parsed into tables_aliases keys rather than columns_aliases_names (see below), so check both.
-    aliased_names = set(parsed.columns_aliases_names) | set(parsed.tables_aliases)
-    invalid_aliases = sorted(a for a in aliased_names if is_scrub_exempt_column(a))
+    # Result scrubbing is keyed on the column name ClickHouse reports (see
+    # is_scrub_exempt_column / scrub_row), so a query that aliases an arbitrary
+    # expression to an exempt name would surface unscrubbed data under a name
+    # the scrubber trusts. Reject any such alias here.
+    #
+    # We can't rely on the parser's alias views to catch every form: plain
+    # `expr AS x` lands in columns_aliases_names, ARRAY JOIN aliases in
+    # tables_aliases, and ClickHouse's `WITH <expr> AS <alias>` is in neither.
+    #
+    # So we walk the token stream and reject whenever the
+    # token right after an AS is an exempt column name.
+    invalid_aliases = sorted(
+        t.next_token.value
+        for t in parsed.tokens
+        if t.is_as_keyword and t.next_token and is_scrub_exempt_column(t.next_token.value)
+    )
     if invalid_aliases:
         raise InvalidCustomQuery(
             f"Aliasing the following columns aren't allowed: {','.join(invalid_aliases)}"

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -368,8 +368,10 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
     if parsed.query_type != QueryType.SELECT:
         raise InvalidCustomQuery("Only SELECT queries are allowed")
 
-    # we need to unscrub some specific values.  Currently we do it by column name.  Don't allow queries that alias those names
-    invalid_aliases = [a for a in parsed.columns_aliases_names if is_scrub_exempt_column(a)]
+    # we need to unscrub some specific values.  Currently we do it by column name.  Don't allow queries that alias those names.
+    # ARRAY JOIN aliases are parsed into tables_aliases keys rather than columns_aliases_names (see below), so check both.
+    aliased_names = set(parsed.columns_aliases_names) | set(parsed.tables_aliases)
+    invalid_aliases = sorted(a for a in aliased_names if is_scrub_exempt_column(a))
     if invalid_aliases:
         raise InvalidCustomQuery(
             f"Aliasing the following columns aren't allowed: {','.join(invalid_aliases)}"

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -33,6 +33,10 @@ class InvalidStorageError(SerializableException):
     pass
 
 
+def is_scrub_exempt_column(col_name: str | None) -> bool:
+    return col_name in {"ai_conversation_id"}
+
+
 def is_valid_node(host: str, port: int, cluster: ClickhouseCluster, storage_name: str) -> bool:
     nodes = [
         cluster.get_query_node(),
@@ -355,6 +359,13 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
 
     if parsed.query_type != QueryType.SELECT:
         raise InvalidCustomQuery("Only SELECT queries are allowed")
+
+    # we need to unscrub some specific values.  Currently we do it by column name.  Don't allow queries that alias those names
+    invalid_aliases = [a for a in parsed.columns_aliases_names if is_scrub_exempt_column(a)]
+    if invalid_aliases:
+        raise InvalidCustomQuery(
+            f"Aliasing the following columns aren't allowed: {','.join(invalid_aliases)}"
+        )
 
     # This parser doesn't handle ARRAY JOIN clauses correctly, so do some
     # massaging to get around that. What ends up happening is that the columns

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
+    is_scrub_exempt_column,
     validate_ro_query,
 )
 from snuba.admin.clickhouse.trace_log_parsing import (
@@ -47,12 +48,13 @@ def run_query_and_get_trace(
         query=query, capture_trace=True, with_column_types=True, settings=settings or {}
     )
     summarized_trace_output = summarize_trace_output(query_result.trace_output)
+    cols = cast("list[tuple[str, str]]", query_result.meta)
     return TraceOutput(
         trace_output=query_result.trace_output,
         summarized_trace_output=summarized_trace_output,
-        cols=cast("list[tuple[str, str]]", query_result.meta),
+        cols=cols,
         num_rows_result=len(query_result.results),
-        result=list(map(scrub_row, query_result.results)),
+        result=[scrub_row(row, cols) for row in query_result.results],
         profile_events_results={},
         profile_events_meta=[],
         profile_events_profile={},
@@ -70,10 +72,11 @@ def is_hex(value: Any) -> bool:
         return False
 
 
-def scrub_row(row: tuple[Any, ...]) -> tuple[Any, ...]:
+def scrub_row(row: tuple[Any, ...], meta: list[tuple[str, str]] | None = None) -> tuple[Any, ...]:
     rv: list[Any] = []
-    for val in row:
-        if isinstance(val, (datetime, UUID)) or is_hex(val):
+    for i, val in enumerate(row):
+        col_name = meta[i][0] if meta and i < len(meta) else None
+        if is_scrub_exempt_column(col_name) or isinstance(val, (datetime, UUID)) or is_hex(val):
             rv.append(val)
         elif isinstance(val, (int, float)):
             if math.isnan(val):

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -38,32 +38,62 @@ def test_ai_conversation_id_column_is_not_scrubbed() -> None:
     assert conversation_id in values
 
 
-def test_aliasing_to_exempt_column_raises() -> None:
-    # The scrub exemption is keyed on the reported column name, so aliasing an
-    # arbitrary expression to an exempt name would let it bypass scrubbing.
-    # Such queries are rejected up front by validate_ro_query.
+# Aliasing an arbitrary expression to the exempt `ai_conversation_id` name must
+# be rejected in every position it can appear -- SELECT scalar, ARRAY JOIN, and
+# CTE (WITH) -- and in every spelling: plain `AS`, keywordless (SELECT only),
+# and quoted (double-quote / backtick, which ClickHouse treats as identifiers).
+_ALIASING_QUERIES = [
+    # SELECT scalar alias
+    pytest.param(
+        f"SELECT project_id AS ai_conversation_id FROM {TABLE}",
+        id="select_scalar-as",
+    ),
+    pytest.param(
+        f"SELECT project_id ai_conversation_id FROM {TABLE}",
+        id="select_scalar-no_as",
+    ),
+    pytest.param(
+        f'SELECT project_id AS "ai_conversation_id" FROM {TABLE}',
+        id="select_scalar-quoted_double",
+    ),
+    pytest.param(
+        f"SELECT project_id AS `ai_conversation_id` FROM {TABLE}",
+        id="select_scalar-quoted_backtick",
+    ),
+    # ARRAY JOIN alias
+    pytest.param(
+        f"SELECT trace_id FROM {TABLE} ARRAY JOIN some_arr AS ai_conversation_id",
+        id="array_join-as",
+    ),
+    pytest.param(
+        f'SELECT trace_id FROM {TABLE} ARRAY JOIN some_arr AS "ai_conversation_id"',
+        id="array_join-quoted_double",
+    ),
+    pytest.param(
+        f"SELECT trace_id FROM {TABLE} ARRAY JOIN some_arr AS `ai_conversation_id`",
+        id="array_join-quoted_backtick",
+    ),
+    # CTE (WITH) alias -- ClickHouse's inverted `WITH <expr> AS <name>`
+    pytest.param(
+        f"WITH project_id AS ai_conversation_id SELECT ai_conversation_id FROM {TABLE}",
+        id="cte-as",
+    ),
+    pytest.param(
+        f'WITH project_id AS "ai_conversation_id" SELECT "ai_conversation_id" FROM {TABLE}',
+        id="cte-quoted_double",
+    ),
+    pytest.param(
+        f"WITH project_id AS `ai_conversation_id` SELECT `ai_conversation_id` FROM {TABLE}",
+        id="cte-quoted_backtick",
+    ),
+]
+
+
+@pytest.mark.parametrize("query", _ALIASING_QUERIES)
+def test_aliasing_to_exempt_column_raises(query: str) -> None:
+    # Result scrubbing trusts the reported column name (see is_scrub_exempt_column
+    # / scrub_row), so aliasing an arbitrary expression to an exempt name would
+    # surface unscrubbed data under a trusted name. validate_ro_query must reject
+    # it up front, in every position and spelling above.
     with pytest.raises(InvalidCustomQuery, match="Aliasing"):
-        run_query_and_get_trace(STORAGE, f"SELECT project_id AS ai_conversation_id FROM {TABLE}")
-
-
-def test_array_join_aliasing_to_exempt_column_raises() -> None:
-    # ARRAY JOIN aliases are parsed into tables_aliases rather than
-    # columns_aliases_names, so they must be rejected too -- otherwise an
-    # arbitrary array could be surfaced under the exempt column name.
-    with pytest.raises(InvalidCustomQuery, match="Aliasing"):
-        run_query_and_get_trace(
-            STORAGE, f"SELECT trace_id FROM {TABLE} ARRAY JOIN some_arr AS ai_conversation_id"
-        )
-
-
-def test_with_clause_aliasing_to_exempt_column_raises() -> None:
-    # ClickHouse `WITH <expr> AS <name>` defines an alias, so a WITH clause can
-    # surface an arbitrary expression under the exempt result column name and
-    # bypass scrubbing. sql_metadata mis-parses this inverted syntax (the exempt
-    # name lands in neither columns_aliases_names nor tables_aliases), so this
-    # must be rejected explicitly. WITH is otherwise allowed in the trace shell.
-    with pytest.raises(InvalidCustomQuery, match="Aliasing"):
-        run_query_and_get_trace(
-            STORAGE,
-            f"WITH project_id AS ai_conversation_id SELECT ai_conversation_id FROM {TABLE}",
-        )
+        run_query_and_get_trace(STORAGE, query)

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -22,7 +22,9 @@ def test_ai_conversation_id_column_is_not_scrubbed() -> None:
     # The proto conversation_id field is written to the ai_conversation_id column.
     conversation_id = "conv-not-hex-zzz"
     item = TraceItem()
-    item.ParseFromString(gen_item_message(start_timestamp=datetime.now(tz=UTC) - timedelta(minutes=5)))
+    item.ParseFromString(
+        gen_item_message(start_timestamp=datetime.now(tz=UTC) - timedelta(minutes=5))
+    )
     item.conversation_id = conversation_id
     write_raw_unprocessed_events(
         get_writable_storage(StorageKey("eap_items")),

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -54,3 +54,16 @@ def test_array_join_aliasing_to_exempt_column_raises() -> None:
         run_query_and_get_trace(
             STORAGE, f"SELECT trace_id FROM {TABLE} ARRAY JOIN some_arr AS ai_conversation_id"
         )
+
+
+def test_with_clause_aliasing_to_exempt_column_raises() -> None:
+    # ClickHouse `WITH <expr> AS <name>` defines an alias, so a WITH clause can
+    # surface an arbitrary expression under the exempt result column name and
+    # bypass scrubbing. sql_metadata mis-parses this inverted syntax (the exempt
+    # name lands in neither columns_aliases_names nor tables_aliases), so this
+    # must be rejected explicitly. WITH is otherwise allowed in the trace shell.
+    with pytest.raises(InvalidCustomQuery, match="Aliasing"):
+        run_query_and_get_trace(
+            STORAGE,
+            f"WITH project_id AS ai_conversation_id SELECT ai_conversation_id FROM {TABLE}",
+        )

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -1,5 +1,44 @@
-from snuba.admin.clickhouse.tracing import scrub_row
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from snuba.admin.clickhouse.common import InvalidCustomQuery
+from snuba.admin.clickhouse.tracing import run_query_and_get_trace
+from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from tests.helpers import write_raw_unprocessed_events
+from tests.web.rpc.v1.test_utils import gen_item_message
+
+STORAGE = "eap_items"
+TABLE = "eap_items_1_local"
 
 
-def test_scrub() -> None:
-    assert scrub_row((1, 2, 3, "release name")) == (1, 2, 3, "<scrubbed: str>")
+@pytest.mark.clickhouse_db
+@pytest.mark.redis_db
+def test_ai_conversation_id_column_is_not_scrubbed() -> None:
+    # Seed a span whose ai_conversation_id is a non-hex string, so that only the
+    # scrub exemption (and not the hex/UUID passthrough) can leave it intact.
+    conversation_id = "conv-not-hex-zzz"
+    write_raw_unprocessed_events(
+        get_writable_storage(StorageKey("eap_items")),
+        [
+            gen_item_message(
+                start_timestamp=datetime.now(tz=UTC) - timedelta(minutes=5),
+                conversation_id=conversation_id,
+            )
+        ],
+    )
+
+    trace = run_query_and_get_trace(STORAGE, f"SELECT ai_conversation_id FROM {TABLE}")
+
+    assert trace.cols[0][0] == "ai_conversation_id"
+    values = [row[0] for row in trace.result]
+    assert conversation_id in values
+
+
+def test_aliasing_to_exempt_column_raises() -> None:
+    # The scrub exemption is keyed on the reported column name, so aliasing an
+    # arbitrary expression to an exempt name would let it bypass scrubbing.
+    # Such queries are rejected up front by validate_ro_query.
+    with pytest.raises(InvalidCustomQuery, match="Aliasing"):
+        run_query_and_get_trace(STORAGE, f"SELECT project_id AS ai_conversation_id FROM {TABLE}")

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from snuba.admin.clickhouse.common import InvalidCustomQuery
 from snuba.admin.clickhouse.tracing import run_query_and_get_trace
@@ -18,15 +19,14 @@ TABLE = "eap_items_1_local"
 def test_ai_conversation_id_column_is_not_scrubbed() -> None:
     # Seed a span whose ai_conversation_id is a non-hex string, so that only the
     # scrub exemption (and not the hex/UUID passthrough) can leave it intact.
+    # The proto conversation_id field is written to the ai_conversation_id column.
     conversation_id = "conv-not-hex-zzz"
+    item = TraceItem()
+    item.ParseFromString(gen_item_message(start_timestamp=datetime.now(tz=UTC) - timedelta(minutes=5)))
+    item.conversation_id = conversation_id
     write_raw_unprocessed_events(
         get_writable_storage(StorageKey("eap_items")),
-        [
-            gen_item_message(
-                start_timestamp=datetime.now(tz=UTC) - timedelta(minutes=5),
-                conversation_id=conversation_id,
-            )
-        ],
+        [item.SerializeToString()],
     )
 
     trace = run_query_and_get_trace(STORAGE, f"SELECT ai_conversation_id FROM {TABLE}")
@@ -42,3 +42,13 @@ def test_aliasing_to_exempt_column_raises() -> None:
     # Such queries are rejected up front by validate_ro_query.
     with pytest.raises(InvalidCustomQuery, match="Aliasing"):
         run_query_and_get_trace(STORAGE, f"SELECT project_id AS ai_conversation_id FROM {TABLE}")
+
+
+def test_array_join_aliasing_to_exempt_column_raises() -> None:
+    # ARRAY JOIN aliases are parsed into tables_aliases rather than
+    # columns_aliases_names, so they must be rejected too -- otherwise an
+    # arbitrary array could be surfaced under the exempt column name.
+    with pytest.raises(InvalidCustomQuery, match="Aliasing"):
+        run_query_and_get_trace(
+            STORAGE, f"SELECT trace_id FROM {TABLE} ARRAY JOIN some_arr AS ai_conversation_id"
+        )


### PR DESCRIPTION
## Summary

Admin ClickHouse trace queries scrub all result values by default, keeping only numbers, datetimes, UUIDs, and hex strings — everything else is replaced with a `<scrubbed: ...>` placeholder. This meant the `ai_conversation_id` column (a non-hex `String`) was unusable in the admin trace tool.

This change exempts `ai_conversation_id` from scrubbing, keyed on the column name reported in the query result metadata.

## Changes

- **`scrub_row` now receives column metadata** and consults `is_scrub_exempt_column` to leave exempt columns intact.
- **`is_scrub_exempt_column` added to `admin/clickhouse/common.py`** — the single, hand-maintained source of truth for which columns bypass scrubbing (currently just `ai_conversation_id`).
- **`validate_ro_query` rejects queries that alias any expression to an exempt column name.** Because the exemption is keyed on the reported result-column name, aliasing an arbitrary expression to `ai_conversation_id` would otherwise surface unscrubbed data under a trusted name. The parser reports aliases inconsistently across forms — `SELECT expr AS x` lands in `columns_aliases_names`, `ARRAY JOIN … AS x` in `tables_aliases`, and ClickHouse's inverted `WITH expr AS x` in neither — so validation walks the token stream and rejects whenever the token following an `AS` is an exempt column name. `WITH` itself remains allowed.

## Tests

- Seeds an `eap_items` row with a non-hex `ai_conversation_id` and verifies it survives a trace query unscrubbed (so the exemption — not the hex/UUID passthrough — is what's exercised).
- Verifies aliasing to `ai_conversation_id` is rejected via plain `AS`, `ARRAY JOIN … AS`, and `WITH … AS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
