### PR TITLE
feat(eap): gate unpopulated normalized columns behind a per-org allowlist

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -407,6 +407,11 @@
       "default": "",
       "description": "Comma-separated org ids allowed to issue EAP-items lightweight deletes; empty means all orgs are allowed."
     },
+    "eap_items_unbackfilled_normalized_columns_org_allowlist": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated org ids that read the not-yet-backfilled EAP-items normalized columns (session_id, ai_conversation_id) as real columns; empty (default) means no orgs are opted in and everyone falls through to the attributes_* map path."
+    },
     "max_parts_mutating_for_delete": {
       "type": "integer",
       "default": 20,

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -407,10 +407,10 @@
       "default": "",
       "description": "Comma-separated org ids allowed to issue EAP-items lightweight deletes; empty means all orgs are allowed."
     },
-    "eap_items_unbackfilled_normalized_columns_org_allowlist": {
+    "eap_items_unpopulated_normalized_columns_org_allowlist": {
       "type": "string",
       "default": "",
-      "description": "Comma-separated org ids that read the not-yet-backfilled EAP-items normalized columns (session_id, ai_conversation_id) as real columns; empty (default) means no orgs are opted in and everyone falls through to the attributes_* map path."
+      "description": "Comma-separated org ids that read the not-yet-populated EAP-items normalized columns (session_id, ai_conversation_id) as real columns; empty (default) means no orgs are opted in and everyone falls through to the attributes_* map path."
     },
     "max_parts_mutating_for_delete": {
       "type": "integer",

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -495,10 +495,10 @@
       "default": "",
       "description": "Comma-separated org ids allowed to issue EAP-items lightweight deletes; empty means all orgs are allowed."
     },
-    "eap_items_unbackfilled_normalized_columns_org_allowlist": {
+    "eap_items_unpopulated_normalized_columns_org_allowlist": {
       "type": "string",
       "default": "",
-      "description": "Comma-separated org ids that read the not-yet-backfilled EAP-items normalized columns (session_id, ai_conversation_id) as real columns; empty (default) means no orgs are opted in and everyone falls through to the attributes_* map path."
+      "description": "Comma-separated org ids that read the not-yet-populated EAP-items normalized columns (session_id, ai_conversation_id) as real columns; empty (default) means no orgs are opted in and everyone falls through to the attributes_* map path."
     },
     "max_parts_mutating_for_delete": {
       "type": "integer",

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -495,6 +495,11 @@
       "default": "",
       "description": "Comma-separated org ids allowed to issue EAP-items lightweight deletes; empty means all orgs are allowed."
     },
+    "eap_items_unbackfilled_normalized_columns_org_allowlist": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-separated org ids that read the not-yet-backfilled EAP-items normalized columns (session_id, ai_conversation_id) as real columns; empty (default) means no orgs are opted in and everyone falls through to the attributes_* map path."
+    },
     "max_parts_mutating_for_delete": {
       "type": "integer",
       "default": 20,

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -14,6 +14,7 @@ from snuba.query.expressions import (
     Lambda,
     SubscriptableReference,
 )
+from snuba.state.sentry_options import get_option
 
 
 class MalformedAttributeException(Exception):
@@ -35,7 +36,7 @@ def sentry_column(column_name: str) -> str:
     return f"sentry.{column_name}"
 
 
-NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
+_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     sentry_column("organization_id"): NormalizedColumn(
         "organization_id", [AttributeKey.Type.TYPE_INT]
     ),
@@ -58,11 +59,44 @@ NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     sentry_column("sampling_factor"): NormalizedColumn(
         "sampling_factor", [AttributeKey.Type.TYPE_DOUBLE]
     ),
+}
+
+# These columns are newly normalized: their dedicated columns are populated going forward,
+# but historical rows have NOT been backfilled. Reading them as real columns is gated per
+# organization, so it's opt-in for orgs that are fine with the missing historical data.
+# For everyone else they fall through to the attributes_* map path (which does cover the
+# historical rows).
+_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     sentry_column("session_id"): NormalizedColumn("session_id", [AttributeKey.Type.TYPE_STRING]),
     "gen_ai.conversation.id": NormalizedColumn(
         "ai_conversation_id", [AttributeKey.Type.TYPE_STRING]
     ),
 }
