### PR TITLE
ci: pin self-hosted e2e to master instead of a specific sha

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -221,7 +221,7 @@ jobs:
 
     steps:
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/self-hosted@411a24321747e451d8747a2a5d3674ed7d9ad515 # master
+        uses: getsentry/self-hosted@master
         with:
           project_name: snuba
           image_url: ghcr.io/getsentry/snuba:${{ github.sha }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -221,7 +221,7 @@ jobs:
 
     steps:
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/self-hosted@3db978e2659e1d34eb2cfb8516b563d72fec58f4 # master
+        uses: getsentry/self-hosted@411a24321747e451d8747a2a5d3674ed7d9ad515 # master
         with:
           project_name: snuba
           image_url: ghcr.io/getsentry/snuba:${{ github.sha }}


### PR DESCRIPTION
Point the self-hosted e2e CI step at `getsentry/self-hosted@master` rather than a pinned commit SHA, so the e2e test always runs against the latest self-hosted `master`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z2N5DBJWGCBavWAAUjjUr)_