### PR TITLE
ref(admin): Restore the Cardinality Analyzer tool

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -76,6 +76,7 @@ class InteractToolAction(ToolAction):
 TOOL_RESOURCES = {
     "snql-to-sql": ToolResource("snql-to-sql"),
     "tracing": ToolResource("tracing"),
+    "cardinality-analyzer": ToolResource("cardinality-analyzer"),
     "production-queries": ToolResource("production-queries"),
     "system-queries": ToolResource("system-queries"),
     "sudo-system-queries": ToolResource("system-queries"),
@@ -170,6 +171,10 @@ ROLES = {
                 ]
             )
         },
+    ),
+    "CardinalityAnalyzer": Role(
+        name="cardinality-analyzer",
+        actions={InteractToolAction([TOOL_RESOURCES["cardinality-analyzer"]])},
     ),
     "AllMigrationsExecutor": Role(
         name="AllMigrationsExecutor",

--- a/snuba/admin/cardinality_analyzer/cardinality_analyzer.py
+++ b/snuba/admin/cardinality_analyzer/cardinality_analyzer.py
@@ -1,0 +1,79 @@
+from typing import cast
+
+from snuba.admin.audit_log.query import audit_log
+from snuba.admin.clickhouse.common import (
+    get_ro_query_node_connection,
+    validate_ro_query,
+)
+from snuba.clickhouse.native import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.storage_key import StorageKey
+
+# HACK (VOLO): Everything in this file is a hack
+
+
+def _stringify_result(result: ClickhouseResult) -> ClickhouseResult:
+    # javascript stores numbers as doubles so in order for it to not round
+    # metric ids (which are all prefixed by (1 << 63)) we strigify them before sending
+    # them to the client
+    result_rows = []
+    for row in result.results:
+        result_rows.append([str(col) for col in row])
+    return ClickhouseResult(result_rows, result.meta)
+
+
+@audit_log
+def run_metrics_query(query: str, user: str) -> ClickhouseResult:
+    """
+    Validates, audit logs, and executes given query against Querylog
+    table in ClickHouse. `user` param is necessary for audit_log
+    decorator.
+    """
+    storage_keys = {
+        StorageKey("generic_metrics_distributions"),
+        StorageKey("generic_metrics_sets"),
+        StorageKey("generic_metrics_counters"),
+        StorageKey("generic_metrics_gauges"),
+    }
+    schemas = {get_storage(storage_key).get_schema() for storage_key in storage_keys}
+    raw_tables = {
+        "generic_metric_sets_raw_dist",
+        "generic_metric_counters_raw_dist",
+        "generic_metric_distributions_raw_dist",
+        "generic_metric_gauges_raw_dist",
+    }
+    meta_tables = set()
+    for mtype in ["counters", "sets", "distributions", "gauges"]:
+        meta_tables.add(f"generic_metric_{mtype}_meta_aggregated_dist")
+        meta_tables.add(f"generic_metric_{mtype}_meta_tag_value_aggregated_dist")
+        meta_tables.add(f"generic_metric_{mtype}_meta_dist")
+        meta_tables.add(f"generic_metric_{mtype}_meta_tag_values_dist")
+
+    validate_ro_query(
+        sql_query=query,
+        allowed_tables=(
+            {cast(TableSchema, schema).get_table_name() for schema in schemas}
+            | raw_tables
+            | meta_tables
+        ),
+    )
+    return _stringify_result(__run_query(query))
+
+
+def __run_query(query: str) -> ClickhouseResult:
+    """
+    Runs given Query against metrics distributions in ClickHouse. This function assumes valid
+    query and does not validate/sanitize query or response data.
+    """
+    connection = get_ro_query_node_connection(
+        StorageKey("generic_metrics_distributions").value,
+        ClickhouseClientSettings.CARDINALITY_ANALYZER,
+    )
+
+    query_result = connection.execute(
+        query=query,
+        with_column_types=True,
+    )
+    return query_result

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -147,21 +147,24 @@ def _driver_cache_token() -> str:
     return "connect" if use_clickhouse_connect_driver() else "native"
 
 
+def _settings_cache_token(client_settings: ClickhouseClientSettings) -> str:
+    # Part of the admin connection cache keys because the ClickHouse settings
+    # (and, for the read-only getters, the credentials) a pool is built with are
+    # baked in at construction. Without this, two tools asking for the same
+    # storage/host with different profiles would collide: whichever ran first
+    # would win and the other would silently execute against the wrong pool. For
+    # example System Queries (QUERY -> readonly user, 25s cap) and the
+    # Cardinality Analyzer (CARDINALITY_ANALYZER -> trace user, max_threads=10,
+    # 60s cap) both reach generic_metrics_distributions on the query node.
+    return client_settings.name
+
+
 def get_ro_node_connection(
     clickhouse_host: str,
     clickhouse_port: int,
     storage_name: str,
     client_settings: ClickhouseClientSettings,
 ) -> ClickhousePool:
-    storage = _get_storage(storage_name)
-
-    key = f"{storage.get_storage_key()}-{clickhouse_host}-{_driver_cache_token()}"
-    if key in NODE_CONNECTIONS:
-        return NODE_CONNECTIONS[key]
-
-    cluster = storage.get_cluster()
-    database = cluster.get_database()
-
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
         ClickhouseClientSettings.QUERYLOG,
@@ -171,6 +174,15 @@ def get_ro_node_connection(
         "admin can only use QUERY, QUERYLOG, TRACING or CARDINALITY_ANALYZER "
         "ClickhouseClientSettings"
     )
+
+    storage = _get_storage(storage_name)
+
+    key = f"{storage.get_storage_key()}-{clickhouse_host}-{_settings_cache_token(client_settings)}-{_driver_cache_token()}"
+    if key in NODE_CONNECTIONS:
+        return NODE_CONNECTIONS[key]
+
+    cluster = storage.get_cluster()
+    database = cluster.get_database()
 
     if (
         client_settings == ClickhouseClientSettings.QUERY
@@ -202,7 +214,7 @@ CLUSTER_CONNECTIONS: MutableMapping[str, ClickhousePool] = {}
 def get_ro_query_node_connection(
     storage_name: str, client_settings: ClickhouseClientSettings
 ) -> ClickhousePool:
-    key = f"{storage_name}-{_driver_cache_token()}"
+    key = f"{storage_name}-{_settings_cache_token(client_settings)}-{_driver_cache_token()}"
     if key in CLUSTER_CONNECTIONS:
         return CLUSTER_CONNECTIONS[key]
 
@@ -225,7 +237,7 @@ def get_sudo_node_connection(
 ) -> ClickhousePool:
     storage = _get_storage(storage_name)
 
-    key = f"{storage.get_storage_key()}-{clickhouse_host}-sudo-{_driver_cache_token()}"
+    key = f"{storage.get_storage_key()}-{clickhouse_host}-sudo-{_settings_cache_token(client_settings)}-{_driver_cache_token()}"
     if key in NODE_CONNECTIONS:
         return NODE_CONNECTIONS[key]
 
@@ -257,7 +269,7 @@ def get_clusterless_node_connection(
     cluster = storage.get_cluster()
     database = cluster.get_database()
 
-    key = f"{storage.get_storage_key()}-{clickhouse_host}-clusterless-{database}-{_driver_cache_token()}"
+    key = f"{storage.get_storage_key()}-{clickhouse_host}-clusterless-{database}-{_settings_cache_token(client_settings)}-{_driver_cache_token()}"
     if key in NODE_CONNECTIONS:
         return NODE_CONNECTIONS[key]
 
@@ -282,18 +294,18 @@ def get_ro_clusterless_node_connection(
     storage_name: str,
     client_settings: ClickhouseClientSettings,
 ) -> ClickhousePool:
-    storage = _get_storage(storage_name)
-    cluster = storage.get_cluster()
-    database = cluster.get_database()
-
-    key = f"{storage.get_storage_key()}-{clickhouse_host}-clusterless-ro-{database}-{_driver_cache_token()}"
-    if key in NODE_CONNECTIONS:
-        return NODE_CONNECTIONS[key]
-
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
         ClickhouseClientSettings.QUERYLOG,
     }, "ro clusterless connections must use a read-only client settings profile"
+
+    storage = _get_storage(storage_name)
+    cluster = storage.get_cluster()
+    database = cluster.get_database()
+
+    key = f"{storage.get_storage_key()}-{clickhouse_host}-clusterless-ro-{database}-{_settings_cache_token(client_settings)}-{_driver_cache_token()}"
+    if key in NODE_CONNECTIONS:
+        return NODE_CONNECTIONS[key]
 
     connection = _build_validated_pool(
         clickhouse_host,

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -117,7 +117,7 @@ def _build_validated_pool(
     # is correct *only* when we are connecting to that endpoint — i.e. the query
     # node, the same host the normal read path reaches on
     # cluster.get_http_port() (this is what get_ro_query_node_connection, and
-    # thus the tracing/querylog tools, rely on). For any other host
+    # thus the tracing/querylog/cardinality tools, rely on). For any other host
     # — a specific individual node selected by host in the admin tools — that
     # port does not apply: an individual node serves HTTP on the well-known
     # default port, so use that instead.
@@ -166,7 +166,11 @@ def get_ro_node_connection(
         ClickhouseClientSettings.QUERY,
         ClickhouseClientSettings.QUERYLOG,
         ClickhouseClientSettings.TRACING,
-    }, "admin can only use QUERY, QUERYLOG or TRACING ClickhouseClientSettings"
+        ClickhouseClientSettings.CARDINALITY_ANALYZER,
+    }, (
+        "admin can only use QUERY, QUERYLOG, TRACING or CARDINALITY_ANALYZER "
+        "ClickhouseClientSettings"
+    )
 
     if (
         client_settings == ClickhouseClientSettings.QUERY

--- a/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
+++ b/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from snuba.admin.clickhouse.common import PreDefinedQuery
+from snuba.utils.registered_class import RegisteredClass
+
+# Start index is 9223372036854775808
+METRICS_START_INDEX = 1 << 63
+
+
+# TODO: These enum definitions do not work right now. Most likely because
+# f-string formatting does not work as intended when defining the sql. We hardcode
+# the values in the queries for now.
+class IndexedIDs(Enum):
+    # Tags
+    SPAN_DESCRIPTION_TAG = METRICS_START_INDEX + 249
+    SPAN_CATEGORY_TAG = METRICS_START_INDEX + 254
+    SPAN_GROUP_TAG = METRICS_START_INDEX + 252
+    # Metric names
+    SPAN_DURATION_METRIC = METRICS_START_INDEX + 404
+    SPAN_EXCLUSIVE_TIME_METRIC = METRICS_START_INDEX + 405
+    SPAN_EXCLUSIVE_TIME_LIGHT_METRIC = METRICS_START_INDEX + 406
+
+
+class CardinalityQuery(PreDefinedQuery, metaclass=RegisteredClass):
+    @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
+
+
+class SpanGroupingCardinality(CardinalityQuery):
+    """Get the span groups with the highest cardinality across all projects and orgs."""
+
+    sql = """
+    SELECT org_id, project_id,
+    tags.raw_value [indexOf(tags.key, 9223372036854776062)] AS `span.category`,
+    uniq(tags.raw_value [indexOf(tags.key, 9223372036854776060)]) AS count_groups
+    FROM generic_metric_distributions_aggregated_dist
+    WHERE (granularity = 2)
+    AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+    AND (metric_id IN [9223372036854776212, 9223372036854776213])
+    AND `span.category` = '{{span_category}}'
+    GROUP BY org_id, project_id, `span.category`
+    ORDER BY count_groups DESC
+    LIMIT 100
+    """
+
+
+class SpanGroupingCardinalitySamples(CardinalityQuery):
+    """
+    Get a sample list of the span groups for a given org and project.
+    """
+
+    sql = """
+    SELECT DISTINCT
+    tags.raw_value[indexOf(tags.key, 9223372036854776062)] AS `span.category`,
+    tags.raw_value[indexOf(tags.key, 9223372036854776060)] AS `span.group`,
+    tags.raw_value[indexOf(tags.key, 9223372036854776057)] AS `span.description`
+    FROM generic_metric_distributions_aggregated_dist
+    WHERE (granularity = 2)
+    AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+    AND (org_id = {{org_id}})
+    AND (project_id = {{project_id}})
+    AND (metric_id = 9223372036854776214)
+    ORDER BY span.description
+    LIMIT 1000
+    """
+
+
+class BucketsByOrgProject(CardinalityQuery):
+    """
+    For a given org/project, find out how many buckets are generated for each granularity.
+    The query asks for which metric type (counters/sets/distributions), the hour window to look back, and the org/project ID.
+
+    Note that gauges uses a different timestamp (rounded_timestamp).
+
+    This also has a totals row at the end.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, count()
+    FROM generic_metric_{{metric_type}}_aggregated_dist
+    WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class BucketsByOrgProjectGauges(CardinalityQuery):
+    """
+    For a given org/project, find out how many buckets are generated for each granularity.
+    This query is for gauges specifically, since it uses timestamps differently.
+    The query asks for the hour window to look back, and the org/project ID.
+
+    This also has a totals row at the end.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, count()
+    FROM generic_metric_gauges_aggregated_dist
+    WHERE rounded_timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class DatapointsByOrgProjectDistributions(CardinalityQuery):
+    """
+    For a given org/project, find out how many datapoints exist for each granularity.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, countMerge(count)
+    FROM generic_metric_distributions_aggregated_dist
+    WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class DatapointsByOrgProjectCounters(CardinalityQuery):
+    """
+    For a given org/project, find out how many datapoints exist for each granularity.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, sumMerge(value)
+    FROM generic_metric_counters_aggregated_dist
+    WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class DatapointsByOrgProjectGauges(CardinalityQuery):
+    """
+    For a given org/project, find out how many datapoints exist for each granularity.
+    """
+
+    sql = """
+    SELECT org_id, project_id, granularity, sumMerge(count)
+    FROM generic_metric_gauges_aggregated_dist
+    WHERE rounded_timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
+    AND org_id = {{org_id}}
+    AND project_id = {{project_id}}
+    GROUP BY org_id, project_id, granularity
+    WITH TOTALS
+    ORDER BY granularity ASC
+    """
+
+
+class BucketsPerOrgOverTime(CardinalityQuery):
+    """
+    Determine how many buckets an org is storing over time. Show the top 5 offenders.
+
+    By default, shows custom metrics. You can adjust the query for metric platform use cases including:
+    spans, tranactions, sessions, escalating_issues, profiles, bundle_analysis, and custom.
+
+    This query can be tweaked by using more/less granular time function (toStartOfTenMinutes)
+    or by using project_id instead of org_id.
+    """
+
+    sql = """
+    SELECT toStartOfHour(timestamp) as time, org_id, count() as total
+    FROM generic_metric_{{metric_type}}_aggregated_dist
+    WHERE timestamp >= (now() - INTERVAL {{hour}} HOUR)
+    AND use_case_id  = 'custom'
+    GROUP BY time, org_id
+    ORDER BY time ASC, total DESC
+    LIMIT 5 BY time
+    """

--- a/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
+++ b/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
@@ -63,7 +63,7 @@ class SpanGroupingCardinalitySamples(CardinalityQuery):
     AND (org_id = {{org_id}})
     AND (project_id = {{project_id}})
     AND (metric_id = 9223372036854776214)
-    ORDER BY span.description
+    ORDER BY `span.description`
     LIMIT 1000
     """
 

--- a/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
+++ b/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
@@ -23,6 +23,11 @@ class IndexedIDs(Enum):
     SPAN_EXCLUSIVE_TIME_LIGHT_METRIC = METRICS_START_INDEX + 406
 
 
+# Every line of a `sql` body below must start with at least the 4 spaces of class
+# indentation: the frontend de-indents predefined queries with
+# `line.substring(4)` (see static/cardinality_analyzer/index.tsx) before putting
+# them in the editor. Indentation *beyond* those 4 spaces is preserved, so the
+# continuation indents here show up in the editor as well.
 class CardinalityQuery(PreDefinedQuery, metaclass=RegisteredClass):
     @classmethod
     def config_key(cls) -> str:
@@ -34,13 +39,13 @@ class SpanGroupingCardinality(CardinalityQuery):
 
     sql = """
     SELECT org_id, project_id,
-    tags.raw_value [indexOf(tags.key, 9223372036854776062)] AS `span.category`,
-    uniq(tags.raw_value [indexOf(tags.key, 9223372036854776060)]) AS count_groups
+        tags.raw_value [indexOf(tags.key, 9223372036854776062)] AS `span.category`,
+        uniq(tags.raw_value [indexOf(tags.key, 9223372036854776060)]) AS count_groups
     FROM generic_metric_distributions_aggregated_dist
     WHERE (granularity = 2)
-    AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
-    AND (metric_id IN [9223372036854776212, 9223372036854776213])
-    AND `span.category` = '{{span_category}}'
+        AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+        AND (metric_id IN [9223372036854776212, 9223372036854776213])
+        AND `span.category` = '{{span_category}}'
     GROUP BY org_id, project_id, `span.category`
     ORDER BY count_groups DESC
     LIMIT 100
@@ -54,15 +59,15 @@ class SpanGroupingCardinalitySamples(CardinalityQuery):
 
     sql = """
     SELECT DISTINCT
-    tags.raw_value[indexOf(tags.key, 9223372036854776062)] AS `span.category`,
-    tags.raw_value[indexOf(tags.key, 9223372036854776060)] AS `span.group`,
-    tags.raw_value[indexOf(tags.key, 9223372036854776057)] AS `span.description`
+        tags.raw_value[indexOf(tags.key, 9223372036854776062)] AS `span.category`,
+        tags.raw_value[indexOf(tags.key, 9223372036854776060)] AS `span.group`,
+        tags.raw_value[indexOf(tags.key, 9223372036854776057)] AS `span.description`
     FROM generic_metric_distributions_aggregated_dist
     WHERE (granularity = 2)
-    AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
-    AND (org_id = {{org_id}})
-    AND (project_id = {{project_id}})
-    AND (metric_id = 9223372036854776214)
+        AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+        AND (org_id = {{org_id}})
+        AND (project_id = {{project_id}})
+        AND (metric_id = 9223372036854776214)
     ORDER BY `span.description`
     LIMIT 1000
     """
@@ -82,10 +87,10 @@ class BucketsByOrgProject(CardinalityQuery):
     SELECT org_id, project_id, granularity, count()
     FROM generic_metric_{{metric_type}}_aggregated_dist
     WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
-    AND org_id = {{org_id}}
-    AND project_id = {{project_id}}
+        AND org_id = {{org_id}}
+        AND project_id = {{project_id}}
     GROUP BY org_id, project_id, granularity
-    WITH TOTALS
+        WITH TOTALS
     ORDER BY granularity ASC
     """
 
@@ -103,10 +108,10 @@ class BucketsByOrgProjectGauges(CardinalityQuery):
     SELECT org_id, project_id, granularity, count()
     FROM generic_metric_gauges_aggregated_dist
     WHERE rounded_timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
-    AND org_id = {{org_id}}
-    AND project_id = {{project_id}}
+        AND org_id = {{org_id}}
+        AND project_id = {{project_id}}
     GROUP BY org_id, project_id, granularity
-    WITH TOTALS
+        WITH TOTALS
     ORDER BY granularity ASC
     """
 
@@ -120,10 +125,10 @@ class DatapointsByOrgProjectDistributions(CardinalityQuery):
     SELECT org_id, project_id, granularity, countMerge(count)
     FROM generic_metric_distributions_aggregated_dist
     WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
-    AND org_id = {{org_id}}
-    AND project_id = {{project_id}}
+        AND org_id = {{org_id}}
+        AND project_id = {{project_id}}
     GROUP BY org_id, project_id, granularity
-    WITH TOTALS
+        WITH TOTALS
     ORDER BY granularity ASC
     """
 
@@ -137,10 +142,10 @@ class DatapointsByOrgProjectCounters(CardinalityQuery):
     SELECT org_id, project_id, granularity, sumMerge(value)
     FROM generic_metric_counters_aggregated_dist
     WHERE timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
-    AND org_id = {{org_id}}
-    AND project_id = {{project_id}}
+        AND org_id = {{org_id}}
+        AND project_id = {{project_id}}
     GROUP BY org_id, project_id, granularity
-    WITH TOTALS
+        WITH TOTALS
     ORDER BY granularity ASC
     """
 
@@ -154,10 +159,10 @@ class DatapointsByOrgProjectGauges(CardinalityQuery):
     SELECT org_id, project_id, granularity, sumMerge(count)
     FROM generic_metric_gauges_aggregated_dist
     WHERE rounded_timestamp >= (now() - INTERVAL {{hour_window}} HOUR)
-    AND org_id = {{org_id}}
-    AND project_id = {{project_id}}
+        AND org_id = {{org_id}}
+        AND project_id = {{project_id}}
     GROUP BY org_id, project_id, granularity
-    WITH TOTALS
+        WITH TOTALS
     ORDER BY granularity ASC
     """
 
@@ -177,7 +182,7 @@ class BucketsPerOrgOverTime(CardinalityQuery):
     SELECT toStartOfHour(timestamp) as time, org_id, count() as total
     FROM generic_metric_{{metric_type}}_aggregated_dist
     WHERE timestamp >= (now() - INTERVAL {{hour}} HOUR)
-    AND use_case_id  = 'custom'
+        AND use_case_id  = 'custom'
     GROUP BY time, org_id
     ORDER BY time ASC, total DESC
     LIMIT 5 BY time

--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -15,6 +15,16 @@
     },
     {
       "members": [
+          "group:team-ingest@sentry.io",
+          "group:team-visibility@sentry.io",
+          "group:team-performance@sentry.io",
+          "group:team-eng-managers@sentry.io",
+          "group:team-telemetry-experience@sentry.io"
+      ],
+      "role": "roles/CardinalityAnalyzer"
+    },
+    {
+      "members": [
         "group:team-ops@sentry.io",
         "group:team-events-analytics-platform@sentry.io"
       ],

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -23,6 +23,10 @@ import {
 } from "SnubaAdmin/snql_to_sql/types";
 
 import { QuerylogRequest, QuerylogResult } from "SnubaAdmin/querylog/types";
+import {
+  CardinalityQueryRequest,
+  CardinalityQueryResult,
+} from "SnubaAdmin/cardinality_analyzer/types";
 
 import { AutoReplacementsBypassProjectsData } from "SnubaAdmin/auto_replacements_bypass_projects/types";
 
@@ -45,6 +49,10 @@ interface Client {
   getPredefinedQuerylogOptions: () => Promise<[PredefinedQuery]>;
   getQuerylogSchema: () => Promise<QuerylogResult>;
   executeQuerylogQuery: (req: QuerylogRequest) => Promise<QuerylogResult>;
+  getPredefinedCardinalityQueryOptions: () => Promise<[PredefinedQuery]>;
+  executeCardinalityQuery: (
+    req: CardinalityQueryRequest,
+  ) => Promise<CardinalityQueryResult>;
   getAllMigrationGroups: () => Promise<MigrationGroupResult[]>;
   runMigration: (req: RunMigrationRequest) => Promise<RunMigrationResult>;
   getAllowedTools: () => Promise<AllowedTools>;
@@ -237,6 +245,24 @@ function Client(): Client {
     },
     executeQuerylogQuery: (query: QuerylogRequest) => {
       const url = baseUrl + "clickhouse_querylog_query";
+      return fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+        body: JSON.stringify(query),
+      }).then((resp) => {
+        if (resp.ok) {
+          return resp.json();
+        } else {
+          return resp.json().then(Promise.reject.bind(Promise));
+        }
+      });
+    },
+    getPredefinedCardinalityQueryOptions: () => {
+      const url = baseUrl + "cardinality_queries";
+      return fetch(url).then((resp) => resp.json());
+    },
+    executeCardinalityQuery: (query: CardinalityQueryRequest) => {
+      const url = baseUrl + "cardinality_query";
       return fetch(url, {
         headers: { "Content-Type": "application/json" },
         method: "POST",

--- a/snuba/admin/static/cardinality_analyzer/index.tsx
+++ b/snuba/admin/static/cardinality_analyzer/index.tsx
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from "react";
+import Client from "SnubaAdmin/api_client";
+import { Table } from "SnubaAdmin/table";
+import QueryDisplay from "SnubaAdmin/cardinality_analyzer/query_display";
+import { CardinalityQueryResult, PredefinedQuery } from "SnubaAdmin/cardinality_analyzer/types";
+
+function CardinalityQueries(props: { api: Client }) {
+  const [predefinedQueryOptions, setPredefinedQueryOptions] = useState<
+    PredefinedQuery[]
+  >([]);
+
+  useEffect(() => {
+    props.api.getPredefinedCardinalityQueryOptions().then((res) => {
+      res.forEach(
+          (queryOption) => (queryOption.sql = formatSQL(queryOption.sql))
+      );
+      setPredefinedQueryOptions(res);
+    });
+  }, []);
+
+  function tablePopulator(queryResult: CardinalityQueryResult) {
+    return (
+      <div style={scroll}>
+        <Table
+          headerData={queryResult.column_names}
+          rowData={queryResult.rows}
+        />
+      </div>
+    );
+  }
+  function formatSQL(sql: string) {
+    const formatted = sql
+      .split("\n")
+      .map((line) => line.substring(4, line.length))
+      .join("\n");
+    return formatted.trim();
+  }
+
+  return (
+    <div>
+      {QueryDisplay({
+        api: props.api,
+        resultDataPopulator: tablePopulator,
+        predefinedQueryOptions: predefinedQueryOptions,
+      })}
+    </div>
+  );
+}
+
+const selectStyle = {
+  marginBottom: 8,
+  height: 30,
+};
+
+const scroll = {
+  overflowX: "scroll" as const,
+  width: "100%",
+};
+
+export default CardinalityQueries;

--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+import Client from "SnubaAdmin/api_client";
+import { Collapse } from "SnubaAdmin/collapse";
+import { CSV } from "SnubaAdmin/utils/CSV";
+import QueryEditor from "SnubaAdmin/query_editor";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
+import { getRecentHistory, setRecentHistory } from "SnubaAdmin/query_history";
+
+import {
+  CardinalityQueryRequest,
+  CardinalityQueryResult,
+  PredefinedQuery,
+} from "SnubaAdmin/cardinality_analyzer/types";
+import QueryResultCopier from "SnubaAdmin/utils/query_result_copier";
+
+enum ClipboardFormats {
+  CSV = "csv",
+  JSON = "json",
+}
+type QueryState = Partial<CardinalityQueryRequest>;
+
+const HISTORY_KEY = "cardinality_analyzer";
+function QueryDisplay(props: {
+  api: Client;
+  resultDataPopulator: (queryResult: CardinalityQueryResult) => JSX.Element;
+  predefinedQueryOptions: Array<PredefinedQuery>;
+}) {
+  const [query, setQuery] = useState<QueryState>({});
+  const [queryResultHistory, setCardinalityQueryResultHistory] = useState<
+    CardinalityQueryResult[]
+  >(getRecentHistory(HISTORY_KEY));
+
+  function updateQuerySql(sql: string) {
+    setQuery((prevQuery) => {
+      return {
+        ...prevQuery,
+        sql,
+      };
+    });
+  }
+
+  function convertResultsToCSV(queryResult: CardinalityQueryResult) {
+    return CSV.sheet([queryResult.column_names, ...queryResult.rows]);
+  }
+
+  function executeQuery() {
+    return props.api
+      .executeCardinalityQuery(query as CardinalityQueryRequest)
+      .then((result) => {
+        result.input_query = query.sql || "<Input Query>";
+        setRecentHistory(HISTORY_KEY, result);
+        setCardinalityQueryResultHistory((prevHistory) => [
+          result,
+          ...prevHistory,
+        ]);
+      });
+  }
+
+  return (
+    <div>
+      <h2>Construct a Metrics Query</h2>
+      <QueryEditor
+        onQueryUpdate={(sql) => {
+          updateQuerySql(sql);
+        }}
+        predefinedQueryOptions={props.predefinedQueryOptions}
+      />
+      <div style={executeActionsStyle}>
+        <ExecuteButton onClick={executeQuery} disabled={!query.sql} />
+      </div>
+      <div>
+        <h2>Query results</h2>
+        {queryResultHistory.map((queryResult, idx) => {
+          if (idx === 0) {
+            return (
+              <div key={idx}>
+                <p>{queryResult.input_query}</p>
+                <QueryResultCopier
+                  jsonInput={JSON.stringify(queryResult)}
+                  csvInput={convertResultsToCSV(queryResult)}
+                />
+                {props.resultDataPopulator(queryResult)}
+              </div>
+            );
+          }
+
+          return (
+            <Collapse key={idx} text={queryResult.input_query}>
+              <QueryResultCopier
+                jsonInput={JSON.stringify(queryResult)}
+                csvInput={convertResultsToCSV(queryResult)}
+              />
+              {props.resultDataPopulator(queryResult)}
+            </Collapse>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const executeActionsStyle = {
+  display: "flex",
+  justifyContent: "space-between",
+  marginTop: 8,
+};
+
+const copyButtonStyle = {
+  height: 30,
+  border: 0,
+  padding: "4px 20px",
+  marginRight: 10,
+};
+
+export default QueryDisplay;

--- a/snuba/admin/static/cardinality_analyzer/types.tsx
+++ b/snuba/admin/static/cardinality_analyzer/types.tsx
@@ -1,0 +1,22 @@
+type QueryResultColumnMetadata = [string];
+type QueryResultRow = [string];
+
+type CardinalityQueryRequest= {
+  sql: string;
+};
+
+type CardinalityQueryResult = {
+  input_query: string;
+  timestamp: number;
+  column_names: QueryResultColumnMetadata;
+  rows: [QueryResultRow];
+  error?: string;
+};
+
+type PredefinedQuery = {
+  name: string;
+  sql: string;
+  description: string;
+};
+
+export { CardinalityQueryRequest, CardinalityQueryResult, PredefinedQuery };

--- a/snuba/admin/static/data.tsx
+++ b/snuba/admin/static/data.tsx
@@ -6,6 +6,7 @@ import TracingQueries from "SnubaAdmin/tracing";
 import SQLShellPage, { SystemShellPage } from "SnubaAdmin/sql_shell";
 import SnQLToSQL from "SnubaAdmin/snql_to_sql";
 import QuerylogQueries from "SnubaAdmin/querylog";
+import CardinalityAnalyzer from "SnubaAdmin/cardinality_analyzer";
 import ProductionQueries from "SnubaAdmin/production_queries";
 import SnubaExplain from "SnubaAdmin/snuba_explain";
 import Welcome from "SnubaAdmin/welcome";
@@ -68,6 +69,11 @@ const NAV_ITEMS = [
     id: "querylog",
     display: "🔍 ClickHouse Querylog",
     component: QuerylogQueries,
+  },
+  {
+    id: "cardinality-analyzer",
+    display: "🔢 Cardinality Analyzer",
+    component: CardinalityAnalyzer,
   },
   {
     id: "production-queries",

--- a/snuba/admin/tool_policies.py
+++ b/snuba/admin/tool_policies.py
@@ -26,6 +26,7 @@ class AdminTools(Enum):
     QUERY_TRACING = "tracing"
     QUERYLOG = "querylog"
     PRODUCTION_QUERIES = "production-queries"
+    CARDINALITY_ANALYZER = "cardinality-analyzer"
     SNUBA_EXPLAIN = "snuba-explain"
     MANUAL_JOBS = "view-jobs"
     RPC_ENDPOINTS = "rpc-endpoints"

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -21,10 +21,14 @@ from snuba import settings
 from snuba.admin.audit_log.action import AuditLogAction
 from snuba.admin.audit_log.base import AuditLog
 from snuba.admin.auth import USER_HEADER_KEY, UnauthorizedException, authorize_request
+from snuba.admin.cardinality_analyzer.cardinality_analyzer import run_metrics_query
 from snuba.admin.clickhouse.common import InvalidCustomQuery, InvalidNodeError
 from snuba.admin.clickhouse.copy_tables import copy_tables
 from snuba.admin.clickhouse.migration_checks import run_migration_checks_and_policies
 from snuba.admin.clickhouse.nodes import get_storage_info
+from snuba.admin.clickhouse.predefined_cardinality_analyzer_queries import (
+    CardinalityQuery,
+)
 from snuba.admin.clickhouse.predefined_querylog_queries import QuerylogQuery
 from snuba.admin.clickhouse.predefined_system_queries import SystemQuery
 from snuba.admin.clickhouse.profile_events import gather_profile_events
@@ -359,6 +363,13 @@ def clickhouse_queries() -> Response:
 @check_tool_perms(tools=[AdminTools.QUERYLOG])
 def querylog_queries() -> Response:
     res = [q.to_json() for q in QuerylogQuery.all_classes()]
+    return make_response(jsonify(res), 200)
+
+
+@application.route("/cardinality_queries")
+@check_tool_perms(tools=[AdminTools.CARDINALITY_ANALYZER])
+def cardinality_queries() -> Response:
+    res = [q.to_json() for q in CardinalityQuery.all_classes()]
     return make_response(jsonify(res), 200)
 
 
@@ -796,6 +807,66 @@ def snuba_debug() -> Response:
         )
     finally:
         explain_cleanup()
+
+
+@application.route("/cardinality_query", methods=["POST"])
+@check_tool_perms(tools=[AdminTools.CARDINALITY_ANALYZER])
+def cardinality_analyzer_query() -> Response:
+    # HACK (Volo):
+    # mostly copypasta from querylog, should not stick around for too long
+    # when production query tool gets made this should not be necessary
+    user = request.headers.get(USER_HEADER_KEY, "unknown")
+    if user == "unknown" and settings.ADMIN_AUTH_PROVIDER != "NOOP":
+        return Response(
+            json.dumps({"error": "Unauthorized"}),
+            401,
+            {"Content-Type": "application/json"},
+        )
+    req = json.loads(request.data)
+    try:
+        raw_sql = req["sql"]
+    except KeyError as e:
+        return make_response(
+            jsonify(
+                {
+                    "error": {
+                        "type": "request",
+                        "message": f"Invalid request, missing key {e.args[0]}",
+                    }
+                }
+            ),
+            400,
+        )
+    try:
+        result = run_metrics_query(raw_sql, user)
+        rows, columns = result.results, result.meta
+        if columns:
+            return make_response(
+                jsonify({"column_names": [name for name, _ in columns], "rows": rows}),
+                200,
+            )
+        return make_response(
+            jsonify({"error": {"type": "unknown", "message": "no columns"}}),
+            500,
+        )
+    except ClickhouseError as err:
+        details = {
+            "type": "clickhouse",
+            "message": str(err),
+            "code": err.code,
+        }
+        return make_response(jsonify({"error": details}), 400)
+    except InvalidCustomQuery as err:
+        return Response(
+            json.dumps({"error": {"message": str(err)}}, indent=4),
+            400,
+            {"Content-Type": "application/json"},
+        )
+    except Exception as err:
+        return make_response(
+            jsonify({"error": {"type": "unknown", "message": str(err)}}),
+            500,
+        )
 
 
 @application.route("/rpc_endpoints", methods=["GET"])

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -102,6 +102,20 @@ class ClickhouseClientSettings(Enum):
         },
         None,
     )
+    CARDINALITY_ANALYZER = ClickhouseClientSettingsType(
+        {
+            # Allow reading data and changing settings.
+            "readonly": 2,
+            # Allow more threads for faster processing since cardinality queries
+            # need more resources.
+            "max_threads": 10,
+            # Don't use up production cache for cardinality analyzer queries.
+            "use_uncompressed_cache": 0,
+            # Allow longer running queries.
+            "max_execution_time": 60,
+        },
+        None,
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/admin/cardinality_analyzer/test_metrics_query.py
+++ b/tests/admin/cardinality_analyzer/test_metrics_query.py
@@ -1,0 +1,44 @@
+import pytest
+
+from snuba.admin.cardinality_analyzer.cardinality_analyzer import _stringify_result
+from snuba.clickhouse.native import ClickhouseResult
+
+
+@pytest.mark.parametrize(
+    "result,expected_result",
+    [
+        pytest.param(
+            ClickhouseResult(
+                [
+                    [9223372036854776050, 909817],
+                    [9223372036854776020, 909817],
+                ]
+            ),
+            ClickhouseResult(
+                [
+                    ["9223372036854776050", "909817"],
+                    ["9223372036854776020", "909817"],
+                ]
+            ),
+            id="simple",
+        ),
+        pytest.param(
+            ClickhouseResult(
+                [
+                    [[123, 456]],
+                    [[567, 8910]],
+                ]
+            ),
+            ClickhouseResult(
+                [
+                    ["[123, 456]"],
+                    ["[567, 8910]"],
+                ]
+            ),
+            id="simple",
+        ),
+    ],
+)
+def test_stringify_result(result: ClickhouseResult, expected_result: ClickhouseResult) -> None:
+    stringified_result = _stringify_result(result)
+    assert stringified_result == expected_result

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -466,6 +466,57 @@ def test_query_node_connection_uses_cluster_http_port() -> None:
         common.CLUSTER_CONNECTIONS.update(saved_cluster)
 
 
+def test_connection_cache_is_keyed_on_client_settings() -> None:
+    """
+    Two admin tools reaching the same storage on the same host with different
+    ClickhouseClientSettings must get their own pool. The settings — and, on the
+    read-only path, the credentials — are baked into a pool when it is built, so
+    a cache keyed only on storage/host would hand the second caller whichever
+    pool the first one happened to create: System Queries (QUERY -> readonly
+    user, 25s cap) and the Cardinality Analyzer (CARDINALITY_ANALYZER -> trace
+    user, max_threads=10, 60s cap) both reach generic_metrics_distributions on
+    the query node.
+    """
+    from snuba.admin.clickhouse import common
+    from snuba.clusters.cluster import connection_cache
+
+    saved_node = dict(common.NODE_CONNECTIONS)
+    saved_cluster = dict(common.CLUSTER_CONNECTIONS)
+    common.NODE_CONNECTIONS.clear()
+    common.CLUSTER_CONNECTIONS.clear()
+    try:
+        with (
+            patch.object(common, "_validate_node"),  # treat the host as valid
+            patch.object(settings, "CLICKHOUSE_READONLY_USER", "ro_user"),
+            patch.object(settings, "CLICKHOUSE_TRACE_USER", "trace_user"),
+            patch.object(connection_cache, "get_node_connection") as mock_pool,
+        ):
+            common.get_ro_query_node_connection("errors", ClickhouseClientSettings.QUERY)
+            common.get_ro_query_node_connection(
+                "errors", ClickhouseClientSettings.CARDINALITY_ANALYZER
+            )
+
+        assert mock_pool.call_count == 2, (
+            "each client settings profile must build its own pool, not reuse the first caller's"
+        )
+        # _build_validated_pool passes (client_settings, node, username, password, ...)
+        profiles = [call.args[0] for call in mock_pool.call_args_list]
+        usernames = [call.args[2] for call in mock_pool.call_args_list]
+        assert profiles == [
+            ClickhouseClientSettings.QUERY,
+            ClickhouseClientSettings.CARDINALITY_ANALYZER,
+        ]
+        assert usernames == ["ro_user", "trace_user"], (
+            "the cardinality profile must not inherit the readonly credentials "
+            "cached by the QUERY profile"
+        )
+    finally:
+        common.NODE_CONNECTIONS.clear()
+        common.NODE_CONNECTIONS.update(saved_node)
+        common.CLUSTER_CONNECTIONS.clear()
+        common.CLUSTER_CONNECTIONS.update(saved_cluster)
+
+
 @pytest.mark.parametrize(
     "sql_query, sudo_mode",
     [


### PR DESCRIPTION
Reverts the Cardinality Analyzer portion of #8200. The other tools removed there stay removed.

Back: `/cardinality_queries` + `/cardinality_query`, `snuba/admin/cardinality_analyzer/`, the predefined query catalog, the `CARDINALITY_ANALYZER` tool / role / IAM binding, `ClickhouseClientSettings.CARDINALITY_ANALYZER`, the frontend module and nav entry, and `test_metrics_query.py`.

Two small deviations from a straight revert: `CSV` is imported from its current home in `static/utils/` instead of re-adding a copy, and the nav label drops the stray `!!!`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLUUFSbEzEqX7Sxsh4biv7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLUUFSbEzEqX7Sxsh4biv7)_