### PR TITLE
feat(eap-items): drop attributes_array JSON column from distributed tables

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0062_drop_attributes_array_json_from_dist.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0062_drop_attributes_array_json_from_dist.py
@@ -1,0 +1,71 @@
+from snuba.clickhouse.columns import JSON, Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.snuba_migrations.events_analytics_platform.templates import SAMPLING_WEIGHTS
+
+storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+ro_storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO
+
+column_name = "attributes_array"
+after = "attributes_float_39"
+
+# Column definition as added by migration 0050, needed to re-add the column
+# on rollback.
+attributes_array_column = Column(
+    column_name,
+    JSON(
+        max_dynamic_paths=128,
+        modifiers=Modifiers(codecs=["ZSTD(1)"]),
+    ),
+)
+
+
+def _dist_tables() -> list[tuple[StorageSetKey, str]]:
+    # The read-only distributed tables (created in 0056 via CREATE TABLE ... AS)
+    # inherited the column from their source dist tables, so drop it there too.
+    tables: list[tuple[StorageSetKey, str]] = [(storage_set, "eap_items_1_dist")]
+    for w in SAMPLING_WEIGHTS:
+        tables.append((storage_set, f"eap_items_1_downsample_{w}_dist"))
+    tables.append((ro_storage_set, "eap_items_1_dist_ro"))
+    for w in SAMPLING_WEIGHTS:
+        tables.append((ro_storage_set, f"eap_items_1_downsample_{w}_dist_ro"))
+    return tables
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """Drop the `attributes_array` JSON column (added by migration 0050) from
+    the distributed eap_items tables.
+
+    The column was replaced by the typed attributes_array_{string,int,float,bool}
+    map columns from migration 0059 and is no longer read. The local tables keep
+    the column for now; this only removes it from the distributed (query-path)
+    tables. No materialized view projects this column, so no view regeneration
+    is needed.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> list[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=ss,
+                table_name=table,
+                column_name=column_name,
+                target=OperationTarget.DISTRIBUTED,
+            )
+            for (ss, table) in _dist_tables()
+        ]
+
+    def backwards_ops(self) -> list[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=ss,
+                table_name=table,
+                column=attributes_array_column,
+                after=after,
+                target=OperationTarget.DISTRIBUTED,
+            )
+            for (ss, table) in reversed(_dist_tables())
+        ]

--- a/snuba/snuba_migrations/events_analytics_platform/0062_drop_attributes_array_json_from_dist_and_downsample.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0062_drop_attributes_array_json_from_dist_and_downsample.py
@@ -22,27 +22,41 @@ attributes_array_column = Column(
 )
 
 
-def _dist_tables() -> list[tuple[StorageSetKey, str]]:
+def _tables() -> list[tuple[StorageSetKey, str, OperationTarget]]:
+    # The downsample materialized views never projected `attributes_array`
+    # (they SELECT an explicit column list built from get_eap_items_columns(),
+    # which has never included it), so the column only ever held default
+    # values on the downsample tables and nothing references it anywhere.
+    # It can therefore be dropped from the downsample tables entirely (local
+    # and distributed); only the full-fidelity eap_items_1_local keeps it.
+    tables: list[tuple[StorageSetKey, str, OperationTarget]] = [
+        (storage_set, "eap_items_1_dist", OperationTarget.DISTRIBUTED),
+    ]
+    for w in SAMPLING_WEIGHTS:
+        tables.append(
+            (storage_set, f"eap_items_1_downsample_{w}_dist", OperationTarget.DISTRIBUTED)
+        )
     # The read-only distributed tables (created in 0056 via CREATE TABLE ... AS)
     # inherited the column from their source dist tables, so drop it there too.
-    tables: list[tuple[StorageSetKey, str]] = [(storage_set, "eap_items_1_dist")]
+    tables.append((ro_storage_set, "eap_items_1_dist_ro", OperationTarget.DISTRIBUTED))
     for w in SAMPLING_WEIGHTS:
-        tables.append((storage_set, f"eap_items_1_downsample_{w}_dist"))
-    tables.append((ro_storage_set, "eap_items_1_dist_ro"))
+        tables.append(
+            (ro_storage_set, f"eap_items_1_downsample_{w}_dist_ro", OperationTarget.DISTRIBUTED)
+        )
     for w in SAMPLING_WEIGHTS:
-        tables.append((ro_storage_set, f"eap_items_1_downsample_{w}_dist_ro"))
+        tables.append((storage_set, f"eap_items_1_downsample_{w}_local", OperationTarget.LOCAL))
     return tables
 
 
 class Migration(migration.ClickhouseNodeMigration):
     """Drop the `attributes_array` JSON column (added by migration 0050) from
