### PR TITLE
ref(ci): Run more of sentry's tests when we change the API in snuba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,16 +225,15 @@ jobs:
             .
 
       - name: Publish snuba-ci image to artifacts
-      # we publish to github artifacts separately so that third-party
-      # contributions also work, as all the test jobs need this image.
-      # otherwise third-party contributors would have to provide a working,
-      # authenticated GHCR, which seems impossible to ensure in the general
-      # case.
+        # we publish to github artifacts separately so that third-party
+        # contributions also work, as all the test jobs need this image.
+        # otherwise third-party contributors would have to provide a working,
+        # authenticated GHCR, which seems impossible to ensure in the general
+        # case.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: snuba-ci
           path: /tmp/snuba-ci.tar
-
 
   docker-deps:
     name: Warm Docker dependency image cache
@@ -470,12 +469,9 @@ jobs:
         if: needs.files-changed.outputs.api_changes == 'false'
         working-directory: sentry
         run: |
-          # Only these dirs carry the `snuba_ci` marker; collecting all of tests/ just to find them is wasteful.
           pytest -k 'not __In' \
-            tests/sentry/snuba \
-            tests/sentry/workflow_engine/endpoints \
-            tests/snuba/rules/conditions \
             -m snuba_ci \
+            tests \
             -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
             -vv
 
@@ -484,36 +480,10 @@ jobs:
         working-directory: sentry
         run: |
           pytest -k 'not __In' \
-              tests/snuba \
-              tests/sentry/snuba \
-              tests/sentry/eventstream/kafka \
-              tests/sentry/post_process_forwarder \
-              tests/sentry/services/eventstore/snuba \
-              tests/sentry/search/events \
-              tests/sentry/event_manager \
-              tests/sentry/api/endpoints/test_organization_profiling_functions.py \
-              tests/sentry/integrations/slack/test_unfurl.py \
-              tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py \
-              tests/sentry/uptime/endpoints/test_organization_uptime_stats.py \
-              tests/sentry/api/endpoints/test_organization_traces.py \
-              tests/sentry/api/endpoints/test_organization_spans_fields.py \
-              tests/sentry/api/endpoints/test_organization_ai_conversations.py \
-              tests/sentry/api/endpoints/test_organization_ai_conversation_details.py \
-              tests/sentry/sentry_metrics/querying \
+              -m snuba \
+              tests \
               -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
               -vv
-
-      - name: Run CI module tests
-        if: needs.files-changed.outputs.api_changes == 'true'
-        working-directory: sentry
-        run: |
-          pytest -k 'not __In' \
-            tests/sentry/snuba \
-            tests/sentry/workflow_engine/endpoints \
-            tests/snuba/rules/conditions \
-            -m snuba_ci \
-            -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
-            -vv
 
   clickhouse-versions:
     needs: [linting, snuba-image, docker-deps]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,8 +465,7 @@ jobs:
       - name: Bootstrap per-worker Snuba instances
         run: python3 sentry/.github/workflows/scripts/bootstrap-snuba.py
 
-      - name: Run snuba tests
-        if: needs.files-changed.outputs.api_changes == 'false'
+      - name: Run snuba CI tests
         working-directory: sentry
         run: |
           pytest -k 'not __In' \
@@ -476,7 +475,6 @@ jobs:
             -vv
 
       - name: Run full tests
-        if: needs.files-changed.outputs.api_changes == 'true'
         working-directory: sentry
         run: |
           pytest -k 'not __In' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,21 +467,22 @@ jobs:
 
       - name: Run snuba CI tests
         working-directory: sentry
-        run: |
-          pytest -k 'not __In' \
-            -m snuba_ci \
-            tests \
-            -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
-            -vv
+        # monolith acceptance tests contain some js
+        run: >
+          pytest -k 'not __In'
+          -m snuba_ci
+          tests --ignore=tests/acceptance
+          -n "$XDIST_WORKERS" --dist=loadfile --reuse-db
+          -vv
 
       - name: Run full tests
         working-directory: sentry
