### PR TITLE
build(deps): bump actions/setup-node from 6.4.0 to 7.0.0

### DIFF
--- a/.github/workflows/admin-sourcemaps.yml
+++ b/.github/workflows/admin-sourcemaps.yml
@@ -18,7 +18,7 @@ jobs:
         name: Checkout code
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - run: uv python install
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version-file: snuba/admin/package.json
       - name: Build admin sourcemaps

--- a/.github/workflows/admin-sourcemaps.yml
+++ b/.github/workflows/admin-sourcemaps.yml
@@ -18,7 +18,7 @@ jobs:
         name: Checkout code
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - run: uv python install
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: snuba/admin/package.json
       - name: Build admin sourcemaps


### PR DESCRIPTION
Bumps `actions/setup-node` from 6.4.0 to 7.0.0 in `.github/workflows/admin-sourcemaps.yml`.

The original dependabot bump updated the pinned commit SHA to the v7.0.0 release but left the trailing version comment as `# v6`. This branch corrects that stale label to `# v7` so the comment matches the pinned version (the repo convention pins actions by SHA with a short major-version comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8TRzpQnR2epMyHZaP2EMZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8TRzpQnR2epMyHZaP2EMZ)_