### PR TITLE
ref(eap-items): remove eap_items_drop_invalid_timestamps

### DIFF
--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -66,7 +66,7 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         let now = Utc::now();
 
         if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
-            let is_future = event_ts > now + chrono::Duration::days(5);
+            let is_future = event_ts > now + chrono::Duration::days(1);
             if should_dlq_for_prior_partition(event_ts, now, grace_min) || is_future {
                 let item_type_str = item_type_name(item_type);
                 let reason = if is_future {

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -66,9 +66,20 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         let now = Utc::now();
 
         if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
-            if should_dlq_for_prior_partition(event_ts, now, grace_min) {
+            let is_future = event_ts > now + chrono::Duration::days(5);
+            if should_dlq_for_prior_partition(event_ts, now, grace_min) || is_future {
                 let item_type_str = item_type_name(item_type);
-                counter!("eap_items.messages.dlqed_prior_partition", 1, "item_type" => item_type_str);
+                let reason = if is_future {
+                    "future_timestamp"
+                } else {
+                    "prior_partition"
+                };
+                counter!(
+                    "eap_items.messages.dlqed_prior_partition",
+                    1,
+                    "item_type" => item_type_str,
+                    "reason" => reason
+                );
                 anyhow::bail!(SilencedDLQMessage);
             }
         }

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -66,18 +66,11 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         let now = Utc::now();
 
         if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
-            let is_future = event_ts > now + chrono::Duration::days(1);
-            if should_dlq_for_prior_partition(event_ts, now, grace_min) || is_future {
-                let item_type_str = item_type_name(item_type);
-                let reason = if is_future {
-                    "future_timestamp"
-                } else {
-                    "prior_partition"
-                };
+            if let Some(reason) = should_dlq(event_ts, now, grace_min) {
                 counter!(
                     "eap_items.messages.dlqed_prior_partition",
                     1,
-                    "item_type" => item_type_str,
+                    "item_type" => item_type_name(item_type),
                     "reason" => reason
                 );
                 anyhow::bail!(SilencedDLQMessage);
@@ -164,17 +157,27 @@ fn prior_partition_boundary(now: DateTime<Utc>) -> DateTime<Utc> {
     monday.and_time(chrono::NaiveTime::MIN).and_utc()
 }
 
-/// True when we should DLQ this message because it belongs to the prior
-/// week's partition and we are far enough past the current partition
-/// boundary that prior-week stragglers should no longer be admitted.
-fn should_dlq_for_prior_partition(
-    event_ts: DateTime<Utc>,
-    now: DateTime<Utc>,
-    grace_min: i64,
-) -> bool {
+/// `Some(reason)` when this message's event `timestamp` falls outside the
+/// weekly partition we are willing to write to, `None` when it should be
+/// admitted. `grace_min` sizes a symmetric window around each partition
+/// boundary in which straddling writes are still allowed:
+///
+/// - prior-week stragglers are admitted until `grace_min` minutes past the
+///   current boundary, then DLQed as `past_ts`
+/// - next-week timestamps are DLQed as `future_ts` until we are within
+///   `grace_min` minutes of that next boundary
+fn should_dlq(event_ts: DateTime<Utc>, now: DateTime<Utc>, grace_min: i64) -> Option<&'static str> {
     let boundary = prior_partition_boundary(now);
-    let past_min = now.signed_duration_since(boundary).num_minutes();
-    past_min >= grace_min && event_ts < boundary
+    let next_boundary = boundary + chrono::Duration::days(7);
+    let grace = chrono::Duration::minutes(grace_min);
+
+    if event_ts < boundary && now >= boundary + grace {
+        return Some("past_ts");
+    }
+    if event_ts >= next_boundary && now < next_boundary - grace {
+        return Some("future_ts");
+    }
+    None
 }
 
 pub fn process_message(
@@ -1038,7 +1041,7 @@ mod tests {
         // 45 min past Monday 00:00 UTC; message timestamp is prior week → DLQ.
         let now = ymd_hms(2026, 5, 18, 0, 45, 0);
         let event_ts = ymd_hms(2026, 5, 17, 23, 30, 0);
-        assert!(should_dlq_for_prior_partition(event_ts, now, 45));
+        assert_eq!(should_dlq(event_ts, now, 45), Some("past_ts"));
     }
 
     #[test]
@@ -1046,7 +1049,7 @@ mod tests {
         // 30 min past Monday 00:00 UTC, grace=45 → not DLQ even though prior week.
         let now = ymd_hms(2026, 5, 18, 0, 30, 0);
         let event_ts = ymd_hms(2026, 5, 17, 23, 30, 0);
-        assert!(!should_dlq_for_prior_partition(event_ts, now, 45));
+        assert_eq!(should_dlq(event_ts, now, 45), None);
     }
 
     #[test]
@@ -1054,7 +1057,7 @@ mod tests {
         // Past grace, but message belongs to current week → never DLQ.
         let now = ymd_hms(2026, 5, 18, 1, 30, 0);
         let event_ts = ymd_hms(2026, 5, 18, 1, 0, 0);
-        assert!(!should_dlq_for_prior_partition(event_ts, now, 45));
+        assert_eq!(should_dlq(event_ts, now, 45), None);
     }
 
     /// The column list we ship with `INSERT INTO ... FORMAT RowBinary` must
@@ -1097,16 +1100,34 @@ mod tests {
         // event_ts == boundary belongs to the new week — must not DLQ.
         let now = ymd_hms(2026, 5, 18, 6, 0, 0);
         let event_ts = ymd_hms(2026, 5, 18, 0, 0, 0);
-        assert!(!should_dlq_for_prior_partition(event_ts, now, 45));
+        assert_eq!(should_dlq(event_ts, now, 45), None);
     }
 
     #[test]
-    fn test_should_not_dlq_future_event_ts() {
-        // Producer clock skew: event_ts > now. Belongs to current week (or future);
-        // event_ts < boundary is false, so we never DLQ.
+    fn test_should_not_dlq_future_event_ts_in_current_week() {
+        // Producer clock skew: event_ts > now, but still inside the current
+        // weekly partition (next boundary is Monday 2026-05-25) → admit.
         let now = ymd_hms(2026, 5, 21, 12, 0, 0);
         let event_ts = ymd_hms(2026, 5, 22, 0, 0, 0);
-        assert!(!should_dlq_for_prior_partition(event_ts, now, 45));
+        assert_eq!(should_dlq(event_ts, now, 45), None);
+    }
+
+    #[test]
+    fn test_should_dlq_next_week_event_ts_outside_grace() {
+        // Thursday: event_ts lands in the next partition (Monday 2026-05-25)
+        // and we are far more than grace_min minutes away from it → DLQ.
+        let now = ymd_hms(2026, 5, 21, 12, 0, 0);
+        let event_ts = ymd_hms(2026, 5, 25, 0, 0, 0);
+        assert_eq!(should_dlq(event_ts, now, 45), Some("future_ts"));
+    }
+
+    #[test]
+    fn test_should_not_dlq_next_week_event_ts_within_grace() {
+        // 30 min before Monday 2026-05-25 00:00 with grace=45 → the next
+        // partition is already open for writes.
+        let now = ymd_hms(2026, 5, 24, 23, 30, 0);
+        let event_ts = ymd_hms(2026, 5, 25, 0, 0, 1);
+        assert_eq!(should_dlq(event_ts, now, 45), None);
     }
 
     #[test]
@@ -1114,7 +1135,18 @@ mod tests {
         // grace=0 → DLQ prior-week messages the instant the new week starts.
         let now = ymd_hms(2026, 5, 18, 0, 0, 0);
         let event_ts = ymd_hms(2026, 5, 17, 23, 59, 59);
-        assert!(should_dlq_for_prior_partition(event_ts, now, 0));
+        assert_eq!(should_dlq(event_ts, now, 0), Some("past_ts"));
+    }
+
+    #[test]
+    fn test_should_dlq_grace_zero_admits_next_week_only_at_boundary() {
+        // grace=0 → next-week timestamps are DLQed right up to the boundary.
+        let event_ts = ymd_hms(2026, 5, 25, 0, 0, 0);
+        assert_eq!(
+            should_dlq(event_ts, ymd_hms(2026, 5, 24, 23, 59, 59), 0),
+            Some("future_ts")
+        );
+        assert_eq!(should_dlq(event_ts, ymd_hms(2026, 5, 25, 0, 0, 0), 0), None);
     }
 
     #[test]

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -15,10 +15,7 @@ use sentry_protos::snuba::v1::any_value::Value;
 use sentry_protos::snuba::v1::{ArrayValue, TraceItem, TraceItemType};
 
 use crate::config::ProcessorConfig;
-use crate::processors::utils::{
-    enforce_retention, get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs,
-    record_invalid_timestamp_metric, SilencedDLQMessage,
-};
+use crate::processors::utils::{enforce_retention, SilencedDLQMessage};
 use crate::strategies::clickhouse::rowbinary;
 use crate::types::CogsData;
 use crate::types::{item_type_name, InsertBatch, ItemTypeMetrics, KafkaMessageMetadata};
@@ -48,7 +45,6 @@ struct ProcessedItem {
     origin_timestamp: Option<DateTime<Utc>>,
     item_type_metrics: ItemTypeMetrics,
     cogs_data: CogsData,
-    should_skip: bool,
 }
 
 fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Result<ProcessedItem> {
@@ -66,24 +62,14 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
     let item_type =
         TraceItemType::try_from(trace_item.item_type).unwrap_or(TraceItemType::Unspecified);
 
-    let mut should_skip = false;
     if let Some(event_ts) = event_timestamp {
         let now = Utc::now();
 
-        // should_skip=true will drop messages that are too old or too far in the future
-        if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
-            let is_future = event_ts > now;
-            record_invalid_timestamp_metric("eap_items.messages", is_future, item_type);
-            should_skip = true;
-        }
-        // only DLQ messages that we don't want to drop (when should_skip=false)
-        if !should_skip {
-            if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
-                if should_dlq_for_prior_partition(event_ts, now, grace_min) {
-                    let item_type_str = item_type_name(item_type);
-                    counter!("eap_items.messages.dlqed_prior_partition", 1, "item_type" => item_type_str);
-                    anyhow::bail!(SilencedDLQMessage);
-                }
+        if let Some(grace_min) = get_dlq_grace_period_min(&config.storage_name) {
+            if should_dlq_for_prior_partition(event_ts, now, grace_min) {
+                let item_type_str = item_type_name(item_type);
+                counter!("eap_items.messages.dlqed_prior_partition", 1, "item_type" => item_type_str);
+                anyhow::bail!(SilencedDLQMessage);
             }
         }
     }
@@ -145,7 +131,6 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
         origin_timestamp,
         item_type_metrics,
         cogs_data,
-        should_skip,
     })
 }
 
@@ -187,9 +172,6 @@ pub fn process_message(
     config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let processed = process_eap_item(msg, config)?;
-    if processed.should_skip {
-        return Ok(InsertBatch::skip());
-    }
     let mut batch = InsertBatch::from_rows([processed.eap_item], processed.origin_timestamp)?;
     batch.item_type_metrics = Some(processed.item_type_metrics);
     batch.cogs_data = Some(processed.cogs_data);
@@ -202,9 +184,6 @@ pub fn process_message_row_binary(
     config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
     let processed = process_eap_item(msg, config)?;
-    if processed.should_skip {
-        return Ok(InsertBatch::skip());
-    }
     let row = EAPItemRow::try_from(processed.eap_item)?;
 
     // Encode the row to RowBinary bytes inline so the wide typed struct (~80
@@ -238,13 +217,6 @@ pub(crate) fn process_message_row_binary_typed(
     config: &ProcessorConfig,
 ) -> anyhow::Result<EAPItemRowBatch> {
     let processed = process_eap_item(msg, config)?;
-    if processed.should_skip {
-        return Ok(EAPItemRowBatch {
-            rows: vec![],
-            cogs_data: None,
-            item_type_metrics: None,
-        });
-    }
     Ok(EAPItemRowBatch {
         rows: vec![EAPItemRow::try_from(processed.eap_item)?],
         cogs_data: Some(processed.cogs_data),

--- a/rust_snuba/src/processors/utils.rs
+++ b/rust_snuba/src/processors/utils.rs
@@ -1,51 +1,11 @@
 use crate::config::EnvConfig;
-use crate::types::item_type_name;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use schemars::JsonSchema;
-use sentry_arroyo::counter;
-use sentry_options::options;
-use sentry_protos::snuba::v1::TraceItemType;
 use serde::{Deserialize, Deserializer, Serialize};
-
-/// One week in seconds. The eap_items table is partitioned by
-/// `(retention_days, toMonday(timestamp))`, so any event more than a week
-/// in the future will add more parts.
-pub const INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS: i64 = 7 * 24 * 60 * 60;
-
-/// Thirty days in seconds. Events older than this are dropped when invalid
-/// timestamp dropping is enabled.
-pub const INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS: i64 = 30 * 24 * 60 * 60;
-
-/// sentry-options key. When `true`, the eap-items consumer skips messages
-/// whose event `timestamp` is more than one week in the future or more than
-/// thirty days in the past (see `out_of_valid_interval_secs`).
-pub const DROP_INVALID_TIMESTAMPS_KEY: &str = "eap_items_drop_invalid_timestamps";
 
 // Equivalent to "%Y-%m-%dT%H:%M:%S.%fZ" in python
 // Notice the differennce of .%fZ vs %.fZ, this comes from a difference in how rust's chrono handles the format
 const PAYLOAD_DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.fZ";
-
-/// Returns true if `ts` is more than one week after `now` or more than thirty
-/// days before `now`.
-pub fn out_of_valid_interval_secs(ts: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-    let offset_sec = ts.signed_duration_since(now).num_seconds();
-    !(-INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS..=INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS)
-        .contains(&offset_sec)
-}
-
-pub fn get_drop_invalid_timestamps_enabled() -> bool {
-    options("snuba")
-        .ok()
-        .and_then(|o| o.get(DROP_INVALID_TIMESTAMPS_KEY).ok())
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-}
-
-pub fn record_invalid_timestamp_metric(prefix: &str, is_future: bool, item_type: TraceItemType) {
-    let metric_name = format!("{prefix}.dropped_out_of_range_timestamp");
-    let item_type_str = item_type_name(item_type);
-    counter!(metric_name, 1, "is_future" => is_future.to_string(), "item_type" => item_type_str);
-}
 
 pub fn enforce_retention(value: Option<u16>, config: &EnvConfig) -> u16 {
     let mut retention_days = value.unwrap_or(config.default_retention_days);
@@ -114,44 +74,3 @@ pub struct StringToIntDatetime64(
 #[derive(Debug, thiserror::Error)]
 #[error("message routed to DLQ (silenced)")]
 pub struct SilencedDLQMessage;
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_out_of_valid_interval_secs_drops_messages_more_than_thirty_days_old() {
-        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let ts =
-            DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS - 1, 0)
-                .unwrap();
-        assert!(out_of_valid_interval_secs(ts, now));
-    }
-
-    #[test]
-    fn test_out_of_valid_interval_secs_drops_messages_more_than_a_week_in_the_future() {
-        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let ts =
-            DateTime::from_timestamp(2_000_000 + INVALID_TIMESTAMP_FUTURE_INTERVAL_SECONDS + 1, 0)
-                .unwrap();
-        assert!(out_of_valid_interval_secs(ts, now));
-    }
-
-    #[test]
-    fn test_out_of_valid_interval_secs_keeps_messages_at_exactly_thirty_days_old() {
-        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let ts = DateTime::from_timestamp(2_000_000 - INVALID_TIMESTAMP_PAST_INTERVAL_SECONDS, 0)
-            .unwrap();
-        assert!(!out_of_valid_interval_secs(ts, now));
-    }
-
-    #[test]
-    fn test_out_of_valid_interval_secs_keeps_messages_within_a_week() {
-        let now = DateTime::from_timestamp(2_000_000, 0).unwrap();
-        let past = DateTime::from_timestamp(2_000_000 - 86_400, 0).unwrap();
-        assert!(!out_of_valid_interval_secs(past, now));
-        let future = DateTime::from_timestamp(2_000_000 + 86_400, 0).unwrap();
-        assert!(!out_of_valid_interval_secs(future, now));
-    }
-}

--- a/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
+++ b/rust_snuba/src/strategies/accepted_outcomes/aggregator.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant};
 
-use chrono::{DateTime, Utc};
 use prost::Message as ProstMessage;
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
 use sentry_arroyo::counter;
@@ -13,10 +12,6 @@ use sentry_arroyo::types::{InnerMessage, Message, Partition};
 use sentry_arroyo::utils::timing::Deadline;
 use sentry_protos::snuba::v1::{TraceItem, TraceItemType};
 
-use crate::processors::utils::{
-    get_drop_invalid_timestamps_enabled, out_of_valid_interval_secs,
-    record_invalid_timestamp_metric,
-};
 use crate::types::{item_type_name, AggregatedOutcomesBatch, BucketKey, ItemDedupKey};
 
 #[derive(Debug, Default)]
@@ -252,21 +247,6 @@ impl<TNext: ProcessingStrategy<AggregatedOutcomesBatch>> ProcessingStrategy<Kafk
                 )));
             }
         };
-
-        let event_timestamp = trace_item
-            .timestamp
-            .as_ref()
-            .and_then(|ts| DateTime::from_timestamp(ts.seconds, 0));
-        if let Some(event_ts) = event_timestamp {
-            let now = Utc::now();
-            if get_drop_invalid_timestamps_enabled() && out_of_valid_interval_secs(event_ts, now) {
-                let item_type = TraceItemType::try_from(trace_item.item_type)
-                    .unwrap_or(TraceItemType::Unspecified);
-                let is_future = event_ts > now;
-                record_invalid_timestamp_metric("accepted_outcomes", is_future, item_type);
-                return Ok(());
-            }
-        }
 
         let ts_secs = trace_item
             .received

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -23,11 +23,6 @@
       "default": 600,
       "description": "Age threshold in seconds for consumer.dlq_by_age_sample_rate_by_storage. Messages whose Kafka broker timestamp is older than this are candidates for being routed to the DLQ."
     },
-    "eap_items_drop_invalid_timestamps": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, the eap-items consumer skips messages whose event timestamp is more than one week in the future or more than thirty days in the past."
-    },
     "experimental_healthcheck": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
Removes the `eap_items_drop_invalid_timestamps` option and all of its logic.

### What's gone
- **`processors/utils.rs`** — `DROP_INVALID_TIMESTAMPS_KEY`, `INVALID_TIMESTAMP_{FUTURE,PAST}_INTERVAL_SECONDS`, `out_of_valid_interval_secs()`, `get_drop_invalid_timestamps_enabled()`, `record_invalid_timestamp_metric()`, and their unit tests.
- **`processors/eap_items.rs`** — the skip check. `should_skip` was only ever set by that check, so the field is gone from `ProcessedItem` along with the three early returns in `process_message`, `process_message_row_binary`, and the test-only `process_message_row_binary_typed`. The `eap_items_dlq_grace_period_min` DLQ killswitch is unchanged, just no longer nested under `if !should_skip`.
- **`strategies/accepted_outcomes/aggregator.rs`** — the drop check in `submit()`.
- **`sentry-options/schemas/snuba/schema.json`** — the option definition.

### Note
The `eap_items.messages.dropped_out_of_range_timestamp` and `accepted_outcomes.dropped_out_of_range_timestamp` metrics are no longer emitted — worth checking for dashboards/alerts on them before this ships.

### Testing
`cargo clippy --all-targets` is clean. Rust tests pass except `processors::eap_items::tests::test_row_binary_clickhouse_insert`, which needs a local ClickHouse (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)