### PR TITLE
ci: target main for sentry-options validate-schema workflow

### DIFF
--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -32,7 +32,7 @@ jobs:
   validate-schema:
     needs: cli-version
     name: Validate Schema Evolution
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@f8b8cdc11b73938dbdb44792c96b7b64a3600033
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@main
     secrets: inherit
     with:
       schemas-path: sentry-options/schemas


### PR DESCRIPTION
This is an alternative to #8198. Instead of pinning the reusable `getsentry/sentry-options/.github/workflows/validate-schema.yml` workflow to a specific commit SHA (which is what Dependabot keeps bumping), point the reference at `main` so it always tracks the latest workflow without follow-up bumps.

Changes `.github/workflows/validate-sentry-options.yml`:
- `uses: ...validate-schema.yml@f8b8cdc11b73938dbdb44792c96b7b64a3600033` → `uses: ...validate-schema.yml@main`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFjfxkFKCam4UACkLfrgFG)_