### PR TITLE
perf(schemas): Cache JSONSchema validator class

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -7,6 +7,31 @@ import jsonschema
 Schema = Mapping[str, Any]  # placeholder for JSON schema
 
 
+def _validate_and_default(
+    validator: object,
+    properties: Mapping[str, Any],
+    instance: MutableMapping[str, Any],
+    schema: Mapping[str, Any],
+) -> Generator[Exception]:
+    for property, subschema in properties.items():
+        if property not in instance and "default" in subschema:
+            if callable(subschema["default"]):
+                default_value = subschema["default"]()
+            else:
+                default_value = copy.deepcopy(subschema["default"])
+            instance[property] = default_value
+
+    yield from jsonschema.Draft6Validator.VALIDATORS["properties"](
+        validator, properties, instance, schema
+    )
+
+
+# validators.extend creates a new class, so do this once rather than for every query.
+_VALIDATOR_WITH_DEFAULTS = jsonschema.validators.extend(
+    jsonschema.Draft4Validator, {"properties": _validate_and_default}
+)
+
+
 def validate_jsonschema(
     value: MutableMapping[str, Any],
     schema: MutableMapping[str, Any],
@@ -17,37 +42,13 @@ def validate_jsonschema(
     value if the value conforms to the schema, otherwise raising a
     ``jsonschema.ValidationError``.
     """
-    orig = jsonschema.Draft6Validator.VALIDATORS["properties"]
-
-    def validate_and_default(
-        validator: object,
-        properties: Mapping[str, Any],
-        instance: MutableMapping[str, Any],
-        schema: Mapping[str, Any],
-    ) -> Generator[Exception]:
-        for property, subschema in properties.items():
-            if property not in instance and "default" in subschema:
-                if callable(subschema["default"]):
-                    default_value = subschema["default"]()
-                else:
-                    default_value = copy.deepcopy(subschema["default"])
-                instance[property] = default_value
-
-        yield from orig(validator, properties, instance, schema)
-
     # Using schema defaults during validation will cause the input value to be
     # mutated, so to be on the safe side we create a deep copy of that value to
     # avoid unwanted side effects for the calling function.
     if set_defaults:
         value = copy.deepcopy(value)
 
-    validator_cls = (
-        jsonschema.validators.extend(
-            jsonschema.Draft4Validator, {"properties": validate_and_default}
-        )
-        if set_defaults
-        else jsonschema.Draft6Validator
-    )
+    validator_cls = _VALIDATOR_WITH_DEFAULTS if set_defaults else jsonschema.Draft6Validator
 
     validator_cls(
         schema,


### PR DESCRIPTION
`validate_jsonschema()` currently rebuilds an extended jsonschema validator class on every validation. This path runs for Python SNQL/MQL HTTP requests, scheduled legacy SnQL subscription execution, delete requests, and admin query validation. RPC requests bypass it.

Move the stateless extended class to module scope while continuing to create a fresh validator instance and `FormatChecker` for each validation.

## Validation benchmark

| | Before | After | Improvement |
|---|---:|---:|---:|
| Median validation time | 214.55 µs | 28.43 µs | 86.7% |

This saves about 186 µs per affected query. Measured with jsonschema 4.23.0 across 7 repeats of 5,000 validations.