### PR TITLE
fix(rpc): escape dangling backslashes in LIKE patterns

### DIFF
--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -570,9 +570,7 @@ def _escape_dangling_like_backslashes(pattern: str) -> str:
     backslash to ``\\\\`` so ClickHouse matches a literal backslash instead of erroring.
     Well-formed escape sequences are left untouched.
     """
-    return _LIKE_ESCAPE_RE.sub(
-        lambda m: m.group(0) if len(m.group(0)) == 2 else "\\\\", pattern
-    )
+    return _LIKE_ESCAPE_RE.sub(lambda m: m.group(0) if len(m.group(0)) == 2 else "\\\\", pattern)
 
 
 def _sanitize_like_pattern_expression(expr: Expression) -> Expression:

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -1,4 +1,5 @@
 import math
+import re
 from collections.abc import Callable, Iterable
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -554,6 +555,10 @@ def _attribute_value_to_expression(v: AttributeValue) -> Expression:
             )
 
 
+# A valid ClickHouse LIKE escape sequence (``\%``, ``\_`` or ``\\``) or a lone backslash.
+_LIKE_ESCAPE_RE = re.compile(r"\\[%_\\]|\\")
+
+
 def _escape_dangling_like_backslashes(pattern: str) -> str:
     """Escape backslashes that do not begin a valid ClickHouse LIKE escape sequence.
 
