### PR TITLE
fix: stop reporting expected client/infra errors to Sentry

### DIFF
--- a/rust_snuba/src/logging.rs
+++ b/rust_snuba/src/logging.rs
@@ -23,12 +23,9 @@ pub fn setup_logging() {
             Level::ERROR if metadata.target().starts_with("sentry_usage_accountant") => {
                 EventFilter::Log
             }
-            // The DogStatsD metrics forwarder logs "Failed to send payload." at
-            // ERROR on every flush it can't deliver (e.g. "Connection refused"
-            // when the agent/socket is unreachable). That's an operational
-            // metrics-pipeline concern, not a per-message ingestion failure, and
-            // an unreachable target produces thousands of identical errors. Keep
-            // them as logs rather than Sentry issues (SNUBA-BQ8).
+            // The DogStatsD forwarder logs at ERROR on every undeliverable flush
+            // (e.g. "Connection refused"), which self-heals but floods Sentry when
+            // the target is unreachable. Keep it as logs only (SNUBA-BQ8).
             Level::ERROR if metadata.target().starts_with("metrics_exporter_dogstatsd") => {
                 EventFilter::Log
             }

--- a/rust_snuba/src/logging.rs
+++ b/rust_snuba/src/logging.rs
@@ -23,6 +23,15 @@ pub fn setup_logging() {
             Level::ERROR if metadata.target().starts_with("sentry_usage_accountant") => {
                 EventFilter::Log
             }
+            // The DogStatsD metrics forwarder logs "Failed to send payload." at
+            // ERROR on every flush it can't deliver (e.g. "Connection refused"
+            // when the agent/socket is unreachable). That's an operational
+            // metrics-pipeline concern, not a per-message ingestion failure, and
+            // an unreachable target produces thousands of identical errors. Keep
+            // them as logs rather than Sentry issues (SNUBA-BQ8).
+            Level::ERROR if metadata.target().starts_with("metrics_exporter_dogstatsd") => {
+                EventFilter::Log
+            }
             Level::ERROR => EventFilter::Event | EventFilter::Log,
             Level::WARN | Level::INFO => EventFilter::Log,
             Level::DEBUG | Level::TRACE => EventFilter::Ignore,

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -420,7 +420,14 @@ def clickhouse_system_query() -> Response:
         return make_response(jsonify({"error": err.message or "Invalid query"}), 400)
 
     except ClickhouseError as err:
-        logger.error(err, exc_info=True)
+        # A ClickhouseError here is almost always an invalid user-submitted query
+        # (e.g. an aggregate used in a WHERE clause -> code 184 ILLEGAL_AGGREGATION),
+        # raised either while validating the query with EXPLAIN or while running it.
+        # It is a client error, not a Snuba fault, and we already surface the
+        # ClickHouse message to the user via the 400 below. Log it at WARNING so it
+        # stays out of Sentry rather than ``logger.error(..., exc_info=True)`` which
+        # the logging integration captures as an issue (SNUBA-3D6).
+        logger.warning(err, exc_info=True)
         return make_response(jsonify({"error": err.message or "Invalid query"}), 400)
 
     except InvalidNodeError as err:

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -420,13 +420,8 @@ def clickhouse_system_query() -> Response:
         return make_response(jsonify({"error": err.message or "Invalid query"}), 400)
 
     except ClickhouseError as err:
-        # A ClickhouseError here is almost always an invalid user-submitted query
-        # (e.g. an aggregate used in a WHERE clause -> code 184 ILLEGAL_AGGREGATION),
-        # raised either while validating the query with EXPLAIN or while running it.
-        # It is a client error, not a Snuba fault, and we already surface the
-        # ClickHouse message to the user via the 400 below. Log it at WARNING so it
-        # stays out of Sentry rather than ``logger.error(..., exc_info=True)`` which
-        # the logging integration captures as an issue (SNUBA-3D6).
+        # Invalid user query (e.g. code 184 ILLEGAL_AGGREGATION), surfaced to the user
+        # via the 400 below. WARNING (not error) keeps this client error out of Sentry.
         logger.warning(err, exc_info=True)
         return make_response(jsonify({"error": err.message or "Invalid query"}), 400)
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -420,9 +420,14 @@ def clickhouse_system_query() -> Response:
         return make_response(jsonify({"error": err.message or "Invalid query"}), 400)
 
     except ClickhouseError as err:
-        # Invalid user query (e.g. code 184 ILLEGAL_AGGREGATION), surfaced to the user
-        # via the 400 below. WARNING (not error) keeps this client error out of Sentry.
-        logger.warning(err, exc_info=True)
+        # A positive server code means ClickHouse rejected the query itself (e.g. 184
+        # ILLEGAL_AGGREGATION) -- a client error, logged at WARNING to stay out of
+        # Sentry. Transport/connection failures wrap with code -1; keep those at ERROR
+        # so infra faults still report.
+        if err.code > 0:
+            logger.warning(err, exc_info=True)
+        else:
+            logger.error(err, exc_info=True)
         return make_response(jsonify({"error": err.message or "Invalid query"}), 400)
 
     except InvalidNodeError as err:

--- a/snuba/pipeline/query_pipeline.py
+++ b/snuba/pipeline/query_pipeline.py
@@ -49,8 +49,18 @@ class QueryPipelineStage(Generic[Tin, Tout]):
     def _process_error(self, pipe_input: QueryPipelineError[Tin]) -> Tout | Exception:
         """default behaviour is to just pass through to the next stage of the pipeline
         Can be overridden to do something else"""
-        logging.exception(pipe_input.error)
-        return pipe_input.error
+        error = pipe_input.error
+        # Errors that opted out via ``should_report=False`` (e.g. an invalid client
+        # query like a malformed UUID filter) must not be surfaced in Sentry.
+        # ``logging.exception`` emits an ERROR-level record on the root logger, which
+        # the Sentry logging integration captures as an event -- bypassing the
+        # ``should_report`` handling in the RPC/HTTP layers. Log such expected errors
+        # below the Sentry capture threshold instead.
+        if getattr(error, "should_report", True):
+            logging.exception(error)
+        else:
+            logging.info("Query pipeline stage failed with a non-reportable error: %s", error)
+        return error
 
     @abstractmethod
     def _process_data(self, pipe_input: QueryPipelineData[Tin]) -> Tout:

--- a/snuba/pipeline/query_pipeline.py
+++ b/snuba/pipeline/query_pipeline.py
@@ -50,12 +50,8 @@ class QueryPipelineStage(Generic[Tin, Tout]):
         """default behaviour is to just pass through to the next stage of the pipeline
         Can be overridden to do something else"""
         error = pipe_input.error
-        # Errors that opted out via ``should_report=False`` (e.g. an invalid client
-        # query like a malformed UUID filter) must not be surfaced in Sentry.
-        # ``logging.exception`` emits an ERROR-level record on the root logger, which
-        # the Sentry logging integration captures as an event -- bypassing the
-        # ``should_report`` handling in the RPC/HTTP layers. Log such expected errors
-        # below the Sentry capture threshold instead.
+        # logging.exception hits the root logger at ERROR, which Sentry captures as
+        # an event -- honor should_report so invalid client queries stay out of Sentry.
         if getattr(error, "should_report", True):
             logging.exception(error)
         else:

--- a/tests/pipeline/test_pipeline_stage.py
+++ b/tests/pipeline/test_pipeline_stage.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from snuba.pipeline.query_pipeline import (
@@ -65,6 +67,41 @@ def test_handle_error() -> None:
     res = ErrorStage().execute(input)
     assert error_processed
     assert res.error == input.error
+
+
+class _NonReportableError(Exception):
+    should_report = False
+
+
+def test_process_error_reportable_logs_at_error(caplog: pytest.LogCaptureFixture) -> None:
+    input: QueryPipelineResult[int] = QueryPipelineResult(
+        data=None,
+        error=Exception("boom"),
+        query_settings=HTTPQuerySettings(),
+        timer=Timer("something"),
+    )
+    with caplog.at_level(logging.INFO):
+        TestQueryPipelineStage().execute(input)
+    # A reportable error keeps the ERROR-level log (captured by Sentry).
+    assert any(record.levelno == logging.ERROR for record in caplog.records)
+
+
+def test_process_error_non_reportable_not_logged_at_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    input: QueryPipelineResult[int] = QueryPipelineResult(
+        data=None,
+        error=_NonReportableError("invalid client query"),
+        query_settings=HTTPQuerySettings(),
+        timer=Timer("something"),
+    )
+    with caplog.at_level(logging.INFO):
+        res = TestQueryPipelineStage().execute(input)
+    # should_report=False errors must not be logged at ERROR, otherwise the Sentry
+    # logging integration captures them as issues despite the opt-out.
+    assert not any(record.levelno == logging.ERROR for record in caplog.records)
+    assert any(record.levelno == logging.INFO for record in caplog.records)
+    assert res.error is input.error
 
 
 def test_recover_from_error() -> None:

--- a/tests/pipeline/test_pipeline_stage.py
+++ b/tests/pipeline/test_pipeline_stage.py
@@ -82,7 +82,6 @@ def test_process_error_reportable_logs_at_error(caplog: pytest.LogCaptureFixture
     )
     with caplog.at_level(logging.INFO):
         TestQueryPipelineStage().execute(input)
-    # A reportable error keeps the ERROR-level log (captured by Sentry).
     assert any(record.levelno == logging.ERROR for record in caplog.records)
 
 
@@ -97,8 +96,7 @@ def test_process_error_non_reportable_not_logged_at_error(
     )
     with caplog.at_level(logging.INFO):
         res = TestQueryPipelineStage().execute(input)
-    # should_report=False errors must not be logged at ERROR, otherwise the Sentry
-    # logging integration captures them as issues despite the opt-out.
+    # should_report=False must not log at ERROR (Sentry would capture it).
     assert not any(record.levelno == logging.ERROR for record in caplog.records)
     assert any(record.levelno == logging.INFO for record in caplog.records)
     assert res.error is input.error


### PR DESCRIPTION
RCA and fixes for three Sentry issues that share one root cause: an expected **client-input or infra error** is emitted at **ERROR log level**, and Snuba's Sentry logging/tracing integration auto-captures ERROR logs/traces as issues. In two of the three, this actively defeats a suppression mechanism the code already has.

### SNUBA-BBA — "Not a valid UUID string" (`logger: root`, referrer `subscription`)
Creating a subscription (`CreateSubscriptionRequest/v1`) validates by running the query via `EndpointTimeSeries`. A malformed UUID in a filter makes `UUIDColumnProcessor` raise `ColumnTypeError("Not a valid UUID string", should_report=False)`. The RPC layer honors `should_report=False`, but `QueryPipelineStage._process_error` unconditionally calls `logging.exception(...)` on the **root logger**, which the Sentry logging integration captures as an event — bypassing the flag (the `logger: root` tag is the fingerprint).

**Fix:** `_process_error` now honors `should_report` — reportable errors keep the ERROR log, non-reportable ones drop to INFO (below the Sentry capture threshold).

### SNUBA-BQ8 — "Failed to send payload." (escalating, Rust metrics consumer)
Not a code bug in itself — the DogStatsD forwarder can't reach its target (`Connection refused (os error 111)`), a config/infra problem. But the crate logs each failed flush at `tracing::error!`, and `rust_snuba/src/logging.rs` maps **all** ERROR traces to Sentry events, so an unreachable target produces thousands of identical issues.

**Fix:** downgrade `metrics_exporter_dogstatsd` ERROR traces to logs only, mirroring the existing `sentry_usage_accountant` carve-out. (The unreachable-endpoint config on the affected environment still needs an infra-side fix.)

### SNUBA-3D6 — ClickHouse code 184 ILLEGAL_AGGREGATION (admin system query)
An invalid admin system query (e.g. an aggregate in a `WHERE` clause) fails `EXPLAIN`-based validation, raising `ClickhouseError`. The handler returns a correct 400 but first logs `logger.error(err, exc_info=True)`, which Sentry captures. It's a client error, not a Snuba fault.

**Fix:** log the validation/exec `ClickhouseError` at WARNING so it stays out of Sentry while still returning the ClickHouse message in the 400.

### Testing
- Added `tests/pipeline/test_pipeline_stage.py` cases asserting a reportable error still logs at ERROR and a `should_report=False` error does not (logs at INFO, error preserved).
- `ruff format --check` and `ruff check` pass on the Python changes; `rustfmt --check` passes on `logging.rs`.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014CsAsWykYHjiNfkEZnSyjV)_