### PR TITLE
feat(eap-items): per-storage control of drop_invalid_timestamps

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -71,7 +71,9 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         let now = Utc::now();
 
         // should_skip=true will drop messages that are too old or too far in the future
-        if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
+        if get_drop_invalid_timestamps_enabled(&config.storage_name)
+            && out_of_valid_interval_secs(event_ts, now)
+        {
             let is_future = event_ts > now;
             record_invalid_timestamp_metric("eap_items.messages", is_future, item_type);
             should_skip = true;

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -16,10 +16,21 @@ pub const INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS: i64 = 7 * 24 * 60 * 60;
 /// timestamp dropping is enabled.
 pub const INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
 
-/// sentry-options key. When `true`, the eap-items consumer skips messages
-/// whose event `timestamp` is more than one week in the future or more than
-/// thirty days in the past (see `out_of_valid_interval_secs`).
+/// sentry-options key. A bool that, when `true`, makes the consumer skip
+/// messages whose event `timestamp` is more than one week in the future or
+/// more than thirty days in the past (see `out_of_valid_interval_secs`).
+/// Applies to every storage. This is the original, global killswitch; prefer
+/// the per-storage `DROP_INVALID_TIMESTAMPS_BY_STORAGE_KEY`, which is checked
+/// first and only falls back to this value when it has no entry for a storage.
 pub const DROP_INVALID_TIMESTAMPS_KEY: &str = "eap_items_drop_invalid_timestamps";
+
+/// sentry-options key. A dict mapping storage name to a bool, letting each
+/// storage be controlled independently (e.g. `eap_items` vs
+/// `eap_items_dlq_replay`). Checked before `DROP_INVALID_TIMESTAMPS_KEY`; a
+/// storage with an entry uses that value, and a storage with no entry falls
+/// back to the global `DROP_INVALID_TIMESTAMPS_KEY`.
+pub const DROP_INVALID_TIMESTAMPS_BY_STORAGE_KEY: &str =
+    "eap_items_drop_invalid_timestamps_by_storage";
 
 // Equivalent to "%Y-%m-%dT%H:%M:%S.%fZ" in python
 // Notice the differennce of .%fZ vs %.fZ, this comes from a difference in how rust's chrono handles the format
@@ -33,10 +44,26 @@ pub fn out_of_valid_interval_secs(ts: DateTime<Utc>, now: DateTime<Utc>) -> bool
         .contains(&offset_sec)
 }
 
