### PR TITLE
fix(eap): Round extrapolated sums of integer attributes

### DIFF
--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -489,6 +489,26 @@ def _is_integer_key_aggregation(aggregation: AttributeConditionalAggregation) ->
     return aggregation.key.type == AttributeKey.TYPE_INT
 
 
+def _get_extrapolated_sum(
+    aggregation: AttributeConditionalAggregation,
+    field: Expression,
+    field_exists: Expression,
+    condition_in_aggregation: Expression,
+    sampling_weight: Expression,
+    alias: str | None,
+) -> CurriedFunctionCall | FunctionCall:
+    alias_dict = {"alias": alias} if alias else {}
+    round_to_int = _is_integer_key_aggregation(aggregation)
+    sum_expr = f.sumIfOrNull(
+        f.multiply(field, sampling_weight),
+        and_cond(field_exists, condition_in_aggregation),
+        **({} if round_to_int else alias_dict),
+    )
+    if round_to_int:
+        return f.round(sum_expr, **alias_dict)
+    return sum_expr
+
+
 def get_extrapolated_function(
     aggregation: AttributeConditionalAggregation,
     field: Expression,
@@ -506,23 +526,15 @@ def get_extrapolated_function(
         use_sampling_factor,
         aggregation.extrapolation_mode,
     )
-    if _is_integer_key_aggregation(aggregation):
-        sum_expr: CurriedFunctionCall | FunctionCall = f.round(
-            f.sumIfOrNull(
-                f.multiply(field, sampling_weight),
-                and_cond(field_exists, condition_in_aggregation),
-            ),
-            **alias_dict,
-        )
-    else:
-        sum_expr = f.sumIfOrNull(
-            f.multiply(field, sampling_weight),
-            and_cond(field_exists, condition_in_aggregation),
-            **alias_dict,
-        )
-
     function_map_sample_weighted: dict[Function.ValueType, CurriedFunctionCall | FunctionCall] = {
-        Function.FUNCTION_SUM: sum_expr,
+        Function.FUNCTION_SUM: _get_extrapolated_sum(
+            aggregation,
+            field,
+            field_exists,
+            condition_in_aggregation,
+            sampling_weight,
+            alias,
+        ),
         Function.FUNCTION_AVERAGE: f.divide(
             f.sumIfOrNull(
                 f.multiply(field, sampling_weight),

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -484,12 +484,6 @@ def _get_possible_percentiles_expression(
 
 
 def _is_integer_key_aggregation(aggregation: AttributeConditionalAggregation) -> bool:
-    """True when the aggregation's source attribute is typed as integer.
-
-    Expression-based aggregations (AttributeKeyExpression formulas) are not treated
-    as integer even if every leaf is TYPE_INT, since the formula itself may produce
-    non-integers (e.g. division).
-    """
     if aggregation.HasField("expression"):
         return False
     return aggregation.key.type == AttributeKey.TYPE_INT
@@ -512,9 +506,6 @@ def get_extrapolated_function(
         use_sampling_factor,
         aggregation.extrapolation_mode,
     )
-    # Sample-weighted sum of integers can produce a float (sum(x_i * w_i)). Round
-    # back to the nearest integer so callers never see a decimal sum of integers
-    # (EAP-101). COUNT is always rounded for the same reason.
     if _is_integer_key_aggregation(aggregation):
         sum_expr: CurriedFunctionCall | FunctionCall = f.round(
             f.sumIfOrNull(

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -483,6 +483,18 @@ def _get_possible_percentiles_expression(
     )
 
 
+def _is_integer_key_aggregation(aggregation: AttributeConditionalAggregation) -> bool:
+    """True when the aggregation's source attribute is typed as integer.
+
+    Expression-based aggregations (AttributeKeyExpression formulas) are not treated
+    as integer even if every leaf is TYPE_INT, since the formula itself may produce
+    non-integers (e.g. division).
+    """
+    if aggregation.HasField("expression"):
+        return False
+    return aggregation.key.type == AttributeKey.TYPE_INT
+
+
 def get_extrapolated_function(
     aggregation: AttributeConditionalAggregation,
     field: Expression,
@@ -500,12 +512,26 @@ def get_extrapolated_function(
         use_sampling_factor,
         aggregation.extrapolation_mode,
     )
-    function_map_sample_weighted: dict[Function.ValueType, CurriedFunctionCall | FunctionCall] = {
-        Function.FUNCTION_SUM: f.sumIfOrNull(
+    # Sample-weighted sum of integers can produce a float (sum(x_i * w_i)). Round
+    # back to the nearest integer so callers never see a decimal sum of integers
+    # (EAP-101). COUNT is always rounded for the same reason.
+    if _is_integer_key_aggregation(aggregation):
+        sum_expr: CurriedFunctionCall | FunctionCall = f.round(
+            f.sumIfOrNull(
+                f.multiply(field, sampling_weight),
+                and_cond(field_exists, condition_in_aggregation),
+            ),
+            **alias_dict,
+        )
+    else:
+        sum_expr = f.sumIfOrNull(
             f.multiply(field, sampling_weight),
             and_cond(field_exists, condition_in_aggregation),
             **alias_dict,
-        ),
+        )
+
+    function_map_sample_weighted: dict[Function.ValueType, CurriedFunctionCall | FunctionCall] = {
+        Function.FUNCTION_SUM: sum_expr,
         Function.FUNCTION_AVERAGE: f.divide(
             f.sumIfOrNull(
                 f.multiply(field, sampling_weight),

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -475,7 +475,6 @@ def test_conditional_aggregation_array_filter_uses_typed_columns() -> None:
 
 
 def test_extrapolated_sum_of_integers_is_rounded() -> None:
-    """EAP-101: sample-weighted sum of TYPE_INT attributes must round to an integer."""
     agg = AttributeConditionalAggregation(
         aggregate=Function.FUNCTION_SUM,
         key=AttributeKey(type=AttributeKey.TYPE_INT, name="custom_measurement"),
@@ -492,7 +491,6 @@ def test_extrapolated_sum_of_integers_is_rounded() -> None:
 
 
 def test_extrapolated_sum_of_doubles_is_not_rounded() -> None:
-    """Sample-weighted sum of non-integer attributes should keep its fractional value."""
     agg = AttributeConditionalAggregation(
         aggregate=Function.FUNCTION_SUM,
         key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="custom_measurement"),

--- a/tests/web/rpc/test_aggregation.py
+++ b/tests/web/rpc/test_aggregation.py
@@ -472,3 +472,34 @@ def test_conditional_aggregation_array_filter_uses_typed_columns() -> None:
     assert "attributes_array_float" not in cols
     assert "attributes_array_bool" not in cols
     assert "attributes_array" not in cols
+
+
+def test_extrapolated_sum_of_integers_is_rounded() -> None:
+    """EAP-101: sample-weighted sum of TYPE_INT attributes must round to an integer."""
+    agg = AttributeConditionalAggregation(
+        aggregate=Function.FUNCTION_SUM,
+        key=AttributeKey(type=AttributeKey.TYPE_INT, name="custom_measurement"),
+        label="sum(custom_measurement)",
+        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+    )
+    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    assert isinstance(expr, FunctionCall)
+    assert expr.function_name == "round"
+    assert expr.alias == "sum(custom_measurement)"
+    inner = expr.parameters[0]
+    assert isinstance(inner, FunctionCall)
+    assert inner.function_name == "sumIfOrNull"
+
+
+def test_extrapolated_sum_of_doubles_is_not_rounded() -> None:
+    """Sample-weighted sum of non-integer attributes should keep its fractional value."""
+    agg = AttributeConditionalAggregation(
+        aggregate=Function.FUNCTION_SUM,
+        key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="custom_measurement"),
+        label="sum(custom_measurement)",
+        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+    )
+    expr = aggregation_to_expression(agg, attribute_key_to_expression)
+    assert isinstance(expr, FunctionCall)
+    assert expr.function_name == "sumIfOrNull"
+    assert expr.alias == "sum(custom_measurement)"

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
@@ -216,6 +216,14 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
                 ),
                 Column(
                     aggregation=AttributeAggregation(
+                        aggregate=Function.FUNCTION_SUM,
+                        key=AttributeKey(type=AttributeKey.TYPE_INT, name="custom_measurement"),
+                        label="sum_int(custom_measurement)",
+                        extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
+                    )
+                ),
+                Column(
+                    aggregation=AttributeAggregation(
                         aggregate=Function.FUNCTION_AVG,
                         key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name="custom_measurement"),
                         label="avg(custom_measurement)",
@@ -252,13 +260,17 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
         )
         response = EndpointTraceItemTable().execute(message)
         measurement_sum = [v.val_double for v in response.column_values[0].results][0]
-        measurement_avg = [v.val_double for v in response.column_values[1].results][0]
+        measurement_sum_int = [v.val_double for v in response.column_values[1].results][0]
+        measurement_avg = [v.val_double for v in response.column_values[2].results][0]
         measurement_count_custom_measurement = [
-            v.val_double for v in response.column_values[2].results
+            v.val_double for v in response.column_values[3].results
         ][0]
-        measurement_count_duration = [v.val_double for v in response.column_values[3].results][0]
-        measurement_p90 = [v.val_double for v in response.column_values[4].results][0]
+        measurement_count_duration = [v.val_double for v in response.column_values[4].results][0]
+        measurement_p90 = [v.val_double for v in response.column_values[5].results][0]
         assert measurement_sum == 98  # weighted sum - 0*1 + 1*2 + 2*4 + 3*8 + 4*16
+        # EAP-101: sum of TYPE_INT attributes is rounded to an integer under extrapolation.
+        assert measurement_sum_int == 98
+        assert measurement_sum_int == int(measurement_sum_int)
         assert (
             abs(measurement_avg - 3.16129032) < 0.000001
         )  # weighted average - (0*1 + 1*2 + 2*4 + 3*8 + 4*16) / (1+2+4+8+16)

--- a/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_table/test_endpoint_trace_item_table_extrapolation.py
@@ -268,7 +268,6 @@ class TestTraceItemTableWithExtrapolation(BaseApiTest):
         measurement_count_duration = [v.val_double for v in response.column_values[4].results][0]
         measurement_p90 = [v.val_double for v in response.column_values[5].results][0]
         assert measurement_sum == 98  # weighted sum - 0*1 + 1*2 + 2*4 + 3*8 + 4*16
-        # EAP-101: sum of TYPE_INT attributes is rounded to an integer under extrapolation.
         assert measurement_sum_int == 98
         assert measurement_sum_int == int(measurement_sum_int)
         assert (


### PR DESCRIPTION
Sample-weighted `sum(value * weight)` can return a float for `TYPE_INT` attributes under extrapolation. Wrap `FUNCTION_SUM` in `round()` for integer keys (same approach as `COUNT`) so callers never see a decimal sum of integers.

Expression-based aggregations are left unchanged, since formulas can legitimately produce non-integers.

Fixes EAP-101