+
+# Comma-separated org-id allowlist (sentry-option). Orgs in this list read the not-yet-
+# backfilled normalized columns above as real columns; everyone else falls through to the
+# attributes_* map path. Unlike org_ids_delete_allowlist, empty (the default) means NO orgs
+# are opted in -- this feature is off until an org is explicitly added.
+UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION = (
+    "eap_items_unbackfilled_normalized_columns_org_allowlist"
+)
+
+
+def _org_allowed_unbackfilled_columns(organization_id: int) -> bool:
+    allowlist = get_option(UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
+    if not allowlist:
+        return False
+    return organization_id in {int(org_id) for org_id in allowlist.split(",")}
+
+
+def get_normalized_columns_eap_items(organization_id: int) -> Mapping[str, NormalizedColumn]:
+    """The normalized EAP-item columns. Includes the not-yet-backfilled columns only for
+    organizations in the ``eap_items_unbackfilled_normalized_columns_org_allowlist``
+    sentry-option."""
+    if _org_allowed_unbackfilled_columns(organization_id):
+        return {**_NORMALIZED_COLUMNS_EAP_ITEMS, **_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS}
+    return _NORMALIZED_COLUMNS_EAP_ITEMS
+
 
 PROTO_TYPE_TO_CLICKHOUSE_TYPE: Final[Mapping[AttributeKey.Type.ValueType, str]] = {
     AttributeKey.Type.TYPE_INT: "Int64",
@@ -305,8 +339,11 @@ def type_array_typed_element_column_native_array(attr_key: AttributeKey) -> Func
     return arrayElement(alias, column(col), literal(attr_key.name))
 
 
-def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
+
+    ``organization_id`` selects the per-org normalized-column set (see
+    ``get_normalized_columns_eap_items``).
 
     Raises:
         MalformedAttributeException: If the attribute key is invalid or malformed.
@@ -321,8 +358,9 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
     if attr_key.name == "attr_key":
         return column("attr_key")
 
-    if attr_key.name in NORMALIZED_COLUMNS_EAP_ITEMS:
-        normalized_column = NORMALIZED_COLUMNS_EAP_ITEMS[attr_key.name]
+    normalized_columns = get_normalized_columns_eap_items(organization_id)
+    if attr_key.name in normalized_columns:
+        normalized_column = normalized_columns[attr_key.name]
         if attr_key.type not in normalized_column.types:
             formatted_attribute_types = ", ".join(
                 map(

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -191,6 +191,12 @@ TYPED_ARRAY_MAP_COLUMNS: tuple[str, ...] = (
     "attributes_array_bool",
 )
 
+# Normalized String columns whose unset value ingests as an empty string (not NULL) — e.g.
+# ai_conversation_id when a TraceItem has no conversation_id. Because the column is never NULL,
+# existence must be checked with notEmpty(...) instead of isNotNull(...), which would otherwise
+# match every row (see get_field_existence_expression).
+EMPTY_STRING_DEFAULT_COLUMNS: tuple[str, ...] = ("ai_conversation_id",)
+
 
 def type_array_typed_columns_select_expressions(attr_key: AttributeKey) -> list[FunctionCall]:
     """Native ``arrayElement`` read per typed array map column, for a deprecated untyped

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -65,11 +65,13 @@ _NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
 }
 
 # These columns are newly normalized: their dedicated columns are populated going forward,
-# but historical rows have NOT been backfilled. Reading them as real columns is gated per
+# but historical rows were never backfilled. Reading them as real columns is gated per
 # organization, so it's opt-in for orgs that are fine with the missing historical data.
 # For everyone else they fall through to the attributes_* map path (which does cover the
 # historical rows).
-_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
+# This should mostly remain empty, and shoudl be only used in scenarios where we add a new index
+# column, and need to wait for the population to happen.
+_UNPOPULATED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     sentry_column("session_id"): NormalizedColumn("session_id", [AttributeKey.Type.TYPE_STRING]),
     "gen_ai.conversation.id": NormalizedColumn(
         "ai_conversation_id", [AttributeKey.Type.TYPE_STRING]
@@ -78,21 +80,21 @@ _UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]
 
 _ALL_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     **_NORMALIZED_COLUMNS_EAP_ITEMS,
-    **_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS,
+    **_UNPOPULATED_NORMALIZED_COLUMNS_EAP_ITEMS,
 }
 
 # Comma-separated org-id allowlist (sentry-option). Orgs in this list read the not-yet-
-# backfilled normalized columns above as real columns; everyone else falls through to the
+# populated normalized columns above as real columns; everyone else falls through to the
 # attributes_* map path. Unlike org_ids_delete_allowlist, empty (the default) means NO orgs
 # are opted in -- this feature is off until an org is explicitly added.
-UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION = (
-    "eap_items_unbackfilled_normalized_columns_org_allowlist"
+UNPOPULATED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION = (
+    "eap_items_unpopulated_normalized_columns_org_allowlist"
 )
 
 
-def _org_allowed_unbackfilled_columns(organization_id: int | None) -> bool:
+def _org_allowed_unpopulated_columns(organization_id: int | None) -> bool:
     # No org in context (e.g. a delete that isn't scoped to one) => opted out.
-    allowlist = get_option(UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
+    allowlist = get_option(UNPOPULATED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
     if not allowlist or organization_id is None:
         return False
     try:
@@ -101,7 +103,7 @@ def _org_allowed_unbackfilled_columns(organization_id: int | None) -> bool:
         # A malformed allowlist (e.g. a stray comma or a non-numeric entry) must not break
         # every EAP query -- treat the org as opted out.
         logger.warning(
-            f"Malformed {UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION} "
+            f"Malformed {UNPOPULATED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION} "
             f"sentry-option: {allowlist!r}; treating org as opted out"
         )
         return False
@@ -110,10 +112,10 @@ def _org_allowed_unbackfilled_columns(organization_id: int | None) -> bool:
 def get_normalized_columns_eap_items(
     organization_id: int | None,
 ) -> Mapping[str, NormalizedColumn]:
-    """The normalized EAP-item columns. Includes the not-yet-backfilled columns only for
-    organizations in the ``eap_items_unbackfilled_normalized_columns_org_allowlist``
+    """The normalized EAP-item columns. Includes the not-yet-populated columns only for
+    organizations in the ``eap_items_unpopulated_normalized_columns_org_allowlist``
     sentry-option. ``organization_id`` is ``None`` when there is no org in context."""
-    if _org_allowed_unbackfilled_columns(organization_id):
+    if _org_allowed_unpopulated_columns(organization_id):
         return _ALL_NORMALIZED_COLUMNS_EAP_ITEMS
     return _NORMALIZED_COLUMNS_EAP_ITEMS
 

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Final, NamedTuple
@@ -15,6 +16,8 @@ from snuba.query.expressions import (
     SubscriptableReference,
 )
 from snuba.state.sentry_options import get_option
+
+logger = logging.getLogger(__name__)
 
 
 class MalformedAttributeException(Exception):
@@ -92,7 +95,16 @@ def _org_allowed_unbackfilled_columns(organization_id: int | None) -> bool:
     allowlist = get_option(UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
     if not allowlist or organization_id is None:
         return False
-    return organization_id in {int(org_id) for org_id in allowlist.split(",")}
+    try:
+        return organization_id in {int(org_id) for org_id in allowlist.split(",")}
+    except Exception:
+        # A malformed allowlist (e.g. a stray comma or a non-numeric entry) must not break
+        # every EAP query -- treat the org as opted out.
+        logger.warning(
+            f"Malformed {UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION} "
+            f"sentry-option: {allowlist!r}; treating org as opted out"
+        )
+        return False
 
 
 def get_normalized_columns_eap_items(

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Final
+from typing import Final, NamedTuple
 
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
@@ -26,23 +26,32 @@ class MalformedAttributeException(Exception):
     pass
 
 
-COLUMN_PREFIX: str = "sentry."
+class NormalizedColumn(NamedTuple):
+    column_name: str
+    types: Sequence[AttributeKey.Type.ValueType]
 
-NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, Sequence[AttributeKey.Type.ValueType]]] = {
-    f"{COLUMN_PREFIX}organization_id": [AttributeKey.Type.TYPE_INT],
-    f"{COLUMN_PREFIX}project_id": [AttributeKey.Type.TYPE_INT],
-    f"{COLUMN_PREFIX}timestamp": [
-        AttributeKey.Type.TYPE_FLOAT,
-        AttributeKey.Type.TYPE_DOUBLE,
-        AttributeKey.Type.TYPE_INT,
-        AttributeKey.Type.TYPE_STRING,
-    ],
-    f"{COLUMN_PREFIX}trace_id": [
-        AttributeKey.Type.TYPE_STRING
-    ],  # this gets converted from a uuid to a string in a storage processor
-    f"{COLUMN_PREFIX}item_id": [AttributeKey.Type.TYPE_STRING],
-    f"{COLUMN_PREFIX}sampling_weight": [AttributeKey.Type.TYPE_DOUBLE],
-    f"{COLUMN_PREFIX}sampling_factor": [AttributeKey.Type.TYPE_DOUBLE],
+
+NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
+    "sentry.organization_id": NormalizedColumn("organization_id", [AttributeKey.Type.TYPE_INT]),
+    "sentry.project_id": NormalizedColumn("project_id", [AttributeKey.Type.TYPE_INT]),
+    "sentry.timestamp": NormalizedColumn(
+        "timestamp",
+        [
+            AttributeKey.Type.TYPE_FLOAT,
+            AttributeKey.Type.TYPE_DOUBLE,
+            AttributeKey.Type.TYPE_INT,
+            AttributeKey.Type.TYPE_STRING,
+        ],
+    ),
+    # trace_id gets converted from a uuid to a string in a storage processor
+    "sentry.trace_id": NormalizedColumn("trace_id", [AttributeKey.Type.TYPE_STRING]),
+    "sentry.item_id": NormalizedColumn("item_id", [AttributeKey.Type.TYPE_STRING]),
+    "sentry.sampling_weight": NormalizedColumn("sampling_weight", [AttributeKey.Type.TYPE_DOUBLE]),
+    "sentry.sampling_factor": NormalizedColumn("sampling_factor", [AttributeKey.Type.TYPE_DOUBLE]),
+    "sentry.session_id": NormalizedColumn("session_id", [AttributeKey.Type.TYPE_STRING]),
+    "gen_ai.conversation.id": NormalizedColumn(
+        "ai_conversation_id", [AttributeKey.Type.TYPE_STRING]
+    ),
 }
 
 PROTO_TYPE_TO_CLICKHOUSE_TYPE: Final[Mapping[AttributeKey.Type.ValueType, str]] = {
@@ -297,11 +306,12 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
         return column("attr_key")
 
     if attr_key.name in NORMALIZED_COLUMNS_EAP_ITEMS:
-        if attr_key.type not in NORMALIZED_COLUMNS_EAP_ITEMS[attr_key.name]:
+        normalized_column = NORMALIZED_COLUMNS_EAP_ITEMS[attr_key.name]
+        if attr_key.type not in normalized_column.types:
             formatted_attribute_types = ", ".join(
                 map(
                     AttributeKey.Type.Name,
-                    NORMALIZED_COLUMNS_EAP_ITEMS[attr_key.name],
+                    normalized_column.types,
                 )
             )
             raise MalformedAttributeException(
@@ -309,7 +319,7 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
             )
 
         return f.cast(
-            column(attr_key.name[len(COLUMN_PREFIX) :]),
+            column(normalized_column.column_name),
             PROTO_TYPE_TO_CLICKHOUSE_TYPE[attr_key.type],
             alias=alias,
         )

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -73,6 +73,11 @@ _UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]
     ),
 }
 
+_ALL_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
+    **_NORMALIZED_COLUMNS_EAP_ITEMS,
+    **_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS,
+}
+
 # Comma-separated org-id allowlist (sentry-option). Orgs in this list read the not-yet-
 # backfilled normalized columns above as real columns; everyone else falls through to the
 # attributes_* map path. Unlike org_ids_delete_allowlist, empty (the default) means NO orgs
@@ -84,10 +89,8 @@ UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION = (
 
 def _org_allowed_unbackfilled_columns(organization_id: int | None) -> bool:
     # No org in context (e.g. a delete that isn't scoped to one) => opted out.
-    if organization_id is None:
-        return False
     allowlist = get_option(UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
-    if not allowlist:
+    if not allowlist or organization_id is None:
         return False
     return organization_id in {int(org_id) for org_id in allowlist.split(",")}
 
@@ -99,7 +102,7 @@ def get_normalized_columns_eap_items(
     organizations in the ``eap_items_unbackfilled_normalized_columns_org_allowlist``
     sentry-option. ``organization_id`` is ``None`` when there is no org in context."""
     if _org_allowed_unbackfilled_columns(organization_id):
-        return {**_NORMALIZED_COLUMNS_EAP_ITEMS, **_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS}
+        return _ALL_NORMALIZED_COLUMNS_EAP_ITEMS
     return _NORMALIZED_COLUMNS_EAP_ITEMS
 
 

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -31,10 +31,16 @@ class NormalizedColumn(NamedTuple):
     types: Sequence[AttributeKey.Type.ValueType]
 
 
+def sentry_column(column_name: str) -> str:
+    return f"sentry.{column_name}"
+
+
 NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
-    "sentry.organization_id": NormalizedColumn("organization_id", [AttributeKey.Type.TYPE_INT]),
-    "sentry.project_id": NormalizedColumn("project_id", [AttributeKey.Type.TYPE_INT]),
-    "sentry.timestamp": NormalizedColumn(
+    sentry_column("organization_id"): NormalizedColumn(
+        "organization_id", [AttributeKey.Type.TYPE_INT]
+    ),
+    sentry_column("project_id"): NormalizedColumn("project_id", [AttributeKey.Type.TYPE_INT]),
+    sentry_column("timestamp"): NormalizedColumn(
         "timestamp",
         [
             AttributeKey.Type.TYPE_FLOAT,
@@ -44,11 +50,15 @@ NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
         ],
     ),
     # trace_id gets converted from a uuid to a string in a storage processor
-    "sentry.trace_id": NormalizedColumn("trace_id", [AttributeKey.Type.TYPE_STRING]),
-    "sentry.item_id": NormalizedColumn("item_id", [AttributeKey.Type.TYPE_STRING]),
-    "sentry.sampling_weight": NormalizedColumn("sampling_weight", [AttributeKey.Type.TYPE_DOUBLE]),
-    "sentry.sampling_factor": NormalizedColumn("sampling_factor", [AttributeKey.Type.TYPE_DOUBLE]),
-    "sentry.session_id": NormalizedColumn("session_id", [AttributeKey.Type.TYPE_STRING]),
+    sentry_column("trace_id"): NormalizedColumn("trace_id", [AttributeKey.Type.TYPE_STRING]),
+    sentry_column("item_id"): NormalizedColumn("item_id", [AttributeKey.Type.TYPE_STRING]),
+    sentry_column("sampling_weight"): NormalizedColumn(
+        "sampling_weight", [AttributeKey.Type.TYPE_DOUBLE]
+    ),
+    sentry_column("sampling_factor"): NormalizedColumn(
+        "sampling_factor", [AttributeKey.Type.TYPE_DOUBLE]
+    ),
+    sentry_column("session_id"): NormalizedColumn("session_id", [AttributeKey.Type.TYPE_STRING]),
     "gen_ai.conversation.id": NormalizedColumn(
         "ai_conversation_id", [AttributeKey.Type.TYPE_STRING]
     ),

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -82,17 +82,22 @@ UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION = (
 )
 
 
-def _org_allowed_unbackfilled_columns(organization_id: int) -> bool:
+def _org_allowed_unbackfilled_columns(organization_id: int | None) -> bool:
+    # No org in context (e.g. a delete that isn't scoped to one) => opted out.
+    if organization_id is None:
+        return False
     allowlist = get_option(UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
     if not allowlist:
         return False
     return organization_id in {int(org_id) for org_id in allowlist.split(",")}
 
 
-def get_normalized_columns_eap_items(organization_id: int) -> Mapping[str, NormalizedColumn]:
+def get_normalized_columns_eap_items(
+    organization_id: int | None,
+) -> Mapping[str, NormalizedColumn]:
     """The normalized EAP-item columns. Includes the not-yet-backfilled columns only for
     organizations in the ``eap_items_unbackfilled_normalized_columns_org_allowlist``
-    sentry-option."""
+    sentry-option. ``organization_id`` is ``None`` when there is no org in context."""
     if _org_allowed_unbackfilled_columns(organization_id):
         return {**_NORMALIZED_COLUMNS_EAP_ITEMS, **_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS}
     return _NORMALIZED_COLUMNS_EAP_ITEMS
@@ -339,11 +344,11 @@ def type_array_typed_element_column_native_array(attr_key: AttributeKey) -> Func
     return arrayElement(alias, column(col), literal(attr_key.name))
 
 
-def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int | None) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
     ``organization_id`` selects the per-org normalized-column set (see
-    ``get_normalized_columns_eap_items``).
+    ``get_normalized_columns_eap_items``); ``None`` when there is no org in context.
 
     Raises:
         MalformedAttributeException: If the attribute key is invalid or malformed.

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -71,12 +71,7 @@ _NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
 # historical rows).
 # This should mostly remain empty, and shoudl be only used in scenarios where we add a new index
 # column, and need to wait for the population to happen.
-_UNPOPULATED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
-    sentry_column("session_id"): NormalizedColumn("session_id", [AttributeKey.Type.TYPE_STRING]),
-    "gen_ai.conversation.id": NormalizedColumn(
-        "ai_conversation_id", [AttributeKey.Type.TYPE_STRING]
-    ),
-}
+_UNPOPULATED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {}
 
 _ALL_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     **_NORMALIZED_COLUMNS_EAP_ITEMS,

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -82,17 +82,22 @@ UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION = (
 )
 
 
-def _org_allowed_unbackfilled_columns(organization_id: int) -> bool:
+def _org_allowed_unbackfilled_columns(organization_id: int | None) -> bool:
+    # No org in context (e.g. a delete that isn't scoped to one) => opted out.
+    if organization_id is None:
+        return False
     allowlist = get_option(UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
     if not allowlist:
         return False
     return organization_id in {int(org_id) for org_id in allowlist.split(",")}
 
 
-def get_normalized_columns_eap_items(organization_id: int) -> Mapping[str, NormalizedColumn]:
+def get_normalized_columns_eap_items(
+    organization_id: int | None,
+) -> Mapping[str, NormalizedColumn]:
     """The normalized EAP-item columns. Includes the not-yet-backfilled columns only for
     organizations in the ``eap_items_unbackfilled_normalized_columns_org_allowlist``
-    sentry-option."""
+    sentry-option. ``organization_id`` is ``None`` when there is no org in context."""
     if _org_allowed_unbackfilled_columns(organization_id):
         return {**_NORMALIZED_COLUMNS_EAP_ITEMS, **_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS}
     return _NORMALIZED_COLUMNS_EAP_ITEMS
@@ -367,11 +372,11 @@ def type_array_typed_element_column_native_array(attr_key: AttributeKey) -> Func
     return arrayElement(alias, column(col), literal(attr_key.name))
 
 
-def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int | None) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
     ``organization_id`` selects the per-org normalized-column set (see
-    ``get_normalized_columns_eap_items``).
+    ``get_normalized_columns_eap_items``); ``None`` when there is no org in context.
 
     Raises:
         MalformedAttributeException: If the attribute key is invalid or malformed.

--- a/snuba/protos/common.py
+++ b/snuba/protos/common.py
@@ -14,6 +14,7 @@ from snuba.query.expressions import (
     Lambda,
     SubscriptableReference,
 )
+from snuba.state.sentry_options import get_option
 
 
 class MalformedAttributeException(Exception):
@@ -35,7 +36,7 @@ def sentry_column(column_name: str) -> str:
     return f"sentry.{column_name}"
 
 
-NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
+_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     sentry_column("organization_id"): NormalizedColumn(
         "organization_id", [AttributeKey.Type.TYPE_INT]
     ),
@@ -58,11 +59,44 @@ NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     sentry_column("sampling_factor"): NormalizedColumn(
         "sampling_factor", [AttributeKey.Type.TYPE_DOUBLE]
     ),
+}
+
+# These columns are newly normalized: their dedicated columns are populated going forward,
+# but historical rows have NOT been backfilled. Reading them as real columns is gated per
+# organization, so it's opt-in for orgs that are fine with the missing historical data.
+# For everyone else they fall through to the attributes_* map path (which does cover the
+# historical rows).
+_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS: Final[Mapping[str, NormalizedColumn]] = {
     sentry_column("session_id"): NormalizedColumn("session_id", [AttributeKey.Type.TYPE_STRING]),
     "gen_ai.conversation.id": NormalizedColumn(
         "ai_conversation_id", [AttributeKey.Type.TYPE_STRING]
     ),
 }
+
+# Comma-separated org-id allowlist (sentry-option). Orgs in this list read the not-yet-
+# backfilled normalized columns above as real columns; everyone else falls through to the
+# attributes_* map path. Unlike org_ids_delete_allowlist, empty (the default) means NO orgs
+# are opted in -- this feature is off until an org is explicitly added.
+UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION = (
+    "eap_items_unbackfilled_normalized_columns_org_allowlist"
+)
+
+
+def _org_allowed_unbackfilled_columns(organization_id: int) -> bool:
+    allowlist = get_option(UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION, "")
+    if not allowlist:
+        return False
+    return organization_id in {int(org_id) for org_id in allowlist.split(",")}
+
+
+def get_normalized_columns_eap_items(organization_id: int) -> Mapping[str, NormalizedColumn]:
+    """The normalized EAP-item columns. Includes the not-yet-backfilled columns only for
+    organizations in the ``eap_items_unbackfilled_normalized_columns_org_allowlist``
+    sentry-option."""
+    if _org_allowed_unbackfilled_columns(organization_id):
+        return {**_NORMALIZED_COLUMNS_EAP_ITEMS, **_UNBACKFILLED_NORMALIZED_COLUMNS_EAP_ITEMS}
+    return _NORMALIZED_COLUMNS_EAP_ITEMS
+
 
 PROTO_TYPE_TO_CLICKHOUSE_TYPE: Final[Mapping[AttributeKey.Type.ValueType, str]] = {
     AttributeKey.Type.TYPE_INT: "Int64",
@@ -333,8 +367,11 @@ def type_array_typed_element_column_native_array(attr_key: AttributeKey) -> Func
     return arrayElement(alias, column(col), literal(attr_key.name))
 
 
-def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
+
+    ``organization_id`` selects the per-org normalized-column set (see
+    ``get_normalized_columns_eap_items``).
 
     Raises:
         MalformedAttributeException: If the attribute key is invalid or malformed.
@@ -349,8 +386,9 @@ def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
     if attr_key.name == "attr_key":
         return column("attr_key")
 
-    if attr_key.name in NORMALIZED_COLUMNS_EAP_ITEMS:
-        normalized_column = NORMALIZED_COLUMNS_EAP_ITEMS[attr_key.name]
+    normalized_columns = get_normalized_columns_eap_items(organization_id)
+    if attr_key.name in normalized_columns:
+        normalized_column = normalized_columns[attr_key.name]
         if attr_key.type not in normalized_column.types:
             formatted_attribute_types = ", ".join(
                 map(

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -421,8 +421,12 @@ def _construct_condition(
         and_conditions.append(exp)
 
     if attr_conditions:
+        # Deletes are scoped to a single org; use it for the per-org normalized-column
+        # gate (see attribute_key_to_expression). Absent org => 0 => feature off.
+        org_ids = columns.get("organization_id", [])
+        organization_id = int(org_ids[0]) if org_ids else 0
         for attr_key, attr_values in attr_conditions.attributes.values():
-            virtual_column = attribute_key_to_expression(attr_key)
+            virtual_column = attribute_key_to_expression(attr_key, organization_id)
 
             if len(attr_values) == 1:
                 exp = equals(virtual_column, literal(attr_values[0]))

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -422,9 +422,9 @@ def _construct_condition(
 
     if attr_conditions:
         # Deletes are scoped to a single org; use it for the per-org normalized-column
-        # gate (see attribute_key_to_expression). Absent org => 0 => feature off.
+        # gate (see attribute_key_to_expression). Absent org => None => feature off.
         org_ids = columns.get("organization_id", [])
-        organization_id = int(org_ids[0]) if org_ids else 0
+        organization_id = int(org_ids[0]) if org_ids else None
         for attr_key, attr_values in attr_conditions.attributes.values():
             virtual_column = attribute_key_to_expression(attr_key, organization_id)
 

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -18,12 +18,12 @@ from snuba.protos.common import (
     ARRAY_TYPES,
     ATTRIBUTES_TO_COALESCE,
     EMPTY_STRING_DEFAULT_COLUMNS,
-    NORMALIZED_COLUMNS_EAP_ITEMS,
     PROTO_TYPE_TO_ATTRIBUTE_COLUMN,
     PROTO_TYPE_TO_CLICKHOUSE_TYPE,
     TYPED_ARRAY_MAP_COLUMNS,
     MalformedAttributeException,
     array_element_column,
+    get_normalized_columns_eap_items,
     sentry_column,
     type_array_to_membership_array_expression_from_typed_columns,
     type_array_typed_column_native_array,
@@ -76,18 +76,19 @@ def _in_or_has(value: Expression, array: Expression, *, as_has: bool) -> Functio
     return in_cond(value, array)
 
 
-def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
     This is a wrapper around the proto-layer function that converts
     MalformedAttributeException to BadSnubaRPCRequestException for
-    HTTP-aware code paths.
+    HTTP-aware code paths. ``organization_id`` selects the per-org normalized-column
+    set (see ``get_normalized_columns_eap_items``).
 
     Raises:
         BadSnubaRPCRequestException: If the attribute key is invalid or malformed.
     """
     try:
-        return _attribute_key_to_expression(attr_key)
+        return _attribute_key_to_expression(attr_key, organization_id)
     except MalformedAttributeException as e:
         raise BadSnubaRPCRequestException(str(e)) from e
 
@@ -336,13 +337,14 @@ def add_existence_check_to_subscriptable_references(query: Query) -> None:
     query.transform_expressions(transform)
 
 
-def _is_map_backed_key(k: AttributeKey) -> bool:
+def _is_map_backed_key(k: AttributeKey, organization_id: int) -> bool:
     """True when ``k`` is a custom attribute stored in an ``attributes_*`` map column, so
     its filters take the ``(value, exists)`` path (see ``_map_backed_operands``). Excludes
-    ``attr_key`` and normalized columns, which are real columns, not map lookups."""
+    ``attr_key`` and normalized columns, which are real columns, not map lookups. The
+    normalized-column set is per-org (see ``get_normalized_columns_eap_items``)."""
     return (
         k.name != "attr_key"
-        and k.name not in NORMALIZED_COLUMNS_EAP_ITEMS
+        and k.name not in get_normalized_columns_eap_items(organization_id)
         and k.type in PROTO_TYPE_TO_ATTRIBUTE_COLUMN
     )
 
@@ -806,6 +808,8 @@ def trace_item_filters_to_expression(
     item_filter: TraceItemFilter,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     membership_as_has: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     """
     Trace Item Filters are things like (span.id=12345 AND start_timestamp >= "june 4th, 2024")
@@ -832,6 +836,7 @@ def trace_item_filters_to_expression(
                 filters[0],
                 attribute_key_to_expression,
                 membership_as_has,
+                organization_id=organization_id,
             )
         return and_cond(
             *(
@@ -839,6 +844,7 @@ def trace_item_filters_to_expression(
                     x,
                     attribute_key_to_expression,
                     membership_as_has,
+                    organization_id=organization_id,
                 )
                 for x in filters
             )
@@ -853,6 +859,7 @@ def trace_item_filters_to_expression(
                 filters[0],
                 attribute_key_to_expression,
                 membership_as_has,
+                organization_id=organization_id,
             )
         return or_cond(
             *(
@@ -860,6 +867,7 @@ def trace_item_filters_to_expression(
                     x,
                     attribute_key_to_expression,
                     membership_as_has,
+                    organization_id=organization_id,
                 )
                 for x in filters
             )
@@ -875,6 +883,7 @@ def trace_item_filters_to_expression(
                     filters[0],
                     attribute_key_to_expression,
                     membership_as_has,
+                    organization_id=organization_id,
                 )
             )
         return not_cond(
@@ -884,6 +893,7 @@ def trace_item_filters_to_expression(
                         x,
                         attribute_key_to_expression,
                         membership_as_has,
+                        organization_id=organization_id,
                     )
                     for x in filters
                 )
@@ -965,7 +975,7 @@ def trace_item_filters_to_expression(
                 return _typed_array_includes_scalar_expression(
                     k, v, item_filter.comparison_filter.ignore_case
                 )
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Map-backed: NULL-free (exists, value) form (see _map_backed_operands).
                 value, exists = _map_backed_operands(k)
                 if v_is_null:  # `attr = null` <=> key absent
@@ -997,7 +1007,7 @@ def trace_item_filters_to_expression(
                         k, v, item_filter.comparison_filter.ignore_case
                     )
                 )
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Negation of OP_EQUALS; an absent key is "not equal".
                 value, exists = _map_backed_operands(k)
                 if v_is_null:  # `attr != null` <=> key present
@@ -1029,7 +1039,7 @@ def trace_item_filters_to_expression(
                     "the LIKE comparison is only supported on string and array keys"
                 )
             comparison_function = f.ilike if item_filter.comparison_filter.ignore_case else f.like
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 value, exists = _map_backed_operands(k)
                 return and_cond(exists, comparison_function(value, v_expression))
             return comparison_function(k_expression, v_expression)
@@ -1044,7 +1054,7 @@ def trace_item_filters_to_expression(
                 raise BadSnubaRPCRequestException(
                     "the NOT LIKE comparison is only supported on string and array keys"
                 )
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Negation of OP_LIKE; an absent key is "not like".
                 like_fn = f.ilike if item_filter.comparison_filter.ignore_case else f.like
                 value, exists = _map_backed_operands(k)
@@ -1082,7 +1092,7 @@ def trace_item_filters_to_expression(
             # note: v_expression must be an array
             # we redefine the way in works for nulls
             # now null in ['hi', null] is true
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Map-backed: keep the existence if(...) out of in() (see helper).
                 return _analyzer_safe_in_expression(
                     k,
@@ -1117,7 +1127,7 @@ def trace_item_filters_to_expression(
             # note: v_expression must be an array
             # we redefine the way not in works for nulls
             # now null not in ['hi'] is true
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Map-backed: keep the existence if(...) out of in() (see helper).
                 return _analyzer_safe_in_expression(
                     k,

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -94,8 +94,9 @@ def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int | N
 
 
 def _trace_item_filter_key_expression(
-    attr_to_key_expression_callable: Callable[[AttributeKey], Expression],
+    attr_to_key_expression_callable: Callable[[AttributeKey, int], Expression],
     key: AttributeKey,
+    organization_id: int,
 ) -> Expression:
     """Array predicates read a per-element array so ``arrayExists`` can compare each
     element (different from the SELECT expression). An element-typed array key reads its
@@ -111,7 +112,7 @@ def _trace_item_filter_key_expression(
             return type_array_to_membership_array_expression_from_typed_columns(key)
         except MalformedAttributeException as e:
             raise BadSnubaRPCRequestException(str(e)) from e
-    return attr_to_key_expression_callable(key)
+    return attr_to_key_expression_callable(key, organization_id)
 
 
 Tin = TypeVar("Tin", bound=ProtobufMessage)
@@ -806,7 +807,7 @@ def _any_attribute_filter_to_expression(
 
 def trace_item_filters_to_expression(
     item_filter: TraceItemFilter,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     membership_as_has: bool = False,
     *,
     organization_id: int,
@@ -911,6 +912,7 @@ def trace_item_filters_to_expression(
         k_expression = _trace_item_filter_key_expression(
             attr_to_key_expression_callable=attribute_key_to_expression,
             key=k,
+            organization_id=organization_id,
         )
 
         value_type = v.WhichOneof("value")
@@ -1158,6 +1160,7 @@ def trace_item_filters_to_expression(
             _trace_item_filter_key_expression(
                 attr_to_key_expression_callable=attribute_key_to_expression,
                 key=item_filter.exists_filter.key,
+                organization_id=organization_id,
             )
         )
 

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -17,6 +17,7 @@ from snuba.clickhouse import DATETIME_FORMAT
 from snuba.protos.common import (
     ARRAY_TYPES,
     ATTRIBUTES_TO_COALESCE,
+    EMPTY_STRING_DEFAULT_COLUMNS,
     NORMALIZED_COLUMNS_EAP_ITEMS,
     PROTO_TYPE_TO_ATTRIBUTE_COLUMN,
     PROTO_TYPE_TO_CLICKHOUSE_TYPE,
@@ -1256,6 +1257,7 @@ def get_field_existence_expression(field: Expression) -> Expression:
         # is the right existence check. Scalar map lookups still use map_key_exists.
         if isinstance(base, Column) and base.column_name in TYPED_ARRAY_MAP_COLUMNS:
             return f.notEmpty(field)
+
         return map_key_exists(field.parameters[0], field.parameters[1])
 
     if isinstance(field, FunctionCall) and field.function_name in ("arrayMap", "arrayConcat"):
@@ -1264,5 +1266,13 @@ def get_field_existence_expression(field: Expression) -> Expression:
         # membership expression (arrayConcat of the per-type map lookups, see
         # type_array_to_membership_array_expression_from_typed_columns).
         return f.notEmpty(field)
+
+    if isinstance(field, FunctionCall) and field.function_name == "cast":
+        # A normalized String column with an empty-string default (e.g. ai_conversation_id)
+        # is never NULL, so isNotNull would always be true. notEmpty distinguishes an unset
+        # (empty) value from a real one.
+        base = field.parameters[0]
+        if isinstance(base, Column) and base.column_name in EMPTY_STRING_DEFAULT_COLUMNS:
+            return f.notEmpty(field)
 
     return f.isNotNull(field)

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -23,6 +23,7 @@ from snuba.protos.common import (
     TYPED_ARRAY_MAP_COLUMNS,
     MalformedAttributeException,
     array_element_column,
+    sentry_column,
     type_array_to_membership_array_expression_from_typed_columns,
     type_array_typed_column_native_array,
 )
@@ -921,7 +922,7 @@ def trace_item_filters_to_expression(
         # index- and partition-prunable. We reuse timestamp_seconds_to_datetime_literal
         # so a bound equal to the mandatory range is byte-identical to it and gets
         # collapsed by dedupe_timestamp_conditions.
-        if k.name == "sentry.timestamp" and value_type in (
+        if k.name == sentry_column("timestamp") and value_type in (
             "val_int",
             "val_float",
             "val_double",

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -17,7 +17,6 @@ from snuba.clickhouse import DATETIME_FORMAT
 from snuba.protos.common import (
     ARRAY_TYPES,
     ATTRIBUTES_TO_COALESCE,
-    COLUMN_PREFIX,
     NORMALIZED_COLUMNS_EAP_ITEMS,
     PROTO_TYPE_TO_ATTRIBUTE_COLUMN,
     PROTO_TYPE_TO_CLICKHOUSE_TYPE,
@@ -922,7 +921,7 @@ def trace_item_filters_to_expression(
         # index- and partition-prunable. We reuse timestamp_seconds_to_datetime_literal
         # so a bound equal to the mandatory range is byte-identical to it and gets
         # collapsed by dedupe_timestamp_conditions.
-        if k.name == f"{COLUMN_PREFIX}timestamp" and value_type in (
+        if k.name == "sentry.timestamp" and value_type in (
             "val_int",
             "val_float",
             "val_double",

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -76,13 +76,13 @@ def _in_or_has(value: Expression, array: Expression, *, as_has: bool) -> Functio
     return in_cond(value, array)
 
 
-def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int | None) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
     This is a wrapper around the proto-layer function that converts
     MalformedAttributeException to BadSnubaRPCRequestException for
     HTTP-aware code paths. ``organization_id`` selects the per-org normalized-column
-    set (see ``get_normalized_columns_eap_items``).
+    set (see ``get_normalized_columns_eap_items``); ``None`` when there is no org in context.
 
     Raises:
         BadSnubaRPCRequestException: If the attribute key is invalid or malformed.

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -1017,7 +1017,8 @@ def trace_item_filters_to_expression(
                 attribute_key_to_expression,
                 membership_as_has,
                 use_indexed_name,
-                organization_id=organization_id)
+                organization_id=organization_id,
+            )
         return and_cond(
             *(
                 trace_item_filters_to_expression(
@@ -1026,7 +1027,8 @@ def trace_item_filters_to_expression(
                     attribute_key_to_expression,
                     membership_as_has,
                     use_indexed_name,
-                    organization_id=organization_id)
+                    organization_id=organization_id,
+                )
                 for x in filters
             )
         )
@@ -1042,7 +1044,8 @@ def trace_item_filters_to_expression(
                 attribute_key_to_expression,
                 membership_as_has,
                 use_indexed_name,
-                organization_id=organization_id)
+                organization_id=organization_id,
+            )
         return or_cond(
             *(
                 trace_item_filters_to_expression(
@@ -1051,7 +1054,8 @@ def trace_item_filters_to_expression(
                     attribute_key_to_expression,
                     membership_as_has,
                     use_indexed_name,
-                    organization_id=organization_id)
+                    organization_id=organization_id,
+                )
                 for x in filters
             )
         )
@@ -1068,7 +1072,8 @@ def trace_item_filters_to_expression(
                     attribute_key_to_expression,
                     membership_as_has,
                     use_indexed_name,
-                    organization_id=organization_id)
+                    organization_id=organization_id,
+                )
             )
         return not_cond(
             and_cond(
@@ -1079,7 +1084,8 @@ def trace_item_filters_to_expression(
                         attribute_key_to_expression,
                         membership_as_has,
                         use_indexed_name,
-                        organization_id=organization_id)
+                        organization_id=organization_id,
+                    )
                     for x in filters
                 )
             )

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -133,8 +133,9 @@ def semver_sort_key(expr: Expression, alias: str | None = None) -> Expression:
 
 
 def _trace_item_filter_key_expression(
-    attr_to_key_expression_callable: Callable[[AttributeKey], Expression],
+    attr_to_key_expression_callable: Callable[[AttributeKey, int], Expression],
     key: AttributeKey,
+    organization_id: int,
 ) -> Expression:
     """Array predicates read a per-element array so ``arrayExists`` can compare each
     element (different from the SELECT expression). An element-typed array key reads its
@@ -150,7 +151,7 @@ def _trace_item_filter_key_expression(
             return type_array_to_membership_array_expression_from_typed_columns(key)
         except MalformedAttributeException as e:
             raise BadSnubaRPCRequestException(str(e)) from e
-    return attr_to_key_expression_callable(key)
+    return attr_to_key_expression_callable(key, organization_id)
 
 
 Tin = TypeVar("Tin", bound=ProtobufMessage)
@@ -979,7 +980,7 @@ def use_indexed_name_for_request(meta: RequestMeta) -> bool:
 def trace_item_filters_to_expression(
     item_type: TraceItemType.ValueType,
     item_filter: TraceItemFilter,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     membership_as_has: bool = False,
     use_indexed_name: bool = False,
     *,
@@ -1095,6 +1096,7 @@ def trace_item_filters_to_expression(
         k_expression = _trace_item_filter_key_expression(
             attr_to_key_expression_callable=attribute_key_to_expression,
             key=k,
+            organization_id=organization_id,
         )
 
         value_type = v.WhichOneof("value")
@@ -1382,6 +1384,7 @@ def trace_item_filters_to_expression(
             _trace_item_filter_key_expression(
                 attr_to_key_expression_callable=attribute_key_to_expression,
                 key=item_filter.exists_filter.key,
+                organization_id=organization_id,
             )
         )
 

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -80,13 +80,13 @@ def _in_or_has(value: Expression, array: Expression, *, as_has: bool) -> Functio
     return in_cond(value, array)
 
 
-def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int | None) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
     This is a wrapper around the proto-layer function that converts
     MalformedAttributeException to BadSnubaRPCRequestException for
     HTTP-aware code paths. ``organization_id`` selects the per-org normalized-column
-    set (see ``get_normalized_columns_eap_items``).
+    set (see ``get_normalized_columns_eap_items``); ``None`` when there is no org in context.
 
     Raises:
         BadSnubaRPCRequestException: If the attribute key is invalid or malformed.

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -18,7 +18,6 @@ from snuba.clickhouse import DATETIME_FORMAT
 from snuba.protos.common import (
     ARRAY_TYPES,
     EMPTY_STRING_DEFAULT_COLUMNS,
-    NORMALIZED_COLUMNS_EAP_ITEMS,
     PROTO_TYPE_TO_ATTRIBUTE_COLUMN,
     PROTO_TYPE_TO_CLICKHOUSE_TYPE,
     TYPED_ARRAY_MAP_COLUMNS,
@@ -26,6 +25,7 @@ from snuba.protos.common import (
     array_element_column,
     coalesced_attribute_names,
     first_present_value,
+    get_normalized_columns_eap_items,
     key_existence_conditions,
     sentry_column,
     type_array_to_membership_array_expression_from_typed_columns,
@@ -80,18 +80,19 @@ def _in_or_has(value: Expression, array: Expression, *, as_has: bool) -> Functio
     return in_cond(value, array)
 
 
-def attribute_key_to_expression(attr_key: AttributeKey) -> Expression:
+def attribute_key_to_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
     """Convert an AttributeKey proto to a Snuba Expression.
 
     This is a wrapper around the proto-layer function that converts
     MalformedAttributeException to BadSnubaRPCRequestException for
-    HTTP-aware code paths.
+    HTTP-aware code paths. ``organization_id`` selects the per-org normalized-column
+    set (see ``get_normalized_columns_eap_items``).
 
     Raises:
         BadSnubaRPCRequestException: If the attribute key is invalid or malformed.
     """
     try:
-        return _attribute_key_to_expression(attr_key)
+        return _attribute_key_to_expression(attr_key, organization_id)
     except MalformedAttributeException as e:
         raise BadSnubaRPCRequestException(str(e)) from e
 
@@ -413,13 +414,14 @@ def add_existence_check_to_map_attribute_reads(query: Query) -> None:
     query.transform_expressions(transform)
 
 
-def _is_map_backed_key(k: AttributeKey) -> bool:
+def _is_map_backed_key(k: AttributeKey, organization_id: int) -> bool:
     """True when ``k`` is a custom attribute stored in an ``attributes_*`` map column, so
     its filters take the ``(value, exists)`` path (see ``_map_backed_operands``). Excludes
-    ``attr_key`` and normalized columns, which are real columns, not map lookups."""
+    ``attr_key`` and normalized columns, which are real columns, not map lookups. The
+    normalized-column set is per-org (see ``get_normalized_columns_eap_items``)."""
     return (
         k.name != "attr_key"
-        and k.name not in NORMALIZED_COLUMNS_EAP_ITEMS
+        and k.name not in get_normalized_columns_eap_items(organization_id)
         and k.type in PROTO_TYPE_TO_ATTRIBUTE_COLUMN
     )
 
@@ -980,6 +982,8 @@ def trace_item_filters_to_expression(
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     membership_as_has: bool = False,
     use_indexed_name: bool = False,
+    *,
+    organization_id: int = 0,
 ) -> Expression:
     """
     Trace Item Filters are things like (span.id=12345 AND start_timestamp >= "june 4th, 2024")
@@ -1012,7 +1016,7 @@ def trace_item_filters_to_expression(
                 attribute_key_to_expression,
                 membership_as_has,
                 use_indexed_name,
-            )
+                organization_id=organization_id)
         return and_cond(
             *(
                 trace_item_filters_to_expression(
@@ -1021,7 +1025,7 @@ def trace_item_filters_to_expression(
                     attribute_key_to_expression,
                     membership_as_has,
                     use_indexed_name,
-                )
+                    organization_id=organization_id)
                 for x in filters
             )
         )
@@ -1037,7 +1041,7 @@ def trace_item_filters_to_expression(
                 attribute_key_to_expression,
                 membership_as_has,
                 use_indexed_name,
-            )
+                organization_id=organization_id)
         return or_cond(
             *(
                 trace_item_filters_to_expression(
@@ -1046,7 +1050,7 @@ def trace_item_filters_to_expression(
                     attribute_key_to_expression,
                     membership_as_has,
                     use_indexed_name,
-                )
+                    organization_id=organization_id)
                 for x in filters
             )
         )
@@ -1063,7 +1067,7 @@ def trace_item_filters_to_expression(
                     attribute_key_to_expression,
                     membership_as_has,
                     use_indexed_name,
-                )
+                    organization_id=organization_id)
             )
         return not_cond(
             and_cond(
@@ -1074,7 +1078,7 @@ def trace_item_filters_to_expression(
                         attribute_key_to_expression,
                         membership_as_has,
                         use_indexed_name,
-                    )
+                        organization_id=organization_id)
                     for x in filters
                 )
             )
@@ -1176,7 +1180,7 @@ def trace_item_filters_to_expression(
                 return _typed_array_includes_scalar_expression(
                     k, v, item_filter.comparison_filter.ignore_case
                 )
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Map-backed: NULL-free (exists, value) form (see _map_backed_operands).
                 value, exists = _map_backed_operands(k)
                 if v_is_null:  # `attr = null` <=> key absent
@@ -1214,7 +1218,7 @@ def trace_item_filters_to_expression(
                         k, v, item_filter.comparison_filter.ignore_case
                     )
                 )
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Negation of OP_EQUALS; an absent key is "not equal".
                 value, exists = _map_backed_operands(k)
                 if v_is_null:  # `attr != null` <=> key present
@@ -1246,7 +1250,7 @@ def trace_item_filters_to_expression(
                     "the LIKE comparison is only supported on string and array keys"
                 )
             comparison_function = f.ilike if item_filter.comparison_filter.ignore_case else f.like
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 value, exists = _map_backed_operands(k)
                 return and_cond(exists, comparison_function(value, v_expression))
             return comparison_function(k_expression, v_expression)
@@ -1261,7 +1265,7 @@ def trace_item_filters_to_expression(
                 raise BadSnubaRPCRequestException(
                     "the NOT LIKE comparison is only supported on string and array keys"
                 )
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Negation of OP_LIKE; an absent key is "not like".
                 like_fn = f.ilike if item_filter.comparison_filter.ignore_case else f.like
                 value, exists = _map_backed_operands(k)
@@ -1299,7 +1303,7 @@ def trace_item_filters_to_expression(
             # note: v_expression must be an array
             # we redefine the way in works for nulls
             # now null in ['hi', null] is true
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Map-backed: keep the existence if(...) out of in() (see helper).
                 return _analyzer_safe_in_expression(
                     k,
@@ -1334,7 +1338,7 @@ def trace_item_filters_to_expression(
             # note: v_expression must be an array
             # we redefine the way not in works for nulls
             # now null not in ['hi'] is true
-            if _is_map_backed_key(k):
+            if _is_map_backed_key(k, organization_id):
                 # Map-backed: keep the existence if(...) out of in() (see helper).
                 return _analyzer_safe_in_expression(
                     k,

--- a/snuba/web/rpc/common/pagination.py
+++ b/snuba/web/rpc/common/pagination.py
@@ -180,7 +180,7 @@ class FlexibleTimeWindowPageWithFilters:
                         for selected_column in in_msg.columns:
                             if selected_column.label == order_by_clause.column.label:
                                 attribute_expression = attribute_key_to_expression(
-                                    selected_column.key
+                                    selected_column.key, in_msg.meta.organization_id
                                 )
                                 break
                         if attribute_expression is None:

--- a/snuba/web/rpc/common/pagination.py
+++ b/snuba/web/rpc/common/pagination.py
@@ -215,7 +215,7 @@ class FlexibleTimeWindowPageWithFilters:
                         for selected_column in in_msg.columns:
                             if selected_column.label == order_by_clause.column.label:
                                 attribute_expression = attribute_key_to_expression(
-                                    selected_column.key
+                                    selected_column.key, in_msg.meta.organization_id
                                 )
                                 selected_key = selected_column.key
                                 break

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections.abc import Iterable
 from datetime import datetime
@@ -259,7 +258,6 @@ def _build_query(
     # are unpopulated.
     meta = query_meta if query_meta is not None else in_msg.meta
     organization_id = in_msg.meta.organization_id
-    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     selected_columns = [
         SelectedExpression("timestamp", f.toUnixTimestamp(column("timestamp"), alias="timestamp")),
         SelectedExpression(
@@ -350,7 +348,7 @@ def _build_query(
             meta,
             trace_item_filters_to_expression(
                 in_msg.filter,
-                attr_expr,
+                attribute_key_to_expression,
                 organization_id=organization_id,
             ),
             *page_token_filter,

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections.abc import Iterable
 from datetime import datetime
@@ -257,13 +258,16 @@ def _build_query(
     # request window, or the SELECT could read typed columns from a window where they
     # are unpopulated.
     meta = query_meta if query_meta is not None else in_msg.meta
+    organization_id = in_msg.meta.organization_id
+    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     selected_columns = [
         SelectedExpression("timestamp", f.toUnixTimestamp(column("timestamp"), alias="timestamp")),
         SelectedExpression(
             name="id",
             expression=(
                 attribute_key_to_expression(
-                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING)
+                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                    organization_id,
                 )
             ),
         ),
@@ -271,7 +275,8 @@ def _build_query(
             "trace_id",
             expression=(
                 attribute_key_to_expression(
-                    AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING)
+                    AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING),
+                    organization_id,
                 )
             ),
         ),
@@ -345,7 +350,8 @@ def _build_query(
             meta,
             trace_item_filters_to_expression(
                 in_msg.filter,
-                attribute_key_to_expression,
+                attr_expr,
+                organization_id=organization_id,
             ),
             *page_token_filter,
             *item_type_filter,

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -43,7 +43,6 @@ from snuba.web.rpc.common.common import (
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
     typed_array_map_selected_expressions,
-    use_indexed_name_for_request,
 )
 from snuba.web.rpc.common.debug_info import setup_trace_query_settings
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections.abc import Iterable
 from datetime import datetime
@@ -260,7 +259,6 @@ def _build_query(
     # are unpopulated.
     meta = query_meta if query_meta is not None else in_msg.meta
     organization_id = in_msg.meta.organization_id
-    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     selected_columns = [
         SelectedExpression("timestamp", f.toUnixTimestamp(column("timestamp"), alias="timestamp")),
         SelectedExpression(
@@ -352,7 +350,7 @@ def _build_query(
             trace_item_filters_to_expression(
                 meta.trace_item_type,
                 in_msg.filter,
-                attr_expr,
+                attribute_key_to_expression,
                 organization_id=organization_id,
             ),
             *page_token_filter,

--- a/snuba/web/rpc/v1/endpoint_export_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_export_trace_items.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections.abc import Iterable
 from datetime import datetime
@@ -258,13 +259,16 @@ def _build_query(
     # request window, or the SELECT could read typed columns from a window where they
     # are unpopulated.
     meta = query_meta if query_meta is not None else in_msg.meta
+    organization_id = in_msg.meta.organization_id
+    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     selected_columns = [
         SelectedExpression("timestamp", f.toUnixTimestamp(column("timestamp"), alias="timestamp")),
         SelectedExpression(
             name="id",
             expression=(
                 attribute_key_to_expression(
-                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING)
+                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                    organization_id,
                 )
             ),
         ),
@@ -272,7 +276,8 @@ def _build_query(
             "trace_id",
             expression=(
                 attribute_key_to_expression(
-                    AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING)
+                    AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING),
+                    organization_id,
                 )
             ),
         ),
@@ -347,8 +352,8 @@ def _build_query(
             trace_item_filters_to_expression(
                 meta.trace_item_type,
                 in_msg.filter,
-                attribute_key_to_expression,
-                use_indexed_name=use_indexed_name_for_request(meta),
+                attr_expr,
+                organization_id=organization_id,
             ),
             *page_token_filter,
             *item_type_filter,

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -185,7 +185,8 @@ def _build_query(
             name="id",
             expression=(
                 attribute_key_to_expression(
-                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING)
+                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                    request.meta.organization_id,
                 )
             ),
         ),
@@ -199,7 +200,8 @@ def _build_query(
                                 item.item_type, "sentry.timestamp"
                             ),
                             type=AttributeKey.Type.TYPE_DOUBLE,
-                        )
+                        ),
+                        request.meta.organization_id,
                     )
                 ),
                 "Float64",
@@ -228,7 +230,9 @@ def _build_query(
                 selected_columns.append(
                     SelectedExpression(
                         name=attribute_key.name,
-                        expression=attribute_key_to_expression(attribute_key),
+                        expression=attribute_key_to_expression(
+                            attribute_key, request.meta.organization_id
+                        ),
                     )
                 )
     else:

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -187,7 +187,8 @@ def _build_query(
             name="id",
             expression=(
                 attribute_key_to_expression(
-                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING)
+                    AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                    request.meta.organization_id,
                 )
             ),
         ),
@@ -201,7 +202,8 @@ def _build_query(
                                 item.item_type, "sentry.timestamp"
                             ),
                             type=AttributeKey.Type.TYPE_DOUBLE,
-                        )
+                        ),
+                        request.meta.organization_id,
                     )
                 ),
                 "Float64",
@@ -230,7 +232,9 @@ def _build_query(
                 selected_columns.append(
                     SelectedExpression(
                         name=attribute_key.name,
-                        expression=attribute_key_to_expression(attribute_key),
+                        expression=attribute_key_to_expression(
+                            attribute_key, request.meta.organization_id
+                        ),
                     )
                 )
     else:

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -156,7 +157,10 @@ def _get_attribute_expression(
     attribute_type: AttributeKey.Type.ValueType,
     request_meta: RequestMeta,
 ) -> Expression:
-    return attribute_key_to_expression(AttributeKey(name=attribute_name, type=attribute_type))
+    return attribute_key_to_expression(
+        AttributeKey(name=attribute_name, type=attribute_type),
+        request_meta.organization_id,
+    )
 
 
 def _attribute_to_expression(
@@ -575,6 +579,8 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
             list
         )
         filter_expressions_by_item_type: dict[TraceItemType.ValueType, Expression] = {}
+        organization_id = request_meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         for trace_filter in filters:
             filters_by_item_type[trace_filter.item_type].append(trace_filter.filter)
 
@@ -587,8 +593,9 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                             filters=filters_by_item_type[item_type],
                         ),
                     ),
-                    attribute_key_to_expression,
+                    attr_expr,
                     membership_as_has=True,
+                    organization_id=organization_id,
                 ),
             )
 
@@ -605,13 +612,16 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
         else:
             item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
 
+        organization_id = request.meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         trace_item_filters_expression = trace_item_filters_to_expression(
             TraceItemFilter(
                 and_filter=AndFilter(
                     filters=[f.filter for f in request.filters],
                 ),
             ),
-            attribute_key_to_expression,
+            attr_expr,
+            organization_id=organization_id,
         )
         selected_columns: list[SelectedExpression] = [
             SelectedExpression(

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -580,7 +579,6 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
         )
         filter_expressions_by_item_type: dict[TraceItemType.ValueType, Expression] = {}
         organization_id = request_meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         for trace_filter in filters:
             filters_by_item_type[trace_filter.item_type].append(trace_filter.filter)
 
@@ -593,7 +591,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                             filters=filters_by_item_type[item_type],
                         ),
                     ),
-                    attr_expr,
+                    attribute_key_to_expression,
                     membership_as_has=True,
                     organization_id=organization_id,
                 ),
@@ -613,14 +611,13 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
             item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
 
         organization_id = request.meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         trace_item_filters_expression = trace_item_filters_to_expression(
             TraceItemFilter(
                 and_filter=AndFilter(
                     filters=[f.filter for f in request.filters],
                 ),
             ),
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=organization_id,
         )
         selected_columns: list[SelectedExpression] = [

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -157,7 +158,10 @@ def _get_attribute_expression(
     attribute_type: AttributeKey.Type.ValueType,
     request_meta: RequestMeta,
 ) -> Expression:
-    return attribute_key_to_expression(AttributeKey(name=attribute_name, type=attribute_type))
+    return attribute_key_to_expression(
+        AttributeKey(name=attribute_name, type=attribute_type),
+        request_meta.organization_id,
+    )
 
 
 def _attribute_to_expression(
@@ -576,6 +580,8 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
             list
         )
         filter_expressions_by_item_type: dict[TraceItemType.ValueType, Expression] = {}
+        organization_id = request_meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         for trace_filter in filters:
             filters_by_item_type[trace_filter.item_type].append(trace_filter.filter)
 
@@ -590,9 +596,9 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                             filters=filters_by_item_type[item_type],
                         ),
                     ),
-                    attribute_key_to_expression,
+                    attr_expr,
                     membership_as_has=True,
-                    use_indexed_name=use_indexed_name,
+                    organization_id=organization_id,
                 ),
             )
 
@@ -609,6 +615,8 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
         else:
             item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
 
+        organization_id = request.meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         trace_item_filters_expression = trace_item_filters_to_expression(
             item_type,
             TraceItemFilter(
@@ -616,8 +624,8 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                     filters=[f.filter for f in request.filters],
                 ),
             ),
-            attribute_key_to_expression,
-            use_indexed_name=use_indexed_name_for_request(request.meta),
+            attr_expr,
+            organization_id=organization_id,
         )
         selected_columns: list[SelectedExpression] = [
             SelectedExpression(

--- a/snuba/web/rpc/v1/endpoint_get_traces.py
+++ b/snuba/web/rpc/v1/endpoint_get_traces.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -581,7 +580,6 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
         )
         filter_expressions_by_item_type: dict[TraceItemType.ValueType, Expression] = {}
         organization_id = request_meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         for trace_filter in filters:
             filters_by_item_type[trace_filter.item_type].append(trace_filter.filter)
 
@@ -596,7 +594,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                             filters=filters_by_item_type[item_type],
                         ),
                     ),
-                    attr_expr,
+                    attribute_key_to_expression,
                     membership_as_has=True,
                     organization_id=organization_id,
                 ),
