### PR TITLE
feat(metrics): instrument req/resp encoding headers.

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -96,11 +96,14 @@ def truncate_dataset(dataset: Dataset) -> None:
 
 
 def _add_compression_attrs(response: Response) -> Response:
-    accept = http_request.headers.get("Accept-Encoding")
-    sentry_sdk.set_attribute("snuba.req_accept_encoding", accept)
-
-    encoding = response.headers.get("Content-Encoding")
-    sentry_sdk.set_attribute("snuba.resp_encoding", encoding)
+    # TODO: update to attributes once we update the sdk
+    # leaving these as tags so I can aggregate by them in the meantime
+    sentry_sdk.set_tag("snuba.req_accept_encoding", http_request.headers.get("Accept-Encoding"))
+    sentry_sdk.set_tag("snuba.resp_encoding", response.headers.get("Content-Encoding"))
+    sentry_sdk.set_tag("snuba.resp_mime_type", response.mimetype)
+    span = sentry_sdk.get_current_span()
+    if span is not None:
+        span.set_data("snuba.resp_content_length", response.content_length)
     return response
 
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -95,8 +95,19 @@ def truncate_dataset(dataset: Dataset) -> None:
                 clickhouse.execute(f"TRUNCATE TABLE IF EXISTS {database}.{table}")
 
 
+def _add_compression_attrs(response: Response) -> Response:
+    accept = http_request.headers.get("Accept-Encoding")
+    sentry_sdk.set_attribute("snuba.req_accept_encoding", accept)
+
+    encoding = response.headers.get("Content-Encoding")
+    sentry_sdk.set_attribute("snuba.resp_encoding", encoding)
+    return response
+
+
 def _configure_response_compression(app: Flask) -> None:
     """Compress large JSON query responses with zstd."""
+    # register BEFORE Compress so it runs *after* compression (after_request = reverse order)
+    app.after_request(_add_compression_attrs)
     app.config["COMPRESS_ALGORITHM"] = ["zstd"]
     app.config["COMPRESS_MIMETYPES"] = ["application/json"]  # only applies to json responses
     app.config["COMPRESS_MIN_SIZE"] = 1024  # skips compressions if response under this size


### PR DESCRIPTION
## What
Record the incoming `Accept-Encoding` and outgoing `Content-Encoding` on snuba-api spans.

  ## How
  An `after_request` hook writes both onto the active span, registered before `Compress()` so it runs after compression and captures the final `Content-Encoding`.

  ## Why
-  Egress didn't drop after the client started requesting zstd.
-  This lets us see whether the header actually reaches snuba and whether responses come back compressed.
-  Suspicion: Ingress controller (envoy or maybe something else in GCP) is stripping headers.

  ## Links
  [EAP-627](https://linear.app/getsentry/issue/EAP-627/enable-compression-on-snuba-query-paths)
  [DD notebook](https://app.datadoghq.com/notebook/15075883)