### PR TITLE
feat(eap): categorize EAP queries and add snuba-admin EAP Stats page

### DIFF
--- a/snuba/admin/audit_log/query.py
+++ b/snuba/admin/audit_log/query.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable, MutableMapping
 from datetime import UTC, datetime
 from enum import Enum
-from functools import partial
-from typing import TypeVar
+from functools import partial, wraps
+from typing import Any, TypeVar
 
 from snuba.admin.audit_log.action import AuditLogAction
 from snuba.admin.audit_log.base import AuditLog
@@ -22,15 +22,19 @@ class QueryExecutionStatus(Enum):
 __query_audit_log_notification_client = AuditLog()
 
 
-def audit_log(fn: Callable[[str, str], Return]) -> Callable[[str, str], Return]:
+def audit_log(fn: Callable[..., Return]) -> Callable[..., Return]:
     """
     Decorator function for querylog query runner.
 
     Logs the user, query, start/end timestamps, and whether or not
     the query was successful.
+
+    Expects the wrapped function to take ``query`` and ``user`` as the first
+    two positional arguments. Additional args/kwargs are forwarded unchanged.
     """
 
-    def audit_log_wrapper(query: str, user: str) -> Return:
+    @wraps(fn)
+    def audit_log_wrapper(query: str, user: str, *args: Any, **kwargs: Any) -> Return:
         data: MutableMapping[str, str | int] = {
             "query": query,
         }
@@ -40,7 +44,7 @@ def audit_log(fn: Callable[[str, str], Return]) -> Callable[[str, str], Return]:
             action=AuditLogAction.RAN_QUERY,
         )
         try:
-            result = fn(query, user)
+            result = fn(query, user, *args, **kwargs)
         except Exception:
             data["status"] = QueryExecutionStatus.FAILED.value
             data["end_timestamp"] = datetime.now(UTC).strftime(DATETIME_FORMAT)

--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -85,6 +85,7 @@ TOOL_RESOURCES = {
     "querylog": ToolResource("querylog"),
     "rpc-endpoints": ToolResource("rpc-endpoints"),
     "clusters": ToolResource("clusters"),
+    "eap-stats": ToolResource("eap-stats"),
     "all": ToolResource("all"),
 }
 