@@ -616,7 +614,6 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
             item_type = TraceItemType.TRACE_ITEM_TYPE_SPAN
 
         organization_id = request.meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         trace_item_filters_expression = trace_item_filters_to_expression(
             item_type,
             TraceItemFilter(
@@ -624,7 +621,7 @@ class EndpointGetTraces(RPCEndpoint[GetTracesRequest, GetTracesResponse]):
                     filters=[f.filter for f in request.filters],
                 ),
             ),
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=organization_id,
         )
         selected_columns: list[SelectedExpression] = [

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections.abc import Iterable
 from typing import Any
@@ -49,9 +48,6 @@ from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
-    attr_expr = functools.partial(
-        attribute_key_to_expression, organization_id=request.meta.organization_id
-    )
     entity = Entity(
         key=EntityKey("eap_items"),
         schema=get_entity(EntityKey("eap_items")).get_data_model(),
@@ -108,7 +104,7 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             ),
             trace_item_filters_to_expression(
                 request.filter,
-                attr_expr,
+                attribute_key_to_expression,
                 organization_id=request.meta.organization_id,
             ),
         ),

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections.abc import Iterable
 from typing import Any
@@ -48,6 +49,9 @@ from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
+    attr_expr = functools.partial(
+        attribute_key_to_expression, organization_id=request.meta.organization_id
+    )
     entity = Entity(
         key=EntityKey("eap_items"),
         schema=get_entity(EntityKey("eap_items")).get_data_model(),
@@ -104,7 +108,8 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             ),
             trace_item_filters_to_expression(
                 request.filter,
-                attribute_key_to_expression,
+                attr_expr,
+                organization_id=request.meta.organization_id,
             ),
         ),
         limit=1,

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections.abc import Iterable
 from typing import Any
@@ -49,6 +50,9 @@ from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
+    attr_expr = functools.partial(
+        attribute_key_to_expression, organization_id=request.meta.organization_id
+    )
     entity = Entity(
         key=EntityKey("eap_items"),
         schema=get_entity(EntityKey("eap_items")).get_data_model(),
@@ -106,8 +110,8 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             trace_item_filters_to_expression(
                 request.meta.trace_item_type,
                 request.filter,
-                attribute_key_to_expression,
-                use_indexed_name=use_indexed_name_for_request(request.meta),
+                attr_expr,
+                organization_id=request.meta.organization_id,
             ),
         ),
         limit=1,

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -35,7 +35,6 @@ from snuba.web.rpc.common.common import (
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
     typed_array_map_selected_expressions,
-    use_indexed_name_for_request,
 )
 from snuba.web.rpc.common.debug_info import (
     extract_response_meta,

--- a/snuba/web/rpc/v1/endpoint_trace_item_details.py
+++ b/snuba/web/rpc/v1/endpoint_trace_item_details.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections.abc import Iterable
 from typing import Any
@@ -50,9 +49,6 @@ from snuba.web.rpc.v1.endpoint_get_trace import convert_to_attribute_value
 
 
 def _build_query(request: TraceItemDetailsRequest) -> Query:
-    attr_expr = functools.partial(
-        attribute_key_to_expression, organization_id=request.meta.organization_id
-    )
     entity = Entity(
         key=EntityKey("eap_items"),
         schema=get_entity(EntityKey("eap_items")).get_data_model(),
@@ -110,7 +106,7 @@ def _build_query(request: TraceItemDetailsRequest) -> Query:
             trace_item_filters_to_expression(
                 request.meta.trace_item_type,
                 request.filter,
-                attr_expr,
+                attribute_key_to_expression,
                 organization_id=request.meta.organization_id,
             ),
         ),

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import defaultdict
 
@@ -111,7 +110,6 @@ class HeatmapBuilder:
         in_msg = self.in_msg
         timer = self.timer
         organization_id = in_msg.meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = heatmap.x_attribute
         y_attribute = heatmap.y_attribute
         y_attribute_val = attribute_key_to_expression(y_attribute, organization_id)
@@ -126,7 +124,7 @@ class HeatmapBuilder:
         )
         filter_expression = trace_item_filters_to_expression(
             filter,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=organization_id,
         )
         condition = base_conditions_and(in_msg.meta, filter_expression)
@@ -203,7 +201,6 @@ class HeatmapBuilder:
         and since theres no data for the buckets 2 or 3, the count() for those buckets is 0.
         """
         organization_id = self.in_msg.meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = self.heatmap.x_attribute
         y_attribute = self.heatmap.y_attribute
         x_attribute_val = attribute_key_to_expression(x_attribute, organization_id)
@@ -219,7 +216,7 @@ class HeatmapBuilder:
         )
         filter_expression = trace_item_filters_to_expression(
             filter,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=organization_id,
         )
         condition = base_conditions_and(self.in_msg.meta, filter_expression)

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 
@@ -109,9 +110,11 @@ class HeatmapBuilder:
         heatmap = self.heatmap
         in_msg = self.in_msg
         timer = self.timer
+        organization_id = in_msg.meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = heatmap.x_attribute
         y_attribute = heatmap.y_attribute
-        y_attribute_val = attribute_key_to_expression(y_attribute)
+        y_attribute_val = attribute_key_to_expression(y_attribute, organization_id)
         filter = TraceItemFilter(
             and_filter=AndFilter(
                 filters=[
@@ -123,7 +126,8 @@ class HeatmapBuilder:
         )
         filter_expression = trace_item_filters_to_expression(
             filter,
-            (attribute_key_to_expression),
+            attr_expr,
+            organization_id=organization_id,
         )
         condition = base_conditions_and(in_msg.meta, filter_expression)
         min_max_query = Query(
@@ -198,10 +202,12 @@ class HeatmapBuilder:
 
         and since theres no data for the buckets 2 or 3, the count() for those buckets is 0.
         """
+        organization_id = self.in_msg.meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = self.heatmap.x_attribute
         y_attribute = self.heatmap.y_attribute
