### PR TITLE
fix(eap): reject trace item table requests with aggregation_filter but no aggregation

### DIFF
--- a/snuba/web/rpc/proto_visitor.py
+++ b/snuba/web/rpc/proto_visitor.py
@@ -247,13 +247,8 @@ class ContainsAggregateVisitor(ProtoVisitor):
     def visit_AggregationComparisonFilterWrapper(
         self, aggregation_comparison_filter_wrapper: AggregationComparisonFilterWrapper
     ) -> None:
-        # An aggregation_filter becomes a HAVING clause, which makes the whole query an
-        # aggregating query even when no aggregate appears in the SELECT columns. The
-        # aggregate lives in the filter's conditional_aggregation (or in a formula, whose
-        # operands are traversed as ColumnWrappers and picked up by visit_ColumnWrapper),
-        # so flag it here. Without this, a request with an aggregation_filter but no
-        # aggregate columns and no group_by would pass validation and emit an invalid
-        # HAVING-without-GROUP-BY query that ClickHouse rejects (Code 215).
+        # An aggregation_filter becomes a HAVING clause, so an aggregate here makes the
+        # query aggregating even when no aggregate appears in the SELECT columns.
         if aggregation_comparison_filter_wrapper.underlying_proto.HasField(
             "conditional_aggregation"
         ):

--- a/snuba/web/rpc/proto_visitor.py
+++ b/snuba/web/rpc/proto_visitor.py
@@ -244,6 +244,21 @@ class ContainsAggregateVisitor(ProtoVisitor):
         if column_wrapper.underlying_proto.HasField("conditional_aggregation"):
             self.contains_aggregate = True
 
+    def visit_AggregationComparisonFilterWrapper(
+        self, aggregation_comparison_filter_wrapper: AggregationComparisonFilterWrapper
+    ) -> None:
+        # An aggregation_filter becomes a HAVING clause, which makes the whole query an
+        # aggregating query even when no aggregate appears in the SELECT columns. The
+        # aggregate lives in the filter's conditional_aggregation (or in a formula, whose
+        # operands are traversed as ColumnWrappers and picked up by visit_ColumnWrapper),
+        # so flag it here. Without this, a request with an aggregation_filter but no
+        # aggregate columns and no group_by would pass validation and emit an invalid
+        # HAVING-without-GROUP-BY query that ClickHouse rejects (Code 215).
+        if aggregation_comparison_filter_wrapper.underlying_proto.HasField(
+            "conditional_aggregation"
+        ):
+            self.contains_aggregate = True
+
 
 class GetExpressionAggregationsVisitor(ProtoVisitor):
     """

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1462,12 +1462,8 @@ class TestTraceItemTable(BaseApiTest):
     def test_aggregation_filter_without_aggregation_or_group_by(
         self, setup_teardown: Any
     ) -> None:
-        """An aggregation_filter becomes a HAVING clause, turning the query into an
-        aggregating query. With no aggregate in the SELECT columns and no group_by,
-        the non-aggregated columns are neither grouped nor aggregated, which ClickHouse
-        rejects (Code 215). Validation must reject it up front with a clear error rather
-        than letting the malformed query reach the database. Regression test for SNUBA-BNG.
-        """
+        """An aggregation_filter (HAVING) with no aggregate column and no group_by must be
+        rejected in validation rather than reaching ClickHouse (Code 215). SNUBA-BNG."""
         message = TraceItemTableRequest(
             meta=RequestMeta(
                 project_ids=[1, 2, 3],

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1459,9 +1459,7 @@ class TestTraceItemTable(BaseApiTest):
         with pytest.raises(BadSnubaRPCRequestException):
             EndpointTraceItemTable().execute(message)
 
-    def test_aggregation_filter_without_aggregation_or_group_by(
-        self, setup_teardown: Any
-    ) -> None:
+    def test_aggregation_filter_without_aggregation_or_group_by(self, setup_teardown: Any) -> None:
         """An aggregation_filter (HAVING) with no aggregate column and no group_by must be
         rejected in validation rather than reaching ClickHouse (Code 215). SNUBA-BNG."""
         message = TraceItemTableRequest(

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table.py
@@ -1459,6 +1459,49 @@ class TestTraceItemTable(BaseApiTest):
         with pytest.raises(BadSnubaRPCRequestException):
             EndpointTraceItemTable().execute(message)
 
+    def test_aggregation_filter_without_aggregation_or_group_by(
+        self, setup_teardown: Any
+    ) -> None:
+        """An aggregation_filter becomes a HAVING clause, turning the query into an
+        aggregating query. With no aggregate in the SELECT columns and no group_by,
+        the non-aggregated columns are neither grouped nor aggregated, which ClickHouse
+        rejects (Code 215). Validation must reject it up front with a clear error rather
+        than letting the malformed query reach the database. Regression test for SNUBA-BNG.
+        """
+        message = TraceItemTableRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            columns=[
+                Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="location")),
+            ],
+            order_by=[
+                TraceItemTableRequest.OrderBy(
+                    column=Column(key=AttributeKey(type=AttributeKey.TYPE_STRING, name="location"))
+                ),
+            ],
+            aggregation_filter=AggregationFilter(
+                comparison_filter=AggregationComparisonFilter(
+                    aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_COUNT,
+                        key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="my.float.field"),
+                        label="count()",
+                    ),
+                    op=AggregationComparisonFilter.OP_EQUALS,
+                    val=644,
+                )
+            ),
+            limit=5,
+        )
+        with pytest.raises(BadSnubaRPCRequestException):
+            EndpointTraceItemTable().execute(message)
+
     def test_table_with_no_columns(self, setup_teardown: Any) -> None:
         """Test that a request with no columns raises a validation error."""
         message = TraceItemTableRequest(


### PR DESCRIPTION
A `TraceItemTableRequest` with an `aggregation_filter` (→ `HAVING`) but no aggregate column and no `group_by` produces an invalid query that ClickHouse rejects with `Code: 215 ... not under aggregate function and not in GROUP BY keys`, surfacing as an unhandled `QueryException` (SNUBA-BNG).

`_validate_select_and_groupby` should catch this, but it uses `ContainsAggregateVisitor` to detect aggregations and that visitor only checked SELECT columns — an aggregate living only in the `aggregation_filter` slipped through, so the bad query reached ClickHouse.

This teaches `ContainsAggregateVisitor` to also detect aggregates in the filter, so validation now returns a `BadSnubaRPCRequestException` (400) instead of a 500-level ClickHouse error. Legitimate aggregation queries are unaffected. Adds a regression test.

Fixes SNUBA-BNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsNYsQDKhcDr72GmtpkNaq



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.