@@ -565,24 +570,9 @@ def _escape_dangling_like_backslashes(pattern: str) -> str:
     backslash to ``\\\\`` so ClickHouse matches a literal backslash instead of erroring.
     Well-formed escape sequences are left untouched.
     """
-    result: list[str] = []
-    i = 0
-    n = len(pattern)
-    while i < n:
-        char = pattern[i]
-        if char == "\\":
-            nxt = pattern[i + 1] if i + 1 < n else None
-            if nxt in ("%", "_", "\\"):
-                result.append(char)
-                result.append(nxt)  # type: ignore[arg-type]
-                i += 2
-                continue
-            result.append("\\\\")
-            i += 1
-            continue
-        result.append(char)
-        i += 1
-    return "".join(result)
+    return _LIKE_ESCAPE_RE.sub(
+        lambda m: m.group(0) if len(m.group(0)) == 2 else "\\\\", pattern
+    )
 
 
 def _sanitize_like_pattern_expression(expr: Expression) -> Expression:

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -51,6 +51,7 @@ from snuba.query.expressions import (
     Expression,
     FunctionCall,
     Lambda,
+    Literal,
     SubscriptableReference,
 )
 from snuba.state.sentry_options import get_option
@@ -553,6 +554,47 @@ def _attribute_value_to_expression(v: AttributeValue) -> Expression:
             )
 
 
+def _escape_dangling_like_backslashes(pattern: str) -> str:
+    """Escape backslashes that do not begin a valid ClickHouse LIKE escape sequence.
+
+    ClickHouse uses ``\\`` as the escape character in LIKE patterns and only accepts
+    ``\\%``, ``\\_`` and ``\\\\`` as escape sequences. Any other backslash — most
+    commonly a trailing backslash at the end of the pattern — is rejected with
+    ``CANNOT_PARSE_ESCAPE_SEQUENCE``. Sentry forwards user-supplied text as a LIKE
+    pattern, so those backslashes are meant literally; we escape each dangling
+    backslash to ``\\\\`` so ClickHouse matches a literal backslash instead of erroring.
+    Well-formed escape sequences are left untouched.
+    """
+    result: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        char = pattern[i]
+        if char == "\\":
+            nxt = pattern[i + 1] if i + 1 < n else None
+            if nxt in ("%", "_", "\\"):
+                # Valid escape sequence, keep both characters as-is.
+                result.append(char)
+                result.append(nxt)  # type: ignore[arg-type]
+                i += 2
+                continue
+            # Dangling backslash: escape it so it matches a literal backslash.
+            result.append("\\\\")
+            i += 1
+            continue
+        result.append(char)
+        i += 1
+    return "".join(result)
+
+
+def _sanitize_like_pattern_expression(expr: Expression) -> Expression:
+    """Sanitize a string LIKE-pattern literal so ClickHouse does not reject it with
+    ``CANNOT_PARSE_ESCAPE_SEQUENCE``. Non-string literals pass through unchanged."""
+    if isinstance(expr, Literal) and isinstance(expr.value, str):
+        return literal(_escape_dangling_like_backslashes(expr.value))
+    return expr
+
+
 _NEGATIVE_OPS = {
     AnyAttributeFilter.OP_NOT_EQUALS,
     AnyAttributeFilter.OP_NOT_LIKE,
@@ -843,10 +885,11 @@ def _any_attribute_filter_to_expression(
         else:
             comparison = f.equals(x, v_expression)
     elif effective_op == AnyAttributeFilter.OP_LIKE:
+        like_pattern = _sanitize_like_pattern_expression(v_expression)
         if filt.ignore_case:
-            comparison = f.ilike(x, v_expression)
+            comparison = f.ilike(x, like_pattern)
         else:
-            comparison = f.like(x, v_expression)
+            comparison = f.like(x, like_pattern)
     elif effective_op == AnyAttributeFilter.OP_IN:
         if filt.ignore_case:
             if value_type == "val_str_array":
@@ -1093,9 +1136,10 @@ def trace_item_filters_to_expression(
             expr_with_null = or_cond(expr, f.xor(f.isNull(k_expression), f.isNull(v_expression)))
             return expr_with_null
         if op == ComparisonFilter.OP_LIKE:
+            like_pattern = _sanitize_like_pattern_expression(v_expression)
             if k.type in ARRAY_TYPES:
                 return _typed_array_like_expression(
-                    k, v_expression, item_filter.comparison_filter.ignore_case
+                    k, like_pattern, item_filter.comparison_filter.ignore_case
                 )
             if k.type != AttributeKey.Type.TYPE_STRING:
                 raise BadSnubaRPCRequestException(
@@ -1104,13 +1148,14 @@ def trace_item_filters_to_expression(
             comparison_function = f.ilike if item_filter.comparison_filter.ignore_case else f.like
             if _is_map_backed_key(k):
                 value, exists = _map_backed_operands(k)
-                return and_cond(exists, comparison_function(value, v_expression))
-            return comparison_function(k_expression, v_expression)
+                return and_cond(exists, comparison_function(value, like_pattern))
+            return comparison_function(k_expression, like_pattern)
         if op == ComparisonFilter.OP_NOT_LIKE:
+            like_pattern = _sanitize_like_pattern_expression(v_expression)
             if k.type in ARRAY_TYPES:
                 return not_cond(
                     _typed_array_like_expression(
-                        k, v_expression, item_filter.comparison_filter.ignore_case
+                        k, like_pattern, item_filter.comparison_filter.ignore_case
                     )
                 )
             if k.type != AttributeKey.Type.TYPE_STRING:
@@ -1121,11 +1166,11 @@ def trace_item_filters_to_expression(
                 # Negation of OP_LIKE; an absent key is "not like".
                 like_fn = f.ilike if item_filter.comparison_filter.ignore_case else f.like
                 value, exists = _map_backed_operands(k)
-                return not_cond(and_cond(exists, like_fn(value, v_expression)))
+                return not_cond(and_cond(exists, like_fn(value, like_pattern)))
             comparison_function = (
                 f.notILike if item_filter.comparison_filter.ignore_case else f.notLike
             )
-            expr = comparison_function(k_expression, v_expression)
+            expr = comparison_function(k_expression, like_pattern)
             # we redefine the way not like works for nulls
             # now null not like "%anything%" is true
             expr_with_null = or_cond(expr, f.isNull(k_expression))

--- a/snuba/web/rpc/common/common.py
+++ b/snuba/web/rpc/common/common.py
@@ -573,12 +573,10 @@ def _escape_dangling_like_backslashes(pattern: str) -> str:
         if char == "\\":
             nxt = pattern[i + 1] if i + 1 < n else None
             if nxt in ("%", "_", "\\"):
-                # Valid escape sequence, keep both characters as-is.
                 result.append(char)
                 result.append(nxt)  # type: ignore[arg-type]
                 i += 2
                 continue
-            # Dangling backslash: escape it so it matches a literal backslash.
             result.append("\\\\")
             i += 1
             continue

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -252,12 +252,12 @@ class TestLikePatternEscaping:
             ("%Background\\", "%Background\\\\"),
             ("%Received\\", "%Received\\\\"),
             ("\\", "\\\\"),
-            ("a\\b", "a\\\\b"),  # dangling backslash before a normal char
-            ("job%", "job%"),  # no backslash, unchanged
-            ("%failed%", "%failed%"),  # no backslash, unchanged
-            ("a\\%b", "a\\%b"),  # valid escape of a wildcard, unchanged
-            ("a\\_b", "a\\_b"),  # valid escape of a wildcard, unchanged
-            ("a\\\\b", "a\\\\b"),  # already-escaped backslash, unchanged
+            ("a\\b", "a\\\\b"),
+            ("job%", "job%"),
+            ("%failed%", "%failed%"),
+            ("a\\%b", "a\\%b"),
+            ("a\\_b", "a\\_b"),
+            ("a\\\\b", "a\\\\b"),
             ("", ""),
         ],
     )

--- a/tests/web/rpc/test_common.py
+++ b/tests/web/rpc/test_common.py
@@ -55,6 +55,7 @@ from snuba.query.logical import Query
 from snuba.web.rpc.common.common import (
     _any_attribute_filter_to_expression,
     _comparison_can_match_column_default,
+    _escape_dangling_like_backslashes,
     add_existence_check_to_map_attribute_reads,
     attribute_key_to_expression,
     dedupe_and_conditions,
@@ -237,6 +238,75 @@ class TestTraceItemFiltersArrayLike:
             match="NOT LIKE comparison is only supported on string and array keys",
         ):
             trace_item_filters_to_expression(item_filter, attribute_key_to_expression)
+
+
+class TestLikePatternEscaping:
+    """A user-supplied LIKE pattern may contain a backslash that is not part of a valid
+    ClickHouse escape sequence (``\\%``, ``\\_``, ``\\\\``) — most commonly a trailing
+    backslash. ClickHouse rejects those with ``CANNOT_PARSE_ESCAPE_SEQUENCE``, so we
+    escape each dangling backslash to a literal ``\\\\`` before building the expression."""
+
+    @pytest.mark.parametrize(
+        "pattern,expected",
+        [
+            ("%Background\\", "%Background\\\\"),
+            ("%Received\\", "%Received\\\\"),
+            ("\\", "\\\\"),
+            ("a\\b", "a\\\\b"),  # dangling backslash before a normal char
+            ("job%", "job%"),  # no backslash, unchanged
+            ("%failed%", "%failed%"),  # no backslash, unchanged
+            ("a\\%b", "a\\%b"),  # valid escape of a wildcard, unchanged
+            ("a\\_b", "a\\_b"),  # valid escape of a wildcard, unchanged
+            ("a\\\\b", "a\\\\b"),  # already-escaped backslash, unchanged
+            ("", ""),
+        ],
+    )
+    def test_escape_dangling_like_backslashes(self, pattern: str, expected: str) -> None:
+        assert _escape_dangling_like_backslashes(pattern) == expected
+
+    def _like_filter(
+        self,
+        pattern: str,
+        op: ComparisonFilter.Op.ValueType = ComparisonFilter.OP_LIKE,
+        key_type: AttributeKey.Type.ValueType = AttributeKey.Type.TYPE_STRING,
+    ) -> TraceItemFilter:
+        return TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(type=key_type, name="sentry.body"),
+                op=op,
+                value=AttributeValue(val_str=pattern),
+            )
+        )
+
+    def test_like_on_string_key_sanitizes_trailing_backslash(self) -> None:
+        result = trace_item_filters_to_expression(
+            self._like_filter("%Background\\"), attribute_key_to_expression
+        )
+        assert "%Background\\\\" in _collect_literal_values(result)
+        assert "%Background\\" not in _collect_literal_values(result)
+
+    def test_not_like_on_string_key_sanitizes_trailing_backslash(self) -> None:
+        result = trace_item_filters_to_expression(
+            self._like_filter("%Received\\", op=ComparisonFilter.OP_NOT_LIKE),
+            attribute_key_to_expression,
+        )
+        assert "%Received\\\\" in _collect_literal_values(result)
+
+    def test_like_on_array_key_sanitizes_trailing_backslash(self) -> None:
+        result = trace_item_filters_to_expression(
+            self._like_filter("%Background\\", key_type=AttributeKey.Type.TYPE_ARRAY_STRING),
+            attribute_key_to_expression,
+        )
+        assert "%Background\\\\" in _collect_literal_values(result)
+
+    def test_any_attribute_like_sanitizes_trailing_backslash(self) -> None:
+        result = _any_attribute_filter_to_expression(
+            AnyAttributeFilter(
+                op=AnyAttributeFilter.OP_LIKE,
+                value=AttributeValue(val_str="%Background\\"),
+            )
+        )
+        assert "%Background\\\\" in _collect_literal_values(result)
 
 
 def _collect_column_names(expr: Expression) -> set[str]:


### PR DESCRIPTION
User-supplied LIKE patterns forwarded from Sentry to `EndpointTraceItemTable` can contain a backslash that does not begin a valid ClickHouse LIKE escape sequence. ClickHouse only accepts `\%`, `\_` and `\\`; anything else — most commonly a **trailing backslash** — is rejected server-side with `CANNOT_PARSE_ESCAPE_SEQUENCE`, failing the entire query.

Observed failures (Sentry issues SNUBA-BVN, SNUBA-BTQ):

```
DB::Exception: Invalid escape sequence at the end of LIKE pattern '%Background\'
DB::Exception: Invalid escape sequence at the end of LIKE pattern '%Received\'
```

Both originate in the map-backed string `LIKE` path built by `trace_item_filters_to_expression` in `snuba/web/rpc/common/common.py`.

### Fix

- Add `_escape_dangling_like_backslashes()`, which escapes each backslash that is not part of a valid escape sequence (`\%`, `\_`, `\\`) into a literal `\\`, so ClickHouse matches it as a literal backslash instead of erroring. Well-formed escape sequences and wildcard-only patterns are left untouched.
- Add `_sanitize_like_pattern_expression()`, which applies that escaping to a string LIKE-pattern literal and passes non-string literals through unchanged.
- Route the pattern through the sanitizer at every `LIKE`/`NOT_LIKE` site: string keys, array keys (`_typed_array_like_expression`), and the any-attribute filter path — covering both `ilike`/`like` and their negations.

Since a backslash in a user's search text is meant literally, escaping preserves the user's intent while making the pattern valid ClickHouse.

### Tests

Added `TestLikePatternEscaping` in `tests/web/rpc/test_common.py`:
- Parametrized unit tests for `_escape_dangling_like_backslashes` (trailing backslash, mid-pattern dangling backslash, already-valid escapes, and no-op cases).
- End-to-end assertions that the sanitized pattern reaches the built expression for string-key LIKE / NOT_LIKE, array-key LIKE, and any-attribute LIKE.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTo7u8JAEBC4he6hvX9vJu

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTo7u8JAEBC4he6hvX9vJu)_