-pub fn get_drop_invalid_timestamps_enabled() -> bool {
-    options("snuba")
+pub fn get_drop_invalid_timestamps_enabled(storage_name: &str) -> bool {
+    let opts = match options("snuba") {
+        Ok(opts) => opts,
+        Err(_) => return false,
+    };
+
+    // Per-storage option takes precedence; only fall back to the global option
+    // when this storage has no entry in the per-storage dict.
+    if !storage_name.is_empty() {
+        if let Some(enabled) = opts
+            .get(DROP_INVALID_TIMESTAMPS_BY_STORAGE_KEY)
+            .ok()
+            .and_then(|v| v.get(storage_name).and_then(|b| b.as_bool()))
+        {
+            return enabled;
+        }
+    }
+
+    opts.get(DROP_INVALID_TIMESTAMPS_KEY)
         .ok()
-        .and_then(|o| o.get(DROP_INVALID_TIMESTAMPS_KEY).ok())
         .and_then(|v| v.as_bool())
         .unwrap_or(false)
 }
@@ -119,6 +146,61 @@ pub struct SilencedDLQMessage;
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use sentry_options::testing::override_options;
+    use serde_json::json;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    fn init_options() {
+        INIT.call_once(|| crate::init_sentry_options().unwrap());
+    }
+
+    #[test]
+    fn test_get_drop_invalid_timestamps_enabled_per_storage_takes_precedence() {
+        init_options();
+        let _guard = override_options(&[
+            (
+                "snuba",
+                DROP_INVALID_TIMESTAMPS_BY_STORAGE_KEY,
+                json!({ "eap_items": true, "eap_items_dlq_replay": false }),
+            ),
+            // Global says false, but the per-storage entry for eap_items wins.
+            ("snuba", DROP_INVALID_TIMESTAMPS_KEY, json!(false)),
+        ])
+        .unwrap();
+        assert!(get_drop_invalid_timestamps_enabled("eap_items"));
+        assert!(!get_drop_invalid_timestamps_enabled("eap_items_dlq_replay"));
+    }
+
+    #[test]
+    fn test_get_drop_invalid_timestamps_enabled_falls_back_to_global() {
+        init_options();
+        let _guard = override_options(&[
+            // Only eap_items has a per-storage entry; other storages fall back
+            // to the global option.
+            (
+                "snuba",
+                DROP_INVALID_TIMESTAMPS_BY_STORAGE_KEY,
+                json!({ "eap_items": false }),
+            ),
+            ("snuba", DROP_INVALID_TIMESTAMPS_KEY, json!(true)),
+        ])
+        .unwrap();
+        // Per-storage entry wins over the global true.
+        assert!(!get_drop_invalid_timestamps_enabled("eap_items"));
+        // No per-storage entry -> global true.
+        assert!(get_drop_invalid_timestamps_enabled("eap_items_dlq_replay"));
+    }
+
+    #[test]
+    fn test_get_drop_invalid_timestamps_enabled_defaults_false() {
+        init_options();
+        let _guard =
+            override_options(&[("snuba", DROP_INVALID_TIMESTAMPS_BY_STORAGE_KEY, json!({}))])
+                .unwrap();
+        // Neither the per-storage dict nor the (unset) global opt it in.
+        assert!(!get_drop_invalid_timestamps_enabled("eap_items"));
+    }
 
     #[test]
     fn test_out_of_valid_interval_secs_drops_messages_more_than_thirty_days_old() {

--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -26,6 +26,11 @@ struct TraceItemOutcome {
     quantity: u64,
 }
 
+/// This consumer only ever processes the eap_items storage, so the per-storage
+/// `eap_items_drop_invalid_timestamps_by_storage` option is always resolved
+/// against this storage name.
+const STORAGE_NAME: &str = "eap_items";
+
 struct TraceItemOutcomes(Vec<TraceItemOutcome>);
 
 impl TraceItemOutcomes {
@@ -259,7 +264,9 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
             .and_then(|ts| DateTime::from_timestamp(ts.seconds, 0));
         if let Some(event_ts) = event_timestamp {
             let now = Utc::now();
-            if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
+            if get_drop_invalid_timestamps_enabled(STORAGE_NAME)
+                && out_of_valid_interval_secs(event_ts, now)
+            {
                 let item_type = TraceItemType::try_from(trace_item.item_type)
                     .unwrap_or(TraceItemType::Unspecified);
                 let is_future = event_ts > now;

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -26,7 +26,13 @@
     "eap_items_drop_invalid_timestamps": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the eap-items consumer skips messages whose event timestamp is more than one week in the future or more than thirty days in the past."
+      "description": "When true, the eap-items consumer skips messages whose event timestamp is more than one week in the future or more than thirty days in the past. Global fallback; prefer eap_items_drop_invalid_timestamps_by_storage, which is checked first per storage."
+    },
+    "eap_items_drop_invalid_timestamps_by_storage": {
+      "type": "object",
+      "additionalProperties": { "type": "boolean" },
+      "default": {},
+      "description": "Dict mapping storage name (e.g. eap_items, eap_items_dlq_replay) to whether that storage's consumer skips messages whose event timestamp is more than one week in the future or more than thirty days in the past. Checked before eap_items_drop_invalid_timestamps; a storage with no entry falls back to that global value."
     },
     "experimental_healthcheck": {
       "type": "boolean",


### PR DESCRIPTION
## Summary

Adds a new per-storage sentry-option so `eap_items` and `eap_items_dlq_replay` can independently opt in/out of dropping messages with out-of-range timestamps. Fully backwards compatible.

- New option `eap_items_drop_invalid_timestamps_by_storage` (dict mapping storage name → bool).
- `get_drop_invalid_timestamps_enabled(storage_name)` checks the per-storage option first, and only falls back to the existing global `eap_items_drop_invalid_timestamps` boolean when the storage has no entry. Existing config keeps working unchanged.
- `eap_items` processor passes `config.storage_name`; the accepted-outcomes aggregator (eap_items-specific) passes an `"eap_items"` constant.
- Added unit tests for precedence, fallback, and default behavior.

## Operational note

The old boolean still applies to any storage without a per-storage entry, so no coordinated config change is required to preserve current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)