### PR TITLE
feat(eap): add controlled block column setting jobs

### DIFF
--- a/snuba/manual_jobs/set_eap_downsampled_table_settings.py
+++ b/snuba/manual_jobs/set_eap_downsampled_table_settings.py
@@ -16,6 +16,8 @@ _DOWNSAMPLED_EAP_TABLES = [
 class SetEAPDownsampledTableSettings(Job):
     """Enable block metadata columns on a downsampled EAP local table."""
 
+    allow_adhoc_run = True
+
     def __init__(self, job_spec: JobSpec) -> None:
         self.__validate_job_params(job_spec.params)
         super().__init__(job_spec)

--- a/snuba/manual_jobs/set_eap_downsampled_table_settings.py
+++ b/snuba/manual_jobs/set_eap_downsampled_table_settings.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -7,7 +6,11 @@ from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.manual_jobs import Job, JobLogger, JobSpec
 
-_DOWNSAMPLED_EAP_TABLE_RE = re.compile(r"eap_items_1_downsample_[0-9]+_local")
+_DOWNSAMPLED_EAP_TABLES = [
+    "eap_items_1_downsample_8_local",
+    "eap_items_1_downsample_64_local",
+    "eap_items_1_downsample_512_local",
+]
 
 
 class SetEAPDownsampledTableSettings(Job):
@@ -20,7 +23,7 @@ class SetEAPDownsampledTableSettings(Job):
     def __validate_job_params(self, params: Mapping[Any, Any] | None) -> None:
         assert params is not None, "table_name parameter required"
         table_name = params.get("table_name")
-        assert isinstance(table_name, str) and _DOWNSAMPLED_EAP_TABLE_RE.fullmatch(table_name), (
+        assert isinstance(table_name, str) and table_name in _DOWNSAMPLED_EAP_TABLES, (
             "table_name must be a downsampled EAP local table"
         )
         self._table_name = table_name

--- a/snuba/manual_jobs/set_eap_downsampled_table_settings.py
+++ b/snuba/manual_jobs/set_eap_downsampled_table_settings.py
@@ -1,0 +1,60 @@
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from snuba.clickhouse.escaping import escape_identifier
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.manual_jobs import Job, JobLogger, JobSpec
+
+_DOWNSAMPLED_EAP_TABLE_RE = re.compile(r"eap_items_1_downsample_[0-9]+_local")
+
+
+class SetEAPDownsampledTableSettings(Job):
+    """Enable block metadata columns on a downsampled EAP local table."""
+
+    def __init__(self, job_spec: JobSpec) -> None:
+        self.__validate_job_params(job_spec.params)
+        super().__init__(job_spec)
+
+    def __validate_job_params(self, params: Mapping[Any, Any] | None) -> None:
+        assert params is not None, "table_name parameter required"
+        table_name = params.get("table_name")
+        assert isinstance(table_name, str) and _DOWNSAMPLED_EAP_TABLE_RE.fullmatch(table_name), (
+            "table_name must be a downsampled EAP local table"
+        )
+        self._table_name = table_name
+
+    def _get_query(self, cluster_name: str | None) -> str:
+        on_cluster = f" ON CLUSTER '{cluster_name}'" if cluster_name else ""
+        escaped_table_name = escape_identifier(self._table_name)
+        assert escaped_table_name is not None
+        return (
+            f"ALTER TABLE {escaped_table_name}{on_cluster} MODIFY SETTING "
+            "enable_block_number_column = 1, enable_block_offset_column = 1;"
+        )
+
+    def execute(self, logger: JobLogger) -> None:
+        cluster = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM)
+        storage_node = cluster.get_local_nodes()[0]
+        connection = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, storage_node)
+        cluster_name = None if cluster.is_single_node() else cluster.get_clickhouse_cluster_name()
+        query = self._get_query(cluster_name)
+
+        logger.info(f"Executing query: {query}")
+        result = connection.execute(query=query)
+        logger.info("complete")
+        logger.info(repr(result))
+
+
+class ResetEAPDownsampledTableSettings(SetEAPDownsampledTableSettings):
+    """Reset block metadata column settings on a downsampled EAP local table."""
+
+    def _get_query(self, cluster_name: str | None) -> str:
+        on_cluster = f" ON CLUSTER '{cluster_name}'" if cluster_name else ""
+        escaped_table_name = escape_identifier(self._table_name)
+        assert escaped_table_name is not None
+        return (
+            f"ALTER TABLE {escaped_table_name}{on_cluster} RESET SETTING "
+            "enable_block_number_column, enable_block_offset_column;"
+        )