-    the distributed eap_items tables.
+    the distributed eap_items tables and the downsampled tables entirely.
 
     The column was replaced by the typed attributes_array_{string,int,float,bool}
-    map columns from migration 0059 and is no longer read. The local tables keep
-    the column for now; this only removes it from the distributed (query-path)
-    tables. No materialized view projects this column, so no view regeneration
-    is needed.
+    map columns from migration 0059 and is no longer read. The downsample
+    materialized views never projected it, so it holds only default values on
+    the downsample tables; nothing references it there. The full-fidelity
+    eap_items_1_local keeps the column, so no view regeneration is needed.
     """
 
     blocking = False
@@ -53,9 +67,9 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=ss,
                 table_name=table,
                 column_name=column_name,
-                target=OperationTarget.DISTRIBUTED,
+                target=target,
             )
-            for (ss, table) in _dist_tables()
+            for (ss, table, target) in _tables()
         ]
 
     def backwards_ops(self) -> list[SqlOperation]:
@@ -65,7 +79,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=table,
                 column=attributes_array_column,
                 after=after,
-                target=OperationTarget.DISTRIBUTED,
+                target=target,
             )
-            for (ss, table) in reversed(_dist_tables())
+            for (ss, table, target) in reversed(_tables())
         ]

--- a/snuba/snuba_migrations/events_analytics_platform/0062_drop_attributes_array_json_from_dist_and_downsample.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0062_drop_attributes_array_json_from_dist_and_downsample.py
@@ -23,12 +23,6 @@ attributes_array_column = Column(
 
 
 def _tables() -> list[tuple[StorageSetKey, str, OperationTarget]]:
-    # The downsample materialized views never projected `attributes_array`
-    # (they SELECT an explicit column list built from get_eap_items_columns(),
-    # which has never included it), so the column only ever held default
-    # values on the downsample tables and nothing references it anywhere.
-    # It can therefore be dropped from the downsample tables entirely (local
-    # and distributed); only the full-fidelity eap_items_1_local keeps it.
     tables: list[tuple[StorageSetKey, str, OperationTarget]] = [
         (storage_set, "eap_items_1_dist", OperationTarget.DISTRIBUTED),
     ]
@@ -53,10 +47,7 @@ class Migration(migration.ClickhouseNodeMigration):
     the distributed eap_items tables and the downsampled tables entirely.
 
     The column was replaced by the typed attributes_array_{string,int,float,bool}
-    map columns from migration 0059 and is no longer read. The downsample
-    materialized views never projected it, so it holds only default values on
-    the downsample tables; nothing references it there. The full-fidelity
-    eap_items_1_local keeps the column, so no view regeneration is needed.
+    map columns from migration 0059 and is no longer read.
     """
 
     blocking = False


### PR DESCRIPTION
Migration 0062 drops the `attributes_array` JSON column (added in 0050, superseded by the typed `attributes_array_{string,int,float,bool}` map columns from 0059) from:

- `eap_items_1_dist` + downsample `_dist` tables (EVENTS_ANALYTICS_PLATFORM)
- `eap_items_1_dist_ro` + downsample `_dist_ro` tables (EVENTS_ANALYTICS_PLATFORM_RO, inherited via `CREATE TABLE ... AS` in 0056)
- downsample `_local` tables (`eap_items_1_downsample_{8,64,512}_local`)

Notes:
- The downsample materialized views never projected `attributes_array` (they SELECT an explicit column list built from `get_eap_items_columns()`, which never included it), so the column only ever held default values on the downsampled tables — nothing references it there.
- The full-fidelity `eap_items_1_local` keeps the column, so no view regeneration is needed.
- Backwards ops re-add the column with its original 0050 definition.