### PR TITLE
ref(metrics): timer histogram metrics are now emitted as distributions…

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3396,6 +3396,7 @@ dependencies = [
  "md5",
  "metrics",
  "metrics-exporter-dogstatsd",
+ "metrics-util",
  "once_cell",
  "parking_lot",
  "procspawn",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -76,6 +76,7 @@ bytes = "1.11"
 
 
 [dev-dependencies]
+metrics-util = "0.20"
 scopeguard = "1.2.0"
 criterion = "0.5.1"
 httpmock = "0.7.0"

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -37,7 +37,7 @@ impl DogStatsDBackend {
             .expect("invalid DogStatsD address")
             .set_global_prefix(prefix)
             .with_global_labels(global_labels)
-            .send_histograms_as_distributions(false)
+            .send_histograms_as_distributions(true)
             .with_telemetry(true)
             .install()
             .expect("failed to install DogStatsD exporter");
@@ -148,10 +148,10 @@ impl Recorder for DogStatsDBackend {
             labels.push(Label::new(k, v));
         }
         let metadata = metrics::Metadata::new("snuba", metrics::Level::INFO, None);
-        let key = metrics::Key::from_parts(key, labels);
 
         match metric.ty {
             MetricType::Counter => {
+                let key = metrics::Key::from_parts(key, labels);
                 let value = match metric.value {
                     MetricValue::I64(v) => v as u64,
                     MetricValue::U64(v) => v,
@@ -164,6 +164,7 @@ impl Recorder for DogStatsDBackend {
                 });
             }
             MetricType::Gauge => {
+                let key = metrics::Key::from_parts(key, labels);
                 let value = match metric.value {
                     MetricValue::I64(v) => v as f64,
                     MetricValue::U64(v) => v as f64,
@@ -176,6 +177,7 @@ impl Recorder for DogStatsDBackend {
                 });
             }
             MetricType::Timer => {
+                let key = metrics::Key::from_parts(format!("{key}.distribution"), labels);
                 let value = match metric.value {
                     MetricValue::I64(v) => v as f64,
                     MetricValue::U64(v) => v as f64,
@@ -205,6 +207,35 @@ mod tests {
         backend.record_metric(metric!(Counter: "a", 1, "tag1" => "value1"));
         backend.record_metric(metric!(Gauge: "b", 20, "tag2" => "value2"));
         backend.record_metric(metric!(Timer: "c", 30, "tag3" => "value3"));
+    }
+
+    #[test]
+    fn timer_is_renamed_with_distribution_suffix() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        // Construct the backend directly (no exporter install), and capture emitted
+        // metrics via a thread-local recorder so we don't touch the global one.
+        let backend = DogStatsDBackend;
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            backend.record_metric(metric!(Timer: "insertions.batch_write_ms", 30));
+            backend.record_metric(metric!(Counter: "insertions.batch_write_msgs", 1));
+        });
+
+        let names: Vec<String> = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ck, _, _, _)| ck.key().name().to_string())
+            .collect();
+
+        // Timer -> renamed to a ".distribution" metric (existing convention)
+        assert_eq!(names[0], "insertions.batch_write_ms.distribution");
+        // Counter -> name unchanged.
+        assert_eq!(names[1], "insertions.batch_write_msgs");
+        assert_eq!(names.len(), 2);
     }
 
     fn env_with(host: Option<&str>, port: Option<u16>, socket: Option<&str>) -> EnvConfig {


### PR DESCRIPTION
Refs [EAP-628](https://linear.app/getsentry/issue/EAP-628/forward-real-dogstatsd-distribution-metrics-from-consumers)

## Description
Timers now emit as DogStatsD distributions under a `.distribution`-suffixed name giving real server-sid percentiles instead of veneur-era pre-aggregated histograms. Matches the Python SentryDatadogMetricsBackend convention (`dualwrite.py`).

## Rollout Plan
*Not controlled by flags.*
Bird-dog s4s2 and deploy previous build / pause deploy pipeline if metrics are mangled.

## Note: 
Applies to all timers, including arroyo ones. Old histogram metric names stop on deploy. dashboards/monitors must move to the `.distribution` names (supposedly already done, but tbd).



### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