--- a/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
+++ b/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
@@ -1,0 +1,120 @@
+from unittest.mock import Mock
+
+import pytest
+
+from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs.set_eap_downsampled_table_settings import (
+    ResetEAPDownsampledTableSettings,
+    SetEAPDownsampledTableSettings,
+)
+
+
+def _build_job(monkeypatch: pytest.MonkeyPatch, table_name: str) -> SetEAPDownsampledTableSettings:
+    monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
+    return SetEAPDownsampledTableSettings(
+        JobSpec(
+            job_id="set-eap-settings",
+            job_type="SetEAPDownsampledTableSettings",
+            params={"table_name": table_name},
+        )
+    )
+
+
+def test_get_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, "eap_items_1_downsample_8_local")
+
+    assert job._get_query("eap_cluster") == (
+        "ALTER TABLE eap_items_1_downsample_8_local ON CLUSTER 'eap_cluster' MODIFY SETTING "
+        "enable_block_number_column = 1, enable_block_offset_column = 1;"
+    )
+
+
+def test_get_reset_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
+    job = ResetEAPDownsampledTableSettings(
+        JobSpec(
+            job_id="reset-eap-settings",
+            job_type="ResetEAPDownsampledTableSettings",
+            params={"table_name": "eap_items_1_downsample_8_local"},
+        )
+    )
+
+    assert job._get_query("eap_cluster") == (
+        "ALTER TABLE eap_items_1_downsample_8_local ON CLUSTER 'eap_cluster' RESET SETTING "
+        "enable_block_number_column, enable_block_offset_column;"
+    )
+
+
+@pytest.mark.parametrize(
+    "table_name",
+    [
+        "eap_items_1_local",
+        "eap_items_1_downsample_8_dist",
+        "eap_items_1_downsample_8_local; DROP TABLE events",
+        "events_local",
+    ],
+)
+def test_rejects_non_downsampled_eap_local_table(
+    monkeypatch: pytest.MonkeyPatch, table_name: str
+) -> None:
+    with pytest.raises(AssertionError, match="downsampled EAP local table"):
+        _build_job(monkeypatch, table_name)
+
+
+def test_execute_uses_eap_local_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, "eap_items_1_downsample_64_local")
+    connection = Mock()
+    cluster = Mock()
+    cluster.get_local_nodes.return_value = ["local-node"]
+    cluster.is_single_node.return_value = False
+    cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.set_eap_downsampled_table_settings.get_cluster",
+        Mock(return_value=cluster),
+    )
+    logger = Mock()
+
+    job.execute(logger)
+
+    cluster.get_node_connection.assert_called_once_with(
+        ClickhouseClientSettings.MIGRATE, "local-node"
+    )
+    connection.execute.assert_called_once_with(
+        query=(
+            "ALTER TABLE eap_items_1_downsample_64_local ON CLUSTER 'eap_cluster' "
+            "MODIFY SETTING enable_block_number_column = 1, "
+            "enable_block_offset_column = 1;"
+        )
+    )
+
+
+def test_reset_execute_uses_eap_local_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
+    job = ResetEAPDownsampledTableSettings(
+        JobSpec(
+            job_id="reset-eap-settings",
+            job_type="ResetEAPDownsampledTableSettings",
+            params={"table_name": "eap_items_1_downsample_64_local"},
+        )
+    )
+    connection = Mock()
+    cluster = Mock()
+    cluster.get_local_nodes.return_value = ["local-node"]
+    cluster.is_single_node.return_value = False
+    cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.set_eap_downsampled_table_settings.get_cluster",
+        Mock(return_value=cluster),
+    )
+
+    job.execute(Mock())
+
+    connection.execute.assert_called_once_with(
+        query=(
+            "ALTER TABLE eap_items_1_downsample_64_local ON CLUSTER 'eap_cluster' "
+            "RESET SETTING enable_block_number_column, enable_block_offset_column;"
+        )
+    )

--- a/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
+++ b/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
@@ -49,8 +49,23 @@ def test_get_reset_query(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.parametrize(
     "table_name",
     [
+        "eap_items_1_downsample_8_local",
+        "eap_items_1_downsample_64_local",
+        "eap_items_1_downsample_512_local",
+    ],
+)
+def test_accepts_supported_downsampled_eap_local_tables(
+    monkeypatch: pytest.MonkeyPatch, table_name: str
+) -> None:
+    _build_job(monkeypatch, table_name)
+
+
+@pytest.mark.parametrize(
+    "table_name",
+    [
         "eap_items_1_local",
         "eap_items_1_downsample_8_dist",
+        "eap_items_1_downsample_16_local",
         "eap_items_1_downsample_8_local; DROP TABLE events",
         "events_local",
     ],

--- a/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
+++ b/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
@@ -21,6 +21,11 @@ def _build_job(monkeypatch: pytest.MonkeyPatch, table_name: str) -> SetEAPDownsa
     )
 
 
+def test_jobs_allow_adhoc_run() -> None:
+    assert SetEAPDownsampledTableSettings.allow_adhoc_run
+    assert ResetEAPDownsampledTableSettings.allow_adhoc_run
+
+
 def test_get_query(monkeypatch: pytest.MonkeyPatch) -> None:
     job = _build_job(monkeypatch, "eap_items_1_downsample_8_local")
 


### PR DESCRIPTION
## Summary

- Add a parameterized manual job to enable `enable_block_number_column` and `enable_block_offset_column` on one downsampled EAP local table.
- Add a corresponding reset job for recovery if the settings cause an issue.
- Validate the table name and execute against the EAP local cluster with `ON CLUSTER` when applicable.

## Motivation

A previous migration-based attempt failed when applied to the full-fidelity EAP table. These jobs provide a more controlled rollout by targeting downsampled local tables individually, with an explicit reset path.

## Testing

- `SNUBA_SETTINGS=test uv run pytest tests/manual_jobs/test_set_eap_downsampled_table_settings.py -q`
- Ruff and mypy checks passed.
- Pre-commit checks passed.

## Usage

```bash
snuba jobs run --job_type SetEAPDownsampledTableSettings --job_id enable-block-columns-8 table_name=eap_items_1_downsample_8_local
snuba jobs run --job_type ResetEAPDownsampledTableSettings --job_id reset-block-columns-8 table_name=eap_items_1_downsample_8_local
```