### PR TITLE
ref(migrations): Run ON CLUSTER DDL asynchronously and poll for status

### DIFF
--- a/snuba/migrations/async_ddl.py
+++ b/snuba/migrations/async_ddl.py
@@ -1,0 +1,184 @@
+"""
+Asynchronous execution of ``ON CLUSTER`` DDL for migrations.
+
+Running ``ON CLUSTER`` DDL synchronously (the ClickHouse default,
+``distributed_ddl_output_mode=throw``) has a bad failure mode: the server streams
+the per-host result table as hosts report in, and if a host does not report
+within ``distributed_ddl_task_timeout`` it raises ``TIMEOUT_EXCEEDED`` *in the
+middle of the response body*. Because the headers and the first rows are already
+on the wire, the server cannot emit a well-formed error payload -- it just closes
+the connection. The client observes::
+
+    Connection broken: IncompleteRead(676 bytes read)
+
+which says nothing about which replica failed or why.
+
+Instead we submit the DDL with ``distributed_ddl_task_timeout=0`` (fire and
+forget, returns as soon as the task is queued in Keeper) and then poll
+``system.distributed_ddl_queue``, which reports ``status``, ``exception_code``
+and ``exception_text`` per host. The task is correlated via a unique
+``log_comment`` set on the submitting query, which ClickHouse persists in the
+queue entry's ``settings`` map.
+
+The DDL itself is unaffected: it is coordinated through Keeper exactly as before.
+Only the way we *observe* its completion changes.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Mapping
+from typing import Any
+
+import structlog
+
+from snuba import settings
+from snuba.clickhouse.escaping import escape_string
+from snuba.clickhouse.native import ClickhousePool
+
+logger = structlog.get_logger().bind(module=__name__)
+
+# The terminal state in system.distributed_ddl_queue's status enum
+# (Inactive / Active / Finished / Removing / Unknown). Any other value means the
+# host has not applied the DDL yet -- 'Inactive' in particular is a replica that
+# is down or has not noticed the queue entry.
+_FINISHED = "Finished"
+
+
+class DistributedDDLTimeout(Exception):
+    """An async ON CLUSTER DDL task did not finish on every host in time."""
+
+
+class DistributedDDLError(Exception):
+    """An async ON CLUSTER DDL task failed on at least one host."""
+
+
+def execute_ddl_async(
+    connection: ClickhousePool,
+    sql: str,
+    cluster_name: str,
+    query_settings: Mapping[str, Any] | None = None,
+    timeout_seconds: int | None = None,
+    poll_interval_seconds: float | None = None,
+) -> None:
+    """
+    Submit ``sql`` (which must already contain an ``ON CLUSTER`` clause) without
+    waiting for the cluster, then poll until every host reports ``Finished``.
+
+    Raises :class:`DistributedDDLError` if any host reported a non-zero
+    ``exception_code``, or :class:`DistributedDDLTimeout` if some host had not
+    finished within the timeout. In the timeout case the DDL task remains queued
+    in Keeper and will still be applied when the lagging replica recovers, so the
+    migration can simply be re-run (migration DDL is written to be idempotent).
+    """
+    if timeout_seconds is None:
+        timeout_seconds = settings.ASYNC_MIGRATION_DDL_TIMEOUT_SECONDS
+    if poll_interval_seconds is None:
+        poll_interval_seconds = settings.ASYNC_MIGRATION_DDL_POLL_INTERVAL_SECONDS
+
+    # Correlates the queue entry back to this specific submission. Matching on the
+    # query text is not reliable: ClickHouse rewrites it before storing (it
+    # normalizes the table name and injects a UUID), and identical DDL may have
+    # been submitted before.
+    task_id = f"snuba-migration-{uuid.uuid4()}"
+
+    submit_settings: dict[str, Any] = dict(query_settings or {})
+    # 0 == "do not wait for any host", return once the task is in Keeper.
+    submit_settings["distributed_ddl_task_timeout"] = 0
+    # With task_timeout=0 nothing is awaited, so no truncated-body failure is
+    # possible; never_throw additionally keeps a slow/unavailable replica from
+    # turning the submission itself into an error.
+    submit_settings["distributed_ddl_output_mode"] = "never_throw"
+    submit_settings["log_comment"] = task_id
+
+    logger.info("Submitting async ON CLUSTER DDL", task_id=task_id, cluster=cluster_name)
+    connection.execute(sql, settings=submit_settings)
+
+    _wait_for_ddl_task(
+        connection,
+        task_id=task_id,
+        cluster_name=cluster_name,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+    )
+
+
+def _wait_for_ddl_task(
+    connection: ClickhousePool,
+    task_id: str,
+    cluster_name: str,
+    timeout_seconds: int,
+    poll_interval_seconds: float,
+) -> None:
+    query = f"""
+        SELECT
+            entry,
+            host,
+            status,
+            exception_code,
+            exception_text
+        FROM system.distributed_ddl_queue
+        WHERE settings['log_comment'] = {escape_string(task_id)}
+    """
+
+    deadline = time.monotonic() + timeout_seconds
+    last_seen: list[tuple[str, str, int, str]] = []
+
+    while True:
+        rows = connection.execute(query).results
+
+        # Rows may be briefly absent: the initiator returns as soon as the task is
+        # written to Keeper, and the queue table is populated from it. Treat an
+        # empty result as "not visible yet" and keep polling until the deadline.
+        if rows:
+            statuses: list[tuple[str, str, int, str]] = [
+                (
+                    str(host),
+                    str(status),
+                    int(exception_code or 0),
+                    str(exception_text or ""),
+                )
+                for _entry, host, status, exception_code, exception_text in rows
+            ]
+            last_seen = statuses
+
+            failures = [(host, code, text) for host, _status, code, text in statuses if code != 0]
+            if failures:
+                detail = "; ".join(f"{host}: [{code}] {text}" for host, code, text in failures)
+                raise DistributedDDLError(
+                    f"ON CLUSTER DDL failed on {len(failures)} host(s) of "
+                    f"cluster '{cluster_name}' (task {task_id}): {detail}"
+                )
+
+            pending = [host for host, status, _c, _t in statuses if status != _FINISHED]
+            if not pending:
+                logger.info(
+                    "Async ON CLUSTER DDL finished on all hosts",
+                    task_id=task_id,
+                    hosts=len(statuses),
+                )
+                return
+
+        if time.monotonic() >= deadline:
+            pending = [
+                f"{host} ({status})" for host, status, _c, _t in last_seen if status != _FINISHED
+            ]
+            unfinished = ", ".join(pending) if pending else "task not visible in queue"
+            raise DistributedDDLTimeout(
+                f"ON CLUSTER DDL on cluster '{cluster_name}' (task {task_id}) did not "
+                f"complete within {timeout_seconds}s. Unfinished hosts: {unfinished}. "
+                "The task is still queued in ClickHouse Keeper and will be applied "
+                "once those replicas recover; check `SELECT * FROM "
+                "system.distributed_ddl_queue WHERE settings['log_comment'] = "
+                f"'{task_id}'` and `system.replicas`, then re-run the migration."
+            )
+
+        time.sleep(poll_interval_seconds)
+
+
+__all__ = [
+    "DistributedDDLError",
+    "DistributedDDLTimeout",
+    "execute_ddl_async",
+]

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -19,6 +19,7 @@ from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters import cluster
 from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseNode, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.async_ddl import execute_ddl_async
 from snuba.migrations.columns import MigrationModifiers
 from snuba.migrations.table_engines import TableEngine
 
@@ -58,8 +59,8 @@ class SqlOperation(ABC):
     def storage_set(self) -> StorageSetKey:
         return self._storage_set
 
-    def _get_on_cluster_clause(self) -> str:
-        """Returns ON CLUSTER clause for multi-node clusters, empty string otherwise.
+    def _get_cluster_name(self) -> str | None:
+        """Returns the cluster name to use for ON CLUSTER, or None for single node.
 
         Uses the appropriate cluster name based on target type:
         - LOCAL: uses cluster_name (for storage nodes)
@@ -67,14 +68,16 @@ class SqlOperation(ABC):
         """
         cluster = get_cluster(self._storage_set)
         if cluster.is_single_node():