@@ -170,6 +171,7 @@ ROLES = {
                     TOOL_RESOURCES["querylog"],
                     TOOL_RESOURCES["rpc-endpoints"],
                     TOOL_RESOURCES["clusters"],
+                    TOOL_RESOURCES["eap-stats"],
                 ]
             )
         },

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -321,6 +321,46 @@ def get_ro_clusterless_node_connection(
     return connection
 
 
+def _strip_sql_string_literals(sql_query: str) -> str:
+    """Replace quoted string contents with empty quotes for safety checks.
+
+    Lets validators ignore disallowed tokens that only appear inside literals
+    (e.g. a referrer filter value containing ``--`` or ``delete``).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(sql_query)
+    while i < n:
+        ch = sql_query[i]
+        if ch in ("'", '"'):
+            quote = ch
+            out.append(quote)
+            i += 1
+            while i < n:
+                cur = sql_query[i]
+                if cur == "\\" and i + 1 < n:
+                    # Skip escaped character inside the literal.
+                    i += 2
+                    continue
+                if cur == quote:
+                    # SQL-style doubled quote escape ('' or "").
+                    if i + 1 < n and sql_query[i + 1] == quote:
+                        i += 2
+                        continue
+                    out.append(quote)
+                    i += 1
+                    break
+                i += 1
+            else:
+                # Unbalanced quote; leave remainder as-is for the caller to reject.
+                out.append(sql_query[i:])
+                break
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) -> None:
     """
     Validates that the query is a safe read-only query.
@@ -336,7 +376,9 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
     if single_quote_count % 2 != 0 or double_quote_count % 2 != 0:
         raise InvalidCustomQuery("Unbalanced quotes detected in query")
 
-    lowered = sql_query.lower()
+    # Ignore tokens that only appear inside string literals when scanning for
+    # disallowed keywords/comments. Parsing still uses the original SQL.
+    lowered = _strip_sql_string_literals(sql_query).lower()
     # Enhanced disallowed keywords to prevent SQL injection and data modification
     disallowed_keywords = [
         "insert",
@@ -363,7 +405,7 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
         elif kw in lowered:
             raise InvalidCustomQuery(f"{kw} is not allowed in the query")
 
-    parsed = Parser(lowered)
+    parsed = Parser(sql_query.lower())
 
     if parsed.query_type != QueryType.SELECT:
         raise InvalidCustomQuery("Only SELECT queries are allowed")

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -321,6 +321,42 @@ def get_ro_clusterless_node_connection(
     return connection
 
 
+def _sql_quotes_are_balanced(sql_query: str) -> bool:
+    """Return True when single/double quotes are balanced, honoring escapes.
+
+    Understands backslash escapes (``\'``) and SQL-style doubled quotes (``''``),
+    so values like ``O'Brien`` escaped as ``O\'Brien`` do not look unbalanced.
+    """
+    i = 0
+    n = len(sql_query)
+    while i < n:
+        ch = sql_query[i]
+        if ch == "\\":
+            # Outside a string, skip an escaped character if present.
+            i += 2 if i + 1 < n else 1
+            continue
+        if ch not in ("'", '"'):
+            i += 1
+            continue
+        quote = ch
+        i += 1
+        while i < n:
+            cur = sql_query[i]
+            if cur == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if cur == quote:
+                if i + 1 < n and sql_query[i + 1] == quote:
+                    i += 2
+                    continue
+                i += 1
+                break
+            i += 1
+        else:
+            return False
+    return True
+
+
 def _strip_sql_string_literals(sql_query: str) -> str:
     """Replace quoted string contents with empty quotes for safety checks.
 
@@ -370,10 +406,7 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
 
     Raises InvalidCustomQuery if query is invalid or not allowed.
     """
-    # Check for balanced quotes to prevent injection
-    single_quote_count = sql_query.count("'")
-    double_quote_count = sql_query.count('"')
-    if single_quote_count % 2 != 0 or double_quote_count % 2 != 0:
+    if not _sql_quotes_are_balanced(sql_query):
         raise InvalidCustomQuery("Unbalanced quotes detected in query")
 
     # Ignore tokens that only appear inside string literals when scanning for

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -321,6 +321,34 @@ def get_ro_clusterless_node_connection(
     return connection
 
 
+def _end_of_sql_string_literal(sql_query: str, start: int) -> int | None:
+    """Return the index just past a string literal that starts at ``start``.
+
+    ``start`` must point at the opening ``'`` or ``"``. Walks forward handling:
+    - backslash escapes (``\'``, ``\"``)
+    - SQL-style doubled quotes (``''``, ``""``)
+
+    Returns ``None`` when no matching closer is found.
+    """
+    quote = sql_query[start]
+    i = start + 1
+    n = len(sql_query)
+    while i < n:
+        ch = sql_query[i]
+        if ch == "\\" and i + 1 < n:
+            # Skip the escaped character (e.g. \' keeps the quote inside).
+            i += 2
+            continue
+        if ch == quote:
+            # Doubled quote is an escaped quote, not a terminator.
+            if i + 1 < n and sql_query[i + 1] == quote:
+                i += 2
+                continue
+            return i + 1
+        i += 1
+    return None
+
+
 def _sql_quotes_are_balanced(sql_query: str) -> bool:
     """Return True when single/double quotes are balanced, honoring escapes.
 
@@ -335,25 +363,13 @@ def _sql_quotes_are_balanced(sql_query: str) -> bool:
             # Outside a string, skip an escaped character if present.
             i += 2 if i + 1 < n else 1
             continue
-        if ch not in ("'", '"'):
-            i += 1
+        if ch in ("'", '"'):
+            end = _end_of_sql_string_literal(sql_query, i)
+            if end is None:
+                return False
+            i = end
             continue
-        quote = ch
         i += 1
-        while i < n:
-            cur = sql_query[i]
-            if cur == "\\" and i + 1 < n:
-                i += 2
-                continue
-            if cur == quote:
-                if i + 1 < n and sql_query[i + 1] == quote:
-                    i += 2
-                    continue
-                i += 1
-                break
-            i += 1
-        else:
-            return False
     return True
 
 
@@ -369,28 +385,15 @@ def _strip_sql_string_literals(sql_query: str) -> str:
     while i < n:
         ch = sql_query[i]
         if ch in ("'", '"'):
-            quote = ch
-            out.append(quote)
-            i += 1
-            while i < n:
-                cur = sql_query[i]
-                if cur == "\\" and i + 1 < n:
-                    # Skip escaped character inside the literal.
-                    i += 2
-                    continue
-                if cur == quote:
-                    # SQL-style doubled quote escape ('' or "").
-                    if i + 1 < n and sql_query[i + 1] == quote:
-                        i += 2
-                        continue
-                    out.append(quote)
-                    i += 1
-                    break
-                i += 1
-            else:
+            end = _end_of_sql_string_literal(sql_query, i)
+            if end is None:
                 # Unbalanced quote; leave remainder as-is for the caller to reject.
                 out.append(sql_query[i:])
                 break
+            # Keep the delimiters so surrounding SQL shape is preserved, drop contents.
+            out.append(ch)
+            out.append(ch)
+            i = end
             continue
         out.append(ch)
         i += 1

--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -10,22 +10,31 @@ from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.state.sentry_options import get_option
 
+# Default cap for interactive querylog SQL. 0 means "use all cores" in ClickHouse
+# and is reserved for intentional full-scan tools (EAP Stats).
 _MAX_CH_THREADS = 4
 
 
 @audit_log
-def run_querylog_query(query: str, user: str) -> ClickhouseResult:
+def run_querylog_query(
+    query: str,
+    user: str,
+    max_threads: int | None = None,
+) -> ClickhouseResult:
     """
     Validates, audit logs, and executes given query against Querylog
     table in ClickHouse. `user` param is necessary for audit_log
     decorator.
+
+    ``max_threads`` overrides the default thread cap. Pass ``0`` to let
+    ClickHouse use all available cores (needed for whole-dataset scans).
     """
     schema = get_storage(StorageKey.QUERYLOG).get_schema()
     assert isinstance(schema, TableSchema)
     validate_ro_query(
         sql_query=query, allowed_tables={schema.get_table_name(), "clickhouse_queries"}
     )
-    return __run_querylog_query(query)
+    return __run_querylog_query(query, max_threads=max_threads)
 
 
 def describe_querylog_schema() -> ClickhouseResult:
@@ -34,12 +43,15 @@ def describe_querylog_schema() -> ClickhouseResult:
     return __run_querylog_query(f"DESCRIBE TABLE {schema.get_table_name()}")
 
 
-def _get_clickhouse_threads() -> int:
+def _get_clickhouse_threads(max_threads: int | None = None) -> int:
+    if max_threads is not None:
+        # Allow 0 (ClickHouse: use all cores). Negative values are invalid.
+        return max(0, int(max_threads))
     config_threads = get_option("admin.querylog_threads", _MAX_CH_THREADS)
     return min(config_threads, _MAX_CH_THREADS)
 
 
-def __run_querylog_query(query: str) -> ClickhouseResult:
+def __run_querylog_query(query: str, max_threads: int | None = None) -> ClickhouseResult:
     """
     Runs given Query against Querylog table in ClickHouse. This function assumes valid
     query and does not validate/sanitize query or response data.
@@ -51,6 +63,6 @@ def __run_querylog_query(query: str) -> ClickhouseResult:
     query_result = connection.execute(
         query=query,
         with_column_types=True,
-        settings={"max_threads": _get_clickhouse_threads()},
+        settings={"max_threads": _get_clickhouse_threads(max_threads)},
     )
     return query_result

--- a/snuba/admin/eap_query_analysis/__init__.py
+++ b/snuba/admin/eap_query_analysis/__init__.py
@@ -1,0 +1,13 @@
+from snuba.admin.eap_query_analysis.analysis import (
+    EapQueryAnalysisRequest,
+    EapQueryAnalysisResult,
+    analyze_eap_queries,
+    result_to_dict,
+)
+
+__all__ = [
+    "EapQueryAnalysisRequest",
+    "EapQueryAnalysisResult",
+    "analyze_eap_queries",
+    "result_to_dict",
+]

--- a/snuba/admin/eap_query_analysis/analysis.py
+++ b/snuba/admin/eap_query_analysis/analysis.py
@@ -315,9 +315,11 @@ def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
 
 
 def _infer_request_class(body: dict[str, Any]) -> type[ProtobufMessage] | None:
-    """Pick a protobuf request type from the shape of the stored JSON body."""
-    if "columns" in body or "groupBy" in body or "group_by" in body:
-        return TraceItemTableRequest
+    """Pick a protobuf request type from the shape of the stored JSON body.
+
+    Order matters: TimeSeriesRequest and TraceItemTableRequest both may carry
+    ``group_by``/``groupBy``, so timeseries-only markers must win first.
+    """
     if (
         "expressions" in body
         or "granularitySecs" in body
@@ -327,6 +329,8 @@ def _infer_request_class(body: dict[str, Any]) -> type[ProtobufMessage] | None:
         return TimeSeriesRequest
     if "statsTypes" in body or "stats_types" in body:
         return TraceItemStatsRequest
+    if "columns" in body or "groupBy" in body or "group_by" in body:
+        return TraceItemTableRequest
     for key in ("request", "body"):
         nested = body.get(key)
         if isinstance(nested, dict):

--- a/snuba/admin/eap_query_analysis/analysis.py
+++ b/snuba/admin/eap_query_analysis/analysis.py
@@ -261,15 +261,6 @@ def _escape_literal(value: str) -> str:
     return value.replace("\\", "\\\\").replace("'", "\\'")
 
 
-def _escape_like_literal(value: str) -> str:
-    """Escape a string for use inside a SQL LIKE pattern.
-
-    Handles quote/backslash escaping plus LIKE wildcards so user input is
-    matched literally (e.g. ``eap_items`` does not match ``eapXitems``).
-    """
-    return _escape_literal(value).replace("%", "\\%").replace("_", "\\_")
-
-
 def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
     table = _schema_table_name()
     dataset_list = ", ".join(f"'{d}'" for d in _EAP_DATASETS)
@@ -280,7 +271,12 @@ def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
     if req.referrer:
         where.append(f"referrer = '{_escape_literal(req.referrer)}'")
     if req.referrer_contains:
-        where.append(f"referrer LIKE '%{_escape_like_literal(req.referrer_contains)}%' ESCAPE '\\'")
+        # Use positionCaseInsensitive for literal substring matching. ClickHouse
+        # 25.x does not support LIKE ... ESCAPE, and LIKE would treat _/% as
+        # wildcards for inputs like "eap_items".
+        where.append(
+            f"positionCaseInsensitive(referrer, '{_escape_literal(req.referrer_contains)}') > 0"
+        )
     if req.organization_id is not None:
         where.append(f"organization = {int(req.organization_id)}")
 
@@ -409,6 +405,16 @@ def _collect_query_ids(values: list[Any] | None) -> list[str]:
     return ids
 
 
+def _eap_profile_cluster_name() -> str | None:
+    """Resolved ClickHouse cluster name for EAP ProfileEvents lookups."""
+    try:
+        cluster = get_storage(StorageKey(_EAP_PROFILE_STORAGE)).get_cluster()
+        return cluster.get_clickhouse_cluster_name()
+    except Exception as e:
+        logger.warning("Failed to resolve EAP cluster name for ProfileEvents: %s", e)
+        return None
+
+
 def _fetch_profile_events(query_ids: list[str], hours: int) -> dict[str, dict[str, int]]:
     """Batch-fetch ProfileEvents from system.query_log on the EAP cluster.
 
@@ -428,16 +434,19 @@ def _fetch_profile_events(query_ids: list[str], hours: int) -> dict[str, dict[st
     all_ids = list({*normalized, *dashed})
     id_list = ", ".join(f"'{_escape_literal(qid)}'" for qid in all_ids)
 
-    sql_cluster = f"""
-        SELECT
-            replaceAll(toString(query_id), '-', '') AS qid,
-            ProfileEvents
-        FROM clusterAllReplicas(default, system.query_log)
-        WHERE type = 'QueryFinish'
-          AND event_time > now() - INTERVAL {int(hours)} HOUR
-          AND replaceAll(toString(query_id), '-', '') IN ({id_list})
-        SETTINGS skip_unavailable_shards = 1, max_threads = 0
-    """
+    cluster_name = _eap_profile_cluster_name()
+    sql_cluster = None
+    if cluster_name:
+        sql_cluster = f"""
+            SELECT
+                replaceAll(toString(query_id), '-', '') AS qid,
+                ProfileEvents
+            FROM clusterAllReplicas('{_escape_literal(cluster_name)}', system.query_log)
+            WHERE type = 'QueryFinish'
+              AND event_time > now() - INTERVAL {int(hours)} HOUR
+              AND replaceAll(toString(query_id), '-', '') IN ({id_list})
+            SETTINGS skip_unavailable_shards = 1, max_threads = 0
+        """
     sql_local = f"""
         SELECT
             replaceAll(toString(query_id), '-', '') AS qid,
@@ -453,10 +462,15 @@ def _fetch_profile_events(query_ids: list[str], hours: int) -> dict[str, dict[st
         connection: ClickhousePool = get_ro_query_node_connection(
             _EAP_PROFILE_STORAGE, ClickhouseClientSettings.QUERY
         )
-        try:
-            result = connection.execute(query=sql_cluster, with_column_types=True)
-        except Exception as e:
-            logger.warning("clusterAllReplicas ProfileEvents lookup failed, trying local: %s", e)
+        if sql_cluster is not None:
+            try:
+                result = connection.execute(query=sql_cluster, with_column_types=True)
+            except Exception as e:
+                logger.warning(
+                    "clusterAllReplicas ProfileEvents lookup failed, trying local: %s", e
+                )
+                result = connection.execute(query=sql_local, with_column_types=True)
+        else:
             result = connection.execute(query=sql_local, with_column_types=True)
     except Exception as e:
         logger.warning("ProfileEvents lookup failed: %s", e)

--- a/snuba/admin/eap_query_analysis/analysis.py
+++ b/snuba/admin/eap_query_analysis/analysis.py
@@ -1,0 +1,783 @@
+"""EAP Stats: categorize historical EAP traffic from the querylog and aggregate
+resource usage (bytes, duration, and optionally ClickHouse ProfileEvents for
+CPU / memory / IO / network).
+
+Used by the snuba-admin "EAP Stats" page.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from google.protobuf.json_format import Parse
+from google.protobuf.message import Message as ProtobufMessage
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import TraceItemStatsRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableRequest
+
+from snuba.admin.clickhouse.common import get_ro_query_node_connection
+from snuba.admin.clickhouse.querylog import run_querylog_query
+from snuba.clickhouse.native import ClickhousePool
+from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.web.rpc.common.query_info import extract_query_info
+
+logger = logging.getLogger(__name__)
+
+# Hard caps. Defaults stay interactive-sized; operators can raise max_rows up to
+# _MAX_ROWS for whole-dataset analysis. ClickHouse queries for this tool always
+# run with max_threads=0 (use all available cores).
+_MAX_HOURS = 24 * 7
+_DEFAULT_HOURS = 6
+_MAX_ROWS = 500_000
+_DEFAULT_ROWS = 1000
+_MAX_EXAMPLES_PER_TYPE = 5
+# ProfileEvents lookup still batches query ids; keep this large enough for
+# full-dataset runs while avoiding giant IN lists.
+_MAX_PROFILE_QUERY_IDS = 50_000
+# EAP Stats intentionally uses all ClickHouse cores.
+_EAP_STATS_MAX_THREADS = 0
+
+# Querylog rows we treat as EAP. `storage_routing` is the hacky payload written
+# by routing strategies; `eap` is the normal run_query path.
+_EAP_DATASETS = ("eap", "storage_routing")
+
+# Storage used to look up system.query_log ProfileEvents for EAP queries.
+_EAP_PROFILE_STORAGE = "eap_items"
+
+# Map of ClickHouse ProfileEvents keys -> our aggregate resource buckets.
+_PROFILE_EVENT_MAP: dict[str, str] = {
+    # CPU
+    "UserTimeMicroseconds": "cpu_user_us",
+    "SystemTimeMicroseconds": "cpu_system_us",
+    "OSCPUVirtualTimeMicroseconds": "cpu_virtual_us",
+    "RealTimeMicroseconds": "realtime_us",
+    # Memory
+    "MemoryTrackerUsage": "memory_usage_bytes",
+    "MemoryTrackerPeakUsage": "memory_peak_bytes",
+    # IO
+    "SelectedBytes": "io_selected_bytes",
+    "SelectedRows": "io_selected_rows",
+    "ReadCompressedBytes": "io_read_compressed_bytes",
+    "CompressedReadBufferBytes": "io_compressed_read_buffer_bytes",
+    "ReadBufferFromFileDescriptorReadBytes": "io_fd_read_bytes",
+    "WriteBufferFromFileDescriptorWriteBytes": "io_fd_write_bytes",
+    # Network
+    "NetworkReceiveBytes": "network_receive_bytes",
+    "NetworkSendBytes": "network_send_bytes",
+    "NetworkReceiveElapsedMicroseconds": "network_receive_us",
+    "NetworkSendElapsedMicroseconds": "network_send_us",
+}
+
+
+@dataclass
+class EapQueryAnalysisRequest:
+    hours: int = _DEFAULT_HOURS
+    max_rows: int = _DEFAULT_ROWS
+    referrer: str | None = None
+    organization_id: int | None = None
+    referrer_contains: str | None = None
+    # When true, look up ProfileEvents from system.query_log on the EAP cluster
+    # for the sampled query ids (CPU / mem / IO / network).
+    include_profile_events: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> EapQueryAnalysisRequest:
+        if not data:
+            return cls()
+        hours = max(1, min(int(data.get("hours", _DEFAULT_HOURS)), _MAX_HOURS))
+        max_rows = max(1, min(int(data.get("max_rows", _DEFAULT_ROWS)), _MAX_ROWS))
+
+        organization_id = data.get("organization_id")
+        if organization_id is not None and organization_id != "":
+            organization_id = int(organization_id)
+        else:
+            organization_id = None
+
+        include_profile_events = bool(data.get("include_profile_events", True))
+
+        return cls(
+            hours=hours,
+            max_rows=max_rows,
+            referrer=data.get("referrer") or None,
+            organization_id=organization_id,
+            referrer_contains=data.get("referrer_contains") or None,
+            include_profile_events=include_profile_events,
+        )
+
+
+@dataclass
+class ResourceTotals:
+    """Aggregated resource counters.
+
+    Profile-derived fields are 0 when enrichment is off or no ProfileEvents were
+    found for the sampled query ids.
+    """
+
+    # Always available from snuba querylog.
+    bytes_scanned: int = 0
+    duration_ms: int = 0
+    # From ClickHouse ProfileEvents (optional).
+    cpu_user_us: int = 0
+    cpu_system_us: int = 0
+    cpu_virtual_us: int = 0
+    realtime_us: int = 0
+    memory_usage_bytes: int = 0
+    memory_peak_bytes: int = 0
+    io_selected_bytes: int = 0
+    io_selected_rows: int = 0
+    io_read_compressed_bytes: int = 0
+    io_compressed_read_buffer_bytes: int = 0
+    io_fd_read_bytes: int = 0
+    io_fd_write_bytes: int = 0
+    network_receive_bytes: int = 0
+    network_send_bytes: int = 0
+    network_receive_us: int = 0
+    network_send_us: int = 0
+    # How many source CH queries contributed ProfileEvents to these totals.
+    profile_events_matched: int = 0
+
+    def add_profile_events(self, events: dict[str, int]) -> None:
+        matched = False
+        for pe_key, field_name in _PROFILE_EVENT_MAP.items():
+            value = int(events.get(pe_key, 0) or 0)
+            if value:
+                matched = True
+            setattr(self, field_name, getattr(self, field_name) + value)
+        if matched:
+            self.profile_events_matched += 1
+
+    def add_other(self, other: ResourceTotals) -> None:
+        for f in self.__dataclass_fields__:
+            setattr(self, f, getattr(self, f) + getattr(other, f))
+
+    @property
+    def cpu_total_us(self) -> int:
+        return self.cpu_user_us + self.cpu_system_us + self.cpu_virtual_us
+
+    @property
+    def io_total_bytes(self) -> int:
+        return self.io_selected_bytes + self.io_read_compressed_bytes
+
+    @property
+    def network_total_bytes(self) -> int:
+        return self.network_receive_bytes + self.network_send_bytes
+
+
+@dataclass
+class QueryTypeBucket:
+    query_type: str
+    query_count: int = 0
+    queries_profiled: int = 0
+    resources: ResourceTotals = field(default_factory=ResourceTotals)
+    avg_bytes_scanned: float = 0.0
+    avg_duration_ms: float = 0.0
+    pct_of_bytes: float = 0.0
+    pct_of_queries: float = 0.0
+    pct_of_cpu: float = 0.0
+    pct_of_memory_peak: float = 0.0
+    pct_of_io: float = 0.0
+    pct_of_network: float = 0.0
+    # Share of this bucket's own queries / bytes that had ProfileEvents.
+    pct_queries_profiled: float = 0.0
+    pct_bytes_profiled: float = 0.0
+    by_trace_item_type: dict[str, int] = field(default_factory=dict)
+    by_filter_profile: dict[str, int] = field(default_factory=dict)
+    by_referrer: dict[str, int] = field(default_factory=dict)
+    examples: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ProfileCoverage:
+    """How much of the sample is backed by ClickHouse ProfileEvents.
+
+    Use this to judge whether CPU / mem / IO / network aggregates are
+    representative. Bytes-weighted coverage is usually the better signal:
+    if 20% of queries but 80% of bytes are profiled, cost totals are still
+    fairly trustworthy.
+    """
+
+    enabled: bool = False
+    # Request-level (snuba querylog rows).
+    queries_total: int = 0
+    queries_with_query_id: int = 0
+    queries_profiled: int = 0
+    # ClickHouse query_id level.
+    query_ids_sampled: int = 0
+    query_ids_looked_up: int = 0
+    query_ids_matched: int = 0
+    query_ids_capped: bool = False
+    # Cost mass covered by profiled requests.
+    bytes_total: int = 0
+    bytes_profiled: int = 0
+    duration_ms_total: int = 0
+    duration_ms_profiled: int = 0
+    # Percentages (0-100).
+    pct_queries_profiled: float = 0.0
+    pct_queries_with_query_id_profiled: float = 0.0
+    pct_query_ids_matched: float = 0.0
+    pct_bytes_profiled: float = 0.0
+    pct_duration_profiled: float = 0.0
+
+
+@dataclass
+class EapQueryAnalysisResult:
+    hours: int
+    max_rows: int
+    rows_scanned: int
+    rows_categorized: int
+    rows_failed: int
+    profile_events_enabled: bool
+    profile_events_matched: int
+    profile_coverage: ProfileCoverage
+    total_resources: ResourceTotals
+    by_query_type: list[QueryTypeBucket]
+    by_filter_profile: list[dict[str, Any]]
+    by_trace_item_type: list[dict[str, Any]]
+    by_referrer: list[dict[str, Any]]
+
+
+def _schema_table_name() -> str:
+    schema = get_storage(StorageKey.QUERYLOG).get_schema()
+    assert isinstance(schema, TableSchema)
+    return schema.get_table_name()
+
+
+def _escape_literal(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
+    table = _schema_table_name()
+    dataset_list = ", ".join(f"'{d}'" for d in _EAP_DATASETS)
+    where = [
+        f"timestamp > now() - INTERVAL {int(req.hours)} HOUR",
+        f"dataset IN ({dataset_list})",
+    ]
+    if req.referrer:
+        where.append(f"referrer = '{_escape_literal(req.referrer)}'")
+    if req.referrer_contains:
+        where.append(f"referrer LIKE '%{_escape_literal(req.referrer_contains)}%'")
+    if req.organization_id is not None:
+        where.append(f"organization = {int(req.organization_id)}")
+
+    where_sql = " AND ".join(where)
+    return f"""
+        SELECT
+            request_id,
+            timestamp,
+            referrer,
+            dataset,
+            organization,
+            duration_ms,
+            status,
+            request_body,
+            clickhouse_queries.query_id,
+            clickhouse_queries.bytes_scanned,
+            clickhouse_queries.duration_ms,
+            clickhouse_queries.stats
+        FROM {table}
+        WHERE {where_sql}
+        ORDER BY timestamp DESC
+        LIMIT {int(req.max_rows)}
+    """
+
+
+def _infer_request_class(body: dict[str, Any]) -> type[ProtobufMessage] | None:
+    """Pick a protobuf request type from the shape of the stored JSON body."""
+    if "columns" in body or "groupBy" in body or "group_by" in body:
+        return TraceItemTableRequest
+    if (
+        "expressions" in body
+        or "granularitySecs" in body
+        or "granularity_secs" in body
+        or "aggregations" in body
+    ):
+        return TimeSeriesRequest
+    if "statsTypes" in body or "stats_types" in body:
+        return TraceItemStatsRequest
+    for key in ("request", "body"):
+        nested = body.get(key)
+        if isinstance(nested, dict):
+            inferred = _infer_request_class(nested)
+            if inferred is not None:
+                return inferred
+    return None
+
+
+def _parse_request_body(raw_body: str) -> ProtobufMessage | None:
+    if not raw_body:
+        return None
+    try:
+        body = json.loads(raw_body)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(body, dict):
+        return None
+
+    request_class = _infer_request_class(body)
+    if request_class is None:
+        return None
+
+    try:
+        return Parse(
+            json.dumps(body),
+            request_class(),
+            ignore_unknown_fields=True,
+        )
+    except Exception:
+        logger.debug("Failed to parse EAP request body into %s", request_class.__name__)
+        return None
+
+
+def _query_info_from_stats(stats_list: list[Any] | None) -> dict[str, str] | None:
+    """Prefer query_info already embedded in routing stats when present."""
+    if not stats_list:
+        return None
+    for entry in stats_list:
+        if entry is None:
+            continue
+        try:
+            parsed = json.loads(entry) if isinstance(entry, str) else entry
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        query_info = parsed.get("query_info")
+        if isinstance(query_info, dict) and query_info.get("query_type"):
+            return {str(k): str(v) for k, v in query_info.items()}
+    return None
+
+
+def _sum_array(values: list[Any] | None) -> int:
+    if not values:
+        return 0
+    total = 0
+    for v in values:
+        try:
+            total += int(v or 0)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _collect_query_ids(values: list[Any] | None) -> list[str]:
+    if not values:
+        return []
+    ids: list[str] = []
+    for v in values:
+        if v is None:
+            continue
+        s = str(v).strip()
+        if s and s not in ("0" * 32, "00000000-0000-0000-0000-000000000000"):
+            ids.append(s)
+    return ids
+
+
+def _fetch_profile_events(query_ids: list[str], hours: int) -> dict[str, dict[str, int]]:
+    """Batch-fetch ProfileEvents from system.query_log on the EAP cluster.
+
+    Returns mapping of normalized query_id -> {ProfileEventName: value}.
+    Failures are swallowed so the page still works from querylog-only data.
+    """
+    if not query_ids:
+        return {}
+
+    capped = query_ids[:_MAX_PROFILE_QUERY_IDS]
+    normalized = list({qid.replace("-", "") for qid in capped})
+    dashed: list[str] = []
+    for qid in capped:
+        raw = qid.replace("-", "")
+        if len(raw) == 32:
+            dashed.append(f"{raw[0:8]}-{raw[8:12]}-{raw[12:16]}-{raw[16:20]}-{raw[20:32]}")
+    all_ids = list({*normalized, *dashed})
+    id_list = ", ".join(f"'{_escape_literal(qid)}'" for qid in all_ids)
+
+    sql_cluster = f"""
+        SELECT
+            replaceAll(toString(query_id), '-', '') AS qid,
+            ProfileEvents
+        FROM clusterAllReplicas(default, system.query_log)
+        WHERE type = 'QueryFinish'
+          AND event_time > now() - INTERVAL {int(hours)} HOUR
+          AND replaceAll(toString(query_id), '-', '') IN ({id_list})
+        SETTINGS skip_unavailable_shards = 1, max_threads = 0
+    """
+    sql_local = f"""
+        SELECT
+            replaceAll(toString(query_id), '-', '') AS qid,
+            ProfileEvents
+        FROM system.query_log
+        WHERE type = 'QueryFinish'
+          AND event_time > now() - INTERVAL {int(hours)} HOUR
+          AND replaceAll(toString(query_id), '-', '') IN ({id_list})
+        SETTINGS max_threads = 0
+    """
+
+    try:
+        connection: ClickhousePool = get_ro_query_node_connection(
+            _EAP_PROFILE_STORAGE, ClickhouseClientSettings.QUERY
+        )
+        try:
+            result = connection.execute(query=sql_cluster, with_column_types=True)
+        except Exception as e:
+            logger.warning("clusterAllReplicas ProfileEvents lookup failed, trying local: %s", e)
+            result = connection.execute(query=sql_local, with_column_types=True)
+    except Exception as e:
+        logger.warning("ProfileEvents lookup failed: %s", e)
+        return {}
+
+    out: dict[str, dict[str, int]] = {}
+    for row in result.results or []:
+        qid, events = row[0], row[1]
+        if not qid or not isinstance(events, dict):
+            continue
+        key = str(qid).replace("-", "")
+        bucket = out.setdefault(key, {})
+        for pe_name, pe_val in events.items():
+            try:
+                bucket[str(pe_name)] = bucket.get(str(pe_name), 0) + int(pe_val or 0)
+            except (TypeError, ValueError):
+                continue
+    return out
+
+
+def _top_n(counts: dict[str, int], n: int = 8) -> dict[str, int]:
+    return dict(sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:n])
+
+
+@dataclass
+class _Accumulator:
+    query_count: int = 0
+    queries_profiled: int = 0
+    bytes_profiled: int = 0
+    resources: ResourceTotals = field(default_factory=ResourceTotals)
+    by_trace_item_type: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    by_filter_profile: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    by_referrer: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    examples: list[dict[str, Any]] = field(default_factory=list)
+
+    def add(
+        self,
+        *,
+        resources: ResourceTotals,
+        profiled: bool,
+        trace_item_type: str,
+        filter_profile: str,
+        referrer: str,
+        example: dict[str, Any] | None,
+    ) -> None:
+        self.query_count += 1
+        self.resources.add_other(resources)
+        if profiled:
+            self.queries_profiled += 1
+            self.bytes_profiled += resources.bytes_scanned
+        self.by_trace_item_type[trace_item_type] += 1
+        self.by_filter_profile[filter_profile] += 1
+        if referrer:
+            self.by_referrer[referrer] += 1
+        if example is not None and len(self.examples) < _MAX_EXAMPLES_PER_TYPE:
+            self.examples.append(example)
+
+
+def _pct(part: int | float, whole: int | float) -> float:
+    if not whole:
+        return 0.0
+    return 100.0 * float(part) / float(whole)
+
+
+def _finalize_buckets(
+    by_type: dict[str, _Accumulator],
+    totals: ResourceTotals,
+    total_queries: int,
+) -> list[QueryTypeBucket]:
+    buckets: list[QueryTypeBucket] = []
+    for query_type, acc in by_type.items():
+        r = acc.resources
+        buckets.append(
+            QueryTypeBucket(
+                query_type=query_type,
+                query_count=acc.query_count,
+                queries_profiled=acc.queries_profiled,
+                resources=r,
+                avg_bytes_scanned=(r.bytes_scanned / acc.query_count if acc.query_count else 0.0),
+                avg_duration_ms=(r.duration_ms / acc.query_count if acc.query_count else 0.0),
+                pct_of_bytes=_pct(r.bytes_scanned, totals.bytes_scanned),
+                pct_of_queries=_pct(acc.query_count, total_queries),
+                pct_of_cpu=_pct(r.cpu_total_us, totals.cpu_total_us),
+                pct_of_memory_peak=_pct(r.memory_peak_bytes, totals.memory_peak_bytes),
+                pct_of_io=_pct(r.io_total_bytes, totals.io_total_bytes),
+                pct_of_network=_pct(r.network_total_bytes, totals.network_total_bytes),
+                pct_queries_profiled=_pct(acc.queries_profiled, acc.query_count),
+                pct_bytes_profiled=_pct(acc.bytes_profiled, r.bytes_scanned),
+                by_trace_item_type=_top_n(dict(acc.by_trace_item_type)),
+                by_filter_profile=_top_n(dict(acc.by_filter_profile)),
+                by_referrer=_top_n(dict(acc.by_referrer)),
+                examples=acc.examples,
+            )
+        )
+    buckets.sort(key=lambda b: b.resources.bytes_scanned, reverse=True)
+    return buckets
+
+
+def _finalize_dimension(
+    counts_bytes: dict[str, int],
+    counts_queries: dict[str, int],
+    counts_cpu: dict[str, int],
+    total_bytes: int,
+    total_cpu: int,
+) -> list[dict[str, Any]]:
+    keys = set(counts_bytes) | set(counts_queries) | set(counts_cpu)
+    rows: list[dict[str, Any]] = []
+    for key in keys:
+        b = counts_bytes.get(key, 0)
+        c = counts_queries.get(key, 0)
+        cpu = counts_cpu.get(key, 0)
+        rows.append(
+            {
+                "key": key,
+                "query_count": c,
+                "total_bytes_scanned": b,
+                "total_cpu_us": cpu,
+                "pct_of_bytes": _pct(b, total_bytes),
+                "pct_of_cpu": _pct(cpu, total_cpu),
+            }
+        )
+    rows.sort(key=lambda r: int(r["total_bytes_scanned"]), reverse=True)
+    return rows[:20]
+
+
+def analyze_eap_queries(req: EapQueryAnalysisRequest, user: str) -> EapQueryAnalysisResult:
+    """Fetch, categorize, and aggregate EAP querylog rows for the admin page.
+
+    Uses the audited querylog runner for the primary scan. ProfileEvents
+    enrichment is best-effort against the EAP cluster's system.query_log.
+    """
+    sql = _build_fetch_sql(req)
+    # run_querylog_query is @audit_log'd — records the user + SQL.
+    # max_threads=0 lets ClickHouse use all cores for whole-dataset scans.
+    result = run_querylog_query(sql, user, max_threads=_EAP_STATS_MAX_THREADS)
+    raw_rows = result.results or []
+
+    parsed_rows: list[dict[str, Any]] = []
+    all_query_ids: list[str] = []
+
+    for row in raw_rows:
+        (
+            request_id,
+            timestamp,
+            referrer,
+            dataset,
+            organization,
+            duration_ms,
+            status,
+            request_body,
+            query_id_arr,
+            bytes_scanned_arr,
+            ch_duration_arr,
+            stats_arr,
+        ) = row
+
+        bytes_scanned = _sum_array(bytes_scanned_arr)
+        ch_duration = _sum_array(ch_duration_arr)
+        duration = ch_duration or int(duration_ms or 0)
+        referrer_s = str(referrer or "")
+        query_ids = _collect_query_ids(query_id_arr)
+        all_query_ids.extend(query_ids)
+
+        query_info = _query_info_from_stats(stats_arr)
+        categorized = True
+        if query_info is None:
+            message = _parse_request_body(request_body or "")
+            if message is None:
+                categorized = False
+                query_info = {
+                    "query_type": "uncategorized",
+                    "trace_item_type": "unknown",
+                    "filter_profile": "none",
+                    "has_groupby": "false",
+                    "groupby_count": "0",
+                    "has_formula": "false",
+                    "has_cross_item": "false",
+                }
+            else:
+                query_info = extract_query_info(message)
+
+        parsed_rows.append(
+            {
+                "request_id": str(request_id),
+                "timestamp": str(timestamp),
+                "referrer": referrer_s,
+                "dataset": str(dataset or ""),
+                "organization": organization,
+                "status": str(status or ""),
+                "bytes_scanned": bytes_scanned,
+                "duration_ms": duration,
+                "query_ids": query_ids,
+                "query_info": query_info,
+                "categorized": categorized,
+            }
+        )
+
+    profile_by_qid: dict[str, dict[str, int]] = {}
+    unique_ids: list[str] = []
+    query_ids_capped = False
+    if req.include_profile_events and all_query_ids:
+        seen: set[str] = set()
+        for qid in all_query_ids:
+            key = qid.replace("-", "")
+            if key not in seen:
+                seen.add(key)
+                unique_ids.append(qid)
+        query_ids_capped = len(unique_ids) > _MAX_PROFILE_QUERY_IDS
+        profile_by_qid = _fetch_profile_events(unique_ids, req.hours)
+
+    by_type: dict[str, _Accumulator] = defaultdict(_Accumulator)
+    filter_bytes: dict[str, int] = defaultdict(int)
+    filter_counts: dict[str, int] = defaultdict(int)
+    filter_cpu: dict[str, int] = defaultdict(int)
+    item_bytes: dict[str, int] = defaultdict(int)
+    item_counts: dict[str, int] = defaultdict(int)
+    item_cpu: dict[str, int] = defaultdict(int)
+    referrer_bytes: dict[str, int] = defaultdict(int)
+    referrer_counts: dict[str, int] = defaultdict(int)
+    referrer_cpu: dict[str, int] = defaultdict(int)
+
+    totals = ResourceTotals()
+    rows_categorized = 0
+    rows_failed = 0
+    queries_with_query_id = 0
+    queries_profiled = 0
+    bytes_profiled = 0
+    duration_ms_profiled = 0
+
+    for prow in parsed_rows:
+        resources = ResourceTotals(
+            bytes_scanned=int(prow["bytes_scanned"]),
+            duration_ms=int(prow["duration_ms"]),
+        )
+        request_profiled = False
+        if prow["query_ids"]:
+            queries_with_query_id += 1
+        for qid in prow["query_ids"]:
+            events = profile_by_qid.get(str(qid).replace("-", ""))
+            if events:
+                resources.add_profile_events(events)
+                request_profiled = True
+
+        if request_profiled:
+            queries_profiled += 1
+            bytes_profiled += resources.bytes_scanned
+            duration_ms_profiled += resources.duration_ms
+
+        totals.add_other(resources)
+
+        query_info = prow["query_info"]
+        query_type = query_info.get("query_type", "uncategorized")
+        trace_item_type = query_info.get("trace_item_type", "unknown")
+        filter_profile = query_info.get("filter_profile", "none")
+        referrer_s = prow["referrer"]
+
+        if prow["categorized"]:
+            rows_categorized += 1
+        else:
+            rows_failed += 1
+
+        cpu = resources.cpu_total_us
+
+        example = {
+            "request_id": prow["request_id"],
+            "timestamp": prow["timestamp"],
+            "referrer": referrer_s,
+            "dataset": prow["dataset"],
+            "organization": prow["organization"],
+            "bytes_scanned": resources.bytes_scanned,
+            "duration_ms": resources.duration_ms,
+            "cpu_us": cpu,
+            "memory_peak_bytes": resources.memory_peak_bytes,
+            "io_selected_bytes": resources.io_selected_bytes,
+            "network_receive_bytes": resources.network_receive_bytes,
+            "profiled": request_profiled,
+            "status": prow["status"],
+            "query_info": query_info,
+        }
+
+        by_type[query_type].add(
+            resources=resources,
+            profiled=request_profiled,
+            trace_item_type=trace_item_type,
+            filter_profile=filter_profile,
+            referrer=referrer_s,
+            example=example,
+        )
+
+        filter_bytes[filter_profile] += resources.bytes_scanned
+        filter_counts[filter_profile] += 1
+        filter_cpu[filter_profile] += cpu
+        item_bytes[trace_item_type] += resources.bytes_scanned
+        item_counts[trace_item_type] += 1
+        item_cpu[trace_item_type] += cpu
+        if referrer_s:
+            referrer_bytes[referrer_s] += resources.bytes_scanned
+            referrer_counts[referrer_s] += 1
+            referrer_cpu[referrer_s] += cpu
+
+    total_queries = len(parsed_rows)
+    total_cpu = totals.cpu_total_us
+    query_ids_sampled = len({qid.replace("-", "") for qid in all_query_ids})
+    query_ids_looked_up = (
+        min(query_ids_sampled, _MAX_PROFILE_QUERY_IDS) if req.include_profile_events else 0
+    )
+    query_ids_matched = len(profile_by_qid)
+
+    coverage = ProfileCoverage(
+        enabled=req.include_profile_events,
+        queries_total=total_queries,
+        queries_with_query_id=queries_with_query_id,
+        queries_profiled=queries_profiled,
+        query_ids_sampled=query_ids_sampled,
+        query_ids_looked_up=query_ids_looked_up,
+        query_ids_matched=query_ids_matched,
+        query_ids_capped=query_ids_capped,
+        bytes_total=totals.bytes_scanned,
+        bytes_profiled=bytes_profiled,
+        duration_ms_total=totals.duration_ms,
+        duration_ms_profiled=duration_ms_profiled,
+        pct_queries_profiled=_pct(queries_profiled, total_queries),
+        pct_queries_with_query_id_profiled=_pct(queries_profiled, queries_with_query_id),
+        pct_query_ids_matched=_pct(query_ids_matched, query_ids_looked_up),
+        pct_bytes_profiled=_pct(bytes_profiled, totals.bytes_scanned),
+        pct_duration_profiled=_pct(duration_ms_profiled, totals.duration_ms),
+    )
+
+    return EapQueryAnalysisResult(
+        hours=req.hours,
+        max_rows=req.max_rows,
+        rows_scanned=total_queries,
+        rows_categorized=rows_categorized,
+        rows_failed=rows_failed,
+        profile_events_enabled=req.include_profile_events,
+        profile_events_matched=totals.profile_events_matched,
+        profile_coverage=coverage,
+        total_resources=totals,
+        by_query_type=_finalize_buckets(by_type, totals, total_queries),
+        by_filter_profile=_finalize_dimension(
+            filter_bytes, filter_counts, filter_cpu, totals.bytes_scanned, total_cpu
+        ),
+        by_trace_item_type=_finalize_dimension(
+            item_bytes, item_counts, item_cpu, totals.bytes_scanned, total_cpu
+        ),
+        by_referrer=_finalize_dimension(
+            referrer_bytes, referrer_counts, referrer_cpu, totals.bytes_scanned, total_cpu
+        ),
+    )
+
+
+def result_to_dict(result: EapQueryAnalysisResult) -> dict[str, Any]:
+    return asdict(result)

--- a/snuba/admin/eap_query_analysis/analysis.py
+++ b/snuba/admin/eap_query_analysis/analysis.py
@@ -148,7 +148,7 @@ class ResourceTotals:
     def add_profile_events(self, events: dict[str, int]) -> None:
         matched = False
         for pe_key, field_name in _PROFILE_EVENT_MAP.items():
-            value = int(events.get(pe_key, 0) or 0)
+            value = int(events.get(pe_key) or 0)
             if value:
                 matched = True
             setattr(self, field_name, getattr(self, field_name) + value)

--- a/snuba/admin/eap_query_analysis/analysis.py
+++ b/snuba/admin/eap_query_analysis/analysis.py
@@ -44,9 +44,11 @@ _MAX_PROFILE_QUERY_IDS = 50_000
 # EAP Stats intentionally uses all ClickHouse cores.
 _EAP_STATS_MAX_THREADS = 0
 
-# Querylog rows we treat as EAP. `storage_routing` is the hacky payload written
-# by routing strategies; `eap` is the normal run_query path.
-_EAP_DATASETS = ("eap", "storage_routing")
+# Prefer the normal run_query path (`dataset = eap`). Storage-routed requests
+# also write a duplicate `storage_routing` row for the same request; counting
+# both roughly doubles bytes/duration/query totals. Estimation queries against
+# the outcomes table also land as `eap` and are filtered out below.
+_EAP_DATASETS = ("eap",)
 
 # Storage used to look up system.query_log ProfileEvents for EAP queries.
 _EAP_PROFILE_STORAGE = "eap_items"
@@ -159,7 +161,12 @@ class ResourceTotals:
 
     @property
     def cpu_total_us(self) -> int:
-        return self.cpu_user_us + self.cpu_system_us + self.cpu_virtual_us
+        # Prefer OSCPUVirtualTimeMicroseconds when present: it already accounts
+        # for threaded user/system work. Falling back to user+system avoids
+        # double-counting when both families are populated.
+        if self.cpu_virtual_us:
+            return self.cpu_virtual_us
+        return self.cpu_user_us + self.cpu_system_us
 
     @property
     def io_total_bytes(self) -> int:
@@ -250,7 +257,17 @@ def _schema_table_name() -> str:
 
 
 def _escape_literal(value: str) -> str:
+    """Escape a string for safe inclusion in a single-quoted SQL literal."""
     return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _escape_like_literal(value: str) -> str:
+    """Escape a string for use inside a SQL LIKE pattern.
+
+    Handles quote/backslash escaping plus LIKE wildcards so user input is
+    matched literally (e.g. ``eap_items`` does not match ``eapXitems``).
+    """
+    return _escape_literal(value).replace("%", "\\%").replace("_", "\\_")
 
 
 def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
@@ -263,9 +280,17 @@ def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
     if req.referrer:
         where.append(f"referrer = '{_escape_literal(req.referrer)}'")
     if req.referrer_contains:
-        where.append(f"referrer LIKE '%{_escape_literal(req.referrer_contains)}%'")
+        where.append(f"referrer LIKE '%{_escape_like_literal(req.referrer_contains)}%' ESCAPE '\\'")
     if req.organization_id is not None:
         where.append(f"organization = {int(req.organization_id)}")
+
+    # Drop routing estimation queries. They share dataset=eap and the customer
+    # referrer, but hit the outcomes tables purely to pick a sampling tier.
+    where.append(
+        "NOT arrayExists("
+        "t -> positionCaseInsensitive(t, 'outcomes') > 0, "
+        "clickhouse_queries.clickhouse_table)"
+    )
 
     where_sql = " AND ".join(where)
     return f"""

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -23,6 +23,7 @@ import {
 } from "SnubaAdmin/snql_to_sql/types";
 
 import { QuerylogRequest, QuerylogResult } from "SnubaAdmin/querylog/types";
+import { EapStatsRequest, EapStatsResult } from "SnubaAdmin/eap_stats/types";
 import {
   CardinalityQueryRequest,
   CardinalityQueryResult,
@@ -52,6 +53,7 @@ interface Client {
   getPredefinedQuerylogOptions: () => Promise<[PredefinedQuery]>;
   getQuerylogSchema: () => Promise<QuerylogResult>;
   executeQuerylogQuery: (req: QuerylogRequest) => Promise<QuerylogResult>;
+  runEapStats: (req: EapStatsRequest) => Promise<EapStatsResult>;
   getPredefinedCardinalityQueryOptions: () => Promise<[PredefinedQuery]>;
   executeCardinalityQuery: (
     req: CardinalityQueryRequest,
@@ -274,6 +276,20 @@ function Client(): Client {
         headers: { "Content-Type": "application/json" },
         method: "POST",
         body: JSON.stringify(query),
+      }).then((resp) => {
+        if (resp.ok) {
+          return resp.json();
+        } else {
+          return resp.json().then(Promise.reject.bind(Promise));
+        }
+      });
+    },
+    runEapStats: (req: EapStatsRequest) => {
+      const url = baseUrl + "eap_stats";
+      return fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+        body: JSON.stringify(req),
       }).then((resp) => {
         if (resp.ok) {
           return resp.json();

--- a/snuba/admin/static/data.tsx
+++ b/snuba/admin/static/data.tsx
@@ -13,6 +13,7 @@ import SnubaExplain from "SnubaAdmin/snuba_explain";
 import Welcome from "SnubaAdmin/welcome";
 import ViewCustomJobs from "SnubaAdmin/manual_jobs";
 import RpcEndpoints from "SnubaAdmin/rpc_endpoints";
+import EapStats from "SnubaAdmin/eap_stats";
 
 const NAV_ITEMS = [
   { id: "overview", display: "🤿 Snuba Admin", component: Welcome },
@@ -75,6 +76,11 @@ const NAV_ITEMS = [
     id: "querylog",
     display: "🔍 ClickHouse Querylog",
     component: QuerylogQueries,
+  },
+  {
+    id: "eap-stats",
+    display: "📊 EAP Stats",
+    component: EapStats,
   },
   {
     id: "cardinality-analyzer",

--- a/snuba/admin/static/eap_stats/index.tsx
+++ b/snuba/admin/static/eap_stats/index.tsx
@@ -64,6 +64,15 @@ function formatPct(n: number): string {
   return `${n.toFixed(1)}%`;
 }
 
+// Prefer virtual CPU time when present; it already covers threaded work.
+function cpuTotalUs(r: {
+  cpu_user_us: number;
+  cpu_system_us: number;
+  cpu_virtual_us: number;
+}): number {
+  return r.cpu_virtual_us || r.cpu_user_us + r.cpu_system_us;
+}
+
 function ResourceCard({
   label,
   value,
@@ -193,8 +202,7 @@ function TotalsPanel({
   result: EapStatsResult;
 }) {
   const r = result.total_resources;
-  // Prefer virtual CPU time when present; it already covers threaded work.
-  const cpu = r.cpu_virtual_us || r.cpu_user_us + r.cpu_system_us;
+  const cpu = cpuTotalUs(r);
   const io = r.io_selected_bytes + r.io_read_compressed_bytes;
   const net = r.network_receive_bytes + r.network_send_bytes;
   const coverage = result.profile_coverage;
@@ -306,7 +314,7 @@ function QueryTypeTable({ buckets }: { buckets: QueryTypeBucket[] }) {
     <Accordion variant="separated" chevronPosition="left">
       {buckets.map((b) => {
         const r = b.resources;
-        const cpu = r.cpu_user_us + r.cpu_system_us + r.cpu_virtual_us;
+        const cpu = cpuTotalUs(r);
         const io = r.io_selected_bytes + r.io_read_compressed_bytes;
         const net = r.network_receive_bytes + r.network_send_bytes;
         return (

--- a/snuba/admin/static/eap_stats/index.tsx
+++ b/snuba/admin/static/eap_stats/index.tsx
@@ -1,0 +1,629 @@
+import React, { useState } from "react";
+import {
+  Accordion,
+  Badge,
+  Checkbox,
+  Code,
+  Group,
+  NumberInput,
+  SimpleGrid,
+  Space,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Title,
+  Paper,
+  Progress,
+  Tooltip,
+} from "@mantine/core";
+import Client from "SnubaAdmin/api_client";
+import ExecuteButton from "SnubaAdmin/utils/execute_button";
+import {
+  DimensionRow,
+  EapStatsRequest,
+  EapStatsResult,
+  ProfileCoverage,
+  QueryTypeBucket,
+} from "SnubaAdmin/eap_stats/types";
+
+function formatBytes(n: number): string {
+  if (!n || n <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+  let v = n;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatDurationMs(ms: number): string {
+  if (!ms || ms <= 0) return "0 ms";
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} s`;
+  return `${(ms / 60_000).toFixed(1)} min`;
+}
+
+function formatCpuUs(us: number): string {
+  if (!us || us <= 0) return "0";
+  if (us < 1000) return `${Math.round(us)} µs`;
+  if (us < 1_000_000) return `${(us / 1000).toFixed(1)} ms`;
+  return `${(us / 1_000_000).toFixed(2)} s`;
+}
+
+function formatCount(n: number): string {
+  if (n == null) return "0";
+  return n.toLocaleString();
+}
+
+function formatPct(n: number): string {
+  if (!n) return "0%";
+  if (n < 0.1) return "<0.1%";
+  return `${n.toFixed(1)}%`;
+}
+
+function ResourceCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <Paper withBorder p="md" radius="md">
+      <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+        {label}
+      </Text>
+      <Text size="xl" fw={700}>
+        {value}
+      </Text>
+      {sub ? (
+        <Text size="xs" c="dimmed">
+          {sub}
+        </Text>
+      ) : null}
+    </Paper>
+  );
+}
+
+function coverageColor(pct: number): string {
+  if (pct >= 80) return "teal";
+  if (pct >= 50) return "yellow";
+  if (pct > 0) return "orange";
+  return "red";
+}
+
+function ProfileCoveragePanel({ coverage }: { coverage: ProfileCoverage }) {
+  if (!coverage?.enabled) {
+    return (
+      <Paper withBorder p="md" radius="md">
+        <Title order={4}>Profile coverage</Title>
+        <Text c="dimmed" size="sm">
+          ProfileEvents enrichment is off. CPU / memory / IO / network totals are unavailable.
+        </Text>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper withBorder p="md" radius="md">
+      <Group position="apart" mb="sm">
+        <div>
+          <Title order={4}>Profile coverage</Title>
+          <Text size="sm" c="dimmed">
+            Share of this sample backed by ClickHouse ProfileEvents. Prefer
+            bytes-weighted coverage when judging whether CPU/mem/IO/network
+            aggregates are representative.
+          </Text>
+        </div>
+        {coverage.query_ids_capped ? (
+          <Badge color="orange">query_id lookup capped</Badge>
+        ) : null}
+      </Group>
+      <SimpleGrid
+        cols={3}
+        breakpoints={[
+          { maxWidth: "md", cols: 2 },
+          { maxWidth: "sm", cols: 1 },
+        ]}
+      >
+        <ResourceCard
+          label="% queries profiled"
+          value={formatPct(coverage.pct_queries_profiled)}
+          sub={`${formatCount(coverage.queries_profiled)} / ${formatCount(
+            coverage.queries_total
+          )} requests`}
+        />
+        <ResourceCard
+          label="% bytes profiled"
+          value={formatPct(coverage.pct_bytes_profiled)}
+          sub={`${formatBytes(coverage.bytes_profiled)} / ${formatBytes(
+            coverage.bytes_total
+          )}`}
+        />
+        <ResourceCard
+          label="% duration profiled"
+          value={formatPct(coverage.pct_duration_profiled)}
+          sub={`${formatDurationMs(coverage.duration_ms_profiled)} / ${formatDurationMs(
+            coverage.duration_ms_total
+          )}`}
+        />
+        <ResourceCard
+          label="% query_ids matched"
+          value={formatPct(coverage.pct_query_ids_matched)}
+          sub={`${formatCount(coverage.query_ids_matched)} / ${formatCount(
+            coverage.query_ids_looked_up
+          )} looked up`}
+        />
+        <ResourceCard
+          label="Requests with query_id"
+          value={formatCount(coverage.queries_with_query_id)}
+          sub={`${formatPct(coverage.pct_queries_with_query_id_profiled)} of those profiled`}
+        />
+        <ResourceCard
+          label="Unique query_ids sampled"
+          value={formatCount(coverage.query_ids_sampled)}
+          sub={
+            coverage.query_ids_capped
+              ? `lookup capped at ${formatCount(coverage.query_ids_looked_up)}`
+              : "all unique ids looked up"
+          }
+        />
+      </SimpleGrid>
+      <Space h="sm" />
+      <Text size="xs" c="dimmed" mb={4}>
+        Bytes-weighted coverage
+      </Text>
+      <Progress
+        value={Math.min(100, coverage.pct_bytes_profiled || 0)}
+        size="lg"
+        color={coverageColor(coverage.pct_bytes_profiled || 0)}
+      />
+    </Paper>
+  );
+}
+
+function TotalsPanel({
+  result,
+}: {
+  result: EapStatsResult;
+}) {
+  const r = result.total_resources;
+  const cpu = r.cpu_user_us + r.cpu_system_us + r.cpu_virtual_us;
+  const io = r.io_selected_bytes + r.io_read_compressed_bytes;
+  const net = r.network_receive_bytes + r.network_send_bytes;
+  const coverage = result.profile_coverage;
+
+  return (
+    <Stack spacing="sm">
+      <Group spacing="xs">
+        <Title order={3}>Sample summary</Title>
+        <Badge color="blue">{formatCount(result.rows_scanned)} rows</Badge>
+        <Badge color="green">{formatCount(result.rows_categorized)} categorized</Badge>
+        {result.rows_failed > 0 ? (
+          <Badge color="yellow">{formatCount(result.rows_failed)} uncategorized</Badge>
+        ) : null}
+        {coverage?.enabled ? (
+          <Badge color={coverageColor(coverage.pct_bytes_profiled || 0)}>
+            {formatPct(coverage.pct_bytes_profiled)} bytes profiled
+          </Badge>
+        ) : (
+          <Badge color="gray">ProfileEvents off</Badge>
+        )}
+      </Group>
+      <ProfileCoveragePanel coverage={coverage} />
+      <SimpleGrid
+        cols={4}
+        breakpoints={[
+          { maxWidth: "md", cols: 2 },
+          { maxWidth: "sm", cols: 1 },
+        ]}
+      >
+        <ResourceCard
+          label="Bytes scanned"
+          value={formatBytes(r.bytes_scanned)}
+          sub={`avg ${formatBytes(
+            result.rows_scanned ? r.bytes_scanned / result.rows_scanned : 0
+          )} / query`}
+        />
+        <ResourceCard
+          label="Duration"
+          value={formatDurationMs(r.duration_ms)}
+          sub={`avg ${formatDurationMs(
+            result.rows_scanned ? r.duration_ms / result.rows_scanned : 0
+          )} / query`}
+        />
+        <ResourceCard
+          label="CPU (ProfileEvents)"
+          value={formatCpuUs(cpu)}
+          sub={`user ${formatCpuUs(r.cpu_user_us)} · sys ${formatCpuUs(
+            r.cpu_system_us
+          )}`}
+        />
+        <ResourceCard
+          label="Memory peak"
+          value={formatBytes(r.memory_peak_bytes)}
+          sub={`usage sum ${formatBytes(r.memory_usage_bytes)}`}
+        />
+        <ResourceCard
+          label="IO"
+          value={formatBytes(io)}
+          sub={`selected ${formatBytes(r.io_selected_bytes)} · compressed ${formatBytes(
+            r.io_read_compressed_bytes
+          )}`}
+        />
+        <ResourceCard
+          label="Network"
+          value={formatBytes(net)}
+          sub={`rx ${formatBytes(r.network_receive_bytes)} · tx ${formatBytes(
+            r.network_send_bytes
+          )}`}
+        />
+        <ResourceCard
+          label="Rows selected"
+          value={formatCount(r.io_selected_rows)}
+        />
+        <ResourceCard
+          label="Realtime (CH)"
+          value={formatCpuUs(r.realtime_us)}
+        />
+      </SimpleGrid>
+    </Stack>
+  );
+}
+
+function PctBar({ value, color }: { value: number; color?: string }) {
+  return (
+    <Tooltip label={formatPct(value)}>
+      <Progress value={Math.min(100, value)} size="sm" color={color || "blue"} />
+    </Tooltip>
+  );
+}
+
+function BreakdownMap({ data }: { data: Record<string, number> }) {
+  const entries = Object.entries(data || {});
+  if (!entries.length) return <Text c="dimmed">—</Text>;
+  return (
+    <Text size="sm">
+      {entries
+        .map(([k, v]) => `${k}: ${v.toLocaleString()}`)
+        .join(" · ")}
+    </Text>
+  );
+}
+
+function QueryTypeTable({ buckets }: { buckets: QueryTypeBucket[] }) {
+  if (!buckets.length) {
+    return <Text c="dimmed">No categorized rows in this sample.</Text>;
+  }
+
+  return (
+    <Accordion variant="separated" chevronPosition="left">
+      {buckets.map((b) => {
+        const r = b.resources;
+        const cpu = r.cpu_user_us + r.cpu_system_us + r.cpu_virtual_us;
+        const io = r.io_selected_bytes + r.io_read_compressed_bytes;
+        const net = r.network_receive_bytes + r.network_send_bytes;
+        return (
+          <Accordion.Item value={b.query_type} key={b.query_type}>
+            <Accordion.Control>
+              <Group position="apart" noWrap style={{ width: "100%", paddingRight: 12 }}>
+                <div style={{ minWidth: 180 }}>
+                  <Text fw={700}>{b.query_type}</Text>
+                  <Text size="xs" c="dimmed">
+                    {formatCount(b.query_count)} queries · {formatPct(b.pct_of_queries)} of sample
+                  </Text>
+                </div>
+                <div style={{ flex: 1, maxWidth: 220 }}>
+                  <Text size="xs" c="dimmed">
+                    Bytes {formatPct(b.pct_of_bytes)}
+                  </Text>
+                  <PctBar value={b.pct_of_bytes} color="blue" />
+                </div>
+                <div style={{ flex: 1, maxWidth: 220 }}>
+                  <Text size="xs" c="dimmed">
+                    CPU {formatPct(b.pct_of_cpu)}
+                  </Text>
+                  <PctBar value={b.pct_of_cpu} color="violet" />
+                </div>
+                <div style={{ minWidth: 180, textAlign: "right" }}>
+                  <Text size="sm" fw={600}>
+                    {formatBytes(r.bytes_scanned)}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {formatCpuUs(cpu)} CPU · {formatBytes(r.memory_peak_bytes)} peak mem
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    profiled {formatPct(b.pct_bytes_profiled)} bytes · {formatPct(b.pct_queries_profiled)} queries
+                  </Text>
+                </div>
+              </Group>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <SimpleGrid cols={4} breakpoints={[{ maxWidth: "md", cols: 2 }]}>
+                <ResourceCard label="Bytes scanned" value={formatBytes(r.bytes_scanned)} sub={`avg ${formatBytes(b.avg_bytes_scanned)}`} />
+                <ResourceCard label="Duration" value={formatDurationMs(r.duration_ms)} sub={`avg ${formatDurationMs(b.avg_duration_ms)}`} />
+                <ResourceCard label="CPU" value={formatCpuUs(cpu)} sub={`${formatPct(b.pct_of_cpu)} of total`} />
+                <ResourceCard label="Memory peak" value={formatBytes(r.memory_peak_bytes)} sub={`${formatPct(b.pct_of_memory_peak)} of total`} />
+                <ResourceCard label="IO" value={formatBytes(io)} sub={`${formatPct(b.pct_of_io)} of total`} />
+                <ResourceCard label="Network" value={formatBytes(net)} sub={`${formatPct(b.pct_of_network)} of total`} />
+                <ResourceCard label="Selected rows" value={formatCount(r.io_selected_rows)} />
+                <ResourceCard label="ProfileEvents matched" value={formatCount(r.profile_events_matched)} />
+              </SimpleGrid>
+              <Space h="md" />
+              <Title order={5}>Breakdowns</Title>
+              <Table striped fontSize="sm" withBorder>
+                <tbody>
+                  <tr>
+                    <td style={{ width: 160 }}>
+                      <Text fw={600}>Trace item type</Text>
+                    </td>
+                    <td>
+                      <BreakdownMap data={b.by_trace_item_type} />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <Text fw={600}>Filter profile</Text>
+                    </td>
+                    <td>
+                      <BreakdownMap data={b.by_filter_profile} />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <Text fw={600}>Top referrers</Text>
+                    </td>
+                    <td>
+                      <BreakdownMap data={b.by_referrer} />
+                    </td>
+                  </tr>
+                </tbody>
+              </Table>
+              {b.examples?.length ? (
+                <>
+                  <Space h="md" />
+                  <Title order={5}>Example queries</Title>
+                  <Table striped fontSize="xs" withBorder>
+                    <thead>
+                      <tr>
+                        <th>Time</th>
+                        <th>Referrer</th>
+                        <th>Org</th>
+                        <th>Bytes</th>
+                        <th>Duration</th>
+                        <th>CPU</th>
+                        <th>Mem peak</th>
+                        <th>Filter</th>
+                        <th>Request ID</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {b.examples.map((ex, idx) => (
+                        <tr key={idx}>
+                          <td>{ex.timestamp}</td>
+                          <td>
+                            <Code>{ex.referrer || "—"}</Code>
+                          </td>
+                          <td>{ex.organization ?? "—"}</td>
+                          <td>{formatBytes(ex.bytes_scanned || 0)}</td>
+                          <td>{formatDurationMs(ex.duration_ms || 0)}</td>
+                          <td>{formatCpuUs(ex.cpu_us || 0)}</td>
+                          <td>{formatBytes(ex.memory_peak_bytes || 0)}</td>
+                          <td>
+                            <Code>{ex.query_info?.filter_profile || "—"}</Code>
+                          </td>
+                          <td>
+                            <Code>{ex.request_id}</Code>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </>
+              ) : null}
+            </Accordion.Panel>
+          </Accordion.Item>
+        );
+      })}
+    </Accordion>
+  );
+}
+
+function DimensionTable({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: DimensionRow[];
+}) {
+  return (
+    <Stack spacing="xs">
+      <Title order={4}>{title}</Title>
+      {!rows.length ? (
+        <Text c="dimmed">No data</Text>
+      ) : (
+        <Table striped withBorder fontSize="sm">
+          <thead>
+            <tr>
+              <th>{title}</th>
+              <th>Queries</th>
+              <th>Bytes scanned</th>
+              <th>% bytes</th>
+              <th>CPU</th>
+              <th>% CPU</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.key}>
+                <td>
+                  <Code>{row.key}</Code>
+                </td>
+                <td>{formatCount(row.query_count)}</td>
+                <td>{formatBytes(row.total_bytes_scanned)}</td>
+                <td style={{ minWidth: 120 }}>
+                  <Text size="xs">{formatPct(row.pct_of_bytes)}</Text>
+                  <PctBar value={row.pct_of_bytes} />
+                </td>
+                <td>{formatCpuUs(row.total_cpu_us)}</td>
+                <td style={{ minWidth: 120 }}>
+                  <Text size="xs">{formatPct(row.pct_of_cpu)}</Text>
+                  <PctBar value={row.pct_of_cpu} color="violet" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+    </Stack>
+  );
+}
+
+function EapStats(props: { api: Client }) {
+  const [hours, setHours] = useState<number | "">(6);
+  const [maxRows, setMaxRows] = useState<number | "">(1000);
+  const [referrer, setReferrer] = useState("");
+  const [referrerContains, setReferrerContains] = useState("");
+  const [organizationId, setOrganizationId] = useState<number | "">("");
+  const [includeProfileEvents, setIncludeProfileEvents] = useState(true);
+  const [result, setResult] = useState<EapStatsResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function execute() {
+    setError(null);
+    const body: EapStatsRequest = {
+      hours: typeof hours === "number" ? hours : 6,
+      max_rows: typeof maxRows === "number" ? maxRows : 1000,
+      include_profile_events: includeProfileEvents,
+    };
+    if (referrer.trim()) body.referrer = referrer.trim();
+    if (referrerContains.trim()) body.referrer_contains = referrerContains.trim();
+    if (organizationId !== "" && organizationId != null) {
+      body.organization_id = organizationId;
+    }
+    return props.api
+      .runEapStats(body)
+      .then((res) => {
+        setResult(res);
+      })
+      .catch((err) => {
+        const message =
+          err?.error?.message || err?.message || JSON.stringify(err) || "Request failed";
+        setError(String(message));
+        setResult(null);
+      });
+  }
+
+  return (
+    <div style={{ padding: 8, maxWidth: 1400 }}>
+      <Title order={2}>EAP Stats</Title>
+      <Text c="dimmed" maw={900}>
+        Sample recent EAP rows from the Snuba querylog, categorize each request by
+        query shape, and aggregate resource cost (bytes scanned, duration, and
+        ClickHouse ProfileEvents for CPU / memory / IO / network). Queries run with
+        max_threads=0 so whole-dataset scans can use all ClickHouse cores. Check
+        profile coverage % before trusting CPU/mem/IO/network totals.
+      </Text>
+      <Space h="md" />
+
+      <Paper withBorder p="md" radius="md">
+        <SimpleGrid
+          cols={3}
+          breakpoints={[
+            { maxWidth: "md", cols: 2 },
+            { maxWidth: "sm", cols: 1 },
+          ]}
+        >
+          <NumberInput
+            label="Lookback hours"
+            description="Max 168 (7 days)"
+            min={1}
+            max={168}
+            value={hours}
+            onChange={setHours}
+          />
+          <NumberInput
+            label="Max rows"
+            description="Sample size (max 500000). Uses max_threads=0."
+            min={1}
+            max={500000}
+            step={1000}
+            value={maxRows}
+            onChange={setMaxRows}
+          />
+          <NumberInput
+            label="Organization ID"
+            description="Optional filter"
+            value={organizationId}
+            onChange={setOrganizationId}
+            min={1}
+          />
+          <TextInput
+            label="Referrer equals"
+            description="Exact match"
+            value={referrer}
+            onChange={(e) => setReferrer(e.currentTarget.value)}
+            placeholder="api.organization_events"
+          />
+          <TextInput
+            label="Referrer contains"
+            description="Substring match"
+            value={referrerContains}
+            onChange={(e) => setReferrerContains(e.currentTarget.value)}
+            placeholder="eap"
+          />
+          <div style={{ display: "flex", alignItems: "end", paddingBottom: 4 }}>
+            <Checkbox
+              label="Enrich with ClickHouse ProfileEvents (CPU / mem / IO / network)"
+              checked={includeProfileEvents}
+              onChange={(e) => setIncludeProfileEvents(e.currentTarget.checked)}
+            />
+          </div>
+        </SimpleGrid>
+        <Space h="md" />
+        <Group>
+          <ExecuteButton onClick={execute} />
+        </Group>
+      </Paper>
+
+      {error ? (
+        <>
+          <Space h="md" />
+          <Paper withBorder p="md" style={{ borderColor: "#fa5252" }}>
+            <Text c="red" fw={600}>
+              Error
+            </Text>
+            <Code block>{error}</Code>
+          </Paper>
+        </>
+      ) : null}
+
+      {result ? (
+        <>
+          <Space h="lg" />
+          <TotalsPanel result={result} />
+          <Space h="lg" />
+          <Title order={3}>By query type</Title>
+          <Text size="sm" c="dimmed" mb="sm">
+            Expand a row for full resource breakdown, filter/item-type mix, and
+            example request ids.
+          </Text>
+          <QueryTypeTable buckets={result.by_query_type} />
+          <Space h="lg" />
+          <SimpleGrid cols={1}>
+            <DimensionTable title="Filter profile" rows={result.by_filter_profile} />
+            <DimensionTable title="Trace item type" rows={result.by_trace_item_type} />
+            <DimensionTable title="Referrer" rows={result.by_referrer} />
+          </SimpleGrid>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+export default EapStats;

--- a/snuba/admin/static/eap_stats/index.tsx
+++ b/snuba/admin/static/eap_stats/index.tsx
@@ -193,7 +193,8 @@ function TotalsPanel({
   result: EapStatsResult;
 }) {
   const r = result.total_resources;
-  const cpu = r.cpu_user_us + r.cpu_system_us + r.cpu_virtual_us;
+  // Prefer virtual CPU time when present; it already covers threaded work.
+  const cpu = r.cpu_virtual_us || r.cpu_user_us + r.cpu_system_us;
   const io = r.io_selected_bytes + r.io_read_compressed_bytes;
   const net = r.network_receive_bytes + r.network_send_bytes;
   const coverage = result.profile_coverage;
@@ -587,7 +588,7 @@ function EapStats(props: { api: Client }) {
         </SimpleGrid>
         <Space h="md" />
         <Group>
-          <ExecuteButton onClick={execute} />
+          <ExecuteButton onClick={execute} disabled={false} />
         </Group>
       </Paper>
 

--- a/snuba/admin/static/eap_stats/types.tsx
+++ b/snuba/admin/static/eap_stats/types.tsx
@@ -1,0 +1,105 @@
+type ResourceTotals = {
+  bytes_scanned: number;
+  duration_ms: number;
+  cpu_user_us: number;
+  cpu_system_us: number;
+  cpu_virtual_us: number;
+  realtime_us: number;
+  memory_usage_bytes: number;
+  memory_peak_bytes: number;
+  io_selected_bytes: number;
+  io_selected_rows: number;
+  io_read_compressed_bytes: number;
+  io_compressed_read_buffer_bytes: number;
+  io_fd_read_bytes: number;
+  io_fd_write_bytes: number;
+  network_receive_bytes: number;
+  network_send_bytes: number;
+  network_receive_us: number;
+  network_send_us: number;
+  profile_events_matched: number;
+};
+
+type ProfileCoverage = {
+  enabled: boolean;
+  queries_total: number;
+  queries_with_query_id: number;
+  queries_profiled: number;
+  query_ids_sampled: number;
+  query_ids_looked_up: number;
+  query_ids_matched: number;
+  query_ids_capped: boolean;
+  bytes_total: number;
+  bytes_profiled: number;
+  duration_ms_total: number;
+  duration_ms_profiled: number;
+  pct_queries_profiled: number;
+  pct_queries_with_query_id_profiled: number;
+  pct_query_ids_matched: number;
+  pct_bytes_profiled: number;
+  pct_duration_profiled: number;
+};
+
+type QueryTypeBucket = {
+  query_type: string;
+  query_count: number;
+  queries_profiled: number;
+  resources: ResourceTotals;
+  avg_bytes_scanned: number;
+  avg_duration_ms: number;
+  pct_of_bytes: number;
+  pct_of_queries: number;
+  pct_of_cpu: number;
+  pct_of_memory_peak: number;
+  pct_of_io: number;
+  pct_of_network: number;
+  pct_queries_profiled: number;
+  pct_bytes_profiled: number;
+  by_trace_item_type: Record<string, number>;
+  by_filter_profile: Record<string, number>;
+  by_referrer: Record<string, number>;
+  examples: Array<Record<string, any>>;
+};
+
+type DimensionRow = {
+  key: string;
+  query_count: number;
+  total_bytes_scanned: number;
+  total_cpu_us: number;
+  pct_of_bytes: number;
+  pct_of_cpu: number;
+};
+
+type EapStatsRequest = {
+  hours: number;
+  max_rows: number;
+  referrer?: string;
+  referrer_contains?: string;
+  organization_id?: number | string;
+  include_profile_events: boolean;
+};
+
+type EapStatsResult = {
+  hours: number;
+  max_rows: number;
+  rows_scanned: number;
+  rows_categorized: number;
+  rows_failed: number;
+  profile_events_enabled: boolean;
+  profile_events_matched: number;
+  profile_coverage: ProfileCoverage;
+  total_resources: ResourceTotals;
+  by_query_type: QueryTypeBucket[];
+  by_filter_profile: DimensionRow[];
+  by_trace_item_type: DimensionRow[];
+  by_referrer: DimensionRow[];
+};
+
+export type {
+  ResourceTotals,
+  ProfileCoverage,
+  QueryTypeBucket,
+  DimensionRow,
+  EapStatsRequest,
+  EapStatsResult,
+};

--- a/snuba/admin/static/tests/nav_items/index.spec.tsx
+++ b/snuba/admin/static/tests/nav_items/index.spec.tsx
@@ -54,4 +54,5 @@ it("should only display all tools", async () => {
   expect(getByText("ClickHouse Migrations", { exact: false })).toBeTruthy();
   expect(getByText("ClickHouse Tracing", { exact: false })).toBeTruthy();
   expect(getByText("ClickHouse Querylog", { exact: false })).toBeTruthy();
+  expect(getByText("EAP Stats", { exact: false })).toBeTruthy();
 });

--- a/snuba/admin/tool_policies.py
+++ b/snuba/admin/tool_policies.py
@@ -31,6 +31,7 @@ class AdminTools(Enum):
     MANUAL_JOBS = "view-jobs"
     RPC_ENDPOINTS = "rpc-endpoints"
     CLUSTERS = "clusters"
+    EAP_STATS = "eap-stats"
 
 
 DEVELOPER_TOOLS: set[AdminTools] = {AdminTools.SNQL_TO_SQL, AdminTools.QUERY_TRACING}

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -40,6 +40,11 @@ from snuba.admin.clickhouse.system_queries import (
 )
 from snuba.admin.clickhouse.trace_log_parsing import summarize_trace_output
 from snuba.admin.clickhouse.tracing import TraceOutput, run_query_and_get_trace
+from snuba.admin.eap_query_analysis import (
+    EapQueryAnalysisRequest,
+    analyze_eap_queries,
+    result_to_dict,
+)
 from snuba.admin.migrations_policies import (
     check_migration_perms,
     get_migration_group_policies,
@@ -728,6 +733,47 @@ def clickhouse_querylog_query() -> Response:
             {"Content-Type": "application/json"},
         )
     except Exception as err:
+        return make_response(
+            jsonify({"error": {"type": "unknown", "message": str(err)}}),
+            500,
+        )
+
+
+@application.route("/eap_stats", methods=["POST"])
+@check_tool_perms(tools=[AdminTools.EAP_STATS])
+def eap_stats() -> Response:
+    """Categorize recent EAP querylog traffic and aggregate resource usage."""
+    user = request.headers.get(USER_HEADER_KEY, "unknown")
+    if user == "unknown" and settings.ADMIN_AUTH_PROVIDER != "NOOP":
+        return Response(
+            json.dumps({"error": "Unauthorized"}),
+            401,
+            {"Content-Type": "application/json"},
+        )
+    try:
+        body = json.loads(request.data) if request.data else {}
+    except Exception:
+        return make_response(jsonify({"error": {"message": "Invalid JSON body"}}), 400)
+
+    try:
+        analysis_req = EapQueryAnalysisRequest.from_dict(body)
+        result = analyze_eap_queries(analysis_req, user)
+        return make_response(jsonify(result_to_dict(result)), 200)
+    except InvalidCustomQuery as err:
+        return Response(
+            json.dumps({"error": {"message": str(err)}}, indent=4),
+            400,
+            {"Content-Type": "application/json"},
+        )
+    except ClickhouseError as err:
+        details = {
+            "type": "clickhouse",
+            "message": str(err),
+            "code": err.code,
+        }
+        return make_response(jsonify({"error": details}), 400)
+    except Exception as err:
+        logger.error(err, exc_info=True)
         return make_response(
             jsonify({"error": {"type": "unknown", "message": str(err)}}),
             500,

--- a/snuba/web/rpc/__init__.py
+++ b/snuba/web/rpc/__init__.py
@@ -33,6 +33,7 @@ from snuba.web.rpc.common.exceptions import (
     RPCRequestException,
     convert_rpc_exception_to_proto,
 )
+from snuba.web.rpc.common.query_info import extract_query_info_tags
 from snuba.web.rpc.storage_routing.routing_strategies.storage_routing import (
     RoutingContext,
     RoutingDecision,
@@ -277,7 +278,13 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         if meta is not None and (not hasattr(meta, "request_id") or not meta.request_id):
             meta.request_id = self.routing_context.query_id
 
-        self._timer.update_tags(self.__extract_request_tags(in_msg))
+        request_tags = self.__extract_request_tags(in_msg)
+        self._timer.update_tags(request_tags)
+        # Mirror the highest-signal shape tags onto the Sentry transaction so
+        # we can slice EAP traces by query type in Discover/Trace View.
+        for key in ("query_type", "trace_item_type", "filter_profile", "has_groupby"):
+            if key in request_tags:
+                sentry_sdk.set_tag(key, request_tags[key])
 
         selected_strategy = RoutingStrategySelector().select_routing_strategy(self.routing_context)
         self.routing_decision = selected_strategy.get_routing_decision(self.routing_context)
@@ -285,35 +292,38 @@ class RPCEndpoint(Generic[Tin, Tout], metaclass=RegisteredClass):
         self._before_execute(in_msg)
 
     def __extract_request_tags(self, in_msg: Tin) -> dict[str, str]:
-        if not hasattr(in_msg, "meta"):
-            return {}
+        tags: dict[str, str] = {}
 
-        meta = in_msg.meta
-        tags = {}
+        if hasattr(in_msg, "meta"):
+            meta = in_msg.meta
 
-        if hasattr(meta, "start_timestamp") and hasattr(meta, "end_timestamp"):
-            start = meta.start_timestamp.ToDatetime()
-            end = meta.end_timestamp.ToDatetime()
-            delta_in_hours = (end - start).total_seconds() / 3600
-            bucket = bisect_left(_TIME_PERIOD_HOURS_BUCKETS, delta_in_hours)
-            if delta_in_hours <= 1:
-                tags["time_period"] = "lte_1_hour"
-            elif delta_in_hours <= 24:
-                tags["time_period"] = "lte_1_day"
-            else:
-                tags["time_period"] = (
-                    f"lte_{_TIME_PERIOD_HOURS_BUCKETS[bucket] // 24}_days"
-                    if bucket < _BUCKETS_COUNT
-                    else f"gt_{_TIME_PERIOD_HOURS_BUCKETS[_BUCKETS_COUNT - 1] // 24}_days"
+            if hasattr(meta, "start_timestamp") and hasattr(meta, "end_timestamp"):
+                start = meta.start_timestamp.ToDatetime()
+                end = meta.end_timestamp.ToDatetime()
+                delta_in_hours = (end - start).total_seconds() / 3600
+                bucket = bisect_left(_TIME_PERIOD_HOURS_BUCKETS, delta_in_hours)
+                if delta_in_hours <= 1:
+                    tags["time_period"] = "lte_1_hour"
+                elif delta_in_hours <= 24:
+                    tags["time_period"] = "lte_1_day"
+                else:
+                    tags["time_period"] = (
+                        f"lte_{_TIME_PERIOD_HOURS_BUCKETS[bucket] // 24}_days"
+                        if bucket < _BUCKETS_COUNT
+                        else f"gt_{_TIME_PERIOD_HOURS_BUCKETS[_BUCKETS_COUNT - 1] // 24}_days"
+                    )
+
+            if hasattr(meta, "referrer"):
+                tags["referrer"] = meta.referrer
+
+            if self._uses_storage_routing(in_msg):
+                tags["storage_routing_mode"] = DownsampledStorageConfig.Mode.Name(
+                    in_msg.meta.downsampled_storage_config.mode
                 )
 
-        if hasattr(meta, "referrer"):
-            tags["referrer"] = meta.referrer
-
-        if self._uses_storage_routing(in_msg):
-            tags["storage_routing_mode"] = DownsampledStorageConfig.Mode.Name(
-                in_msg.meta.downsampled_storage_config.mode
-            )
+        # Query-shape tags (query_type, groupby, filter profile, etc.) used to
+        # attribute RPC cost. Always attempt this even when meta is missing.
+        tags.update(extract_query_info_tags(in_msg, endpoint_name=self.__class__.__name__))
 
         return tags
 

--- a/snuba/web/rpc/common/query_info.py
+++ b/snuba/web/rpc/common/query_info.py
@@ -1,0 +1,446 @@
+"""Categorize EAP RPC queries for metrics and cost analysis.
+
+Produces a small set of low-cardinality tags that describe the *shape* of a
+request (aggregate vs samples, groupby, formulas, cross-item, filter profile,
+etc.). These tags are attached to RPC and routing-strategy metrics so we can
+break down latency and bytes-scanned by query type without exploding metric
+cardinality.
+
+Design notes
+------------
+* ``query_type`` is the primary dimension for dashboards (e.g. table_groupby vs
+  timeseries_formula vs stats_heatmap).
+* Counts are bucketed (``0`` / ``1`` / ``2_3`` / ``gt_3``) rather than raw ints.
+* Filter trees are collapsed into a single ``filter_profile`` plus a few cheap
+  booleans so we can spot expensive patterns (LIKE, full-text, deep ORs).
+* Categorization is best-effort and never raises into the request path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.protobuf.message import Message as ProtobufMessage
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    Expression as TimeSeriesExpression,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import TraceItemStatsRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    ComparisonFilter,
+    TraceItemFilter,
+)
+
+# Keep every tag value as a short, stable string. Prefer buckets over raw counts
+# so Datadog/Sentry metric cardinality stays bounded.
+_GROUPBY_BUCKETS = (
+    (0, "0"),
+    (1, "1"),
+    (3, "2_3"),
+)
+_SELECT_BUCKETS = (
+    (1, "1"),
+    (5, "2_5"),
+    (10, "6_10"),
+)
+_FILTER_COUNT_BUCKETS = (
+    (0, "0"),
+    (1, "1"),
+    (5, "2_5"),
+    (10, "6_10"),
+)
+_GRANULARITY_BUCKETS_SECS = (
+    (60, "lte_1m"),
+    (300, "lte_5m"),
+    (3600, "lte_1h"),
+    (86400, "lte_1d"),
+)
+
+# Tags attached to every RPC / routing metric. Keep this set small: each extra
+# tag multiplies series count against endpoint/referrer/time_period.
+_METRIC_TAG_KEYS = (
+    "query_type",
+    "trace_item_type",
+    "has_groupby",
+    "groupby_count",
+    "has_formula",
+    "has_cross_item",
+    "filter_profile",
+)
+
+
+def _bucket(value: int, buckets: tuple[tuple[int, str], ...], overflow: str) -> str:
+    for upper, label in buckets:
+        if value <= upper:
+            return label
+    return overflow
+
+
+def _trace_item_type_name(meta: RequestMeta | None) -> str:
+    if meta is None:
+        return "none"
+    try:
+        name = TraceItemType.Name(meta.trace_item_type)
+    except ValueError:
+        return "unknown"
+    # Strip the common prefix so tags stay short: TRACE_ITEM_TYPE_SPAN -> span
+    prefix = "TRACE_ITEM_TYPE_"
+    if name.startswith(prefix):
+        return name[len(prefix) :].lower()
+    return name.lower()
+
+
+def _bool_tag(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _analyze_filter(item_filter: TraceItemFilter | None) -> dict[str, str]:
+    """Walk a TraceItemFilter tree and summarize its cost-relevant shape."""
+    if item_filter is None or not item_filter.HasField("value"):
+        return {
+            "filter_leaf_count": "0",
+            "filter_depth": "0",
+            "filter_profile": "none",
+            "has_or_filter": "false",
+            "has_not_filter": "false",
+            "has_like_filter": "false",
+            "has_search_filter": "false",
+        }
+
+    leaf_count = 0
+    max_depth = 0
+    has_or = False
+    has_not = False
+    has_like = False
+    has_range = False
+    has_in = False
+    has_exists = False
+    has_any_attr = False
+    has_equality = False
+
+    def walk(node: TraceItemFilter, depth: int) -> None:
+        nonlocal leaf_count, max_depth, has_or, has_not, has_like, has_range
+        nonlocal has_in, has_exists, has_any_attr, has_equality
+
+        max_depth = max(max_depth, depth)
+        kind = node.WhichOneof("value")
+        if kind is None:
+            return
+
+        if kind in ("and_filter", "or_filter", "not_filter"):
+            if kind == "or_filter":
+                has_or = True
+            if kind == "not_filter":
+                has_not = True
+            for child in getattr(node, kind).filters:
+                walk(child, depth + 1)
+            return
+
+        leaf_count += 1
+        if kind == "exists_filter":
+            has_exists = True
+            return
+        if kind == "any_attribute_filter":
+            has_any_attr = True
+            any_op = node.any_attribute_filter.op
+            if any_op in (
+                node.any_attribute_filter.OP_LIKE,
+                node.any_attribute_filter.OP_NOT_LIKE,
+            ):
+                has_like = True
+            return
+        if kind == "comparison_filter":
+            op = node.comparison_filter.op
+            if op in (ComparisonFilter.OP_LIKE, ComparisonFilter.OP_NOT_LIKE):
+                has_like = True
+            elif op in (
+                ComparisonFilter.OP_LESS_THAN,
+                ComparisonFilter.OP_GREATER_THAN,
+                ComparisonFilter.OP_LESS_THAN_OR_EQUALS,
+                ComparisonFilter.OP_GREATER_THAN_OR_EQUALS,
+            ):
+                has_range = True
+            elif op in (
+                ComparisonFilter.OP_IN,
+                ComparisonFilter.OP_NOT_IN,
+                ComparisonFilter.OP_HAS_ANY,
+                ComparisonFilter.OP_HAS_ALL,
+            ):
+                has_in = True
+            elif op in (ComparisonFilter.OP_EQUALS, ComparisonFilter.OP_NOT_EQUALS):
+                has_equality = True
+
+    walk(item_filter, 1)
+
+    # Single primary profile, ordered from most to least expensive/interesting.
+    if has_any_attr:
+        profile = "full_text_search"
+    elif has_like:
+        profile = "like"
+    elif has_or and (has_range or has_in or has_exists):
+        profile = "or_mixed"
+    elif has_or:
+        profile = "or_equality"
+    elif has_range and (has_in or has_exists or has_equality):
+        profile = "mixed"
+    elif has_range:
+        profile = "range"
+    elif has_in:
+        profile = "in"
+    elif has_exists and not has_equality:
+        profile = "exists"
+    elif has_equality or has_exists:
+        profile = "equality"
+    else:
+        profile = "other"
+
+    return {
+        "filter_leaf_count": _bucket(leaf_count, _FILTER_COUNT_BUCKETS, "gt_10"),
+        "filter_depth": _bucket(max_depth, _FILTER_COUNT_BUCKETS, "gt_10"),
+        "filter_profile": profile,
+        "has_or_filter": _bool_tag(has_or),
+        "has_not_filter": _bool_tag(has_not),
+        "has_like_filter": _bool_tag(has_like),
+        "has_search_filter": _bool_tag(has_any_attr),
+    }
+
+
+def _column_has_formula(column: Column) -> bool:
+    return column.WhichOneof("column") in ("formula", "conditional_formula")
+
+
+def _column_is_aggregate(column: Column) -> bool:
+    kind = column.WhichOneof("column")
+    if kind in ("aggregation", "conditional_aggregation"):
+        return True
+    if kind == "formula":
+        return _column_is_aggregate(column.formula.left) or _column_is_aggregate(
+            column.formula.right
+        )
+    if kind == "conditional_formula":
+        cond = column.conditional_formula
+        parts: list[Column] = []
+        if cond.HasField("condition"):
+            if cond.condition.HasField("left"):
+                parts.append(cond.condition.left)
+            if cond.condition.HasField("right"):
+                parts.append(cond.condition.right)
+        if cond.HasField("match"):
+            parts.append(cond.match)
+        if cond.HasField("default"):
+            parts.append(cond.default)
+        return any(_column_is_aggregate(part) for part in parts)
+    return False
+
+
+def _expression_has_formula(expression: TimeSeriesExpression) -> bool:
+    return expression.WhichOneof("expression") == "formula"
+
+
+def _categorize_table_request(request: TraceItemTableRequest) -> dict[str, str]:
+    columns = list(request.columns)
+    has_agg = any(_column_is_aggregate(col) for col in columns)
+    has_formula = any(_column_has_formula(col) for col in columns)
+    groupby_count = len(request.group_by)
+    has_groupby = groupby_count > 0
+    has_cross_item = len(request.trace_filters) > 0
+    has_agg_filter = request.HasField("aggregation_filter")
+    has_limit_by = request.HasField("limit_by")
+    has_order_by = len(request.order_by) > 0
+    select_count = len(columns)
+
+    if has_cross_item:
+        query_type = "table_cross_item"
+    elif has_formula and has_groupby:
+        query_type = "table_formula_groupby"
+    elif has_formula:
+        query_type = "table_formula"
+    elif has_groupby:
+        query_type = "table_groupby"
+    elif has_agg:
+        query_type = "table_aggregate"
+    else:
+        query_type = "table_samples"
+
+    tags = {
+        "query_type": query_type,
+        "has_groupby": _bool_tag(has_groupby),
+        "groupby_count": _bucket(groupby_count, _GROUPBY_BUCKETS, "gt_3"),
+        "has_formula": _bool_tag(has_formula),
+        "has_aggregate": _bool_tag(has_agg),
+        "has_cross_item": _bool_tag(has_cross_item),
+        "has_agg_filter": _bool_tag(has_agg_filter),
+        "has_limit_by": _bool_tag(has_limit_by),
+        "has_order_by": _bool_tag(has_order_by),
+        "select_count": _bucket(select_count, _SELECT_BUCKETS, "gt_10"),
+    }
+    filter_tags = _analyze_filter(request.filter if request.HasField("filter") else None)
+    tags.update(filter_tags)
+    return tags
+
+
+def _categorize_timeseries_request(request: TimeSeriesRequest) -> dict[str, str]:
+    expressions = list(request.expressions)
+    # Legacy field; endpoints normally convert aggregations -> expressions first,
+    # but categorize defensively in case we're called earlier.
+    legacy_aggs = list(request.aggregations)
+    has_formula = any(_expression_has_formula(expr) for expr in expressions)
+    groupby_count = len(request.group_by)
+    has_groupby = groupby_count > 0
+    has_cross_item = len(request.trace_filters) > 0
+    expr_count = max(len(expressions), len(legacy_aggs))
+
+    if has_cross_item:
+        query_type = "timeseries_cross_item"
+    elif has_formula and has_groupby:
+        query_type = "timeseries_formula_groupby"
+    elif has_formula:
+        query_type = "timeseries_formula"
+    elif has_groupby:
+        query_type = "timeseries_groupby"
+    else:
+        query_type = "timeseries"
+
+    tags = {
+        "query_type": query_type,
+        "has_groupby": _bool_tag(has_groupby),
+        "groupby_count": _bucket(groupby_count, _GROUPBY_BUCKETS, "gt_3"),
+        "has_formula": _bool_tag(has_formula),
+        # Time series requests are aggregate-by-definition (bucketed expressions).
+        "has_aggregate": "true",
+        "has_cross_item": _bool_tag(has_cross_item),
+        "has_agg_filter": "false",
+        "has_limit_by": "false",
+        "has_order_by": "false",
+        "select_count": _bucket(expr_count, _SELECT_BUCKETS, "gt_10"),
+        "granularity": _bucket(
+            int(request.granularity_secs or 0), _GRANULARITY_BUCKETS_SECS, "gt_1d"
+        ),
+    }
+    filter_tags = _analyze_filter(request.filter if request.HasField("filter") else None)
+    tags.update(filter_tags)
+    return tags
+
+
+def _categorize_stats_request(request: TraceItemStatsRequest) -> dict[str, str]:
+    stats_kinds: set[str] = set()
+    for stats_type in request.stats_types:
+        kind = stats_type.WhichOneof("type")
+        if kind is not None:
+            stats_kinds.add(kind)
+
+    if stats_kinds == {"heatmap"}:
+        query_type = "stats_heatmap"
+    elif stats_kinds == {"attribute_distributions"}:
+        query_type = "stats_distributions"
+    elif len(stats_kinds) > 1:
+        query_type = "stats_mixed"
+    elif stats_kinds:
+        query_type = f"stats_{next(iter(stats_kinds))}"
+    else:
+        query_type = "stats_unknown"
+
+    tags = {
+        "query_type": query_type,
+        "has_groupby": "false",
+        "groupby_count": "0",
+        "has_formula": "false",
+        "has_aggregate": "true",
+        "has_cross_item": "false",
+        "has_agg_filter": "false",
+        "has_limit_by": "false",
+        "has_order_by": "false",
+        "select_count": _bucket(len(request.stats_types), _SELECT_BUCKETS, "gt_10"),
+    }
+    filter_tags = _analyze_filter(request.filter if request.HasField("filter") else None)
+    tags.update(filter_tags)
+    return tags
+
+
+# Endpoint request classes that are not shape-rich still get a stable query_type
+# so dashboards can group "everything else" without special-casing missing tags.
+_ENDPOINT_QUERY_TYPES: dict[str, str] = {
+    "EndpointGetTrace": "get_trace",
+    "EndpointGetTraces": "get_traces",
+    "EndpointTraceItemDetails": "item_details",
+    "EndpointTraceItemAttributeNames": "attribute_names",
+    "EndpointTraceItemAttributeValues": "attribute_values",
+    "EndpointDeleteTraceItems": "delete_items",
+    "EndpointExportTraceItems": "export_items",
+    "EndpointCreateSubscription": "create_subscription",
+}
+
+
+def _default_shape_tags(query_type: str) -> dict[str, str]:
+    return {
+        "query_type": query_type,
+        "has_groupby": "false",
+        "groupby_count": "0",
+        "has_formula": "false",
+        "has_aggregate": "false",
+        "has_cross_item": "false",
+        "has_agg_filter": "false",
+        "has_limit_by": "false",
+        "has_order_by": "false",
+        "select_count": "0",
+        "filter_leaf_count": "0",
+        "filter_depth": "0",
+        "filter_profile": "none",
+        "has_or_filter": "false",
+        "has_not_filter": "false",
+        "has_like_filter": "false",
+        "has_search_filter": "false",
+    }
+
+
+def extract_query_info(
+    in_msg: ProtobufMessage,
+    endpoint_name: str | None = None,
+) -> dict[str, str]:
+    """Full query-shape description (metrics + spans + querylog).
+
+    Safe to call on any protobuf message; unknown request types yield a minimal
+    default tag set keyed by endpoint name when available. Never raises.
+    """
+    try:
+        if isinstance(in_msg, TraceItemTableRequest):
+            tags = _categorize_table_request(in_msg)
+        elif isinstance(in_msg, TimeSeriesRequest):
+            tags = _categorize_timeseries_request(in_msg)
+        elif isinstance(in_msg, TraceItemStatsRequest):
+            tags = _categorize_stats_request(in_msg)
+        else:
+            query_type = "other"
+            if endpoint_name is not None:
+                query_type = _ENDPOINT_QUERY_TYPES.get(endpoint_name, "other")
+            tags = _default_shape_tags(query_type)
+
+        meta: RequestMeta | None = getattr(in_msg, "meta", None)
+        tags["trace_item_type"] = _trace_item_type_name(meta)
+        return tags
+    except Exception:
+        # Categorization must never break the request path.
+        tags = _default_shape_tags("categorization_error")
+        tags["trace_item_type"] = "unknown"
+        return tags
+
+
+def extract_query_info_tags(
+    in_msg: ProtobufMessage,
+    endpoint_name: str | None = None,
+) -> dict[str, str]:
+    """Low-cardinality subset of :func:`extract_query_info` for metric tags."""
+    full = extract_query_info(in_msg, endpoint_name=endpoint_name)
+    return {key: full[key] for key in _METRIC_TAG_KEYS if key in full}
+
+
+def extract_query_info_for_log(
+    in_msg: ProtobufMessage, endpoint_name: str | None = None
+) -> dict[str, Any]:
+    """Dict form suitable for embedding in querylog / span data."""
+    return dict(extract_query_info(in_msg, endpoint_name=endpoint_name))

--- a/snuba/web/rpc/common/query_info.py
+++ b/snuba/web/rpc/common/query_info.py
@@ -369,10 +369,11 @@ _ENDPOINT_QUERY_TYPES: dict[str, str] = {
     "EndpointGetTraces": "get_traces",
     "EndpointTraceItemDetails": "item_details",
     "EndpointTraceItemAttributeNames": "attribute_names",
-    "EndpointTraceItemAttributeValues": "attribute_values",
+    # Class names match RPCEndpoint subclasses (self.__class__.__name__).
+    "AttributeValuesRequest": "attribute_values",
     "EndpointDeleteTraceItems": "delete_items",
     "EndpointExportTraceItems": "export_items",
-    "EndpointCreateSubscription": "create_subscription",
+    "CreateSubscriptionRequest": "create_subscription",
 }
 
 

--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -54,6 +54,7 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.registered_class import import_submodules_in_directory
 from snuba.web import QueryException, QueryResult
 from snuba.web.rpc.common.exceptions import RPCAllocationPolicyException
+from snuba.web.rpc.common.query_info import extract_query_info, extract_query_info_tags
 from snuba.web.rpc.storage_routing.common import extract_message_meta
 from snuba.web.rpc.storage_routing.load_retriever import LoadInfo, get_cluster_loadinfo
 
@@ -176,6 +177,7 @@ class RoutingDecision:
             "clickhouse_settings": self.clickhouse_settings,
             "result_info": query_result,
             "routed_tier": self.tier.name,
+            "query_info": extract_query_info(self.routing_context.in_msg),
             "allocation_policies_recommendations": {
                 key: quota_allowance.to_dict()
                 for key, quota_allowance in self.routing_context.allocation_policies_recommendations.items()
@@ -552,10 +554,12 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
             self.update_allocation_policies_balances(routing_decision, error)
 
             # these metrics are meant to track reject/throttle/success decisions, so they get emitted even if the query did not run successfully after routing
+            query_info_tags = extract_query_info_tags(routing_decision.routing_context.in_msg)
             tags = {
                 "strategy": self.class_name(),
                 "resource_identifier": routing_decision.strategy.resource_identifier.value,
                 "referrer": cast(str, routing_decision.routing_context.tenant_ids["referrer"]),
+                **query_info_tags,
             }
             if not routing_decision.can_run:
                 self.metrics.increment("rejected_query", tags=tags)
@@ -570,13 +574,14 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                 {}, {"stats": {}, "sql": "", "experiments": {}}
             )
             profile = query_result.result.get("profile", {}) or {}
+            cost_tags = {"tier": routing_decision.tier.name, **query_info_tags}
             if elapsed := profile.get("elapsed"):
                 self._record_value_in_span_and_DD(
                     routing_context=routing_decision.routing_context,
                     metrics_backend_func=self.metrics.timing,
                     name="query_timing",
                     value=elapsed,
-                    tags={"tier": routing_decision.tier.name},
+                    tags=cost_tags,
                 )
             if bytes_scanned := profile.get("progress_bytes"):
                 self._record_value_in_span_and_DD(
@@ -584,7 +589,7 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                     metrics_backend_func=self.metrics.timing,
                     name="query_bytes_scanned",
                     value=bytes_scanned,
-                    tags={"tier": routing_decision.tier.name},
+                    tags=cost_tags,
                 )
             record_query(_construct_hacky_querylog_payload(self, routing_decision))
         except Exception as e:

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -64,3 +64,16 @@ def test_replace_dml_rejected() -> None:
         validate_ro_query("REPLACE INTO my_table VALUES (1, 2, 3)")
     with pytest.raises(InvalidCustomQuery):
         validate_ro_query("REPLACE TABLE my_table SELECT * FROM other_table")
+
+
+def test_disallowed_tokens_inside_string_literals_allowed() -> None:
+    # Filter values may legitimately contain comment/keyword substrings.
+    validate_ro_query("SELECT * FROM my_table WHERE referrer = 'api.org--test'")
+    validate_ro_query("SELECT * FROM my_table WHERE msg = 'please delete me'")
+
+
+def test_comment_tokens_outside_literals_rejected() -> None:
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query("SELECT * FROM my_table -- drop everything")
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query("SELECT * FROM my_table /* bad */")

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -72,6 +72,14 @@ def test_disallowed_tokens_inside_string_literals_allowed() -> None:
     validate_ro_query("SELECT * FROM my_table WHERE msg = 'please delete me'")
 
 
+def test_escaped_quotes_inside_literals_allowed() -> None:
+    # Backslash-escaped and SQL-doubled quotes should not look unbalanced.
+    validate_ro_query(r"SELECT * FROM my_table WHERE referrer = 'O\'Brien'")
+    validate_ro_query("SELECT * FROM my_table WHERE referrer = 'O''Brien'")
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query("SELECT * FROM my_table WHERE referrer = 'unterminated")
+
+
 def test_comment_tokens_outside_literals_rejected() -> None:
     with pytest.raises(InvalidCustomQuery):
         validate_ro_query("SELECT * FROM my_table -- drop everything")

--- a/tests/admin/eap_query_analysis/test_analysis.py
+++ b/tests/admin/eap_query_analysis/test_analysis.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from google.protobuf.json_format import MessageToDict
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    Expression as TimeSeriesExpression,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    Function,
+)
+
+from snuba.admin.eap_query_analysis.analysis import (
+    EapQueryAnalysisRequest,
+    ResourceTotals,
+    _infer_request_class,
+    _parse_request_body,
+    analyze_eap_queries,
+    result_to_dict,
+)
+from snuba.clickhouse.native import ClickhouseResult
+
+
+def _meta() -> RequestMeta:
+    return RequestMeta(
+        project_ids=[1],
+        organization_id=1,
+        referrer="test.referrer",
+        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+    )
+
+
+def _table_body() -> dict[str, Any]:
+    req = TraceItemTableRequest(
+        meta=_meta(),
+        columns=[
+            Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT,
+                    key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="d"),
+                    label="c",
+                ),
+                label="c",
+            )
+        ],
+        group_by=[AttributeKey(type=AttributeKey.TYPE_STRING, name="op")],
+    )
+    return MessageToDict(req)
+
+
+def _timeseries_body() -> dict[str, Any]:
+    req = TimeSeriesRequest(
+        meta=_meta(),
+        granularity_secs=60,
+        expressions=[
+            TimeSeriesExpression(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_AVG,
+                    key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="d"),
+                    label="avg",
+                ),
+                label="avg",
+            )
+        ],
+    )
+    return MessageToDict(req)
+
+
+def test_infer_request_class() -> None:
+    assert _infer_request_class(_table_body()) is TraceItemTableRequest
+    assert _infer_request_class(_timeseries_body()) is TimeSeriesRequest
+    assert _infer_request_class({"foo": "bar"}) is None
+
+
+def test_parse_request_body() -> None:
+    msg = _parse_request_body(json.dumps(_table_body()))
+    assert msg is not None
+    assert isinstance(msg, TraceItemTableRequest)
+    assert len(msg.group_by) == 1
+
+
+def test_resource_totals_add_profile_events() -> None:
+    r = ResourceTotals()
+    r.add_profile_events(
+        {
+            "UserTimeMicroseconds": 1000,
+            "MemoryTrackerPeakUsage": 4096,
+            "SelectedBytes": 100,
+            "NetworkReceiveBytes": 50,
+            "IgnoredEvent": 999,
+        }
+    )
+    assert r.cpu_user_us == 1000
+    assert r.memory_peak_bytes == 4096
+    assert r.io_selected_bytes == 100
+    assert r.network_receive_bytes == 50
+    assert r.profile_events_matched == 1
+    assert r.cpu_total_us == 1000
+
+
+def test_analyze_eap_queries_categorizes_and_aggregates() -> None:
+    table_body = json.dumps(_table_body())
+    ts_body = json.dumps(_timeseries_body())
+
+    # Columns match the SELECT in _build_fetch_sql.
+    rows = [
+        (
+            "req-1",
+            "2024-01-01 00:00:00",
+            "api.table",
+            "eap",
+            1,
+            120,
+            "success",
+            table_body,
+            ["qid-aaaa"],
+            [1_000_000],
+            [100],
+            None,
+        ),
+        (
+            "req-2",
+            "2024-01-01 00:01:00",
+            "api.timeseries",
+            "eap",
+            1,
+            250,
+            "success",
+            ts_body,
+            ["qid-bbbb"],
+            [5_000_000],
+            [200],
+            None,
+        ),
+        (
+            "req-3",
+            "2024-01-01 00:02:00",
+            "api.unknown",
+            "eap",
+            1,
+            10,
+            "success",
+            json.dumps({"not": "a request"}),
+            [],
+            [10],
+            [5],
+            None,
+        ),
+    ]
+
+    mock_result = ClickhouseResult(results=rows, meta=[("x", "String")] * 12)
+
+    profile_events = {
+        "qid-aaaa": {
+            "UserTimeMicroseconds": 2_000,
+            "MemoryTrackerPeakUsage": 8_000,
+            "SelectedBytes": 1_000_000,
+            "NetworkReceiveBytes": 100,
+        },
+        "qidbbbb": {},  # unused
+        "qid-bbbb": {
+            "UserTimeMicroseconds": 8_000,
+            "MemoryTrackerPeakUsage": 32_000,
+            "SelectedBytes": 5_000_000,
+            "NetworkReceiveBytes": 500,
+        },
+    }
+    # keys are normalized without dashes in implementation
+    profile_events_norm = {
+        "qidaaaa": profile_events["qid-aaaa"],
+        "qidbbbb": profile_events["qid-bbbb"],
+    }
+
+    with (
+        patch(
+            "snuba.admin.eap_query_analysis.analysis.run_querylog_query",
+            return_value=mock_result,
+        ) as mock_ql,
+        patch(
+            "snuba.admin.eap_query_analysis.analysis._schema_table_name",
+            return_value="querylog_local",
+        ),
+        patch(
+            "snuba.admin.eap_query_analysis.analysis._fetch_profile_events",
+            return_value=profile_events_norm,
+        ) as mock_pe,
+    ):
+        result = analyze_eap_queries(
+            EapQueryAnalysisRequest(hours=1, max_rows=100, include_profile_events=True),
+            user="tester@sentry.io",
+        )
+
+    mock_ql.assert_called_once()
+    assert mock_ql.call_args.kwargs.get("max_threads") == 0
+    mock_pe.assert_called_once()
+
+    assert result.rows_scanned == 3
+    assert result.rows_categorized == 2
+    assert result.rows_failed == 1
+    assert result.total_resources.bytes_scanned == 1_000_000 + 5_000_000 + 10
+    assert result.total_resources.cpu_user_us == 10_000
+    assert result.total_resources.memory_peak_bytes == 40_000
+    assert result.profile_events_matched == 2
+
+    coverage = result.profile_coverage
+    assert coverage.enabled is True
+    assert coverage.queries_total == 3
+    assert coverage.queries_profiled == 2  # uncategorized row has no query ids matched
+    assert coverage.queries_with_query_id == 2
+    assert coverage.pct_queries_profiled == pytest.approx(200.0 / 3.0)
+    assert coverage.bytes_profiled == 1_000_000 + 5_000_000
+    assert coverage.pct_bytes_profiled == pytest.approx(
+        100.0 * (1_000_000 + 5_000_000) / (1_000_000 + 5_000_000 + 10)
+    )
+    assert coverage.query_ids_matched == 2
+
+    by_type = {b.query_type: b for b in result.by_query_type}
+    assert "table_groupby" in by_type
+    assert "timeseries" in by_type
+    assert "uncategorized" in by_type
+
+    # Timeseries scanned more bytes, so it should rank first.
+    assert result.by_query_type[0].query_type == "timeseries"
+    assert result.by_query_type[0].resources.bytes_scanned == 5_000_000
+    assert result.by_query_type[0].pct_of_cpu > 0
+
+    payload = result_to_dict(result)
+    assert "by_query_type" in payload
+    assert payload["total_resources"]["bytes_scanned"] == result.total_resources.bytes_scanned
+
+
+def test_analyze_without_profile_events() -> None:
+    rows = [
+        (
+            "req-1",
+            "2024-01-01 00:00:00",
+            "api.table",
+            "eap",
+            1,
+            120,
+            "success",
+            json.dumps(_table_body()),
+            ["qid-1"],
+            [1000],
+            [50],
+            None,
+        ),
+    ]
+    mock_result = ClickhouseResult(results=rows, meta=[])
+    with (
+        patch(
+            "snuba.admin.eap_query_analysis.analysis.run_querylog_query",
+            return_value=mock_result,
+        ),
+        patch(
+            "snuba.admin.eap_query_analysis.analysis._schema_table_name",
+            return_value="querylog_local",
+        ),
+        patch(
+            "snuba.admin.eap_query_analysis.analysis._fetch_profile_events",
+        ) as mock_pe,
+    ):
+        result = analyze_eap_queries(
+            EapQueryAnalysisRequest(include_profile_events=False),
+            user="tester",
+        )
+    mock_pe.assert_not_called()
+    assert result.profile_events_enabled is False
+    assert result.total_resources.cpu_user_us == 0
+    assert result.total_resources.bytes_scanned == 1000
+
+
+def test_request_from_dict_clamps() -> None:
+    req = EapQueryAnalysisRequest.from_dict(
+        {"hours": 9999, "max_rows": 9999999, "include_profile_events": False}
+    )
+    assert req.hours == 24 * 7
+    assert req.max_rows == 500_000
+    assert req.include_profile_events is False
+
+
+def test_prefers_embedded_query_info_from_stats() -> None:
+    stats = [
+        json.dumps(
+            {
+                "query_info": {
+                    "query_type": "table_cross_item",
+                    "trace_item_type": "span",
+                    "filter_profile": "like",
+                    "has_groupby": "true",
+                    "groupby_count": "1",
+                    "has_formula": "false",
+                    "has_cross_item": "true",
+                }
+            }
+        )
+    ]
+    rows: list[tuple[Any, ...]] = [
+        (
+            "req-1",
+            "2024-01-01 00:00:00",
+            "api.x",
+            "storage_routing",
+            1,
+            10,
+            "success",
+            "{}",  # body intentionally unparseable / empty
+            [],
+            [42],
+            [1],
+            stats,
+        )
+    ]
+    mock_result = ClickhouseResult(results=rows, meta=[])
+    with (
+        patch(
+            "snuba.admin.eap_query_analysis.analysis.run_querylog_query",
+            return_value=mock_result,
+        ),
+        patch(
+            "snuba.admin.eap_query_analysis.analysis._schema_table_name",
+            return_value="querylog_local",
+        ),
+        patch(
+            "snuba.admin.eap_query_analysis.analysis._fetch_profile_events",
+            return_value={},
+        ),
+    ):
+        result = analyze_eap_queries(EapQueryAnalysisRequest(), user="t")
+
+    assert result.rows_categorized == 1
+    assert result.by_query_type[0].query_type == "table_cross_item"

--- a/tests/admin/eap_query_analysis/test_analysis.py
+++ b/tests/admin/eap_query_analysis/test_analysis.py
@@ -24,6 +24,9 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
 from snuba.admin.eap_query_analysis.analysis import (
     EapQueryAnalysisRequest,
     ResourceTotals,
+    _build_fetch_sql,
+    _escape_like_literal,
+    _escape_literal,
     _infer_request_class,
     _parse_request_body,
     analyze_eap_queries,
@@ -107,6 +110,17 @@ def test_resource_totals_add_profile_events() -> None:
     assert r.network_receive_bytes == 50
     assert r.profile_events_matched == 1
     assert r.cpu_total_us == 1000
+
+    # Virtual CPU time already covers threaded user/system work; prefer it.
+    r2 = ResourceTotals()
+    r2.add_profile_events(
+        {
+            "UserTimeMicroseconds": 1000,
+            "SystemTimeMicroseconds": 500,
+            "OSCPUVirtualTimeMicroseconds": 2000,
+        }
+    )
+    assert r2.cpu_total_us == 2000
 
 
 def test_analyze_eap_queries_categorizes_and_aggregates() -> None:
@@ -311,7 +325,7 @@ def test_prefers_embedded_query_info_from_stats() -> None:
             "req-1",
             "2024-01-01 00:00:00",
             "api.x",
-            "storage_routing",
+            "eap",
             1,
             10,
             "success",
@@ -341,3 +355,22 @@ def test_prefers_embedded_query_info_from_stats() -> None:
 
     assert result.rows_categorized == 1
     assert result.by_query_type[0].query_type == "table_cross_item"
+
+
+def test_escape_like_literal_escapes_wildcards() -> None:
+    assert _escape_literal("eap_items") == "eap_items"
+    assert _escape_like_literal("eap_items") == "eap\\_items"
+    assert _escape_like_literal("a%b_c'\\") == "a\\%b\\_c\\'\\\\"
+
+
+def test_build_fetch_sql_filters_estimation_and_duplicates() -> None:
+    with patch(
+        "snuba.admin.eap_query_analysis.analysis._schema_table_name",
+        return_value="querylog_local",
+    ):
+        sql = _build_fetch_sql(EapQueryAnalysisRequest(hours=1, referrer_contains="eap_items"))
+    assert "dataset IN ('eap')" in sql
+    assert "storage_routing" not in sql
+    assert "positionCaseInsensitive(t, 'outcomes')" in sql
+    assert "LIKE '%eap\\_items%'" in sql
+    assert "ESCAPE '\\'" in sql

--- a/tests/admin/eap_query_analysis/test_analysis.py
+++ b/tests/admin/eap_query_analysis/test_analysis.py
@@ -85,6 +85,11 @@ def test_infer_request_class() -> None:
     assert _infer_request_class(_timeseries_body()) is TimeSeriesRequest
     assert _infer_request_class({"foo": "bar"}) is None
 
+    # TimeSeriesRequest can also carry group_by; timeseries markers must win.
+    timeseries_groupby = _timeseries_body()
+    timeseries_groupby["groupBy"] = [{"name": "op", "type": "TYPE_STRING"}]
+    assert _infer_request_class(timeseries_groupby) is TimeSeriesRequest
+
 
 def test_parse_request_body() -> None:
     msg = _parse_request_body(json.dumps(_table_body()))

--- a/tests/admin/eap_query_analysis/test_analysis.py
+++ b/tests/admin/eap_query_analysis/test_analysis.py
@@ -25,7 +25,6 @@ from snuba.admin.eap_query_analysis.analysis import (
     EapQueryAnalysisRequest,
     ResourceTotals,
     _build_fetch_sql,
-    _escape_like_literal,
     _escape_literal,
     _infer_request_class,
     _parse_request_body,
@@ -362,12 +361,6 @@ def test_prefers_embedded_query_info_from_stats() -> None:
     assert result.by_query_type[0].query_type == "table_cross_item"
 
 
-def test_escape_like_literal_escapes_wildcards() -> None:
-    assert _escape_literal("eap_items") == "eap_items"
-    assert _escape_like_literal("eap_items") == "eap\\_items"
-    assert _escape_like_literal("a%b_c'\\") == "a\\%b\\_c\\'\\\\"
-
-
 def test_build_fetch_sql_filters_estimation_and_duplicates() -> None:
     with patch(
         "snuba.admin.eap_query_analysis.analysis._schema_table_name",
@@ -377,5 +370,8 @@ def test_build_fetch_sql_filters_estimation_and_duplicates() -> None:
     assert "dataset IN ('eap')" in sql
     assert "storage_routing" not in sql
     assert "positionCaseInsensitive(t, 'outcomes')" in sql
-    assert "LIKE '%eap\\_items%'" in sql
-    assert "ESCAPE '\\'" in sql
+    # Literal substring match avoids LIKE wildcards and unsupported ESCAPE.
+    assert "positionCaseInsensitive(referrer, 'eap_items') > 0" in sql
+    assert "LIKE" not in sql
+    assert "ESCAPE" not in sql
+    assert _escape_literal("a'b\\c") == "a\\'b\\\\c"

--- a/tests/web/rpc/test_base.py
+++ b/tests/web/rpc/test_base.py
@@ -160,6 +160,13 @@ def test_metrics() -> None:
             "referrer": "something",
             "endpoint_name": "MyRPC",
             "version": "v1",
+            "query_type": "timeseries",
+            "trace_item_type": "span",
+            "has_groupby": "false",
+            "groupby_count": "0",
+            "has_formula": "false",
+            "has_cross_item": "false",
+            "filter_profile": "none",
         }
         for _ in range(len(metrics_backend.calls))
     ]
@@ -180,13 +187,19 @@ def test_error_metrics() -> None:
         with pytest.raises(RPCException):
             rpc_call.execute(_get_in_msg())
         metric_tags = [m.tags for m in metrics_backend.calls]
-        # the last tags set only contains endpoint_name and version because in __after_execute's metrics_backend.increment, we don't pass in the other tags
         assert metric_tags == [
             {
                 "time_period": "lte_1_day",
                 "referrer": "something",
                 "endpoint_name": "ErrorRPC",
                 "version": "v1",
+                "query_type": "timeseries",
+                "trace_item_type": "span",
+                "has_groupby": "false",
+                "groupby_count": "0",
+                "has_formula": "false",
+                "has_cross_item": "false",
+                "filter_profile": "none",
             }
             for _ in range(len(metrics_backend.calls))
         ]
@@ -272,6 +285,13 @@ def test_tagged_metrics(hours: int, expected_time_bucket: str) -> None:
             "version": "v1",
             "time_period": expected_time_bucket,
             "referrer": _REFERRER,
+            "query_type": "table_samples",
+            "trace_item_type": "span",
+            "has_groupby": "false",
+            "groupby_count": "0",
+            "has_formula": "false",
+            "has_cross_item": "false",
+            "filter_profile": "none",
         }
         for _ in range(len(metrics_backend.calls))
     ]

--- a/tests/web/rpc/test_query_info.py
+++ b/tests/web/rpc/test_query_info.py
@@ -330,6 +330,12 @@ def test_unknown_endpoint_defaults() -> None:
     info = extract_query_info(_meta(), endpoint_name="SomeFutureEndpoint")
     assert info["query_type"] == "other"
 
+    # Endpoint class names must match RPCEndpoint subclasses.
+    info = extract_query_info(_meta(), endpoint_name="CreateSubscriptionRequest")
+    assert info["query_type"] == "create_subscription"
+    info = extract_query_info(_meta(), endpoint_name="AttributeValuesRequest")
+    assert info["query_type"] == "attribute_values"
+
 
 def test_groupby_bucket_overflow() -> None:
     request = TraceItemTableRequest(

--- a/tests/web/rpc/test_query_info.py
+++ b/tests/web/rpc/test_query_info.py
@@ -1,0 +1,341 @@
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
+    Expression as TimeSeriesExpression,
+)
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
+    AttributeDistributionsRequest,
+    HeatmapRequest,
+    StatsType,
+    TraceItemStatsRequest,
+)
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeKey,
+    AttributeValue,
+    Function,
+)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
+    AndFilter,
+    AnyAttributeFilter,
+    ComparisonFilter,
+    ExistsFilter,
+    OrFilter,
+    TraceItemFilter,
+)
+
+from snuba.web.rpc.common.query_info import extract_query_info, extract_query_info_tags
+
+
+def _meta(item_type: TraceItemType.ValueType = TraceItemType.TRACE_ITEM_TYPE_SPAN) -> RequestMeta:
+    return RequestMeta(
+        project_ids=[1],
+        organization_id=1,
+        referrer="test",
+        trace_item_type=item_type,
+    )
+
+
+def _attr(name: str = "sentry.duration_ms") -> AttributeKey:
+    return AttributeKey(type=AttributeKey.TYPE_DOUBLE, name=name)
+
+
+def _str_attr(name: str = "sentry.op") -> AttributeKey:
+    return AttributeKey(type=AttributeKey.TYPE_STRING, name=name)
+
+
+def _eq_filter(name: str = "sentry.op", value: str = "http.server") -> TraceItemFilter:
+    return TraceItemFilter(
+        comparison_filter=ComparisonFilter(
+            key=_str_attr(name),
+            op=ComparisonFilter.OP_EQUALS,
+            value=AttributeValue(val_str=value),
+        )
+    )
+
+
+def test_table_samples() -> None:
+    request = TraceItemTableRequest(
+        meta=_meta(),
+        columns=[Column(key=_attr(), label="duration")],
+    )
+    info = extract_query_info(request)
+    assert info["query_type"] == "table_samples"
+    assert info["has_aggregate"] == "false"
+    assert info["has_groupby"] == "false"
+    assert info["trace_item_type"] == "span"
+    assert info["filter_profile"] == "none"
+    assert info["select_count"] == "1"
+
+
+def test_table_aggregate_and_groupby() -> None:
+    request = TraceItemTableRequest(
+        meta=_meta(TraceItemType.TRACE_ITEM_TYPE_LOG),
+        columns=[
+            Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_AVG,
+                    key=_attr(),
+                    label="avg_duration",
+                ),
+                label="avg_duration",
+            )
+        ],
+        group_by=[_str_attr()],
+        filter=_eq_filter(),
+    )
+    info = extract_query_info(request)
+    assert info["query_type"] == "table_groupby"
+    assert info["has_aggregate"] == "true"
+    assert info["has_groupby"] == "true"
+    assert info["groupby_count"] == "1"
+    assert info["trace_item_type"] == "log"
+    assert info["filter_profile"] == "equality"
+    assert info["filter_leaf_count"] == "1"
+
+
+def test_table_formula_groupby() -> None:
+    left = Column(
+        aggregation=AttributeAggregation(aggregate=Function.FUNCTION_SUM, key=_attr(), label="a")
+    )
+    right = Column(
+        aggregation=AttributeAggregation(aggregate=Function.FUNCTION_COUNT, key=_attr(), label="b")
+    )
+    request = TraceItemTableRequest(
+        meta=_meta(),
+        columns=[
+            Column(
+                formula=Column.BinaryFormula(
+                    op=Column.BinaryFormula.OP_DIVIDE,
+                    left=left,
+                    right=right,
+                ),
+                label="ratio",
+            )
+        ],
+        group_by=[_str_attr("a"), _str_attr("b")],
+    )
+    info = extract_query_info(request)
+    assert info["query_type"] == "table_formula_groupby"
+    assert info["has_formula"] == "true"
+    assert info["groupby_count"] == "2_3"
+
+
+def test_table_cross_item_takes_priority() -> None:
+    request = TraceItemTableRequest(
+        meta=_meta(),
+        columns=[
+            Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT, key=_attr(), label="c"
+                ),
+                label="c",
+            )
+        ],
+        group_by=[_str_attr()],
+        trace_filters=[],
+    )
+    # Populate cross-item filter list via the repeated field.
+    request.trace_filters.add()
+    info = extract_query_info(request)
+    assert info["query_type"] == "table_cross_item"
+    assert info["has_cross_item"] == "true"
+
+
+def test_timeseries_formula() -> None:
+    request = TimeSeriesRequest(
+        meta=_meta(),
+        granularity_secs=60,
+        expressions=[
+            TimeSeriesExpression(
+                formula=TimeSeriesExpression.BinaryFormula(
+                    op=TimeSeriesExpression.BinaryFormula.OP_DIVIDE,
+                    left=TimeSeriesExpression(
+                        aggregation=AttributeAggregation(
+                            aggregate=Function.FUNCTION_SUM, key=_attr(), label="a"
+                        ),
+                        label="a",
+                    ),
+                    right=TimeSeriesExpression(
+                        aggregation=AttributeAggregation(
+                            aggregate=Function.FUNCTION_COUNT, key=_attr(), label="b"
+                        ),
+                        label="b",
+                    ),
+                ),
+                label="ratio",
+            )
+        ],
+    )
+    info = extract_query_info(request)
+    assert info["query_type"] == "timeseries_formula"
+    assert info["has_formula"] == "true"
+    assert info["has_aggregate"] == "true"
+    assert info["granularity"] == "lte_1m"
+
+
+def test_timeseries_groupby() -> None:
+    request = TimeSeriesRequest(
+        meta=_meta(),
+        granularity_secs=3600,
+        expressions=[
+            TimeSeriesExpression(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_AVG, key=_attr(), label="avg"
+                ),
+                label="avg",
+            )
+        ],
+        group_by=[_str_attr()],
+    )
+    info = extract_query_info(request)
+    assert info["query_type"] == "timeseries_groupby"
+    assert info["granularity"] == "lte_1h"
+    assert info["groupby_count"] == "1"
+
+
+def test_stats_heatmap_and_distributions() -> None:
+    heatmap = TraceItemStatsRequest(
+        meta=_meta(),
+        stats_types=[
+            StatsType(
+                heatmap=HeatmapRequest(
+                    x_attribute=_str_attr(),
+                    y_attribute=_attr(),
+                    num_y_buckets=10,
+                )
+            )
+        ],
+    )
+    assert extract_query_info(heatmap)["query_type"] == "stats_heatmap"
+
+    distributions = TraceItemStatsRequest(
+        meta=_meta(),
+        stats_types=[
+            StatsType(attribute_distributions=AttributeDistributionsRequest(max_buckets=10))
+        ],
+    )
+    assert extract_query_info(distributions)["query_type"] == "stats_distributions"
+
+    mixed = TraceItemStatsRequest(
+        meta=_meta(),
+        stats_types=[
+            StatsType(heatmap=HeatmapRequest(x_attribute=_str_attr(), y_attribute=_attr())),
+            StatsType(attribute_distributions=AttributeDistributionsRequest()),
+        ],
+    )
+    assert extract_query_info(mixed)["query_type"] == "stats_mixed"
+
+
+def test_filter_profiles() -> None:
+    like_filter = TraceItemFilter(
+        comparison_filter=ComparisonFilter(
+            key=_str_attr("message"),
+            op=ComparisonFilter.OP_LIKE,
+            value=AttributeValue(val_str="%error%"),
+        )
+    )
+    info = extract_query_info(TraceItemTableRequest(meta=_meta(), filter=like_filter))
+    assert info["filter_profile"] == "like"
+    assert info["has_like_filter"] == "true"
+
+    search_filter = TraceItemFilter(
+        any_attribute_filter=AnyAttributeFilter(
+            op=AnyAttributeFilter.OP_LIKE,
+            value=AttributeValue(val_str="%foo%"),
+        )
+    )
+    info = extract_query_info(TraceItemTableRequest(meta=_meta(), filter=search_filter))
+    assert info["filter_profile"] == "full_text_search"
+    assert info["has_search_filter"] == "true"
+
+    or_filter = TraceItemFilter(
+        or_filter=OrFilter(
+            filters=[
+                _eq_filter("a", "1"),
+                _eq_filter("b", "2"),
+            ]
+        )
+    )
+    info = extract_query_info(TraceItemTableRequest(meta=_meta(), filter=or_filter))
+    assert info["filter_profile"] == "or_equality"
+    assert info["has_or_filter"] == "true"
+    assert info["filter_leaf_count"] == "2_5"
+    assert info["filter_depth"] == "2_5"
+
+    range_filter = TraceItemFilter(
+        comparison_filter=ComparisonFilter(
+            key=_attr(),
+            op=ComparisonFilter.OP_GREATER_THAN,
+            value=AttributeValue(val_double=100.0),
+        )
+    )
+    info = extract_query_info(TraceItemTableRequest(meta=_meta(), filter=range_filter))
+    assert info["filter_profile"] == "range"
+
+    nested = TraceItemFilter(
+        and_filter=AndFilter(
+            filters=[
+                _eq_filter(),
+                TraceItemFilter(exists_filter=ExistsFilter(key=_str_attr("http.status"))),
+                range_filter,
+            ]
+        )
+    )
+    info = extract_query_info(TraceItemTableRequest(meta=_meta(), filter=nested))
+    assert info["filter_profile"] == "mixed"
+    assert info["filter_leaf_count"] == "2_5"
+
+
+def test_metric_tags_are_low_cardinality_subset() -> None:
+    request = TraceItemTableRequest(
+        meta=_meta(),
+        columns=[
+            Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT, key=_attr(), label="c"
+                ),
+                label="c",
+            )
+        ],
+        group_by=[_str_attr()],
+        filter=_eq_filter(),
+    )
+    full = extract_query_info(request)
+    metric_tags = extract_query_info_tags(request)
+    assert set(metric_tags) == {
+        "query_type",
+        "trace_item_type",
+        "has_groupby",
+        "groupby_count",
+        "has_formula",
+        "has_cross_item",
+        "filter_profile",
+    }
+    for key, value in metric_tags.items():
+        assert full[key] == value
+
+
+def test_unknown_endpoint_defaults() -> None:
+    # A bare RequestMeta isn't a full request type; pass a message without shape.
+    info = extract_query_info(_meta(), endpoint_name="EndpointGetTrace")
+    assert info["query_type"] == "get_trace"
+    # No nested `.meta` on RequestMeta itself, so item type falls back.
+    assert info["trace_item_type"] == "none"
+
+    info = extract_query_info(_meta(), endpoint_name="SomeFutureEndpoint")
+    assert info["query_type"] == "other"
+
+
+def test_groupby_bucket_overflow() -> None:
+    request = TraceItemTableRequest(
+        meta=_meta(),
+        columns=[Column(key=_attr(), label="d")],
+        group_by=[_str_attr(f"k{i}") for i in range(5)],
+    )
+    info = extract_query_info(request)
+    assert info["groupby_count"] == "gt_3"

--- a/tests/web/rpc/v1/test_storage_routing.py
+++ b/tests/web/rpc/v1/test_storage_routing.py
@@ -323,7 +323,16 @@ def test_metrics_output() -> None:
                 "sampling_in_storage_query_timing": {
                     "type": "timing",
                     "value": 1.0,
-                    "tags": {"tier": "TIER_8"},
+                    "tags": {
+                        "tier": "TIER_8",
+                        "query_type": "timeseries",
+                        "trace_item_type": "span",
+                        "has_groupby": "false",
+                        "groupby_count": "0",
+                        "has_formula": "false",
+                        "has_cross_item": "false",
+                        "filter_profile": "none",
+                    },
                 },
                 "sampling_in_storage_routing_success": {
                     "type": "increment",
@@ -388,6 +397,27 @@ def test_metrics_output() -> None:
             "is_duplicate": 0,
             "consistent": False,
             "strategy": "MetricsStrategy",
+            "query_info": {
+                "query_type": "timeseries",
+                "has_groupby": "false",
+                "groupby_count": "0",
+                "has_formula": "false",
+                "has_aggregate": "true",
+                "has_cross_item": "false",
+                "has_agg_filter": "false",
+                "has_limit_by": "false",
+                "has_order_by": "false",
+                "select_count": "1",
+                "granularity": "lte_1m",
+                "filter_leaf_count": "0",
+                "filter_depth": "0",
+                "filter_profile": "none",
+                "has_or_filter": "false",
+                "has_not_filter": "false",
+                "has_like_filter": "false",
+                "has_search_filter": "false",
+                "trace_item_type": "span",
+            },
         }
         schema = get_codec("snuba-queries")
         payload_bytes = json.dumps(recorded_payload).encode("utf-8")


### PR DESCRIPTION
Fixes EAP-637

https://linear.app/getsentry/issue/EAP-637/map-query-workload-against-resources

## Summary
- Categorize EAP RPC requests by query shape (`query_type`, groupby/formula/cross-item, filter profile) and attach low-cardinality tags to RPC + routing metrics (timing / bytes scanned).
- Add a snuba-admin **EAP Stats** page that re-categorizes recent querylog traffic, aggregates bytes/duration plus optional ClickHouse ProfileEvents (CPU / mem / IO / network) by query type, and shows profile coverage % so totals can be judged for representativeness.
- EAP Stats querylog/ProfileEvents scans run with `max_threads=0` to support whole-dataset analysis.

## Test plan
- [x] `pytest tests/web/rpc/test_query_info.py tests/web/rpc/test_base.py`
- [x] `pytest tests/admin/eap_query_analysis/test_analysis.py tests/admin/test_querylog_audit_log.py`
- [ ] Open snuba-admin → EAP Stats, run a short lookback, confirm categorization + coverage % render
- [ ] Confirm metric tags appear on `rpc.*` / `routing_strategy.sampling_in_storage_query_*` after deploy