-        run: |
-          pytest -k 'not __In' \
-              -m snuba \
-              tests \
-              -n "$XDIST_WORKERS" --dist=loadfile --reuse-db \
-              -vv
+        run: >
+          pytest -k 'not __In'
+          -m snuba
+          tests --ignore=tests/acceptance
+          -n "$XDIST_WORKERS" --dist=loadfile --reuse-db
+          -vv
 
   clickhouse-versions:
     needs: [linting, snuba-image, docker-deps]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,16 +467,16 @@ jobs:
 
       - name: Run snuba CI tests
         working-directory: sentry
-        # monolith acceptance tests contain some js
-        env:
-          PYTEST_ADDOPTS: "-k 'not __In' -m snuba_ci -n ${{ env.XDIST_WORKERS }} --dist=loadfile -vv"
-        run: make test-python-ci
+        run: |
+          export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -k 'not __In' -m snuba_ci -n $XDIST_WORKERS --dist=loadfile -vv"
+          make test-python-ci
 
       - name: Run full tests
+        if: needs.files-changed.outputs.api_changes == 'true'
         working-directory: sentry
-        env:
-          PYTEST_ADDOPTS: "-k 'not __In' -m snuba -n ${{ env.XDIST_WORKERS }} --dist=loadfile -vv"
-        run: make test-python-ci
+        run: |
+          export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -k 'not __In' -m snuba -n $XDIST_WORKERS --dist=loadfile -vv"
+          make test-python-ci
 
   clickhouse-versions:
     needs: [linting, snuba-image, docker-deps]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,7 +475,7 @@ jobs:
         if: needs.files-changed.outputs.api_changes == 'true'
         working-directory: sentry
         run: |
-          export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -k 'not __In' -m snuba -n $XDIST_WORKERS --dist=loadfile -vv"
+          export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -k 'not __In' -m 'snuba and not snuba_ci' -n $XDIST_WORKERS --dist=loadfile -vv"
           make test-python-ci
 
   clickhouse-versions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,21 +468,15 @@ jobs:
       - name: Run snuba CI tests
         working-directory: sentry
         # monolith acceptance tests contain some js
-        run: >
-          pytest -k 'not __In'
-          -m snuba_ci
-          tests --ignore=tests/acceptance
-          -n "$XDIST_WORKERS" --dist=loadfile --reuse-db
-          -vv
+        env:
+          PYTEST_ADDOPTS: "-k 'not __In' -m snuba_ci -n ${{ env.XDIST_WORKERS }} --dist=loadfile -vv"
+        run: make test-python-ci
 
       - name: Run full tests
         working-directory: sentry
-        run: >
-          pytest -k 'not __In'
-          -m snuba
-          tests --ignore=tests/acceptance
-          -n "$XDIST_WORKERS" --dist=loadfile --reuse-db
-          -vv
+        env:
+          PYTEST_ADDOPTS: "-k 'not __In' -m snuba -n ${{ env.XDIST_WORKERS }} --dist=loadfile -vv"
+        run: make test-python-ci
 
   clickhouse-versions:
     needs: [linting, snuba-image, docker-deps]


### PR DESCRIPTION
The sentry job no longer keeps a hand-curated list of `tests/sentry/...` paths. Selection is driven by Sentry's `snuba` / `snuba_ci` markers via `make test-python-ci`, so newly marked tests are picked up without editing this repo.

- Always: `-m snuba_ci` over the tree Sentry's Makefile already collects (acceptance / apidocs / js / tools ignored).
- On API changes: also `-m 'snuba and not snuba_ci'`, so dual-marked tests run once.
- `PYTEST_ADDOPTS` is appended, not replaced, so setup-sentry's reruns and fail-slow defaults stay.

Unmarked tests that previously rode along on the path list are no longer collected. That is intentional: `SnubaTestCase` / `@pytest.mark.snuba` is the contract for "this talks to Snuba."