-            return ""
+            return None
 
         # Use the appropriate cluster name based on target type
         if self.target == OperationTarget.DISTRIBUTED:
-            cluster_name = cluster.get_clickhouse_distributed_cluster_name()
-        else:
-            cluster_name = cluster.get_clickhouse_cluster_name()
+            return cluster.get_clickhouse_distributed_cluster_name()
+        return cluster.get_clickhouse_cluster_name()
 
+    def _get_on_cluster_clause(self) -> str:
+        """Returns ON CLUSTER clause for multi-node clusters, empty string otherwise."""
+        cluster_name = self._get_cluster_name()
         if cluster_name:
             return f" ON CLUSTER '{cluster_name}'"
         return ""
@@ -133,10 +136,23 @@ class SqlOperation(ABC):
         if settings.LOG_MIGRATIONS:
             logger.info(f"Executing op: {sql}")
             logger.info(f"Executing on {self.target.value} node: {node}")
+        cluster_name = self._get_cluster_name()
         try:
-            connection.execute(sql, settings=self._settings)
-            # No polling needed - alter_sync=2 and mutations_sync=2 ensure ClickHouse
-            # blocks until all replicas confirm completion
+            if cluster_name and settings.ASYNC_MIGRATION_DDL:
+                # Submit the ON CLUSTER DDL without blocking on the cluster, then poll
+                # system.distributed_ddl_queue for per-host status. Waiting inline
+                # (distributed_ddl_output_mode=throw) makes a lagging replica surface as
+                # an opaque "IncompleteRead" truncated response instead of a real error.
+                execute_ddl_async(
+                    connection,
+                    sql,
+                    cluster_name=cluster_name,
+                    query_settings=self._settings,
+                )
+            else:
+                # Single node, or async explicitly disabled: alter_sync=2 and
+                # mutations_sync=2 make ClickHouse block until replicas confirm.
+                connection.execute(sql, settings=self._settings)
         except Exception:
             logger.exception(
                 f"Failed to execute operation on {self.storage_set}, target: {self.target}\n{sql}\n{self._settings}"

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -423,6 +423,31 @@ SLICED_STORAGE_SETS: Mapping[str, int] = {}
 
 LOG_MIGRATIONS = True
 
+# Run ON CLUSTER DDL asynchronously and poll system.distributed_ddl_queue for
+# completion, instead of letting the initiator node block on the response.
+#
+# Synchronous ON CLUSTER DDL (distributed_ddl_output_mode=throw) makes ClickHouse
+# stream the per-host result table and then raise TIMEOUT_EXCEEDED mid-body when a
+# replica does not report in. Headers and the first rows are already on the wire,
+# so the server cannot emit a well-formed error payload and simply closes the
+# connection. The client sees an opaque
+#   Connection broken: IncompleteRead(N bytes read)
+# and the real per-replica error is lost.
+#
+# Submitting with distributed_ddl_task_timeout=0 returns immediately, and we then
+# poll the queue, which gives us the exact per-host status, exception_code and
+# exception_text.
+ASYNC_MIGRATION_DDL = os.environ.get("ASYNC_MIGRATION_DDL", "1") != "0"
+
+# How long to poll system.distributed_ddl_queue for an async DDL task before
+# giving up, and how long to sleep between polls.
+ASYNC_MIGRATION_DDL_TIMEOUT_SECONDS = int(
+    os.environ.get("ASYNC_MIGRATION_DDL_TIMEOUT_SECONDS", 300)
+)
+ASYNC_MIGRATION_DDL_POLL_INTERVAL_SECONDS = float(
+    os.environ.get("ASYNC_MIGRATION_DDL_POLL_INTERVAL_SECONDS", 1.0)
+)
+
 # Mapping storage set key to a mapping of logical partition
 # to slice id
 LOGICAL_PARTITION_MAPPING: Mapping[str, Mapping[int, int]] = {}

--- a/tests/migrations/test_async_ddl.py
+++ b/tests/migrations/test_async_ddl.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from snuba.clusters.cluster import ClickhouseCluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.async_ddl import (
+    DistributedDDLError,
+    DistributedDDLTimeout,
+    execute_ddl_async,
+)
+from snuba.migrations.operations import OperationTarget, RunSql
+
+FINISHED = "Finished"
+INACTIVE = "Inactive"
+
+
+def _result(rows: list[tuple[Any, ...]]) -> Mock:
+    result = Mock()
+    result.results = rows
+    return result
+
+
+def _pool(poll_results: list[list[tuple[Any, ...]]]) -> Mock:
+    """A connection whose first execute() is the submit, then one per poll."""
+    pool = Mock()
+    pool.execute.side_effect = [_result([])] + [_result(rows) for rows in poll_results]
+    return pool
+
+
+def test_submits_without_waiting_and_tags_the_task() -> None:
+    pool = _pool([[("query-1", "n1", FINISHED, 0, "")]])
+
+    execute_ddl_async(
+        pool,
+        "CREATE TABLE t ON CLUSTER 'c1' (a UInt64) ENGINE MergeTree ORDER BY a",
+        cluster_name="c1",
+    )
+
+    submit_settings = pool.execute.call_args_list[0].kwargs["settings"]
+    # task_timeout=0 is what makes the submission return immediately, which is the
+    # whole point: waiting inline is what produces truncated "IncompleteRead" bodies.
+    assert submit_settings["distributed_ddl_task_timeout"] == 0
+    assert submit_settings["distributed_ddl_output_mode"] == "never_throw"
+    assert submit_settings["log_comment"].startswith("snuba-migration-")
+
+    # The poll query correlates on that same log_comment.
+    poll_query = pool.execute.call_args_list[1].args[0]
+    assert "system.distributed_ddl_queue" in poll_query
+    assert submit_settings["log_comment"] in poll_query
+
+
+def test_preserves_caller_settings() -> None:
+    pool = _pool([[("query-1", "n1", FINISHED, 0, "")]])
+
+    execute_ddl_async(
+        pool,
+        "ALTER TABLE t ON CLUSTER 'c1' DROP INDEX i",
+        cluster_name="c1",
+        query_settings={"allow_suspicious_primary_key": 1},
+    )
+
+    submit_settings = pool.execute.call_args_list[0].kwargs["settings"]
+    assert submit_settings["allow_suspicious_primary_key"] == 1
+    assert submit_settings["distributed_ddl_task_timeout"] == 0
+
+
+def test_succeeds_when_all_hosts_finish() -> None:
+    pool = _pool(
+        [
+            [("query-1", "n1", FINISHED, 0, ""), ("query-1", "n2", INACTIVE, None, None)],
+            [("query-1", "n1", FINISHED, 0, ""), ("query-1", "n2", FINISHED, 0, "")],
+        ]
+    )
+
+    execute_ddl_async(
+        pool,
+        "CREATE TABLE t ON CLUSTER 'c1' (a UInt64) ENGINE Log",
+        cluster_name="c1",
+        poll_interval_seconds=0,
+    )
+
+    # submit + 2 polls
+    assert pool.execute.call_count == 3
+
+
+def test_raises_real_error_from_queue() -> None:
+    """A failing DDL must surface the server's message, not an opaque transport error."""
+    pool = _pool(
+        [
+            [
+                ("query-1", "n1", FINISHED, 16, "Code: 16. Wrong column name."),
+                ("query-1", "n2", FINISHED, 16, "Code: 16. Wrong column name."),
+            ]
+        ]
+    )
+
+    with pytest.raises(DistributedDDLError) as excinfo:
+        execute_ddl_async(
+            pool,
+            "ALTER TABLE t ON CLUSTER 'c1' ADD COLUMN b UInt64 AFTER nope",
+            cluster_name="c1",
+            poll_interval_seconds=0,
+        )
+
+    message = str(excinfo.value)
+    assert "Wrong column name" in message
+    assert "n1" in message and "n2" in message
+
+
+def test_timeout_names_the_unfinished_host() -> None:
+    """This is the case that used to be IncompleteRead(N bytes read)."""
+    pool = Mock()
+    pool.execute.side_effect = [_result([])] + [
+        _result([("query-1", "n1", FINISHED, 0, ""), ("query-1", "n2", INACTIVE, None, None)])
+        for _ in range(50)
+    ]
+
+    with pytest.raises(DistributedDDLTimeout) as excinfo:
+        execute_ddl_async(
+            pool,
+            "CREATE TABLE t ON CLUSTER 'c1' (a UInt64) ENGINE Log",
+            cluster_name="c1",
+            timeout_seconds=0,
+            poll_interval_seconds=0,
+        )
+
+    message = str(excinfo.value)
+    assert "n2 (Inactive)" in message
+    assert "n1" not in message.split("Unfinished hosts:")[1].split(".")[0]
+    # Must tell the operator the task is still pending and the re-run is safe.
+    assert "still queued" in message
+    assert "system.distributed_ddl_queue" in message
+
+
+def test_timeout_when_task_never_appears() -> None:
+    pool = Mock()
+    pool.execute.side_effect = [_result([])] + [_result([]) for _ in range(50)]
+
+    with pytest.raises(DistributedDDLTimeout) as excinfo:
+        execute_ddl_async(
+            pool,
+            "CREATE TABLE t ON CLUSTER 'c1' (a UInt64) ENGINE Log",
+            cluster_name="c1",
+            timeout_seconds=0,
+            poll_interval_seconds=0,
+        )
+
+    assert "task not visible in queue" in str(excinfo.value)
+
+
+def _mock_cluster(single_node: bool) -> Mock:
+    cluster = Mock(spec=ClickhouseCluster)
+    cluster.is_single_node.return_value = single_node
+    cluster.get_clickhouse_cluster_name.return_value = None if single_node else "test_cluster"
+    cluster.get_clickhouse_distributed_cluster_name.return_value = (
+        None if single_node else "test_cluster"
+    )
+    cluster.get_local_nodes.return_value = [Mock()]
+    cluster.get_distributed_nodes.return_value = [Mock()]
+    return cluster
+
+
+class TestOperationIntegration:
+    """SqlOperation.execute() should route ON CLUSTER DDL through the async path."""
+
+    @patch("snuba.migrations.operations.execute_ddl_async")
+    @patch("snuba.migrations.operations.get_cluster")
+    def test_multi_node_uses_async(self, mock_get_cluster: Mock, mock_async: Mock) -> None:
+        mock_get_cluster.return_value = _mock_cluster(single_node=False)
+
+        RunSql(
+            StorageSetKey.EVENTS,
+            "ALTER TABLE t ON CLUSTER 'test_cluster' MODIFY COLUMN a UInt64",
+            target=OperationTarget.LOCAL,
+        ).execute()
+
+        assert mock_async.call_count == 1
+        assert mock_async.call_args.kwargs["cluster_name"] == "test_cluster"
+
+    @patch("snuba.migrations.operations.execute_ddl_async")
+    @patch("snuba.migrations.operations.get_cluster")
+    def test_single_node_stays_synchronous(self, mock_get_cluster: Mock, mock_async: Mock) -> None:
+        cluster = _mock_cluster(single_node=True)
+        mock_get_cluster.return_value = cluster
+
+        RunSql(
+            StorageSetKey.EVENTS,
+            "ALTER TABLE t MODIFY COLUMN a UInt64",
+            target=OperationTarget.LOCAL,
+        ).execute()
+
+        # No ON CLUSTER to coordinate, so there is nothing to poll for.
+        assert mock_async.call_count == 0
+        assert cluster.get_node_connection.return_value.execute.call_count == 1
+
+    @patch("snuba.migrations.operations.settings")
+    @patch("snuba.migrations.operations.execute_ddl_async")
+    @patch("snuba.migrations.operations.get_cluster")
+    def test_async_can_be_disabled(
+        self, mock_get_cluster: Mock, mock_async: Mock, mock_settings: Mock
+    ) -> None:
+        mock_settings.ASYNC_MIGRATION_DDL = False
+        mock_settings.LOG_MIGRATIONS = False
+        cluster = _mock_cluster(single_node=False)
+        mock_get_cluster.return_value = cluster
+
+        RunSql(
+            StorageSetKey.EVENTS,
+            "ALTER TABLE t ON CLUSTER 'test_cluster' MODIFY COLUMN a UInt64",
+            target=OperationTarget.LOCAL,
+        ).execute()
+
+        assert mock_async.call_count == 0
+        assert cluster.get_node_connection.return_value.execute.call_count == 1

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -748,10 +748,16 @@ class TestOnCluster:
         assert "ON CLUSTER 'query_cluster'" in sql
 
     @patch("snuba.migrations.operations.get_cluster")
+    @patch("snuba.migrations.operations.execute_ddl_async")
     def test_run_sql_with_on_cluster_uses_single_node_execution(
-        self, mock_get_cluster: Mock
+        self, mock_execute_ddl_async: Mock, mock_get_cluster: Mock
     ) -> None:
-        """RunSql with ON CLUSTER in statement should use single-node execution."""
+        """RunSql with ON CLUSTER in statement should use single-node execution.
+
+        On a multi-node cluster the statement is submitted from one node and then
+        polled via system.distributed_ddl_queue (see snuba.migrations.async_ddl),
+        rather than being run once per node.
+        """
         mock_cluster = _make_mock_cluster(single_node=False)
         mock_node = Mock()
         mock_cluster.get_local_nodes.return_value = [mock_node]
@@ -763,8 +769,11 @@ class TestOnCluster:
         op = RunSql(StorageSetKey.EVENTS, sql, target=OperationTarget.LOCAL)
         op.execute()
 
-        # Should execute once (single-node execution via parent's execute())
-        mock_connection.execute.assert_called_once_with(sql, settings=None)
+        # Submitted exactly once, from a single node, through the async DDL path.
+        mock_execute_ddl_async.assert_called_once()
+        assert mock_execute_ddl_async.call_args.args[1] == sql
+        assert mock_execute_ddl_async.call_args.kwargs["cluster_name"] == "test_cluster"
+        mock_cluster.get_node_connection.assert_called_once()
 
     @patch("snuba.migrations.operations.get_cluster")
     def test_run_sql_without_on_cluster_uses_per_node_execution(
@@ -787,7 +796,10 @@ class TestOnCluster:
         assert mock_connection.execute.call_count == 2
 
     @patch("snuba.migrations.operations.get_cluster")
-    def test_run_sql_on_cluster_case_insensitive(self, mock_get_cluster: Mock) -> None:
+    @patch("snuba.migrations.operations.execute_ddl_async")
+    def test_run_sql_on_cluster_case_insensitive(
+        self, mock_execute_ddl_async: Mock, mock_get_cluster: Mock
+    ) -> None:
         """RunSql should detect ON CLUSTER regardless of case."""
         mock_cluster = _make_mock_cluster(single_node=False)
         mock_node = Mock()
@@ -801,5 +813,5 @@ class TestOnCluster:
         op = RunSql(StorageSetKey.EVENTS, sql, target=OperationTarget.LOCAL)
         op.execute()
 
-        # Should execute once (detected ON CLUSTER)
-        mock_connection.execute.assert_called_once()
+        # Should submit once (detected ON CLUSTER), not once per node
+        mock_execute_ddl_async.assert_called_once()


### PR DESCRIPTION
Migrations wait on `ON CLUSTER` DDL inline, which fails opaquely when a replica is slow or down:

```
snuba.clickhouse.errors.ClickhouseError: Error ('Connection broken: IncompleteRead(676 bytes read)', ...)
```

With `distributed_ddl_output_mode=throw`, ClickHouse streams the per-host result table and then raises `TIMEOUT_EXCEEDED` mid-body. Headers and the first rows are already sent, so it closes the connection without a well-formed error payload and the real per-replica error is lost.

Submit with `distributed_ddl_task_timeout=0` and poll `system.distributed_ddl_queue` instead, correlating the entry via a unique `log_comment` (ClickHouse rewrites the query text before storing it, so matching on SQL is unreliable). We now get the actual per-host `exception_code`/`exception_text`, and the unfinished hosts are named on timeout.

Generated SQL is unchanged. Single-node clusters keep the synchronous path. Disable with `ASYNC_MIGRATION_DDL=0`.

Verified against a 2-node replicated cluster (Keeper + `internal_replication`):

| scenario | before | after |
|---|---|---|
| healthy | ok | ok |
| replica down | `IncompleteRead(428 bytes read)` | `Unfinished hosts: n2 (Inactive)` |
| invalid DDL | opaque | `n1: [16] Wrong column name ... (NO_SUCH_COLUMN_IN_TABLE)` |
| re-run after recovery | — | succeeds |

Note: on timeout the task stays queued in Keeper and still applies once the replica recovers, so it means "unconfirmed", not "did not happen". Migration DDL is uniformly `IF [NOT] EXISTS`, so re-running is safe.

Two existing `RunSql` tests asserted the literal synchronous call; updated to assert the same intent (submitted once from one node, not per-node) against the async path.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.