-        x_attribute_val = attribute_key_to_expression(x_attribute)
-        y_attribute_val = attribute_key_to_expression(y_attribute)
+        x_attribute_val = attribute_key_to_expression(x_attribute, organization_id)
+        y_attribute_val = attribute_key_to_expression(y_attribute, organization_id)
         filter = TraceItemFilter(
             and_filter=AndFilter(
                 filters=[
@@ -213,7 +219,8 @@ class HeatmapBuilder:
         )
         filter_expression = trace_item_filters_to_expression(
             filter,
-            (attribute_key_to_expression),
+            attr_expr,
+            organization_id=organization_id,
         )
         condition = base_conditions_and(self.in_msg.meta, filter_expression)
         bucket_index_y = f.least(

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import defaultdict
 
@@ -112,7 +111,6 @@ class HeatmapBuilder:
         in_msg = self.in_msg
         timer = self.timer
         organization_id = in_msg.meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = heatmap.x_attribute
         y_attribute = heatmap.y_attribute
         y_attribute_val = attribute_key_to_expression(y_attribute, organization_id)
@@ -128,7 +126,7 @@ class HeatmapBuilder:
         filter_expression = trace_item_filters_to_expression(
             in_msg.meta.trace_item_type,
             filter,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=organization_id,
         )
         condition = base_conditions_and(in_msg.meta, filter_expression)
@@ -205,7 +203,6 @@ class HeatmapBuilder:
         and since theres no data for the buckets 2 or 3, the count() for those buckets is 0.
         """
         organization_id = self.in_msg.meta.organization_id
-        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = self.heatmap.x_attribute
         y_attribute = self.heatmap.y_attribute
         x_attribute_val = attribute_key_to_expression(x_attribute, organization_id)
@@ -222,7 +219,7 @@ class HeatmapBuilder:
         filter_expression = trace_item_filters_to_expression(
             self.in_msg.meta.trace_item_type,
             filter,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=organization_id,
         )
         condition = base_conditions_and(self.in_msg.meta, filter_expression)

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 
@@ -110,9 +111,11 @@ class HeatmapBuilder:
         heatmap = self.heatmap
         in_msg = self.in_msg
         timer = self.timer
+        organization_id = in_msg.meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = heatmap.x_attribute
         y_attribute = heatmap.y_attribute
-        y_attribute_val = attribute_key_to_expression(y_attribute)
+        y_attribute_val = attribute_key_to_expression(y_attribute, organization_id)
         filter = TraceItemFilter(
             and_filter=AndFilter(
                 filters=[
@@ -125,8 +128,8 @@ class HeatmapBuilder:
         filter_expression = trace_item_filters_to_expression(
             in_msg.meta.trace_item_type,
             filter,
-            (attribute_key_to_expression),
-            use_indexed_name=use_indexed_name_for_request(in_msg.meta),
+            attr_expr,
+            organization_id=organization_id,
         )
         condition = base_conditions_and(in_msg.meta, filter_expression)
         min_max_query = Query(
@@ -201,10 +204,12 @@ class HeatmapBuilder:
 
         and since theres no data for the buckets 2 or 3, the count() for those buckets is 0.
         """
+        organization_id = self.in_msg.meta.organization_id
+        attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
         x_attribute = self.heatmap.x_attribute
         y_attribute = self.heatmap.y_attribute
-        x_attribute_val = attribute_key_to_expression(x_attribute)
-        y_attribute_val = attribute_key_to_expression(y_attribute)
+        x_attribute_val = attribute_key_to_expression(x_attribute, organization_id)
+        y_attribute_val = attribute_key_to_expression(y_attribute, organization_id)
         filter = TraceItemFilter(
             and_filter=AndFilter(
                 filters=[
@@ -217,8 +222,8 @@ class HeatmapBuilder:
         filter_expression = trace_item_filters_to_expression(
             self.in_msg.meta.trace_item_type,
             filter,
-            (attribute_key_to_expression),
-            use_indexed_name=use_indexed_name_for_request(self.in_msg.meta),
+            attr_expr,
+            organization_id=organization_id,
         )
         condition = base_conditions_and(self.in_msg.meta, filter_expression)
         bucket_index_y = f.least(

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/heatmap_builder.py
@@ -35,7 +35,6 @@ from snuba.web.rpc.common.common import (
     base_conditions_and,
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
-    use_indexed_name_for_request,
 )
 from snuba.web.rpc.common.debug_info import setup_trace_query_settings
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -1,7 +1,6 @@
-import functools
 import uuid
 from collections import defaultdict
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from dataclasses import replace
 from datetime import datetime
 from typing import Any
@@ -20,7 +19,6 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
-    AttributeKey,
     ExtrapolationMode,
 )
 
@@ -81,14 +79,6 @@ OP_TO_EXPR = {
     ProtoExpression.BinaryFormula.OP_MULTIPLY: f.multiply,
     ProtoExpression.BinaryFormula.OP_DIVIDE: f.divide,
 }
-
-
-def _get_attribute_key_to_expression_function(
-    request_meta: RequestMeta,
-) -> Callable[[AttributeKey], Expression]:
-    return functools.partial(
-        attribute_key_to_expression, organization_id=request_meta.organization_id
-    )
 
 
 def _convert_result_timeseries(
@@ -253,7 +243,7 @@ def _get_reliability_context_columns(
         ]:
             confidence_interval_column = get_confidence_interval_column(
                 aggregation,
-                _get_attribute_key_to_expression_function(request_meta),
+                attribute_key_to_expression,
                 organization_id=request_meta.organization_id,
             )
             if confidence_interval_column is not None:
@@ -266,7 +256,7 @@ def _get_reliability_context_columns(
 
             average_sample_rate_column = get_average_sample_rate_column(
                 aggregation,
-                _get_attribute_key_to_expression_function(request_meta),
+                attribute_key_to_expression,
                 organization_id=request_meta.organization_id,
             )
             additional_context_columns.append(
@@ -277,7 +267,7 @@ def _get_reliability_context_columns(
             )
         count_column = get_count_column(
             aggregation,
-            _get_attribute_key_to_expression_function(request_meta),
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         additional_context_columns.append(
@@ -306,7 +296,7 @@ def _proto_expression_to_ast_expression(
         case "conditional_aggregation":
             aggregate_expr = aggregation_to_expression(
                 expr.conditional_aggregation,
-                _get_attribute_key_to_expression_function(request_meta),
+                attribute_key_to_expression,
                 use_sampling_factor(request_meta),
                 organization_id=request_meta.organization_id,
             )
@@ -375,7 +365,7 @@ def build_query(
     groupby_columns = [
         SelectedExpression(
             name=attr_key.name,
-            expression=_get_attribute_key_to_expression_function(request.meta)(attr_key),
+            expression=attribute_key_to_expression(attr_key, request.meta.organization_id),
         )
         for attr_key in request.group_by
     ]
@@ -428,7 +418,7 @@ def build_query(
             request.meta,
             trace_item_filters_to_expression(
                 request.filter,
-                _get_attribute_key_to_expression_function(request.meta),
+                attribute_key_to_expression,
                 organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),
@@ -438,7 +428,7 @@ def build_query(
         groupby=[
             column("time_slot"),
             *[
-                _get_attribute_key_to_expression_function(request.meta)(attr_key)
+                attribute_key_to_expression(attr_key, request.meta.organization_id)
                 for attr_key in request.group_by
             ],
         ],

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -85,7 +86,9 @@ OP_TO_EXPR = {
 def _get_attribute_key_to_expression_function(
     request_meta: RequestMeta,
 ) -> Callable[[AttributeKey], Expression]:
-    return attribute_key_to_expression
+    return functools.partial(
+        attribute_key_to_expression, organization_id=request_meta.organization_id
+    )
 
 
 def _convert_result_timeseries(
@@ -251,6 +254,7 @@ def _get_reliability_context_columns(
             confidence_interval_column = get_confidence_interval_column(
                 aggregation,
                 _get_attribute_key_to_expression_function(request_meta),
+                organization_id=request_meta.organization_id,
             )
             if confidence_interval_column is not None:
                 additional_context_columns.append(
@@ -263,6 +267,7 @@ def _get_reliability_context_columns(
             average_sample_rate_column = get_average_sample_rate_column(
                 aggregation,
                 _get_attribute_key_to_expression_function(request_meta),
+                organization_id=request_meta.organization_id,
             )
             additional_context_columns.append(
                 SelectedExpression(
@@ -273,6 +278,7 @@ def _get_reliability_context_columns(
         count_column = get_count_column(
             aggregation,
             _get_attribute_key_to_expression_function(request_meta),
+            organization_id=request_meta.organization_id,
         )
         additional_context_columns.append(
             SelectedExpression(name=count_column.alias, expression=count_column)
@@ -300,8 +306,9 @@ def _proto_expression_to_ast_expression(
         case "conditional_aggregation":
             aggregate_expr = aggregation_to_expression(
                 expr.conditional_aggregation,
-                (attribute_key_to_expression),
+                _get_attribute_key_to_expression_function(request_meta),
                 use_sampling_factor(request_meta),
+                organization_id=request_meta.organization_id,
             )
             match expr.conditional_aggregation.WhichOneof("default_value"):
                 case None:
@@ -422,6 +429,7 @@ def build_query(
             trace_item_filters_to_expression(
                 request.filter,
                 _get_attribute_key_to_expression_function(request.meta),
+                organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),
             *item_type_conds,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -1,7 +1,6 @@
-import functools
 import uuid
 from collections import defaultdict
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from dataclasses import replace
 from datetime import datetime
 from typing import Any
@@ -20,7 +19,6 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
-    AttributeKey,
     ExtrapolationMode,
 )
 
@@ -82,14 +80,6 @@ OP_TO_EXPR = {
     ProtoExpression.BinaryFormula.OP_MULTIPLY: f.multiply,
     ProtoExpression.BinaryFormula.OP_DIVIDE: f.divide,
 }
-
-
-def _get_attribute_key_to_expression_function(
-    request_meta: RequestMeta,
-) -> Callable[[AttributeKey], Expression]:
-    return functools.partial(
-        attribute_key_to_expression, organization_id=request_meta.organization_id
-    )
 
 
 def _convert_result_timeseries(
@@ -254,7 +244,7 @@ def _get_reliability_context_columns(
         ]:
             confidence_interval_column = get_confidence_interval_column(
                 aggregation,
-                _get_attribute_key_to_expression_function(request_meta),
+                attribute_key_to_expression,
                 organization_id=request_meta.organization_id,
             )
             if confidence_interval_column is not None:
@@ -267,7 +257,7 @@ def _get_reliability_context_columns(
 
             average_sample_rate_column = get_average_sample_rate_column(
                 aggregation,
-                _get_attribute_key_to_expression_function(request_meta),
+                attribute_key_to_expression,
                 organization_id=request_meta.organization_id,
             )
             additional_context_columns.append(
@@ -278,7 +268,7 @@ def _get_reliability_context_columns(
             )
         count_column = get_count_column(
             aggregation,
-            _get_attribute_key_to_expression_function(request_meta),
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         additional_context_columns.append(
@@ -307,7 +297,7 @@ def _proto_expression_to_ast_expression(
         case "conditional_aggregation":
             aggregate_expr = aggregation_to_expression(
                 expr.conditional_aggregation,
-                _get_attribute_key_to_expression_function(request_meta),
+                attribute_key_to_expression,
                 use_sampling_factor(request_meta),
                 organization_id=request_meta.organization_id,
             )
@@ -376,7 +366,7 @@ def build_query(
     groupby_columns = [
         SelectedExpression(
             name=attr_key.name,
-            expression=_get_attribute_key_to_expression_function(request.meta)(attr_key),
+            expression=attribute_key_to_expression(attr_key, request.meta.organization_id),
         )
         for attr_key in request.group_by
     ]
@@ -430,7 +420,7 @@ def build_query(
             trace_item_filters_to_expression(
                 request.meta.trace_item_type,
                 request.filter,
-                _get_attribute_key_to_expression_function(request.meta),
+                attribute_key_to_expression,
                 organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),
@@ -440,7 +430,7 @@ def build_query(
         groupby=[
             column("time_slot"),
             *[
-                _get_attribute_key_to_expression_function(request.meta)(attr_key)
+                attribute_key_to_expression(attr_key, request.meta.organization_id)
                 for attr_key in request.group_by
             ],
         ],

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -45,7 +45,6 @@ from snuba.web.rpc.common.common import (
     base_conditions_and,
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
-    use_indexed_name_for_request,
     use_sampling_factor,
     valid_sampling_factor_conditions,
 )

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_time_series.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -86,7 +87,9 @@ OP_TO_EXPR = {
 def _get_attribute_key_to_expression_function(
     request_meta: RequestMeta,
 ) -> Callable[[AttributeKey], Expression]:
-    return attribute_key_to_expression
+    return functools.partial(
+        attribute_key_to_expression, organization_id=request_meta.organization_id
+    )
 
 
 def _convert_result_timeseries(
@@ -252,6 +255,7 @@ def _get_reliability_context_columns(
             confidence_interval_column = get_confidence_interval_column(
                 aggregation,
                 _get_attribute_key_to_expression_function(request_meta),
+                organization_id=request_meta.organization_id,
             )
             if confidence_interval_column is not None:
                 additional_context_columns.append(
@@ -264,6 +268,7 @@ def _get_reliability_context_columns(
             average_sample_rate_column = get_average_sample_rate_column(
                 aggregation,
                 _get_attribute_key_to_expression_function(request_meta),
+                organization_id=request_meta.organization_id,
             )
             additional_context_columns.append(
                 SelectedExpression(
@@ -274,6 +279,7 @@ def _get_reliability_context_columns(
         count_column = get_count_column(
             aggregation,
             _get_attribute_key_to_expression_function(request_meta),
+            organization_id=request_meta.organization_id,
         )
         additional_context_columns.append(
             SelectedExpression(name=count_column.alias, expression=count_column)
@@ -301,8 +307,9 @@ def _proto_expression_to_ast_expression(
         case "conditional_aggregation":
             aggregate_expr = aggregation_to_expression(
                 expr.conditional_aggregation,
-                (attribute_key_to_expression),
+                _get_attribute_key_to_expression_function(request_meta),
                 use_sampling_factor(request_meta),
+                organization_id=request_meta.organization_id,
             )
             match expr.conditional_aggregation.WhichOneof("default_value"):
                 case None:
@@ -424,7 +431,7 @@ def build_query(
                 request.meta.trace_item_type,
                 request.filter,
                 _get_attribute_key_to_expression_function(request.meta),
-                use_indexed_name=use_indexed_name_for_request(request.meta),
+                organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),
             *item_type_conds,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -234,7 +233,7 @@ def _build_attr_distribution_query(
 
     trace_item_filters_expression = trace_item_filters_to_expression(
         in_msg.filter,
-        functools.partial(attribute_key_to_expression, organization_id=in_msg.meta.organization_id),
+        attribute_key_to_expression,
         organization_id=in_msg.meta.organization_id,
     )
     item_type_filter = f.equals(column("item_type"), in_msg.meta.trace_item_type)

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -233,7 +234,8 @@ def _build_attr_distribution_query(
 
     trace_item_filters_expression = trace_item_filters_to_expression(
         in_msg.filter,
-        (attribute_key_to_expression),
+        functools.partial(attribute_key_to_expression, organization_id=in_msg.meta.organization_id),
+        organization_id=in_msg.meta.organization_id,
     )
     item_type_filter = f.equals(column("item_type"), in_msg.meta.trace_item_type)
     query = Query(

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -46,7 +46,6 @@ from snuba.web.rpc.common.common import (
     base_conditions_and,
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
-    use_indexed_name_for_request,
 )
 from snuba.web.rpc.common.debug_info import (
     extract_response_meta,

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -238,7 +237,7 @@ def _build_attr_distribution_query(
     trace_item_filters_expression = trace_item_filters_to_expression(
         in_msg.meta.trace_item_type,
         in_msg.filter,
-        functools.partial(attribute_key_to_expression, organization_id=in_msg.meta.organization_id),
+        attribute_key_to_expression,
         organization_id=in_msg.meta.organization_id,
     )
     item_type_filter = f.equals(column("item_type"), in_msg.meta.trace_item_type)

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -237,8 +238,8 @@ def _build_attr_distribution_query(
     trace_item_filters_expression = trace_item_filters_to_expression(
         in_msg.meta.trace_item_type,
         in_msg.filter,
-        (attribute_key_to_expression),
-        use_indexed_name=use_indexed_name_for_request(in_msg.meta),
+        functools.partial(attribute_key_to_expression, organization_id=in_msg.meta.organization_id),
+        organization_id=in_msg.meta.organization_id,
     )
     item_type_filter = f.equals(column("item_type"), in_msg.meta.trace_item_type)
     query = Query(

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -248,14 +247,10 @@ def aggregation_filter_to_expression(
                     _formula_to_expression(agg_filter.comparison_filter.formula, request_meta),
                     agg_filter.comparison_filter.val,
                 )
-            attr_expr = functools.partial(
-                attribute_key_to_expression,
-                organization_id=request_meta.organization_id,
-            )
             return op_expr(
                 aggregation_to_expression(
                     agg_filter.comparison_filter.conditional_aggregation,
-                    attr_expr,
+                    attribute_key_to_expression,
                     use_sampling_factor(request_meta),
                     organization_id=request_meta.organization_id,
                 ),
@@ -360,16 +355,12 @@ def _convert_order_by(
                 )
             )
         elif x.column.HasField("conditional_aggregation"):
-            attr_expr = functools.partial(
-                attribute_key_to_expression,
-                organization_id=request_meta.organization_id,
-            )
             res.append(
                 OrderBy(
                     direction=direction,
                     expression=aggregation_to_expression(
                         x.column.conditional_aggregation,
-                        attr_expr,
+                        attribute_key_to_expression,
                         use_sampling_factor(request_meta),
                         organization_id=request_meta.organization_id,
                     ),
@@ -446,13 +437,9 @@ def _get_reliability_context_columns(
         ExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
     ]:
         context_columns = []
-        attr_expr = functools.partial(
-            attribute_key_to_expression,
-            organization_id=request_meta.organization_id,
-        )
         confidence_interval_column = get_confidence_interval_column(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         if confidence_interval_column is not None:
@@ -465,7 +452,7 @@ def _get_reliability_context_columns(
 
         average_sample_rate_column = get_average_sample_rate_column(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         context_columns.append(
@@ -477,7 +464,7 @@ def _get_reliability_context_columns(
 
         count_column = get_count_column(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         context_columns.append(SelectedExpression(name=count_column.alias, expression=count_column))
@@ -555,13 +542,9 @@ def _column_to_expression(column: Column, request_meta: RequestMeta) -> Expressi
     if column.HasField("key"):
         return attribute_key_to_expression(column.key, request_meta.organization_id)
     if column.HasField("conditional_aggregation"):
-        attr_expr = functools.partial(
-            attribute_key_to_expression,
-            organization_id=request_meta.organization_id,
-        )
         function_expr = aggregation_to_expression(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             use_sampling_factor(request_meta),
             organization_id=request_meta.organization_id,
         )
@@ -698,10 +681,7 @@ def build_query(
             request.meta,
             trace_item_filters_to_expression(
                 request.filter,
-                functools.partial(
-                    attribute_key_to_expression,
-                    organization_id=request.meta.organization_id,
-                ),
+                attribute_key_to_expression,
                 organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -34,6 +34,7 @@ from snuba.downsampled_storage_tiers import Tier
 from snuba.protos.common import (
     NORMALIZED_COLUMNS_EAP_ITEMS,
     TYPED_ARRAY_MAP_COLUMNS,
+    NormalizedColumn,
     type_array_typed_columns_select_expressions,
 )
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
@@ -189,13 +190,12 @@ def _apply_virtual_columns(
         if context is None:
             return expression
 
+        from_column_type = NORMALIZED_COLUMNS_EAP_ITEMS.get(
+            context.from_column_name,
+            NormalizedColumn(context.from_column_name, [AttributeKey.TYPE_STRING]),
+        ).types[0]
         from_column = attribute_key_to_expression(
-            AttributeKey(
-                name=context.from_column_name,
-                type=NORMALIZED_COLUMNS_EAP_ITEMS.get(
-                    context.from_column_name, [AttributeKey.TYPE_STRING]
-                )[0],
-            )
+            AttributeKey(name=context.from_column_name, type=from_column_type)
         )
         if is_existence:
             return get_field_existence_expression(from_column)

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -32,9 +33,9 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.downsampled_storage_tiers import Tier
 from snuba.protos.common import (
-    NORMALIZED_COLUMNS_EAP_ITEMS,
     TYPED_ARRAY_MAP_COLUMNS,
     NormalizedColumn,
+    get_normalized_columns_eap_items,
     type_array_typed_columns_select_expressions,
 )
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
@@ -114,7 +115,9 @@ COMPARISON_OP_TO_EXPR: dict[int, Callable[..., FunctionCall]] = {
 
 
 def _apply_virtual_columns(
-    query: Query, virtual_column_contexts: Sequence[VirtualColumnContext]
+    query: Query,
+    virtual_column_contexts: Sequence[VirtualColumnContext],
+    organization_id: int,
 ) -> None:
     """Injects virtual column mappings into the clickhouse query. Works with NORMALIZED_COLUMNS on the table or
     dynamic columns in attr_str
@@ -190,12 +193,17 @@ def _apply_virtual_columns(
         if context is None:
             return expression
 
-        from_column_type = NORMALIZED_COLUMNS_EAP_ITEMS.get(
-            context.from_column_name,
-            NormalizedColumn(context.from_column_name, [AttributeKey.TYPE_STRING]),
-        ).types[0]
+        from_column_type = (
+            get_normalized_columns_eap_items(organization_id)
+            .get(
+                context.from_column_name,
+                NormalizedColumn(context.from_column_name, [AttributeKey.TYPE_STRING]),
+            )
+            .types[0]
+        )
         from_column = attribute_key_to_expression(
-            AttributeKey(name=context.from_column_name, type=from_column_type)
+            AttributeKey(name=context.from_column_name, type=from_column_type),
+            organization_id,
         )
         if is_existence:
             return get_field_existence_expression(from_column)
@@ -240,11 +248,16 @@ def aggregation_filter_to_expression(
                     _formula_to_expression(agg_filter.comparison_filter.formula, request_meta),
                     agg_filter.comparison_filter.val,
                 )
+            attr_expr = functools.partial(
+                attribute_key_to_expression,
+                organization_id=request_meta.organization_id,
+            )
             return op_expr(
                 aggregation_to_expression(
                     agg_filter.comparison_filter.conditional_aggregation,
-                    attribute_key_to_expression,
+                    attr_expr,
                     use_sampling_factor(request_meta),
+                    organization_id=request_meta.organization_id,
                 ),
                 agg_filter.comparison_filter.val,
             )
@@ -274,7 +287,7 @@ def aggregation_filter_to_expression(
             raise BadSnubaRPCRequestException(f"Unsupported aggregation filter type: {default}")
 
 
-def _groupby_order_by_expression(attr_key: AttributeKey) -> Expression:
+def _groupby_order_by_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
     """
     Maps an attribute key used in GROUP BY / ORDER BY to its expression.
 
@@ -286,7 +299,7 @@ def _groupby_order_by_expression(attr_key: AttributeKey) -> Expression:
     """
     if attr_key.name == "sentry.timestamp":
         return snuba_column("timestamp")
-    return attribute_key_to_expression(attr_key)
+    return attribute_key_to_expression(attr_key, organization_id)
 
 
 def _convert_order_by(
@@ -341,17 +354,24 @@ def _convert_order_by(
             res.append(
                 OrderBy(
                     direction=direction,
-                    expression=_groupby_order_by_expression(x.column.key),
+                    expression=_groupby_order_by_expression(
+                        x.column.key, request_meta.organization_id
+                    ),
                 )
             )
         elif x.column.HasField("conditional_aggregation"):
+            attr_expr = functools.partial(
+                attribute_key_to_expression,
+                organization_id=request_meta.organization_id,
+            )
             res.append(
                 OrderBy(
                     direction=direction,
                     expression=aggregation_to_expression(
                         x.column.conditional_aggregation,
-                        attribute_key_to_expression,
+                        attr_expr,
                         use_sampling_factor(request_meta),
+                        organization_id=request_meta.organization_id,
                     ),
                 )
             )
@@ -426,9 +446,14 @@ def _get_reliability_context_columns(
         ExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
     ]:
         context_columns = []
+        attr_expr = functools.partial(
+            attribute_key_to_expression,
+            organization_id=request_meta.organization_id,
+        )
         confidence_interval_column = get_confidence_interval_column(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
+            organization_id=request_meta.organization_id,
         )
         if confidence_interval_column is not None:
             context_columns.append(
@@ -440,7 +465,8 @@ def _get_reliability_context_columns(
 
         average_sample_rate_column = get_average_sample_rate_column(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
+            organization_id=request_meta.organization_id,
         )
         context_columns.append(
             SelectedExpression(
@@ -451,7 +477,8 @@ def _get_reliability_context_columns(
 
         count_column = get_count_column(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
+            organization_id=request_meta.organization_id,
         )
         context_columns.append(SelectedExpression(name=count_column.alias, expression=count_column))
         return context_columns
@@ -526,12 +553,17 @@ def _column_to_expression(column: Column, request_meta: RequestMeta) -> Expressi
     Given a column protobuf object, translates it into a Expression object and returns it.
     """
     if column.HasField("key"):
-        return attribute_key_to_expression(column.key)
+        return attribute_key_to_expression(column.key, request_meta.organization_id)
     if column.HasField("conditional_aggregation"):
+        attr_expr = functools.partial(
+            attribute_key_to_expression,
+            organization_id=request_meta.organization_id,
+        )
         function_expr = aggregation_to_expression(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
             use_sampling_factor(request_meta),
+            organization_id=request_meta.organization_id,
         )
         match column.conditional_aggregation.WhichOneof("default_value"):
             case None:
@@ -654,7 +686,10 @@ def build_query(
     if page_token_filter:
         additional_conditions.append(page_token_filter)
 
-    groupby = [_groupby_order_by_expression(attr_key) for attr_key in request.group_by]
+    groupby = [
+        _groupby_order_by_expression(attr_key, request.meta.organization_id)
+        for attr_key in request.group_by
+    ]
 
     res = Query(
         from_clause=entity,
@@ -663,7 +698,11 @@ def build_query(
             request.meta,
             trace_item_filters_to_expression(
                 request.filter,
-                attribute_key_to_expression,
+                functools.partial(
+                    attribute_key_to_expression,
+                    organization_id=request.meta.organization_id,
+                ),
+                organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),
             *item_type_conds,
@@ -688,7 +727,7 @@ def build_query(
         ),
     )
     treeify_or_and_conditions(res)
-    _apply_virtual_columns(res, request.virtual_column_contexts)
+    _apply_virtual_columns(res, request.virtual_column_contexts, request.meta.organization_id)
     add_existence_check_to_subscriptable_references(res)
     return res
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -32,9 +33,9 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_dataset import PluggableDataset
 from snuba.downsampled_storage_tiers import Tier
 from snuba.protos.common import (
-    NORMALIZED_COLUMNS_EAP_ITEMS,
     TYPED_ARRAY_MAP_COLUMNS,
     NormalizedColumn,
+    get_normalized_columns_eap_items,
     type_array_typed_columns_select_expressions,
 )
 from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
@@ -116,7 +117,9 @@ COMPARISON_OP_TO_EXPR: dict[int, Callable[..., FunctionCall]] = {
 
 
 def _apply_virtual_columns(
-    query: Query, virtual_column_contexts: Sequence[VirtualColumnContext]
+    query: Query,
+    virtual_column_contexts: Sequence[VirtualColumnContext],
+    organization_id: int,
 ) -> None:
     """Injects virtual column mappings into the clickhouse query. Works with NORMALIZED_COLUMNS on the table or
     dynamic columns in attr_str
@@ -192,12 +195,17 @@ def _apply_virtual_columns(
         if context is None:
             return expression
 
-        from_column_type = NORMALIZED_COLUMNS_EAP_ITEMS.get(
-            context.from_column_name,
-            NormalizedColumn(context.from_column_name, [AttributeKey.TYPE_STRING]),
-        ).types[0]
+        from_column_type = (
+            get_normalized_columns_eap_items(organization_id)
+            .get(
+                context.from_column_name,
+                NormalizedColumn(context.from_column_name, [AttributeKey.TYPE_STRING]),
+            )
+            .types[0]
+        )
         from_column = attribute_key_to_expression(
-            AttributeKey(name=context.from_column_name, type=from_column_type)
+            AttributeKey(name=context.from_column_name, type=from_column_type),
+            organization_id,
         )
         if is_existence:
             return get_field_existence_expression(from_column)
@@ -242,11 +250,16 @@ def aggregation_filter_to_expression(
                     _formula_to_expression(agg_filter.comparison_filter.formula, request_meta),
                     agg_filter.comparison_filter.val,
                 )
+            attr_expr = functools.partial(
+                attribute_key_to_expression,
+                organization_id=request_meta.organization_id,
+            )
             return op_expr(
                 aggregation_to_expression(
                     agg_filter.comparison_filter.conditional_aggregation,
-                    attribute_key_to_expression,
+                    attr_expr,
                     use_sampling_factor(request_meta),
+                    organization_id=request_meta.organization_id,
                 ),
                 agg_filter.comparison_filter.val,
             )
@@ -276,7 +289,7 @@ def aggregation_filter_to_expression(
             raise BadSnubaRPCRequestException(f"Unsupported aggregation filter type: {default}")
 
 
-def _groupby_order_by_expression(attr_key: AttributeKey) -> Expression:
+def _groupby_order_by_expression(attr_key: AttributeKey, organization_id: int) -> Expression:
     """
     Maps an attribute key used in GROUP BY / ORDER BY to its expression.
 
@@ -292,7 +305,7 @@ def _groupby_order_by_expression(attr_key: AttributeKey) -> Expression:
     """
     if attr_key.name == "sentry.timestamp":
         return snuba_column("timestamp")
-    return attribute_key_to_expression(attr_key)
+    return attribute_key_to_expression(attr_key, organization_id)
 
 
 def _convert_order_by(
@@ -355,17 +368,24 @@ def _convert_order_by(
             res.append(
                 OrderBy(
                     direction=direction,
-                    expression=expression,
+                    expression=_groupby_order_by_expression(
+                        x.column.key, request_meta.organization_id
+                    ),
                 )
             )
         elif x.column.HasField("conditional_aggregation"):
+            attr_expr = functools.partial(
+                attribute_key_to_expression,
+                organization_id=request_meta.organization_id,
+            )
             res.append(
                 OrderBy(
                     direction=direction,
                     expression=aggregation_to_expression(
                         x.column.conditional_aggregation,
-                        attribute_key_to_expression,
+                        attr_expr,
                         use_sampling_factor(request_meta),
+                        organization_id=request_meta.organization_id,
                     ),
                 )
             )
@@ -483,9 +503,14 @@ def _get_reliability_context_columns(
         ExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
     ]:
         context_columns = []
+        attr_expr = functools.partial(
+            attribute_key_to_expression,
+            organization_id=request_meta.organization_id,
+        )
         confidence_interval_column = get_confidence_interval_column(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
+            organization_id=request_meta.organization_id,
         )
         if confidence_interval_column is not None:
             context_columns.append(
@@ -497,7 +522,8 @@ def _get_reliability_context_columns(
 
         average_sample_rate_column = get_average_sample_rate_column(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
+            organization_id=request_meta.organization_id,
         )
         context_columns.append(
             SelectedExpression(
@@ -508,7 +534,8 @@ def _get_reliability_context_columns(
 
         count_column = get_count_column(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
+            organization_id=request_meta.organization_id,
         )
         context_columns.append(SelectedExpression(name=count_column.alias, expression=count_column))
         return context_columns
@@ -583,12 +610,17 @@ def _column_to_expression(column: Column, request_meta: RequestMeta) -> Expressi
     Given a column protobuf object, translates it into a Expression object and returns it.
     """
     if column.HasField("key"):
-        return attribute_key_to_expression(column.key)
+        return attribute_key_to_expression(column.key, request_meta.organization_id)
     if column.HasField("conditional_aggregation"):
+        attr_expr = functools.partial(
+            attribute_key_to_expression,
+            organization_id=request_meta.organization_id,
+        )
         function_expr = aggregation_to_expression(
             column.conditional_aggregation,
-            attribute_key_to_expression,
+            attr_expr,
             use_sampling_factor(request_meta),
+            organization_id=request_meta.organization_id,
         )
         match column.conditional_aggregation.WhichOneof("default_value"):
             case None:
@@ -711,7 +743,10 @@ def build_query(
     if page_token_filter:
         additional_conditions.append(page_token_filter)
 
-    groupby = [_groupby_order_by_expression(attr_key) for attr_key in request.group_by]
+    groupby = [
+        _groupby_order_by_expression(attr_key, request.meta.organization_id)
+        for attr_key in request.group_by
+    ]
 
     res = Query(
         from_clause=entity,
@@ -721,8 +756,11 @@ def build_query(
             trace_item_filters_to_expression(
                 request.meta.trace_item_type,
                 request.filter,
-                attribute_key_to_expression,
-                use_indexed_name=use_indexed_name_for_request(request.meta),
+                functools.partial(
+                    attribute_key_to_expression,
+                    organization_id=request.meta.organization_id,
+                ),
+                organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),
             *item_type_conds,
@@ -748,19 +786,8 @@ def build_query(
         ),
     )
     treeify_or_and_conditions(res)
-    _apply_virtual_columns(res, request.virtual_column_contexts)
-    add_existence_check_to_map_attribute_reads(res)
-    # The transforms above (notably virtual-column rewriting) can re-apply aliases to
-    # limit_by expressions; a LIMIT BY must stay alias-free unless the alias is declared
-    # in the SELECT, so strip any aliases they reintroduced.
-    limitby = res.get_limitby()
-    if limitby is not None:
-        res.set_limitby(
-            LimitBy(
-                limit=limitby.limit,
-                columns=[_strip_aliases(column) for column in limitby.columns],
-            )
-        )
+    _apply_virtual_columns(res, request.virtual_column_contexts, request.meta.organization_id)
+    add_existence_check_to_subscriptable_references(res)
     return res
 
 

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -250,14 +249,10 @@ def aggregation_filter_to_expression(
                     _formula_to_expression(agg_filter.comparison_filter.formula, request_meta),
                     agg_filter.comparison_filter.val,
                 )
-            attr_expr = functools.partial(
-                attribute_key_to_expression,
-                organization_id=request_meta.organization_id,
-            )
             return op_expr(
                 aggregation_to_expression(
                     agg_filter.comparison_filter.conditional_aggregation,
-                    attr_expr,
+                    attribute_key_to_expression,
                     use_sampling_factor(request_meta),
                     organization_id=request_meta.organization_id,
                 ),
@@ -374,16 +369,12 @@ def _convert_order_by(
                 )
             )
         elif x.column.HasField("conditional_aggregation"):
-            attr_expr = functools.partial(
-                attribute_key_to_expression,
-                organization_id=request_meta.organization_id,
-            )
             res.append(
                 OrderBy(
                     direction=direction,
                     expression=aggregation_to_expression(
                         x.column.conditional_aggregation,
-                        attr_expr,
+                        attribute_key_to_expression,
                         use_sampling_factor(request_meta),
                         organization_id=request_meta.organization_id,
                     ),
@@ -503,13 +494,9 @@ def _get_reliability_context_columns(
         ExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
     ]:
         context_columns = []
-        attr_expr = functools.partial(
-            attribute_key_to_expression,
-            organization_id=request_meta.organization_id,
-        )
         confidence_interval_column = get_confidence_interval_column(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         if confidence_interval_column is not None:
@@ -522,7 +509,7 @@ def _get_reliability_context_columns(
 
         average_sample_rate_column = get_average_sample_rate_column(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         context_columns.append(
@@ -534,7 +521,7 @@ def _get_reliability_context_columns(
 
         count_column = get_count_column(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             organization_id=request_meta.organization_id,
         )
         context_columns.append(SelectedExpression(name=count_column.alias, expression=count_column))
@@ -612,13 +599,9 @@ def _column_to_expression(column: Column, request_meta: RequestMeta) -> Expressi
     if column.HasField("key"):
         return attribute_key_to_expression(column.key, request_meta.organization_id)
     if column.HasField("conditional_aggregation"):
-        attr_expr = functools.partial(
-            attribute_key_to_expression,
-            organization_id=request_meta.organization_id,
-        )
         function_expr = aggregation_to_expression(
             column.conditional_aggregation,
-            attr_expr,
+            attribute_key_to_expression,
             use_sampling_factor(request_meta),
             organization_id=request_meta.organization_id,
         )
@@ -756,10 +739,7 @@ def build_query(
             trace_item_filters_to_expression(
                 request.meta.trace_item_type,
                 request.filter,
-                functools.partial(
-                    attribute_key_to_expression,
-                    organization_id=request.meta.organization_id,
-                ),
+                attribute_key_to_expression,
                 organization_id=request.meta.organization_id,
             ),
             valid_sampling_factor_conditions(),

--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_table.py
@@ -59,7 +59,6 @@ from snuba.request import Request as SnubaRequest
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import run_query
 from snuba.web.rpc.common.common import (
-    add_existence_check_to_map_attribute_reads,
     attribute_key_to_expression,
     base_conditions_and,
     get_field_existence_expression,
@@ -68,7 +67,6 @@ from snuba.web.rpc.common.common import (
     trace_item_filters_to_expression,
     treeify_or_and_conditions,
     typed_array_select_subcolumn_name,
-    use_indexed_name_for_request,
     use_sampling_factor,
     valid_sampling_factor_conditions,
 )

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -64,6 +64,8 @@ SERVER_SAMPLE_RATE_ATTRIBUTE = "server_sample_rate"
 def _get_condition_in_aggregation(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    *,
+    organization_id: int,
 ) -> Expression:
     condition_in_aggregation: Expression = literal(True)
     if isinstance(aggregation, AttributeConditionalAggregation):
@@ -75,6 +77,7 @@ def _get_condition_in_aggregation(
             aggregation.filter,
             attribute_key_to_expression,
             membership_as_has=True,
+            organization_id=organization_id,
         )
     return condition_in_aggregation
 
@@ -378,6 +381,8 @@ def get_average_sample_rate_column(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     alias = CustomColumnInformation(
         custom_column_id="average_sample_rate",
@@ -390,7 +395,7 @@ def get_average_sample_rate_column(
     )
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     return f.divide(
         f.countIf(
@@ -418,13 +423,17 @@ def _get_count_column_alias(
 def get_count_column(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    *,
+    organization_id: int,
 ) -> Expression:
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     return f.countIf(
         field,
         and_cond(
             field_exists,
-            _get_condition_in_aggregation(aggregation, attribute_key_to_expression),
+            _get_condition_in_aggregation(
+                aggregation, attribute_key_to_expression, organization_id=organization_id
+            ),
         ),
         alias=_get_count_column_alias(aggregation),
     )
@@ -487,11 +496,13 @@ def get_extrapolated_function(
     field_exists: Expression,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> CurriedFunctionCall | FunctionCall | None:
     alias = aggregation.label if aggregation.label else None
     alias_dict = {"alias": alias} if alias else {}
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
 
     sampling_weight = _get_sampling_weight_expression(
@@ -609,6 +620,8 @@ def _get_ci_count(
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     r"""
     confidence interval = Z \cdot \sqrt{\sum_{i=1}^n w_i^2 - w_i}
@@ -632,7 +645,7 @@ def _get_ci_count(
 
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     alias_dict = {"alias": alias} if alias else {}
     sampling_weight = _get_sampling_weight_expression(
@@ -659,6 +672,8 @@ def _get_ci_sum(
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     r"""
     confidence interval = Z \cdot \sqrt{\sum_{i=1}^n x_i^2 \cdot (w_i^2 - w_i)}
@@ -676,7 +691,7 @@ def _get_ci_sum(
 
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     alias_dict = {"alias": alias} if alias else {}
     sampling_weight = _get_sampling_weight_expression(
@@ -705,6 +720,8 @@ def _get_ci_avg(
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     alias: str | None = None,
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     """
     confidence interval = (\\frac{t + err_t}{c - err_c} - \\frac{t - err_t}{c + err_c}) \\cdot 0.5
@@ -731,7 +748,7 @@ def _get_ci_avg(
 
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     alias_dict = {"alias": alias} if alias else {}
     sampling_weight = _get_sampling_weight_expression(
@@ -756,6 +773,7 @@ def _get_ci_avg(
         f"{alias}__sum_err",
         Z_VALUE_P975,
         use_sampling_factor,
+        organization_id=organization_id,
     )
     expr_count_err = _get_ci_count(
         aggregation,
@@ -763,6 +781,7 @@ def _get_ci_avg(
         f"{alias}__count_err",
         Z_VALUE_P975,
         use_sampling_factor,
+        organization_id=organization_id,
     )
 
     return f.divide(
@@ -787,6 +806,8 @@ def get_confidence_interval_column(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression | None:
     """
     Returns the expression for calculating the upper confidence limit for a given aggregation. If the aggregation cannot be extrapolated, returns None.
@@ -801,18 +822,21 @@ def get_confidence_interval_column(
             attribute_key_to_expression,
             alias,
             use_sampling_factor=use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_SUM: _get_ci_sum(
             aggregation,
             attribute_key_to_expression,
             alias,
             use_sampling_factor=use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_AVG: _get_ci_avg(
             aggregation,
             attribute_key_to_expression,
             alias,
             use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P50: _get_possible_percentiles_expression(
             aggregation, 0.5, attribute_key_to_expression, use_sampling_factor
@@ -888,12 +912,14 @@ def aggregation_to_expression(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     alias = aggregation.label if aggregation.label else None
     alias_dict = {"alias": alias} if alias else {}
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
 
     if aggregation.key.type in ARRAY_TYPES:
@@ -967,6 +993,7 @@ def aggregation_to_expression(
             field_exists,
             attribute_key_to_expression,
             use_sampling_factor,
+            organization_id=organization_id,
         )
     else:
         agg_func_expr = function_map.get(aggregation.aggregate)

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -63,7 +63,7 @@ SERVER_SAMPLE_RATE_ATTRIBUTE = "server_sample_rate"
 
 def _get_condition_in_aggregation(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     *,
     organization_id: int,
 ) -> Expression:
@@ -92,13 +92,14 @@ _ATTR_KEY_EXPR_OP_TO_FUNC = {
 
 def _attribute_key_expression_to_expression(
     expr: AttributeKeyExpression,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
+    organization_id: int,
 ) -> tuple[Expression, list[AttributeKey]]:
     """Recursively converts an AttributeKeyExpression proto to a Snuba AST Expression,
     also collecting all leaf AttributeKey nodes encountered during traversal."""
     match expr.WhichOneof("expression"):
         case "key":
-            return attribute_key_to_expression(expr.key), [expr.key]
+            return attribute_key_to_expression(expr.key, organization_id), [expr.key]
         case "formula":
             func = _ATTR_KEY_EXPR_OP_TO_FUNC.get(expr.formula.op)
             if func is None:
@@ -106,10 +107,10 @@ def _attribute_key_expression_to_expression(
                     f"Unknown AttributeKeyExpression op: {expr.formula.op}"
                 )
             left_expr, left_keys = _attribute_key_expression_to_expression(
-                expr.formula.left, attribute_key_to_expression
+                expr.formula.left, attribute_key_to_expression, organization_id
             )
             right_expr, right_keys = _attribute_key_expression_to_expression(
-                expr.formula.right, attribute_key_to_expression
+                expr.formula.right, attribute_key_to_expression, organization_id
             )
             return func(left_expr, right_expr), left_keys + right_keys
         case _:
@@ -118,7 +119,8 @@ def _attribute_key_expression_to_expression(
 
 def _resolve_field_and_existence(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
+    organization_id: int,
 ) -> tuple[Expression, Expression]:
     """Given a protobuf aggregation, returns (aggregation expression, existence expression)
     Aggregation expression - the actual aggregation ex: sum(attr1 + attr2)
@@ -126,10 +128,11 @@ def _resolve_field_and_existence(
     """
     if aggregation.HasField("expression"):
         field, keys = _attribute_key_expression_to_expression(
-            aggregation.expression, attribute_key_to_expression
+            aggregation.expression, attribute_key_to_expression, organization_id
         )
         existence_checks = [
-            get_field_existence_expression(attribute_key_to_expression(k)) for k in keys
+            get_field_existence_expression(attribute_key_to_expression(k, organization_id))
+            for k in keys
         ]
 
         existence: Expression = existence_checks[0]
@@ -143,7 +146,7 @@ def _resolve_field_and_existence(
     # Array keys resolve like scalars now: attribute_key_to_expression reads the typed
     # array column(s) natively and get_field_existence_expression maps that read to a
     # notEmpty existence check (see snuba.web.rpc.common.common).
-    field = attribute_key_to_expression(aggregation.key)
+    field = attribute_key_to_expression(aggregation.key, organization_id)
     return field, get_field_existence_expression(field)
 
 
@@ -379,7 +382,7 @@ def get_attribute_confidence_interval_alias(
 
 def get_average_sample_rate_column(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
@@ -393,7 +396,9 @@ def get_average_sample_rate_column(
         use_sampling_factor,
         aggregation.extrapolation_mode,
     )
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -422,11 +427,13 @@ def _get_count_column_alias(
 
 def get_count_column(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     *,
     organization_id: int,
 ) -> Expression:
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     return f.countIf(
         field,
         and_cond(
@@ -458,10 +465,12 @@ def _get_possible_percentiles(percentile: float, granularity: float, width: floa
 def _get_possible_percentiles_expression(
     aggregation: AttributeConditionalAggregation,
     percentile: float,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     granularity: float = 0.005,
     width: float = 0.1,
+    *,
+    organization_id: int,
 ) -> Expression:
     """
     In order to approximate the confidence intervals, we calculate a bunch of quantiles around the desired percentile, using the given granularity and width.
@@ -473,7 +482,9 @@ def _get_possible_percentiles_expression(
     The width isn't important as long as it contains the range of values that we actually care about, I just added it as a performance optimization.
     The granularity might need to be adjusted, but I think this is a good starting value.
     """
-    field, _field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, _field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     possible_percentiles = _get_possible_percentiles(percentile, granularity, width)
     alias = get_attribute_confidence_interval_alias(
         aggregation, {"granularity": str(granularity), "width": str(width)}
@@ -494,7 +505,7 @@ def get_extrapolated_function(
     aggregation: AttributeConditionalAggregation,
     field: Expression,
     field_exists: Expression,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
@@ -616,7 +627,7 @@ def get_extrapolated_function(
 
 def _get_ci_count(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
@@ -643,7 +654,9 @@ def _get_ci_count(
         dependent inclusion probabilities from the HT formula zero out.
     """
 
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -668,7 +681,7 @@ def _get_ci_count(
 
 def _get_ci_sum(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
@@ -689,7 +702,9 @@ def _get_ci_sum(
     variance of the total.
     """
 
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -717,7 +732,7 @@ def _get_ci_sum(
 
 def _get_ci_avg(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     alias: str | None = None,
     use_sampling_factor: bool = False,
     *,
@@ -746,7 +761,9 @@ def _get_ci_avg(
     average between the upper and lower error.
     """
 
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -804,7 +821,7 @@ def _get_ci_avg(
 
 def get_confidence_interval_column(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
@@ -839,19 +856,39 @@ def get_confidence_interval_column(
             organization_id=organization_id,
         ),
         Function.FUNCTION_P50: _get_possible_percentiles_expression(
-            aggregation, 0.5, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.5,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P75: _get_possible_percentiles_expression(
-            aggregation, 0.75, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.75,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P90: _get_possible_percentiles_expression(
-            aggregation, 0.9, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.9,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P95: _get_possible_percentiles_expression(
-            aggregation, 0.95, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.95,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P99: _get_possible_percentiles_expression(
-            aggregation, 0.99, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.99,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
     }
 
@@ -910,12 +947,14 @@ def _array_aggregation_to_expression(
 
 def aggregation_to_expression(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
 ) -> Expression:
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     alias = aggregation.label if aggregation.label else None
     alias_dict = {"alias": alias} if alias else {}
     condition_in_aggregation = _get_condition_in_aggregation(

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -67,7 +67,7 @@ SERVER_SAMPLE_RATE_ATTRIBUTE = "server_sample_rate"
 
 def _get_condition_in_aggregation(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     *,
     organization_id: int,
 ) -> Expression:
@@ -97,13 +97,14 @@ _ATTR_KEY_EXPR_OP_TO_FUNC = {
 
 def _attribute_key_expression_to_expression(
     expr: AttributeKeyExpression,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
+    organization_id: int,
 ) -> tuple[Expression, list[AttributeKey]]:
     """Recursively converts an AttributeKeyExpression proto to a Snuba AST Expression,
     also collecting all leaf AttributeKey nodes encountered during traversal."""
     match expr.WhichOneof("expression"):
         case "key":
-            return attribute_key_to_expression(expr.key), [expr.key]
+            return attribute_key_to_expression(expr.key, organization_id), [expr.key]
         case "formula":
             func = _ATTR_KEY_EXPR_OP_TO_FUNC.get(expr.formula.op)
             if func is None:
@@ -111,10 +112,10 @@ def _attribute_key_expression_to_expression(
                     f"Unknown AttributeKeyExpression op: {expr.formula.op}"
                 )
             left_expr, left_keys = _attribute_key_expression_to_expression(
-                expr.formula.left, attribute_key_to_expression
+                expr.formula.left, attribute_key_to_expression, organization_id
             )
             right_expr, right_keys = _attribute_key_expression_to_expression(
-                expr.formula.right, attribute_key_to_expression
+                expr.formula.right, attribute_key_to_expression, organization_id
             )
             return func(left_expr, right_expr), left_keys + right_keys
         case _:
@@ -123,7 +124,8 @@ def _attribute_key_expression_to_expression(
 
 def _resolve_field_and_existence(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
+    organization_id: int,
 ) -> tuple[Expression, Expression]:
     """Given a protobuf aggregation, returns (aggregation expression, existence expression)
     Aggregation expression - the actual aggregation ex: sum(attr1 + attr2)
@@ -131,10 +133,11 @@ def _resolve_field_and_existence(
     """
     if aggregation.HasField("expression"):
         field, keys = _attribute_key_expression_to_expression(
-            aggregation.expression, attribute_key_to_expression
+            aggregation.expression, attribute_key_to_expression, organization_id
         )
         existence_checks = [
-            get_field_existence_expression(attribute_key_to_expression(k)) for k in keys
+            get_field_existence_expression(attribute_key_to_expression(k, organization_id))
+            for k in keys
         ]
 
         existence: Expression = existence_checks[0]
@@ -148,7 +151,7 @@ def _resolve_field_and_existence(
     # Array keys resolve like scalars now: attribute_key_to_expression reads the typed
     # array column(s) natively and get_field_existence_expression maps that read to a
     # notEmpty existence check (see snuba.web.rpc.common.common).
-    field = attribute_key_to_expression(aggregation.key)
+    field = attribute_key_to_expression(aggregation.key, organization_id)
     return field, get_field_existence_expression(field)
 
 
@@ -384,7 +387,7 @@ def get_attribute_confidence_interval_alias(
 
 def get_average_sample_rate_column(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
@@ -398,7 +401,9 @@ def get_average_sample_rate_column(
         use_sampling_factor,
         aggregation.extrapolation_mode,
     )
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -427,11 +432,13 @@ def _get_count_column_alias(
 
 def get_count_column(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     *,
     organization_id: int,
 ) -> Expression:
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     return f.countIf(
         field,
         and_cond(
@@ -463,10 +470,12 @@ def _get_possible_percentiles(percentile: float, granularity: float, width: floa
 def _get_possible_percentiles_expression(
     aggregation: AttributeConditionalAggregation,
     percentile: float,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     granularity: float = 0.005,
     width: float = 0.1,
+    *,
+    organization_id: int,
 ) -> Expression:
     """
     In order to approximate the confidence intervals, we calculate a bunch of quantiles around the desired percentile, using the given granularity and width.
@@ -478,7 +487,9 @@ def _get_possible_percentiles_expression(
     The width isn't important as long as it contains the range of values that we actually care about, I just added it as a performance optimization.
     The granularity might need to be adjusted, but I think this is a good starting value.
     """
-    field, _field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, _field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     possible_percentiles = _get_possible_percentiles(percentile, granularity, width)
     alias = get_attribute_confidence_interval_alias(
         aggregation, {"granularity": str(granularity), "width": str(width)}
@@ -525,7 +536,7 @@ def get_extrapolated_function(
     aggregation: AttributeConditionalAggregation,
     field: Expression,
     field_exists: Expression,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
@@ -601,7 +612,7 @@ def get_extrapolated_function(
 
 def _get_ci_count(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
@@ -628,7 +639,9 @@ def _get_ci_count(
         dependent inclusion probabilities from the HT formula zero out.
     """
 
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -653,7 +666,7 @@ def _get_ci_count(
 
 def _get_ci_sum(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
@@ -674,7 +687,9 @@ def _get_ci_sum(
     variance of the total.
     """
 
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -702,7 +717,7 @@ def _get_ci_sum(
 
 def _get_ci_avg(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     alias: str | None = None,
     use_sampling_factor: bool = False,
     *,
@@ -731,7 +746,9 @@ def _get_ci_avg(
     average between the upper and lower error.
     """
 
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     condition_in_aggregation = _get_condition_in_aggregation(
         aggregation, attribute_key_to_expression, organization_id=organization_id
     )
@@ -789,7 +806,7 @@ def _get_ci_avg(
 
 def get_confidence_interval_column(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
@@ -824,19 +841,39 @@ def get_confidence_interval_column(
             organization_id=organization_id,
         ),
         Function.FUNCTION_P50: _get_possible_percentiles_expression(
-            aggregation, 0.5, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.5,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P75: _get_possible_percentiles_expression(
-            aggregation, 0.75, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.75,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P90: _get_possible_percentiles_expression(
-            aggregation, 0.9, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.9,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P95: _get_possible_percentiles_expression(
-            aggregation, 0.95, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.95,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P99: _get_possible_percentiles_expression(
-            aggregation, 0.99, attribute_key_to_expression, use_sampling_factor
+            aggregation,
+            0.99,
+            attribute_key_to_expression,
+            use_sampling_factor,
+            organization_id=organization_id,
         ),
     }
 
@@ -927,12 +964,14 @@ def _build_ordered_agg_sort_key(
 
 def aggregation_to_expression(
     aggregation: AttributeConditionalAggregation,
-    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    attribute_key_to_expression: Callable[[AttributeKey, int], Expression],
     use_sampling_factor: bool = False,
     *,
     organization_id: int,
 ) -> Expression:
-    field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
+    field, field_exists = _resolve_field_and_existence(
+        aggregation, attribute_key_to_expression, organization_id
+    )
     alias = aggregation.label if aggregation.label else None
     alias_dict = {"alias": alias} if alias else {}
     condition_in_aggregation = _get_condition_in_aggregation(

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -68,6 +68,8 @@ SERVER_SAMPLE_RATE_ATTRIBUTE = "server_sample_rate"
 def _get_condition_in_aggregation(
     aggregation: AttributeAggregation | AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    *,
+    organization_id: int,
 ) -> Expression:
     condition_in_aggregation: Expression = literal(True)
     if isinstance(aggregation, AttributeConditionalAggregation):
@@ -80,6 +82,7 @@ def _get_condition_in_aggregation(
             aggregation.filter,
             attribute_key_to_expression,
             membership_as_has=True,
+            organization_id=organization_id,
         )
     return condition_in_aggregation
 
@@ -383,6 +386,8 @@ def get_average_sample_rate_column(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     alias = CustomColumnInformation(
         custom_column_id="average_sample_rate",
@@ -395,7 +400,7 @@ def get_average_sample_rate_column(
     )
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     return f.divide(
         f.countIf(
@@ -423,13 +428,17 @@ def _get_count_column_alias(
 def get_count_column(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
+    *,
+    organization_id: int,
 ) -> Expression:
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     return f.countIf(
         field,
         and_cond(
             field_exists,
-            _get_condition_in_aggregation(aggregation, attribute_key_to_expression),
+            _get_condition_in_aggregation(
+                aggregation, attribute_key_to_expression, organization_id=organization_id
+            ),
         ),
         alias=_get_count_column_alias(aggregation),
     )
@@ -518,6 +527,8 @@ def get_extrapolated_function(
     field_exists: Expression,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> CurriedFunctionCall | FunctionCall | None:
     alias = aggregation.label or None
     alias_dict = {"alias": alias} if alias else {}
@@ -532,7 +543,7 @@ def get_extrapolated_function(
         )
 
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
 
     sampling_weight = _get_sampling_weight_expression(
@@ -594,6 +605,8 @@ def _get_ci_count(
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     r"""
     confidence interval = Z \cdot \sqrt{\sum_{i=1}^n w_i^2 - w_i}
@@ -617,7 +630,7 @@ def _get_ci_count(
 
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     alias_dict = {"alias": alias} if alias else {}
     sampling_weight = _get_sampling_weight_expression(
@@ -644,6 +657,8 @@ def _get_ci_sum(
     alias: str | None = None,
     z_value: float = Z_VALUE_P95,
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     r"""
     confidence interval = Z \cdot \sqrt{\sum_{i=1}^n x_i^2 \cdot (w_i^2 - w_i)}
@@ -661,7 +676,7 @@ def _get_ci_sum(
 
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     alias_dict = {"alias": alias} if alias else {}
     sampling_weight = _get_sampling_weight_expression(
@@ -690,6 +705,8 @@ def _get_ci_avg(
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     alias: str | None = None,
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     """
     confidence interval = (\\frac{t + err_t}{c - err_c} - \\frac{t - err_t}{c + err_c}) \\cdot 0.5
@@ -716,7 +733,7 @@ def _get_ci_avg(
 
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     alias_dict = {"alias": alias} if alias else {}
     sampling_weight = _get_sampling_weight_expression(
@@ -741,6 +758,7 @@ def _get_ci_avg(
         f"{alias}__sum_err",
         Z_VALUE_P975,
         use_sampling_factor,
+        organization_id=organization_id,
     )
     expr_count_err = _get_ci_count(
         aggregation,
@@ -748,6 +766,7 @@ def _get_ci_avg(
         f"{alias}__count_err",
         Z_VALUE_P975,
         use_sampling_factor,
+        organization_id=organization_id,
     )
 
     return f.divide(
@@ -772,6 +791,8 @@ def get_confidence_interval_column(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression | None:
     """
     Returns the expression for calculating the upper confidence limit for a given aggregation. If the aggregation cannot be extrapolated, returns None.
@@ -786,18 +807,21 @@ def get_confidence_interval_column(
             attribute_key_to_expression,
             alias,
             use_sampling_factor=use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_SUM: _get_ci_sum(
             aggregation,
             attribute_key_to_expression,
             alias,
             use_sampling_factor=use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_AVG: _get_ci_avg(
             aggregation,
             attribute_key_to_expression,
             alias,
             use_sampling_factor,
+            organization_id=organization_id,
         ),
         Function.FUNCTION_P50: _get_possible_percentiles_expression(
             aggregation, 0.5, attribute_key_to_expression, use_sampling_factor
@@ -905,12 +929,14 @@ def aggregation_to_expression(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
     use_sampling_factor: bool = False,
+    *,
+    organization_id: int,
 ) -> Expression:
     field, field_exists = _resolve_field_and_existence(aggregation, attribute_key_to_expression)
     alias = aggregation.label if aggregation.label else None
     alias_dict = {"alias": alias} if alias else {}
     condition_in_aggregation = _get_condition_in_aggregation(
-        aggregation, attribute_key_to_expression
+        aggregation, attribute_key_to_expression, organization_id=organization_id
     )
     max_array_size = get_option("snuba_query_max_array_size", 1000)
 
@@ -1010,6 +1036,7 @@ def aggregation_to_expression(
             field_exists,
             attribute_key_to_expression,
             use_sampling_factor,
+            organization_id=organization_id,
         )
     else:
         agg_func_expr = function_map.get(aggregation.aggregate)

--- a/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
+++ b/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 
 from google.protobuf.json_format import MessageToDict
@@ -132,6 +133,8 @@ def get_trace_ids_sql_for_cross_item_query(
     # (a SELECT-clause aggregate), where the membership must be has(array, x) so its
     # result-block column name is stable across mixed-version ClickHouse nodes
     # (membership_as_has, see common._in_or_has).
+    organization_id = request_meta.organization_id
+    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     filter_expressions = []
     having_filter_expressions = []
     if trace_filters:
@@ -151,7 +154,8 @@ def get_trace_ids_sql_for_cross_item_query(
                     item_type_cond,
                     trace_item_filters_to_expression(
                         trace_filter.filter,
-                        attribute_key_to_expression,
+                        attr_expr,
+                        organization_id=organization_id,
                     ),
                 )
             )
@@ -160,8 +164,9 @@ def get_trace_ids_sql_for_cross_item_query(
                     item_type_cond,
                     trace_item_filters_to_expression(
                         trace_filter.filter,
-                        attribute_key_to_expression,
+                        attr_expr,
                         membership_as_has=True,
+                        organization_id=organization_id,
                     ),
                 )
             )

--- a/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
+++ b/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 
 from google.protobuf.json_format import MessageToDict
@@ -134,7 +133,6 @@ def get_trace_ids_sql_for_cross_item_query(
     # result-block column name is stable across mixed-version ClickHouse nodes
     # (membership_as_has, see common._in_or_has).
     organization_id = request_meta.organization_id
-    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     filter_expressions = []
     having_filter_expressions = []
     if trace_filters:
@@ -154,7 +152,7 @@ def get_trace_ids_sql_for_cross_item_query(
                     item_type_cond,
                     trace_item_filters_to_expression(
                         trace_filter.filter,
-                        attr_expr,
+                        attribute_key_to_expression,
                         organization_id=organization_id,
                     ),
                 )
@@ -164,7 +162,7 @@ def get_trace_ids_sql_for_cross_item_query(
                     item_type_cond,
                     trace_item_filters_to_expression(
                         trace_filter.filter,
-                        attr_expr,
+                        attribute_key_to_expression,
                         membership_as_has=True,
                         organization_id=organization_id,
                     ),

--- a/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
+++ b/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 
 from google.protobuf.json_format import MessageToDict
@@ -133,6 +134,8 @@ def get_trace_ids_sql_for_cross_item_query(
     # (a SELECT-clause aggregate), where the membership must be has(array, x) so its
     # result-block column name is stable across mixed-version ClickHouse nodes
     # (membership_as_has, see common._in_or_has).
+    organization_id = request_meta.organization_id
+    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     filter_expressions = []
     having_filter_expressions = []
     if trace_filters:
@@ -154,8 +157,8 @@ def get_trace_ids_sql_for_cross_item_query(
                     trace_item_filters_to_expression(
                         trace_filter.item_type,
                         trace_filter.filter,
-                        attribute_key_to_expression,
-                        use_indexed_name=use_indexed_name,
+                        attr_expr,
+                        organization_id=organization_id,
                     ),
                 )
             )
@@ -165,9 +168,9 @@ def get_trace_ids_sql_for_cross_item_query(
                     trace_item_filters_to_expression(
                         trace_filter.item_type,
                         trace_filter.filter,
-                        attribute_key_to_expression,
+                        attr_expr,
                         membership_as_has=True,
-                        use_indexed_name=use_indexed_name,
+                        organization_id=organization_id,
                     ),
                 )
             )

--- a/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
+++ b/snuba/web/rpc/v1/resolvers/common/cross_item_queries.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 
 from google.protobuf.json_format import MessageToDict
@@ -135,7 +134,6 @@ def get_trace_ids_sql_for_cross_item_query(
     # result-block column name is stable across mixed-version ClickHouse nodes
     # (membership_as_has, see common._in_or_has).
     organization_id = request_meta.organization_id
-    attr_expr = functools.partial(attribute_key_to_expression, organization_id=organization_id)
     filter_expressions = []
     having_filter_expressions = []
     if trace_filters:
@@ -157,7 +155,7 @@ def get_trace_ids_sql_for_cross_item_query(
                     trace_item_filters_to_expression(
                         trace_filter.item_type,
                         trace_filter.filter,
-                        attr_expr,
+                        attribute_key_to_expression,
                         organization_id=organization_id,
                     ),
                 )
@@ -168,7 +166,7 @@ def get_trace_ids_sql_for_cross_item_query(
                     trace_item_filters_to_expression(
                         trace_filter.item_type,
                         trace_filter.filter,
-                        attr_expr,
+                        attribute_key_to_expression,
                         membership_as_has=True,
                         organization_id=organization_id,
                     ),

--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -57,7 +57,7 @@ _ATTRIBUTE_TYPE_TO_COLUMN: dict["AttributeKey.Type.ValueType", str] = {
 
 
 def _build_conditions(request: TraceItemAttributeValuesRequest) -> Expression:
-    attribute_key = attribute_key_to_expression(request.key)
+    attribute_key = attribute_key_to_expression(request.key, request.meta.organization_id)
 
     try:
         attributes_column = _ATTRIBUTE_TYPE_TO_COLUMN[request.key.type]
@@ -125,7 +125,7 @@ def _build_query(
         schema=get_entity(entity_key).get_data_model(),
         sample=None,
     )
-    attr_value = attribute_key_to_expression(request.key)
+    attr_value = attribute_key_to_expression(request.key, request.meta.organization_id)
     assert attr_value.alias
     inner_query = Query(
         from_clause=entity,

--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -58,7 +58,7 @@ _ATTRIBUTE_TYPE_TO_COLUMN: dict["AttributeKey.Type.ValueType", str] = {
 
 
 def _build_conditions(request: TraceItemAttributeValuesRequest) -> Expression:
-    attribute_key = attribute_key_to_expression(request.key)
+    attribute_key = attribute_key_to_expression(request.key, request.meta.organization_id)
 
     try:
         attributes_column = _ATTRIBUTE_TYPE_TO_COLUMN[request.key.type]
@@ -126,7 +126,7 @@ def _build_query(
         schema=get_entity(entity_key).get_data_model(),
         sample=None,
     )
-    attr_value = attribute_key_to_expression(request.key)
+    attr_value = attribute_key_to_expression(request.key, request.meta.organization_id)
     assert attr_value.alias
     inner_query = Query(
         from_clause=entity,

--- a/tests/protos/test_protos_common.py
+++ b/tests/protos/test_protos_common.py
@@ -20,11 +20,13 @@ class TestAttributeKeyToExpression:
                 type=AttributeKey.TYPE_STRING,
                 name="sentry.trace_id",
             ),
+            1,
         ) == f.cast(column("trace_id"), "String", alias="sentry.trace_id_TYPE_STRING")
 
     def test_attributes(self) -> None:
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_STRING, name="derp"),
+            1,
         ) == SubscriptableReference(
             alias="derp_TYPE_STRING",
             column=column("attributes_string"),
@@ -33,6 +35,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_FLOAT, name="derp"),
+            1,
         ) == SubscriptableReference(
             alias="derp_TYPE_FLOAT",
             column=column("attributes_float"),
@@ -41,6 +44,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="derp"),
+            1,
         ) == SubscriptableReference(
             alias="derp_TYPE_DOUBLE",
             column=column("attributes_float"),
@@ -49,6 +53,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_INT, name="derp"),
+            1,
         ) == f.cast(
             SubscriptableReference(
                 alias=None,
@@ -61,6 +66,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="derp"),
+            1,
         ) == f.cast(
             arrayElement(
                 None,
@@ -88,6 +94,7 @@ class TestAttributeKeyToExpression:
                 type=AttributeKey.TYPE_STRING,
                 name=new_attribute,
             ),
+            1,
         ) == f.coalesce(
             SubscriptableReference(
                 alias=None,
@@ -102,6 +109,7 @@ class TestAttributeKeyToExpression:
         for name in ATTRIBUTES_TO_COALESCE:
             result = attribute_key_to_expression(
                 AttributeKey(type=AttributeKey.TYPE_STRING, name=name),
+                1,
             )
             assert isinstance(result, FunctionCall)
             assert result.function_name == "coalesce"
@@ -150,13 +158,13 @@ class TestAttributeKeyToExpression:
     def test_unspecified_type_raises_exception(self) -> None:
         with pytest.raises(MalformedAttributeException) as exc_info:
             attribute_key_to_expression(
-                AttributeKey(type=AttributeKey.TYPE_UNSPECIFIED, name="test_attr")
+                AttributeKey(type=AttributeKey.TYPE_UNSPECIFIED, name="test_attr"), 1
             )
         assert "must have a type specified" in str(exc_info.value)
 
     def test_invalid_type_for_normalized_column_raises_exception(self) -> None:
         with pytest.raises(MalformedAttributeException) as exc_info:
             attribute_key_to_expression(
-                AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.trace_id")
+                AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.trace_id"), 1
             )
         assert "must be one of" in str(exc_info.value)

--- a/tests/protos/test_protos_common.py
+++ b/tests/protos/test_protos_common.py
@@ -1,12 +1,15 @@
 import pytest
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
+from sentry_options.testing import override_options
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.protos.common import (
     ATTRIBUTES_TO_COALESCE,
+    UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION,
     MalformedAttributeException,
     _resolve_canonical,
     attribute_key_to_expression,
+    get_normalized_columns_eap_items,
 )
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import arrayElement, column, literal
@@ -168,3 +171,37 @@ class TestAttributeKeyToExpression:
                 AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.trace_id"), 1
             )
         assert "must be one of" in str(exc_info.value)
+
+
+# An unbackfilled normalized column key; present in the resolved column set only when the
+# org is opted into the allowlist (see get_normalized_columns_eap_items).
+_UNBACKFILLED_KEY = "gen_ai.conversation.id"
+
+
+class TestGetNormalizedColumnsEapItems:
+    @pytest.mark.parametrize(
+        "allowlist,organization_id,expected_unbackfilled",
+        [
+            # opted in: the org appears in a well-formed allowlist
+            ("1,2,3", 2, True),
+            (" 1 , 2 ", 2, True),  # surrounding whitespace is tolerated
+            # opted out: org absent, no org in context, or feature off (empty allowlist)
+            ("1,2,3", 5, False),
+            ("1", None, False),
+            ("", 1, False),
+            # malformed allowlist must not raise -> org falls back to opted out, even when
+            # the numeric id would otherwise match
+            ("1,2,", 1, False),  # trailing comma -> empty token
+            ("1,abc", 1, False),  # non-numeric entry
+        ],
+    )
+    def test_unbackfilled_columns_gate(
+        self, allowlist: str, organization_id: int | None, expected_unbackfilled: bool
+    ) -> None:
+        with override_options(
+            "snuba", {UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION: allowlist}
+        ):
+            columns = get_normalized_columns_eap_items(organization_id)
+        assert (_UNBACKFILLED_KEY in columns) is expected_unbackfilled
+        # backfilled normalized columns are always present regardless of the gate
+        assert "sentry.trace_id" in columns

--- a/tests/protos/test_protos_common.py
+++ b/tests/protos/test_protos_common.py
@@ -5,7 +5,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.protos.common import (
     ATTRIBUTES_TO_COALESCE,
-    UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION,
+    UNPOPULATED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION,
     MalformedAttributeException,
     _resolve_canonical,
     attribute_key_to_expression,
@@ -173,14 +173,14 @@ class TestAttributeKeyToExpression:
         assert "must be one of" in str(exc_info.value)
 
 
-# An unbackfilled normalized column key; present in the resolved column set only when the
+# An unpopulated normalized column key; present in the resolved column set only when the
 # org is opted into the allowlist (see get_normalized_columns_eap_items).
-_UNBACKFILLED_KEY = "gen_ai.conversation.id"
+_UNPOPULATED_KEY = "gen_ai.conversation.id"
 
 
 class TestGetNormalizedColumnsEapItems:
     @pytest.mark.parametrize(
-        "allowlist,organization_id,expected_unbackfilled",
+        "allowlist,organization_id,expected_unpopulated",
         [
             # opted in: the org appears in a well-formed allowlist
             ("1,2,3", 2, True),
@@ -195,13 +195,13 @@ class TestGetNormalizedColumnsEapItems:
             ("1,abc", 1, False),  # non-numeric entry
         ],
     )
-    def test_unbackfilled_columns_gate(
-        self, allowlist: str, organization_id: int | None, expected_unbackfilled: bool
+    def test_unpopulated_columns_gate(
+        self, allowlist: str, organization_id: int | None, expected_unpopulated: bool
     ) -> None:
         with override_options(
-            "snuba", {UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION: allowlist}
+            "snuba", {UNPOPULATED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION: allowlist}
         ):
             columns = get_normalized_columns_eap_items(organization_id)
-        assert (_UNBACKFILLED_KEY in columns) is expected_unbackfilled
-        # backfilled normalized columns are always present regardless of the gate
+        assert (_UNPOPULATED_KEY in columns) is expected_unpopulated
+        # populated normalized columns are always present regardless of the gate
         assert "sentry.trace_id" in columns

--- a/tests/protos/test_protos_common.py
+++ b/tests/protos/test_protos_common.py
@@ -5,7 +5,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.protos.common import (
     ATTRIBUTES_TO_COALESCE,
-    UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION,
+    UNPOPULATED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION,
     MalformedAttributeException,
     _resolve_canonical,
     attribute_key_to_expression,
@@ -178,14 +178,14 @@ class TestAttributeKeyToExpression:
         assert "must be one of" in str(exc_info.value)
 
 
-# An unbackfilled normalized column key; present in the resolved column set only when the
+# An unpopulated normalized column key; present in the resolved column set only when the
 # org is opted into the allowlist (see get_normalized_columns_eap_items).
-_UNBACKFILLED_KEY = "gen_ai.conversation.id"
+_UNPOPULATED_KEY = "gen_ai.conversation.id"
 
 
 class TestGetNormalizedColumnsEapItems:
     @pytest.mark.parametrize(
-        "allowlist,organization_id,expected_unbackfilled",
+        "allowlist,organization_id,expected_unpopulated",
         [
             # opted in: the org appears in a well-formed allowlist
             ("1,2,3", 2, True),
@@ -200,13 +200,13 @@ class TestGetNormalizedColumnsEapItems:
             ("1,abc", 1, False),  # non-numeric entry
         ],
     )
-    def test_unbackfilled_columns_gate(
-        self, allowlist: str, organization_id: int | None, expected_unbackfilled: bool
+    def test_unpopulated_columns_gate(
+        self, allowlist: str, organization_id: int | None, expected_unpopulated: bool
     ) -> None:
         with override_options(
-            "snuba", {UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION: allowlist}
+            "snuba", {UNPOPULATED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION: allowlist}
         ):
             columns = get_normalized_columns_eap_items(organization_id)
-        assert (_UNBACKFILLED_KEY in columns) is expected_unbackfilled
-        # backfilled normalized columns are always present regardless of the gate
+        assert (_UNPOPULATED_KEY in columns) is expected_unpopulated
+        # populated normalized columns are always present regardless of the gate
         assert "sentry.trace_id" in columns

--- a/tests/protos/test_protos_common.py
+++ b/tests/protos/test_protos_common.py
@@ -1,12 +1,15 @@
 import pytest
 from sentry_conventions.attributes import ATTRIBUTE_METADATA
+from sentry_options.testing import override_options
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 
 from snuba.protos.common import (
     ATTRIBUTES_TO_COALESCE,
+    UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION,
     MalformedAttributeException,
     _resolve_canonical,
     attribute_key_to_expression,
+    get_normalized_columns_eap_items,
 )
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import arrayElement, column, literal, map_key_exists
@@ -173,3 +176,37 @@ class TestAttributeKeyToExpression:
                 AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.trace_id"), 1
             )
         assert "must be one of" in str(exc_info.value)
+
+
+# An unbackfilled normalized column key; present in the resolved column set only when the
+# org is opted into the allowlist (see get_normalized_columns_eap_items).
+_UNBACKFILLED_KEY = "gen_ai.conversation.id"
+
+
+class TestGetNormalizedColumnsEapItems:
+    @pytest.mark.parametrize(
+        "allowlist,organization_id,expected_unbackfilled",
+        [
+            # opted in: the org appears in a well-formed allowlist
+            ("1,2,3", 2, True),
+            (" 1 , 2 ", 2, True),  # surrounding whitespace is tolerated
+            # opted out: org absent, no org in context, or feature off (empty allowlist)
+            ("1,2,3", 5, False),
+            ("1", None, False),
+            ("", 1, False),
+            # malformed allowlist must not raise -> org falls back to opted out, even when
+            # the numeric id would otherwise match
+            ("1,2,", 1, False),  # trailing comma -> empty token
+            ("1,abc", 1, False),  # non-numeric entry
+        ],
+    )
+    def test_unbackfilled_columns_gate(
+        self, allowlist: str, organization_id: int | None, expected_unbackfilled: bool
+    ) -> None:
+        with override_options(
+            "snuba", {UNBACKFILLED_NORMALIZED_COLUMNS_ORG_ALLOWLIST_OPTION: allowlist}
+        ):
+            columns = get_normalized_columns_eap_items(organization_id)
+        assert (_UNBACKFILLED_KEY in columns) is expected_unbackfilled
+        # backfilled normalized columns are always present regardless of the gate
+        assert "sentry.trace_id" in columns

--- a/tests/protos/test_protos_common.py
+++ b/tests/protos/test_protos_common.py
@@ -20,11 +20,13 @@ class TestAttributeKeyToExpression:
                 type=AttributeKey.TYPE_STRING,
                 name="sentry.trace_id",
             ),
+            1,
         ) == f.cast(column("trace_id"), "String", alias="sentry.trace_id_TYPE_STRING")
 
     def test_attributes(self) -> None:
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_STRING, name="derp"),
+            1,
         ) == SubscriptableReference(
             alias="derp_TYPE_STRING",
             column=column("attributes_string"),
@@ -33,6 +35,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_FLOAT, name="derp"),
+            1,
         ) == SubscriptableReference(
             alias="derp_TYPE_FLOAT",
             column=column("attributes_float"),
@@ -41,6 +44,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="derp"),
+            1,
         ) == SubscriptableReference(
             alias="derp_TYPE_DOUBLE",
             column=column("attributes_float"),
@@ -49,6 +53,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_INT, name="derp"),
+            1,
         ) == f.cast(
             SubscriptableReference(
                 alias=None,
@@ -61,6 +66,7 @@ class TestAttributeKeyToExpression:
 
         assert attribute_key_to_expression(
             AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="derp"),
+            1,
         ) == f.cast(
             arrayElement(
                 None,
@@ -94,12 +100,22 @@ class TestAttributeKeyToExpression:
                 type=AttributeKey.TYPE_STRING,
                 name=new_attribute,
             ),
-        ) == f.multiIf(*multiif_args, alias=f"{new_attribute}_TYPE_STRING")
+            1,
+        ) == f.coalesce(
+            SubscriptableReference(
+                alias=None,
+                column=column("attributes_string"),
+                key=literal(new_attribute),
+            ),
+            *references,
+            alias=f"{new_attribute}_TYPE_STRING",
+        )
 
     def test_coalesce_queried_attribute_is_first(self) -> None:
         for name in ATTRIBUTES_TO_COALESCE:
             result = attribute_key_to_expression(
                 AttributeKey(type=AttributeKey.TYPE_STRING, name=name),
+                1,
             )
             assert isinstance(result, FunctionCall)
             assert result.function_name == "multiIf"
@@ -147,13 +163,13 @@ class TestAttributeKeyToExpression:
     def test_unspecified_type_raises_exception(self) -> None:
         with pytest.raises(MalformedAttributeException) as exc_info:
             attribute_key_to_expression(
-                AttributeKey(type=AttributeKey.TYPE_UNSPECIFIED, name="test_attr")
+                AttributeKey(type=AttributeKey.TYPE_UNSPECIFIED, name="test_attr"), 1
             )
         assert "must have a type specified" in str(exc_info.value)
 
     def test_invalid_type_for_normalized_column_raises_exception(self) -> None:
         with pytest.raises(MalformedAttributeException) as exc_info:
             attribute_key_to_expression(
-                AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.trace_id")
+                AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.trace_id"), 1
             )
         assert "must be one of" in str(exc_info.value)

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any
 
 import pytest
@@ -106,7 +107,8 @@ def test_get_confidence_interval_column_for_non_extrapolatable_column() -> None:
                 label="min(test)",
                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
             ),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         is None
     )
@@ -274,7 +276,7 @@ def test_attribute_key_to_expression_typed_array() -> None:
 
     # An element-typed array key reads its single typed column natively.
     attr_key = AttributeKey(type=AttributeKey.TYPE_ARRAY_INT, name="user_ids")
-    expr = attribute_key_to_expression(attr_key)
+    expr = attribute_key_to_expression(attr_key, 1)
     assert isinstance(expr, FunctionCall)
     assert expr.function_name == "arrayElement"
     assert expr.alias == "user_ids_TYPE_ARRAY_INT"
@@ -287,7 +289,7 @@ def test_attribute_key_to_expression_deprecated_type_array() -> None:
     # The deprecated untyped TYPE_ARRAY concatenates all four typed columns (normalized to
     # Array(String)); no read of the legacy attributes_array JSON column.
     attr_key = AttributeKey(type=AttributeKey.TYPE_ARRAY, name="user_ids")
-    expr = attribute_key_to_expression(attr_key)
+    expr = attribute_key_to_expression(attr_key, 1)
     assert isinstance(expr, FunctionCall)
     assert expr.function_name == "arrayConcat"
     columns = _collect_column_names(expr)
@@ -345,7 +347,11 @@ def test_aggregation_to_expression_uniq_typed_array() -> None:
         label="uniq_users",
         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     )
-    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    expr = aggregation_to_expression(
+        agg,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
+    )
     assert isinstance(expr, FunctionCall)
     assert expr.function_name == "round"
     assert expr.alias == "uniq_users"
@@ -367,7 +373,11 @@ def test_aggregation_to_expression_uniq_deprecated_type_array() -> None:
         label="uniq_users",
         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     )
-    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    expr = aggregation_to_expression(
+        agg,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
+    )
     assert isinstance(expr, FunctionCall)
     inner = expr.parameters[0]
     assert isinstance(inner, FunctionCall)
@@ -386,7 +396,11 @@ def test_aggregation_to_expression_sum_type_array_raises() -> None:
         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     )
     with pytest.raises(BadSnubaRPCRequestException, match="not supported for array attribute"):
-        aggregation_to_expression(agg, attribute_key_to_expression)
+        aggregation_to_expression(
+            agg,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
 
 def test_conditional_aggregation_uses_has_for_in_sets() -> None:
@@ -414,7 +428,11 @@ def test_conditional_aggregation_uses_has_for_in_sets() -> None:
         ),
     )
 
-    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    expr = aggregation_to_expression(
+        agg,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
+    )
 
     # No in() over a constant array may survive (it would reintroduce the __set_* id).
     in_over_arrays = [
@@ -464,7 +482,13 @@ def test_conditional_aggregation_array_filter_uses_typed_columns() -> None:
         ),
     )
 
-    cols = _aggregation_column_names(aggregation_to_expression(agg, attribute_key_to_expression))
+    cols = _aggregation_column_names(
+        aggregation_to_expression(
+            agg,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
+    )
     # A LIKE pattern on a string array reads just the typed string array column — not the
     # other typed columns nor the legacy JSON column.
     assert "attributes_array_string" in cols

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -1,4 +1,3 @@
-import functools
 from typing import Any
 
 import pytest
@@ -107,7 +106,7 @@ def test_get_confidence_interval_column_for_non_extrapolatable_column() -> None:
                 label="min(test)",
                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         is None
@@ -349,7 +348,7 @@ def test_aggregation_to_expression_uniq_typed_array() -> None:
     )
     expr = aggregation_to_expression(
         agg,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
     assert isinstance(expr, FunctionCall)
@@ -375,7 +374,7 @@ def test_aggregation_to_expression_uniq_deprecated_type_array() -> None:
     )
     expr = aggregation_to_expression(
         agg,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
     assert isinstance(expr, FunctionCall)
@@ -398,7 +397,7 @@ def test_aggregation_to_expression_sum_type_array_raises() -> None:
     with pytest.raises(BadSnubaRPCRequestException, match="not supported for array attribute"):
         aggregation_to_expression(
             agg,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -430,7 +429,7 @@ def test_conditional_aggregation_uses_has_for_in_sets() -> None:
 
     expr = aggregation_to_expression(
         agg,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
 
@@ -485,7 +484,7 @@ def test_conditional_aggregation_array_filter_uses_typed_columns() -> None:
     cols = _aggregation_column_names(
         aggregation_to_expression(
             agg,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
     )

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any
 
 import pytest
@@ -107,7 +108,8 @@ def test_get_confidence_interval_column_for_non_extrapolatable_column() -> None:
                 label="min(test)",
                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
             ),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         is None
     )
@@ -275,7 +277,7 @@ def test_attribute_key_to_expression_typed_array() -> None:
 
     # An element-typed array key reads its single typed column natively.
     attr_key = AttributeKey(type=AttributeKey.TYPE_ARRAY_INT, name="user_ids")
-    expr = attribute_key_to_expression(attr_key)
+    expr = attribute_key_to_expression(attr_key, 1)
     assert isinstance(expr, FunctionCall)
     assert expr.function_name == "arrayElement"
     assert expr.alias == "user_ids_TYPE_ARRAY_INT"
@@ -288,7 +290,7 @@ def test_attribute_key_to_expression_deprecated_type_array() -> None:
     # The deprecated untyped TYPE_ARRAY concatenates all four typed columns (normalized to
     # Array(String)); no read of the legacy attributes_array JSON column.
     attr_key = AttributeKey(type=AttributeKey.TYPE_ARRAY, name="user_ids")
-    expr = attribute_key_to_expression(attr_key)
+    expr = attribute_key_to_expression(attr_key, 1)
     assert isinstance(expr, FunctionCall)
     assert expr.function_name == "arrayConcat"
     columns = _collect_column_names(expr)
@@ -346,7 +348,11 @@ def test_aggregation_to_expression_uniq_typed_array() -> None:
         label="uniq_users",
         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     )
-    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    expr = aggregation_to_expression(
+        agg,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
+    )
     assert isinstance(expr, FunctionCall)
     assert expr.function_name == "round"
     assert expr.alias == "uniq_users"
@@ -368,7 +374,11 @@ def test_aggregation_to_expression_uniq_deprecated_type_array() -> None:
         label="uniq_users",
         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     )
-    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    expr = aggregation_to_expression(
+        agg,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
+    )
     assert isinstance(expr, FunctionCall)
     inner = expr.parameters[0]
     assert isinstance(inner, FunctionCall)
@@ -387,7 +397,11 @@ def test_aggregation_to_expression_sum_type_array_raises() -> None:
         extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
     )
     with pytest.raises(BadSnubaRPCRequestException, match="not supported for array attribute"):
-        aggregation_to_expression(agg, attribute_key_to_expression)
+        aggregation_to_expression(
+            agg,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
 
 def _collect_unique_aggregation(
@@ -469,7 +483,11 @@ def test_conditional_aggregation_uses_has_for_in_sets() -> None:
         ),
     )
 
-    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    expr = aggregation_to_expression(
+        agg,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
+    )
 
     # No in() over a constant array may survive (it would reintroduce the __set_* id).
     in_over_arrays = [
@@ -519,7 +537,13 @@ def test_conditional_aggregation_array_filter_uses_typed_columns() -> None:
         ),
     )
 
-    cols = _aggregation_column_names(aggregation_to_expression(agg, attribute_key_to_expression))
+    cols = _aggregation_column_names(
+        aggregation_to_expression(
+            agg,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
+    )
     # A LIKE pattern on a string array reads just the typed string array column — not the
     # other typed columns nor the legacy JSON column.
     assert "attributes_array_string" in cols

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -1,4 +1,3 @@
-import functools
 from typing import Any
 
 import pytest
@@ -108,7 +107,7 @@ def test_get_confidence_interval_column_for_non_extrapolatable_column() -> None:
                 label="min(test)",
                 extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         is None
@@ -350,7 +349,7 @@ def test_aggregation_to_expression_uniq_typed_array() -> None:
     )
     expr = aggregation_to_expression(
         agg,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
     assert isinstance(expr, FunctionCall)
@@ -376,7 +375,7 @@ def test_aggregation_to_expression_uniq_deprecated_type_array() -> None:
     )
     expr = aggregation_to_expression(
         agg,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
     assert isinstance(expr, FunctionCall)
@@ -399,7 +398,7 @@ def test_aggregation_to_expression_sum_type_array_raises() -> None:
     with pytest.raises(BadSnubaRPCRequestException, match="not supported for array attribute"):
         aggregation_to_expression(
             agg,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -485,7 +484,7 @@ def test_conditional_aggregation_uses_has_for_in_sets() -> None:
 
     expr = aggregation_to_expression(
         agg,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
 
@@ -540,7 +539,7 @@ def test_conditional_aggregation_array_filter_uses_typed_columns() -> None:
     cols = _aggregation_column_names(
         aggregation_to_expression(
             agg,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
     )

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -122,7 +123,11 @@ class TestTraceItemFiltersArrayLike:
 
     def test_like_on_array_key(self) -> None:
         item_filter = self._make_like_filter("my_tags", AttributeKey.Type.TYPE_ARRAY, "%error%")
-        result = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
         # First param is a Lambda with like
@@ -138,7 +143,11 @@ class TestTraceItemFiltersArrayLike:
         item_filter = self._make_like_filter(
             "my_tags", AttributeKey.Type.TYPE_ARRAY, "%error%", ignore_case=True
         )
-        result = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
         lam = result.parameters[0]
@@ -153,7 +162,11 @@ class TestTraceItemFiltersArrayLike:
             "%error%",
             op=ComparisonFilter.OP_NOT_LIKE,
         )
-        result = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         # Result should be NOT(arrayExists(...))
         assert isinstance(result, FunctionCall)
         assert result.function_name == "not"
@@ -173,7 +186,11 @@ class TestTraceItemFiltersArrayLike:
             op=ComparisonFilter.OP_NOT_LIKE,
             ignore_case=True,
         )
-        result = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "not"
         inner = result.parameters[0]
@@ -196,7 +213,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="LIKE/NOT_LIKE on array keys requires a string pattern",
         ):
-            trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
     def test_equals_on_array_key_with_str_array_value_raises(self) -> None:
         item_filter = TraceItemFilter(
@@ -210,7 +231,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="OP_EQUALS/OP_NOT_EQUALS on array keys require a scalar value",
         ):
-            trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
     def test_like_on_int_key_raises(self) -> None:
         item_filter = self._make_like_filter("my_int", AttributeKey.Type.TYPE_INT, "%something%")
@@ -218,7 +243,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="LIKE comparison is only supported on string and array keys",
         ):
-            trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
     def test_not_like_on_int_key_raises(self) -> None:
         item_filter = self._make_like_filter(
@@ -231,7 +260,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="NOT LIKE comparison is only supported on string and array keys",
         ):
-            trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
 
 def _collect_column_names(expr: Expression) -> set[str]:
@@ -309,7 +342,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="%error%"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -325,7 +359,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="error"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -342,7 +377,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="12"),
                 AttributeKey.Type.TYPE_ARRAY_INT,
             ),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -356,7 +392,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="true"),
                 AttributeKey.Type.TYPE_ARRAY_BOOL,
             ),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -369,7 +406,11 @@ class TestTraceItemFiltersArrayMapColumns:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_ARRAY_INT, name="my_tags")
             )
         )
-        result = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         # Existence is notEmpty(arrayElement(attributes_array_int, 'my_tags')).
         assert isinstance(result, FunctionCall)
         assert result.function_name == "notEmpty"
@@ -382,7 +423,8 @@ class TestTraceItemFiltersArrayMapColumns:
         # a float, so it searches both numeric columns plus the string column natively.
         result = trace_item_filters_to_expression(
             self._array_filter(ComparisonFilter.OP_EQUALS, AttributeValue(val_str="12")),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "or"
@@ -402,7 +444,8 @@ class TestTraceItemFiltersArrayMapColumns:
     ) -> None:
         result = trace_item_filters_to_expression(
             self._array_filter(ComparisonFilter.OP_NOT_EQUALS, AttributeValue(val_str="12")),
-            attribute_key_to_expression,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "not"
@@ -421,7 +464,11 @@ class TestTraceItemFiltersArrayMapColumns:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_ARRAY, name="my_tags")
             )
         )
-        result = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         # Existence is notEmpty(arrayConcat(...)) over the four typed columns.
         assert isinstance(result, FunctionCall)
         assert result.function_name == "notEmpty"
@@ -468,7 +515,11 @@ class TestExistsFilterCoalesced:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_STRING, name=canonical)
             )
         )
-        expr = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        expr = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == "or"
         checked_keys = self._collect_existence_keys(expr)
@@ -482,7 +533,11 @@ class TestExistsFilterCoalesced:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_STRING, name="some.custom.tag")
             )
         )
-        expr = trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        expr = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == "has"
 
@@ -513,7 +568,11 @@ class TestSentryTimestampFilter:
     def test_range_filter_uses_raw_timestamp_column(
         self, op: "ComparisonFilter.Op.ValueType", expected_function: str
     ) -> None:
-        expr = trace_item_filters_to_expression(self._range_filter(op), attribute_key_to_expression)
+        expr = trace_item_filters_to_expression(
+            self._range_filter(op),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == expected_function
 
@@ -552,7 +611,11 @@ class TestSentryTimestampFilter:
                 value=AttributeValue(val_double=1781040732.7),
             )
         )
-        expr = trace_item_filters_to_expression(fractional, attribute_key_to_expression)
+        expr = trace_item_filters_to_expression(
+            fractional,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         rhs = expr.parameters[1]
         assert isinstance(rhs, FunctionCall)
@@ -565,7 +628,9 @@ class TestSentryTimestampFilter:
     def test_equals_filter_unchanged(self) -> None:
         """Non-range comparisons keep the existing CAST-based behavior."""
         expr = trace_item_filters_to_expression(
-            self._range_filter(ComparisonFilter.OP_EQUALS), attribute_key_to_expression
+            self._range_filter(ComparisonFilter.OP_EQUALS),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         # equals path wraps in the null-aware OR; the LHS of the equals is still the CAST.
         assert isinstance(expr, FunctionCall)
@@ -678,7 +743,11 @@ class TestAnalyzerSafeFilters:
                 ignore_case=ignore_case,
             )
         )
-        return trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        return trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
     # --- pruned forms: literal != column default, so no existence guard ---
 
@@ -825,7 +894,11 @@ class TestBooleanAttributeFilters:
                 value=value,
             )
         )
-        return trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        return trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
     def test_equals_false_keeps_existence_guard(self) -> None:
         expr = self._build(ComparisonFilter.OP_EQUALS, value=AttributeValue(val_bool=False))
@@ -873,7 +946,11 @@ class TestNormalizedColumnsNotMapBacked:
                 value=AttributeValue(val_str="abc"),
             )
         )
-        return trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+        return trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
     def test_normalized_string_column_bypasses_map_backed_path(self) -> None:
         expr = self._build("sentry.trace_id")
@@ -1451,12 +1528,20 @@ class TestAnyAttributeFilterOption:
 
     def test_enabled_by_default_translates_filter(self) -> None:
         # Schema default is true: the filter is translated, not short-circuited.
-        result = trace_item_filters_to_expression(self._filter(), attribute_key_to_expression)
+        result = trace_item_filters_to_expression(
+            self._filter(),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
 
     def test_disabled_returns_always_true(self) -> None:
         with override_options("snuba", {"enable_any_attribute_filter": False}):
-            result = trace_item_filters_to_expression(self._filter(), attribute_key_to_expression)
+            result = trace_item_filters_to_expression(
+                self._filter(),
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
         assert isinstance(result, Literal)
         assert result.value is True

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -125,7 +124,7 @@ class TestTraceItemFiltersArrayLike:
         item_filter = self._make_like_filter("my_tags", AttributeKey.Type.TYPE_ARRAY, "%error%")
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -145,7 +144,7 @@ class TestTraceItemFiltersArrayLike:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -164,7 +163,7 @@ class TestTraceItemFiltersArrayLike:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # Result should be NOT(arrayExists(...))
@@ -188,7 +187,7 @@ class TestTraceItemFiltersArrayLike:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -215,7 +214,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -233,7 +232,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -245,7 +244,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -262,7 +261,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -342,7 +341,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="%error%"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -359,7 +358,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="error"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -377,7 +376,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="12"),
                 AttributeKey.Type.TYPE_ARRAY_INT,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -392,7 +391,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="true"),
                 AttributeKey.Type.TYPE_ARRAY_BOOL,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -408,7 +407,7 @@ class TestTraceItemFiltersArrayMapColumns:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # Existence is notEmpty(arrayElement(attributes_array_int, 'my_tags')).
@@ -423,7 +422,7 @@ class TestTraceItemFiltersArrayMapColumns:
         # a float, so it searches both numeric columns plus the string column natively.
         result = trace_item_filters_to_expression(
             self._array_filter(ComparisonFilter.OP_EQUALS, AttributeValue(val_str="12")),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -444,7 +443,7 @@ class TestTraceItemFiltersArrayMapColumns:
     ) -> None:
         result = trace_item_filters_to_expression(
             self._array_filter(ComparisonFilter.OP_NOT_EQUALS, AttributeValue(val_str="12")),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -466,7 +465,7 @@ class TestTraceItemFiltersArrayMapColumns:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # Existence is notEmpty(arrayConcat(...)) over the four typed columns.
@@ -517,7 +516,7 @@ class TestExistsFilterCoalesced:
         )
         expr = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -535,7 +534,7 @@ class TestExistsFilterCoalesced:
         )
         expr = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -570,7 +569,7 @@ class TestSentryTimestampFilter:
     ) -> None:
         expr = trace_item_filters_to_expression(
             self._range_filter(op),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -613,7 +612,7 @@ class TestSentryTimestampFilter:
         )
         expr = trace_item_filters_to_expression(
             fractional,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -629,7 +628,7 @@ class TestSentryTimestampFilter:
         """Non-range comparisons keep the existing CAST-based behavior."""
         expr = trace_item_filters_to_expression(
             self._range_filter(ComparisonFilter.OP_EQUALS),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # equals path wraps in the null-aware OR; the LHS of the equals is still the CAST.
@@ -745,7 +744,7 @@ class TestAnalyzerSafeFilters:
         )
         return trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -896,7 +895,7 @@ class TestBooleanAttributeFilters:
         )
         return trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -948,7 +947,7 @@ class TestNormalizedColumnsNotMapBacked:
         )
         return trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -1530,7 +1529,7 @@ class TestAnyAttributeFilterOption:
         # Schema default is true: the filter is translated, not short-circuited.
         result = trace_item_filters_to_expression(
             self._filter(),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -1540,7 +1539,7 @@ class TestAnyAttributeFilterOption:
         with override_options("snuba", {"enable_any_attribute_filter": False}):
             result = trace_item_filters_to_expression(
                 self._filter(),
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
         assert isinstance(result, Literal)

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -131,7 +130,7 @@ class TestTraceItemFiltersArrayLike:
         item_filter = self._make_like_filter("my_tags", AttributeKey.Type.TYPE_ARRAY, "%error%")
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -151,7 +150,7 @@ class TestTraceItemFiltersArrayLike:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -170,7 +169,7 @@ class TestTraceItemFiltersArrayLike:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # Result should be NOT(arrayExists(...))
@@ -194,7 +193,7 @@ class TestTraceItemFiltersArrayLike:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -221,7 +220,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -241,7 +240,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -253,7 +252,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -270,7 +269,7 @@ class TestTraceItemFiltersArrayLike:
         ):
             trace_item_filters_to_expression(
                 item_filter,
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 
@@ -350,7 +349,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="%error%"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -367,7 +366,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="error"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -385,7 +384,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="12"),
                 AttributeKey.Type.TYPE_ARRAY_INT,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -400,7 +399,7 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="true"),
                 AttributeKey.Type.TYPE_ARRAY_BOOL,
             ),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -416,7 +415,7 @@ class TestTraceItemFiltersArrayMapColumns:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # Existence is notEmpty(arrayElement(attributes_array_int, 'my_tags')).
@@ -431,7 +430,7 @@ class TestTraceItemFiltersArrayMapColumns:
         # a float, so it searches both numeric columns plus the string column natively.
         result = _span_expression(
             self._array_filter(ComparisonFilter.OP_EQUALS, AttributeValue(val_str="12")),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -452,7 +451,7 @@ class TestTraceItemFiltersArrayMapColumns:
     ) -> None:
         result = _span_expression(
             self._array_filter(ComparisonFilter.OP_NOT_EQUALS, AttributeValue(val_str="12")),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -474,7 +473,7 @@ class TestTraceItemFiltersArrayMapColumns:
         )
         result = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # Existence is notEmpty(arrayConcat(...)) over the four typed columns.
@@ -708,7 +707,7 @@ class TestExistsFilterCoalesced:
         )
         expr = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -726,7 +725,7 @@ class TestExistsFilterCoalesced:
         )
         expr = trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -761,7 +760,7 @@ class TestSentryTimestampFilter:
     ) -> None:
         expr = trace_item_filters_to_expression(
             self._range_filter(op),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -804,7 +803,7 @@ class TestSentryTimestampFilter:
         )
         expr = trace_item_filters_to_expression(
             fractional,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(expr, FunctionCall)
@@ -820,7 +819,7 @@ class TestSentryTimestampFilter:
         """Non-range comparisons keep the existing CAST-based behavior."""
         expr = trace_item_filters_to_expression(
             self._range_filter(ComparisonFilter.OP_EQUALS),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         # equals path wraps in the null-aware OR; the LHS of the equals is still the CAST.
@@ -936,7 +935,7 @@ class TestAnalyzerSafeFilters:
         )
         return trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -1088,7 +1087,7 @@ class TestBooleanAttributeFilters:
         )
         return trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -1161,7 +1160,7 @@ class TestNormalizedColumnsNotMapBacked:
         )
         return trace_item_filters_to_expression(
             item_filter,
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
 
@@ -1806,7 +1805,7 @@ class TestAnyAttributeFilterOption:
         # Schema default is true: the filter is translated, not short-circuited.
         result = trace_item_filters_to_expression(
             self._filter(),
-            functools.partial(attribute_key_to_expression, organization_id=1),
+            attribute_key_to_expression,
             organization_id=1,
         )
         assert isinstance(result, FunctionCall)
@@ -1816,7 +1815,7 @@ class TestAnyAttributeFilterOption:
         with override_options("snuba", {"enable_any_attribute_filter": False}):
             result = trace_item_filters_to_expression(
                 self._filter(),
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
         assert isinstance(result, Literal)

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -128,7 +129,11 @@ class TestTraceItemFiltersArrayLike:
 
     def test_like_on_array_key(self) -> None:
         item_filter = self._make_like_filter("my_tags", AttributeKey.Type.TYPE_ARRAY, "%error%")
-        result = _span_expression(item_filter)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
         # First param is a Lambda with like
@@ -144,7 +149,11 @@ class TestTraceItemFiltersArrayLike:
         item_filter = self._make_like_filter(
             "my_tags", AttributeKey.Type.TYPE_ARRAY, "%error%", ignore_case=True
         )
-        result = _span_expression(item_filter)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
         lam = result.parameters[0]
@@ -159,7 +168,11 @@ class TestTraceItemFiltersArrayLike:
             "%error%",
             op=ComparisonFilter.OP_NOT_LIKE,
         )
-        result = _span_expression(item_filter)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         # Result should be NOT(arrayExists(...))
         assert isinstance(result, FunctionCall)
         assert result.function_name == "not"
@@ -179,7 +192,11 @@ class TestTraceItemFiltersArrayLike:
             op=ComparisonFilter.OP_NOT_LIKE,
             ignore_case=True,
         )
-        result = _span_expression(item_filter)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "not"
         inner = result.parameters[0]
@@ -202,7 +219,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="LIKE/NOT_LIKE on array keys requires a string pattern",
         ):
-            _span_expression(item_filter)
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
     def test_equals_on_untyped_array_key_with_str_array_value_raises(self) -> None:
         # Exact array equality (array RHS) is element-typed-array only; the deprecated
@@ -218,7 +239,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="exact array equality .* is only supported on element-typed array keys",
         ):
-            _span_expression(item_filter)
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
     def test_like_on_int_key_raises(self) -> None:
         item_filter = self._make_like_filter("my_int", AttributeKey.Type.TYPE_INT, "%something%")
@@ -226,7 +251,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="LIKE comparison is only supported on string and array keys",
         ):
-            _span_expression(item_filter)
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
     def test_not_like_on_int_key_raises(self) -> None:
         item_filter = self._make_like_filter(
@@ -239,13 +268,11 @@ class TestTraceItemFiltersArrayLike:
             BadSnubaRPCRequestException,
             match="NOT LIKE comparison is only supported on string and array keys",
         ):
-            _span_expression(item_filter)
-
-
-def _span_expression(item_filter: TraceItemFilter) -> Expression:
-    return trace_item_filters_to_expression(
-        TraceItemType.TRACE_ITEM_TYPE_SPAN, item_filter, attribute_key_to_expression
-    )
+            trace_item_filters_to_expression(
+                item_filter,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
 
 
 def _collect_column_names(expr: Expression) -> set[str]:
@@ -323,6 +350,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="%error%"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -338,6 +367,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="error"),
                 AttributeKey.Type.TYPE_ARRAY_STRING,
             ),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -354,6 +385,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="12"),
                 AttributeKey.Type.TYPE_ARRAY_INT,
             ),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -367,6 +400,8 @@ class TestTraceItemFiltersArrayMapColumns:
                 AttributeValue(val_str="true"),
                 AttributeKey.Type.TYPE_ARRAY_BOOL,
             ),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
@@ -379,7 +414,11 @@ class TestTraceItemFiltersArrayMapColumns:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_ARRAY_INT, name="my_tags")
             )
         )
-        result = _span_expression(item_filter)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         # Existence is notEmpty(arrayElement(attributes_array_int, 'my_tags')).
         assert isinstance(result, FunctionCall)
         assert result.function_name == "notEmpty"
@@ -392,6 +431,8 @@ class TestTraceItemFiltersArrayMapColumns:
         # a float, so it searches both numeric columns plus the string column natively.
         result = _span_expression(
             self._array_filter(ComparisonFilter.OP_EQUALS, AttributeValue(val_str="12")),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "or"
@@ -411,6 +452,8 @@ class TestTraceItemFiltersArrayMapColumns:
     ) -> None:
         result = _span_expression(
             self._array_filter(ComparisonFilter.OP_NOT_EQUALS, AttributeValue(val_str="12")),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
         )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "not"
@@ -429,7 +472,11 @@ class TestTraceItemFiltersArrayMapColumns:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_ARRAY, name="my_tags")
             )
         )
-        result = _span_expression(item_filter)
+        result = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         # Existence is notEmpty(arrayConcat(...)) over the four typed columns.
         assert isinstance(result, FunctionCall)
         assert result.function_name == "notEmpty"
@@ -659,7 +706,11 @@ class TestExistsFilterCoalesced:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_STRING, name=canonical)
             )
         )
-        expr = _span_expression(item_filter)
+        expr = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == "or"
         checked_keys = self._collect_existence_keys(expr)
@@ -673,7 +724,11 @@ class TestExistsFilterCoalesced:
                 key=AttributeKey(type=AttributeKey.Type.TYPE_STRING, name="some.custom.tag")
             )
         )
-        expr = _span_expression(item_filter)
+        expr = trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == "has"
 
@@ -704,7 +759,11 @@ class TestSentryTimestampFilter:
     def test_range_filter_uses_raw_timestamp_column(
         self, op: "ComparisonFilter.Op.ValueType", expected_function: str
     ) -> None:
-        expr = _span_expression(self._range_filter(op))
+        expr = trace_item_filters_to_expression(
+            self._range_filter(op),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == expected_function
 
@@ -743,7 +802,11 @@ class TestSentryTimestampFilter:
                 value=AttributeValue(val_double=1781040732.7),
             )
         )
-        expr = _span_expression(fractional)
+        expr = trace_item_filters_to_expression(
+            fractional,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(expr, FunctionCall)
         rhs = expr.parameters[1]
         assert isinstance(rhs, FunctionCall)
@@ -755,7 +818,11 @@ class TestSentryTimestampFilter:
 
     def test_equals_filter_unchanged(self) -> None:
         """Non-range comparisons keep the existing CAST-based behavior."""
-        expr = _span_expression(self._range_filter(ComparisonFilter.OP_EQUALS))
+        expr = trace_item_filters_to_expression(
+            self._range_filter(ComparisonFilter.OP_EQUALS),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         # equals path wraps in the null-aware OR; the LHS of the equals is still the CAST.
         assert isinstance(expr, FunctionCall)
         assert expr.function_name == "or"
@@ -867,7 +934,11 @@ class TestAnalyzerSafeFilters:
                 ignore_case=ignore_case,
             )
         )
-        return _span_expression(item_filter)
+        return trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
     # --- pruned forms: literal != column default, so no existence guard ---
 
@@ -1015,7 +1086,11 @@ class TestBooleanAttributeFilters:
                 value=value,
             )
         )
-        return _span_expression(item_filter)
+        return trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
     def test_equals_false_keeps_existence_guard(self) -> None:
         expr = self._build(ComparisonFilter.OP_EQUALS, value=AttributeValue(val_bool=False))
@@ -1084,7 +1159,11 @@ class TestNormalizedColumnsNotMapBacked:
                 value=AttributeValue(val_str="abc"),
             )
         )
-        return _span_expression(item_filter)
+        return trace_item_filters_to_expression(
+            item_filter,
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
 
     def test_normalized_string_column_bypasses_map_backed_path(self) -> None:
         expr = self._build("sentry.trace_id")
@@ -1725,13 +1804,21 @@ class TestAnyAttributeFilterOption:
 
     def test_enabled_by_default_translates_filter(self) -> None:
         # Schema default is true: the filter is translated, not short-circuited.
-        result = _span_expression(self._filter())
+        result = trace_item_filters_to_expression(
+            self._filter(),
+            functools.partial(attribute_key_to_expression, organization_id=1),
+            organization_id=1,
+        )
         assert isinstance(result, FunctionCall)
         assert result.function_name == "arrayExists"
 
     def test_disabled_returns_always_true(self) -> None:
         with override_options("snuba", {"enable_any_attribute_filter": False}):
-            result = _span_expression(self._filter())
+            result = trace_item_filters_to_expression(
+                self._filter(),
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
+            )
         assert isinstance(result, Literal)
         assert result.value is True
 

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Generator
@@ -962,7 +961,7 @@ def test_filter_membership_as_has_for_select_clause() -> None:
     # Default (WHERE) form keeps the prepared IN-set over the constant array.
     where_expr = trace_item_filters_to_expression(
         proto_filter,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
     assert _in_calls_over_arrays(where_expr), (
@@ -972,7 +971,7 @@ def test_filter_membership_as_has_for_select_clause() -> None:
     # SELECT-clause form (membership_as_has=True) builds has(array, x) and no IN-set.
     select_expr = trace_item_filters_to_expression(
         proto_filter,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         membership_as_has=True,
         organization_id=1,
     )

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Generator
@@ -959,14 +960,21 @@ def test_filter_membership_as_has_for_select_clause() -> None:
     )
 
     # Default (WHERE) form keeps the prepared IN-set over the constant array.
-    where_expr = trace_item_filters_to_expression(proto_filter, attribute_key_to_expression)
+    where_expr = trace_item_filters_to_expression(
+        proto_filter,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
+    )
     assert _in_calls_over_arrays(where_expr), (
         "WHERE-form filters must keep in() over the constant array (needed for pruning)"
     )
 
     # SELECT-clause form (membership_as_has=True) builds has(array, x) and no IN-set.
     select_expr = trace_item_filters_to_expression(
-        proto_filter, attribute_key_to_expression, membership_as_has=True
+        proto_filter,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        membership_as_has=True,
+        organization_id=1,
     )
     assert not _in_calls_over_arrays(select_expr), (
         "membership_as_has must build has() instead of in() over a constant array "

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Generator
@@ -957,7 +958,9 @@ def test_filter_membership_as_has_for_select_clause() -> None:
 
     # Default (WHERE) form keeps the prepared IN-set over the constant array.
     where_expr = trace_item_filters_to_expression(
-        TraceItemType.TRACE_ITEM_TYPE_SPAN, proto_filter, attribute_key_to_expression
+        proto_filter,
+        functools.partial(attribute_key_to_expression, organization_id=1),
+        organization_id=1,
     )
     assert _in_calls_over_arrays(where_expr), (
         "WHERE-form filters must keep in() over the constant array (needed for pruning)"
@@ -965,10 +968,10 @@ def test_filter_membership_as_has_for_select_clause() -> None:
 
     # SELECT-clause form (membership_as_has=True) builds has(array, x) and no IN-set.
     select_expr = trace_item_filters_to_expression(
-        TraceItemType.TRACE_ITEM_TYPE_SPAN,
         proto_filter,
-        attribute_key_to_expression,
+        functools.partial(attribute_key_to_expression, organization_id=1),
         membership_as_has=True,
+        organization_id=1,
     )
     assert not _in_calls_over_arrays(select_expr), (
         "membership_as_has must build has() instead of in() over a constant array "

--- a/tests/web/rpc/v1/test_endpoint_get_traces.py
+++ b/tests/web/rpc/v1/test_endpoint_get_traces.py
@@ -1,4 +1,3 @@
-import functools
 import uuid
 from collections import defaultdict
 from collections.abc import Generator
@@ -959,7 +958,7 @@ def test_filter_membership_as_has_for_select_clause() -> None:
     # Default (WHERE) form keeps the prepared IN-set over the constant array.
     where_expr = trace_item_filters_to_expression(
         proto_filter,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         organization_id=1,
     )
     assert _in_calls_over_arrays(where_expr), (
@@ -969,7 +968,7 @@ def test_filter_membership_as_has_for_select_clause() -> None:
     # SELECT-clause form (membership_as_has=True) builds has(array, x) and no IN-set.
     select_expr = trace_item_filters_to_expression(
         proto_filter,
-        functools.partial(attribute_key_to_expression, organization_id=1),
+        attribute_key_to_expression,
         membership_as_has=True,
         organization_id=1,
     )

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1,4 +1,3 @@
-import functools
 import random
 import re
 from datetime import datetime, timedelta
@@ -4206,7 +4205,7 @@ class TestArrayOperationsRejected:
                     key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags"),
                     label="count(tags)",
                 ),
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1,3 +1,4 @@
+import functools
 import random
 import re
 from datetime import datetime, timedelta
@@ -4205,7 +4206,8 @@ class TestArrayOperationsRejected:
                     key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags"),
                     label="count(tags)",
                 ),
-                attribute_key_to_expression,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
             )
 
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1,4 +1,3 @@
-import functools
 import random
 import re
 from dataclasses import replace
@@ -5174,7 +5173,7 @@ class TestArrayOperationsRejected:
                     key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags"),
                     label="count(tags)",
                 ),
-                functools.partial(attribute_key_to_expression, organization_id=1),
+                attribute_key_to_expression,
                 organization_id=1,
             )
 

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1,4 +1,3 @@
-import random
 import re
 from dataclasses import replace
 from datetime import datetime, timedelta

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1,3 +1,5 @@
+import functools
+import random
 import re
 from dataclasses import replace
 from datetime import datetime, timedelta
@@ -5172,7 +5174,8 @@ class TestArrayOperationsRejected:
                     key=AttributeKey(type=AttributeKey.TYPE_ARRAY, name="tags"),
                     label="count(tags)",
                 ),
-                attribute_key_to_expression,
+                functools.partial(attribute_key_to_expression, organization_id=1),
+                organization_id=1,
             )
 
 

--- a/tests/web/rpc/v1/test_indexed_columns.py
+++ b/tests/web/rpc/v1/test_indexed_columns.py
@@ -81,7 +81,7 @@ class TestIndexedColumnSkipIndex:
         # org 1 is opted in, so session_id / ai_conversation_id resolve to their real
         # (indexed) columns instead of falling through to the attributes_* map.
         with override_options(
-            "snuba", {"eap_items_unbackfilled_normalized_columns_org_allowlist": "1"}
+            "snuba", {"eap_items_unpopulated_normalized_columns_org_allowlist": "1"}
         ):
             yield
 
@@ -235,7 +235,7 @@ class TestIndexedColumnSkipIndex:
         # therefore not applied, and since the consumer writes these values only to the
         # dedicated columns (never the map), the map lookup matches nothing.
         with override_options(
-            "snuba", {"eap_items_unbackfilled_normalized_columns_org_allowlist": "999"}
+            "snuba", {"eap_items_unpopulated_normalized_columns_org_allowlist": "999"}
         ):
             sql, colors = self._execute(
                 TraceItemFilter(

--- a/tests/web/rpc/v1/test_indexed_columns.py
+++ b/tests/web/rpc/v1/test_indexed_columns.py
@@ -1,0 +1,180 @@
+"""EAP-620: `sentry.session_id` and `gen_ai.conversation.id` resolve to their indexed
+physical columns (`session_id`, `ai_conversation_id`) as bare columns, so `=` / `IN <literal>`
+filters prune granules via the bloom-filter skip index (`bf_session_id`,
+`bf_ai_conversation_id`). These tests execute a real `TraceItemTable` query, then run
+`EXPLAIN indexes = 1` on the generated ClickHouse SQL to assert the skip index is applied,
+and check the filter returns the right rows.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    AttributeValue,
+    StrArray,
+)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    ComparisonFilter,
+    TraceItemFilter,
+)
+from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
+
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.web.rpc.v1.endpoint_trace_item_table import EndpointTraceItemTable
+from tests.helpers import write_raw_unprocessed_events
+
+# Two items: item A (session/conversation "a", color red), item B ("b", color blue).
+SESSION_A = "11111111-1111-1111-1111-111111111111"
+SESSION_B = "22222222-2222-2222-2222-222222222222"
+CONV_A = "conv-a"
+CONV_B = "conv-b"
+
+
+def _item_message(ts: datetime, session_id: str, conversation_id: str, color: str) -> bytes:
+    item_ts = Timestamp()
+    item_ts.FromDatetime(ts)
+    received = Timestamp()
+    received.GetCurrentTime()
+    return TraceItem(
+        organization_id=1,
+        project_id=1,
+        item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        timestamp=item_ts,
+        trace_id=uuid.uuid4().hex,
+        item_id=uuid.uuid4().int.to_bytes(16, "little"),
+        received=received,
+        retention_days=90,
+        server_sample_rate=1.0,
+        session_id=session_id,
+        conversation_id=conversation_id,
+        attributes={
+            "color": AnyValue(string_value=color),
+            "sentry.end_timestamp_precise": AnyValue(
+                double_value=(ts + timedelta(seconds=1)).timestamp()
+            ),
+            "sentry.received": AnyValue(double_value=received.seconds),
+            "sentry.start_timestamp_precise": AnyValue(double_value=ts.timestamp()),
+            "start_timestamp_ms": AnyValue(double_value=int(ts.timestamp() * 1000)),
+        },
+    ).SerializeToString()
+
+
+@pytest.mark.eap
+@pytest.mark.redis_db
+class TestIndexedColumnSkipIndex:
+    @pytest.fixture(autouse=True)
+    def setup(self, eap: None, redis_db: None) -> None:
+        self.base_time = datetime.now(tz=UTC).replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(hours=1)
+        self.start_ts = Timestamp(seconds=int((self.base_time - timedelta(hours=1)).timestamp()))
+        self.end_ts = Timestamp(seconds=int((self.base_time + timedelta(hours=2)).timestamp()))
+        messages = [
+            _item_message(self.base_time, SESSION_A, CONV_A, "red"),
+            _item_message(self.base_time + timedelta(minutes=1), SESSION_B, CONV_B, "blue"),
+        ]
+        write_raw_unprocessed_events(get_writable_storage(StorageKey("eap_items")), messages)
+
+    def _execute(self, filt: TraceItemFilter) -> tuple[str, list[str]]:
+        """Run a TraceItemTable query in debug mode; return (generated_sql, sorted colors)."""
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1],
+                organization_id=1,
+                cogs_category="test",
+                referrer="test",
+                start_timestamp=self.start_ts,
+                end_timestamp=self.end_ts,
+                request_id=uuid.uuid4().hex,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                debug=True,
+            ),
+            filter=filt,
+            columns=[Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="color"))],
+            limit=100,
+        )
+        response = EndpointTraceItemTable().execute(message)
+        sql = response.meta.query_info[0].metadata.sql
+        colors = (
+            sorted(r.val_str for r in response.column_values[0].results)
+            if response.column_values
+            else []
+        )
+        return sql, colors
+
+    @staticmethod
+    def _explain_uses_index(sql: str, index_name: str) -> bool:
+        conn = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM).get_query_connection(
+            ClickhouseClientSettings.QUERY
+        )
+        plan = "\n".join(str(row[0]) for row in conn.execute(f"EXPLAIN indexes = 1 {sql}").results)
+        # The index only appears in the plan's "Skip" section when ClickHouse can analyze the
+        # condition against it — i.e. when the column is bare. A value-changing wrapper
+        # (Nullable cast, replaceAll, ...) drops it from the plan. (With a single granule
+        # nothing is pruned, so we assert the index is *applied to the plan*, not a count.)
+        return index_name in plan
+
+    # honestly this test is probably unnecessary. It was useful when I was developing, so I figured why not merge it in.
+    @pytest.mark.parametrize(
+        "attribute_name,op,value,expected_index,expected_colors",
+        [
+            (
+                "sentry.session_id",
+                ComparisonFilter.OP_EQUALS,
+                AttributeValue(val_str=SESSION_A),
+                "bf_session_id",
+                ["red"],
+            ),
+            (
+                "sentry.session_id",
+                ComparisonFilter.OP_IN,
+                AttributeValue(val_str_array=StrArray(values=[SESSION_A, SESSION_B])),
+                "bf_session_id",
+                ["blue", "red"],
+            ),
+            (
+                "gen_ai.conversation.id",
+                ComparisonFilter.OP_EQUALS,
+                AttributeValue(val_str=CONV_A),
+                "bf_ai_conversation_id",
+                ["red"],
+            ),
+            (
+                "gen_ai.conversation.id",
+                ComparisonFilter.OP_IN,
+                AttributeValue(val_str_array=StrArray(values=[CONV_A, CONV_B])),
+                "bf_ai_conversation_id",
+                ["blue", "red"],
+            ),
+        ],
+    )
+    def test_filter_uses_skip_index_and_matches(
+        self,
+        attribute_name: str,
+        op: "ComparisonFilter.Op.ValueType",
+        value: AttributeValue,
+        expected_index: str,
+        expected_colors: list[str],
+    ) -> None:
+        sql, colors = self._execute(
+            TraceItemFilter(
+                comparison_filter=ComparisonFilter(
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name=attribute_name),
+                    op=op,
+                    value=value,
+                )
+            )
+        )
+        assert colors == expected_colors
+        assert self._explain_uses_index(sql, expected_index), sql

--- a/tests/web/rpc/v1/test_indexed_columns.py
+++ b/tests/web/rpc/v1/test_indexed_columns.py
@@ -7,10 +7,12 @@ and check the filter returns the right rows.
 """
 
 import uuid
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_options.testing import override_options
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
     Column,
     TraceItemTableRequest,
@@ -74,6 +76,15 @@ def _item_message(ts: datetime, session_id: str, conversation_id: str, color: st
 @pytest.mark.eap
 @pytest.mark.redis_db
 class TestIndexedColumnSkipIndex:
+    @pytest.fixture
+    def org_1_allowlisted(self) -> Iterator[None]:
+        # org 1 is opted in, so session_id / ai_conversation_id resolve to their real
+        # (indexed) columns instead of falling through to the attributes_* map.
+        with override_options(
+            "snuba", {"eap_items_unbackfilled_normalized_columns_org_allowlist": "1"}
+        ):
+            yield
+
     @pytest.fixture(autouse=True)
     def setup(self, eap: None, redis_db: None) -> None:
         self.base_time = datetime.now(tz=UTC).replace(
@@ -167,6 +178,7 @@ class TestIndexedColumnSkipIndex:
     )
     def test_filter_uses_skip_index_and_matches(
         self,
+        org_1_allowlisted: None,
         attribute_name: str,
         op: "ComparisonFilter.Op.ValueType",
         value: AttributeValue,
@@ -185,7 +197,9 @@ class TestIndexedColumnSkipIndex:
         assert colors == expected_colors
         assert self._explain_uses_index(sql, expected_index), sql
 
-    def test_exists_on_conversation_id_excludes_rows_without_a_value(self) -> None:
+    def test_exists_on_conversation_id_excludes_rows_without_a_value(
+        self, org_1_allowlisted: None
+    ) -> None:
         # gen_ai.conversation.id is optional: the "green" span never set it, so its
         # ai_conversation_id is empty. exists() must treat empty as absent and exclude
         # it, rather than matching every row (a non-nullable column is never NULL, so a
@@ -198,3 +212,39 @@ class TestIndexedColumnSkipIndex:
             )
         )
         assert colors == ["blue", "red"]
+
+    @pytest.mark.parametrize(
+        "attribute_name,index_name,value",
+        [
+            ("sentry.session_id", "bf_session_id", AttributeValue(val_str=SESSION_A)),
+            (
+                "gen_ai.conversation.id",
+                "bf_ai_conversation_id",
+                AttributeValue(val_str=CONV_A),
+            ),
+        ],
+    )
+    def test_org_not_allowlisted_falls_through_to_map(
+        self,
+        attribute_name: str,
+        index_name: str,
+        value: AttributeValue,
+    ) -> None:
+        # org 1 is NOT in the allowlist, so session_id / ai_conversation_id resolve via the
+        # attributes_string map rather than their dedicated columns. The skip index is
+        # therefore not applied, and since the consumer writes these values only to the
+        # dedicated columns (never the map), the map lookup matches nothing.
+        with override_options(
+            "snuba", {"eap_items_unbackfilled_normalized_columns_org_allowlist": "999"}
+        ):
+            sql, colors = self._execute(
+                TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(type=AttributeKey.TYPE_STRING, name=attribute_name),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=value,
+                    )
+                )
+            )
+        assert colors == []
+        assert not self._explain_uses_index(sql, index_name), sql

--- a/tests/web/rpc/v1/test_indexed_columns.py
+++ b/tests/web/rpc/v1/test_indexed_columns.py
@@ -23,6 +23,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
 )
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     ComparisonFilter,
+    ExistsFilter,
     TraceItemFilter,
 )
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
@@ -83,6 +84,11 @@ class TestIndexedColumnSkipIndex:
         messages = [
             _item_message(self.base_time, SESSION_A, CONV_A, "red"),
             _item_message(self.base_time + timedelta(minutes=1), SESSION_B, CONV_B, "blue"),
+            # "green" sets neither: an unset conversation_id ingests as an empty
+            # ai_conversation_id, so exists on gen_ai.conversation.id must exclude it.
+            # (session_id is intentionally not exercised for exists: an unset session_id
+            # ingests as a random non-nil UUID, so absence is indistinguishable there.)
+            _item_message(self.base_time + timedelta(minutes=2), "", "", "green"),
         ]
         write_raw_unprocessed_events(get_writable_storage(StorageKey("eap_items")), messages)
 
@@ -178,3 +184,17 @@ class TestIndexedColumnSkipIndex:
         )
         assert colors == expected_colors
         assert self._explain_uses_index(sql, expected_index), sql
+
+    def test_exists_on_conversation_id_excludes_rows_without_a_value(self) -> None:
+        # gen_ai.conversation.id is optional: the "green" span never set it, so its
+        # ai_conversation_id is empty. exists() must treat empty as absent and exclude
+        # it, rather than matching every row (a non-nullable column is never NULL, so a
+        # plain isNotNull check would always be true).
+        _, colors = self._execute(
+            TraceItemFilter(
+                exists_filter=ExistsFilter(
+                    key=AttributeKey(type=AttributeKey.TYPE_STRING, name="gen_ai.conversation.id")
+                )
+            )
+        )
+        assert colors == ["blue", "red"]


### PR DESCRIPTION
## What

Gate the not-yet-populated EAP-items normalized columns (`sentry.session_id` → `session_id`, `gen_ai.conversation.id` → `ai_conversation_id`) behind a **per-organization allowlist** instead of resolving them unconditionally.

A new sentry-option, `eap_items_unpopulated_normalized_columns_org_allowlist` (comma-separated org ids), controls it:

- **Org in the allowlist** → these attributes resolve to their dedicated, bloom-filter-indexed columns (fast granule pruning).
- **Org not in it** (default: empty ⇒ nobody) → they fall through to the `attributes_*` map path, which covers historical rows the dedicated columns were never populated with.

Unlike `org_ids_delete_allowlist`, an **empty** allowlist means *no* orgs are opted in — the feature stays off until an org is explicitly added. A **malformed** allowlist (stray comma, non-numeric entry) is logged and treated as opted out rather than breaking every EAP query.

## How

`get_normalized_columns_eap_items(organization_id)` now takes the org and consults the allowlist. Rather than a global/ambient flag, `organization_id` is threaded explicitly as an argument through the query-build path:

- `attribute_key_to_expression(attr_key, organization_id)` and `trace_item_filters_to_expression(..., *, organization_id)` (keyword-only) carry it.
- The `aggregation.py` helpers that build filter conditions (`aggregation_to_expression`, `get_confidence_interval_column`, `get_average_sample_rate_column`, `get_count_column`, and their internals) take a keyword-only `organization_id`.
- At each resolver/endpoint entry point the org comes from `request.meta.organization_id`. The resolver callables are typed `Callable[[AttributeKey, int], Expression]` and receive the org id as a plain argument — no `functools.partial` binding.

**Non-RPC delete path** (`delete_query.py`): the org is taken from the delete's `column_conditions` (deletes are per-org), falling back to `None` (no org in context ⇒ feature off).

## Test plan

- New `tests/web/rpc/v1/test_indexed_columns.py` coverage:
  - **allowlisted org** → skip index (`bf_session_id` / `bf_ai_conversation_id`) is applied and filters match the expected rows.
  - **non-allowlisted org** → skip index is *not* applied, and the map lookup matches nothing (the consumer writes these only to the dedicated columns).
- New `TestGetNormalizedColumnsEapItems` in `tests/protos/test_protos_common.py` exercises the gate directly (opted in, absent org, `None` org, empty allowlist, and malformed allowlists → opted out).
- `mypy .` clean (1074 files); `ruff check`/`format` clean.
- Updated the existing direct-call unit tests (`test_common.py`, `test_aggregation.py`, `test_protos_common.py`, etc.) for the new signatures.

## Notes

- Stacked on top of #8185 (base branch `ref/use-indexed-columns`); review/merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
