### PR TITLE
fix(querylog): Gate RPC querylog produce on RECORD_QUERIES

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -246,10 +246,6 @@ def _record_query_delivery_callback(error: KafkaError | None, message: KafkaMess
 
 
 def record_query(query_metadata: snuba_queries_v1.Querylog) -> None:
-    # Central gate for all querylog producers (SNQL + RPC storage routing).
-    # Self-hosted leaves RECORD_QUERIES=False and does not run a querylog
-    # consumer; producing anyway piles messages into librdkafka and burns
-    # API worker CPU (see getsentry/snuba#8181).
     if not settings.RECORD_QUERIES:
         return
 

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -246,6 +246,13 @@ def _record_query_delivery_callback(error: KafkaError | None, message: KafkaMess
 
 
 def record_query(query_metadata: snuba_queries_v1.Querylog) -> None:
+    # Central gate for all querylog producers (SNQL + RPC storage routing).
+    # Self-hosted leaves RECORD_QUERIES=False and does not run a querylog
+    # consumer; producing anyway piles messages into librdkafka and burns
+    # API worker CPU (see getsentry/snuba#8181).
+    if not settings.RECORD_QUERIES:
+        return
+
     try:
         producer = _kafka_producer()
         data = safe_dumps(query_metadata)

--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -586,7 +586,13 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                     value=bytes_scanned,
                     tags={"tier": routing_decision.tier.name},
                 )
-            record_query(_construct_hacky_querylog_payload(self, routing_decision))
+            # Honor RECORD_QUERIES before building the payload. Storage routing
+            # used to call state.record_query unconditionally, which on
+            # self-hosted (RECORD_QUERIES=False, no querylog consumer) left the
+            # librdkafka producer queue filling forever and pegged a snuba-api
+            # worker core (getsentry/snuba#8181).
+            if settings.RECORD_QUERIES:
+                record_query(_construct_hacky_querylog_payload(self, routing_decision))
         except Exception as e:
             self.metrics.increment("after_execute_failure")
             sentry_sdk.capture_message(f"Error in routing strategy after execute: {e}")

--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -586,11 +586,6 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                     value=bytes_scanned,
                     tags={"tier": routing_decision.tier.name},
                 )
-            # Honor RECORD_QUERIES before building the payload. Storage routing
-            # used to call state.record_query unconditionally, which on
-            # self-hosted (RECORD_QUERIES=False, no querylog consumer) left the
-            # librdkafka producer queue filling forever and pegged a snuba-api
-            # worker core (getsentry/snuba#8181).
             if settings.RECORD_QUERIES:
                 record_query(_construct_hacky_querylog_payload(self, routing_decision))
         except Exception as e:

--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -586,8 +586,7 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                     value=bytes_scanned,
                     tags={"tier": routing_decision.tier.name},
                 )
-            if settings.RECORD_QUERIES:
-                record_query(_construct_hacky_querylog_payload(self, routing_decision))
+            record_query(_construct_hacky_querylog_payload(self, routing_decision))
         except Exception as e:
             self.metrics.increment("after_execute_failure")
             sentry_sdk.capture_message(f"Error in routing strategy after execute: {e}")

--- a/tests/state/test_record.py
+++ b/tests/state/test_record.py
@@ -1,5 +1,39 @@
-from snuba.state import _kafka_producer
+from unittest import mock
+
+from snuba.state import _kafka_producer, record_query
 
 
 def test_get_producer() -> None:
     assert _kafka_producer() is not None
+
+
+def test_record_query_respects_record_queries_setting() -> None:
+    payload = {
+        "request": {"id": "00000000-0000-0000-0000-000000000000", "body": {}, "referrer": "t"},
+        "dataset": "storage_routing",
+        "entity": "eap",
+        "start_timestamp": 0,
+        "end_timestamp": 0,
+        "status": "TIER_1",
+        "request_status": "NA",
+        "slo": "N/A",
+        "projects": [],
+        "timing": {"timestamp": 0, "duration_ms": 0, "marks_ms": {}, "tags": {}},
+        "snql_anonymized": "",
+        "query_list": [],
+    }
+
+    with (
+        mock.patch("snuba.state.settings.RECORD_QUERIES", False),
+        mock.patch("snuba.state._kafka_producer") as producer_factory,
+    ):
+        record_query(payload)  # type: ignore[arg-type]
+        producer_factory.assert_not_called()
+
+    producer = mock.Mock()
+    with (
+        mock.patch("snuba.state.settings.RECORD_QUERIES", True),
+        mock.patch("snuba.state._kafka_producer", return_value=producer),
+    ):
+        record_query(payload)  # type: ignore[arg-type]
+        producer.produce.assert_called_once()


### PR DESCRIPTION
RPC storage routing always produced querylog payloads after Traces/Logs queries, ignoring `RECORD_QUERIES`. On self-hosted that setting is false and there is no querylog consumer, so librdkafka buffered forever and pegged a `snuba-api` worker core.

Gate produce on `RECORD_QUERIES` inside `state.record_query`. SaaS is unchanged.

Fixes #8181
Fixes https://linear.app/getsentry/issue/EAP-617/unusual-high-cpu-consumption-snuba-api-worker-1
