### PR TITLE
fix(migrations): Stop logging transient ClickHouse connection retries as errors

### DIFF
--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -83,11 +83,6 @@ def check_clickhouse_connections(
 
         for attempt in range(max_attempts):
             try:
-                logger.debug(
-                    "Attempting to connect to Clickhouse cluster %s (attempt %d)",
-                    cluster,
-                    attempt,
-                )
                 check_clickhouse(clickhouse)
                 break
             except InvalidClickhouseVersion as e:

--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -71,21 +71,22 @@ def get_clusters_for_readiness_states(
 
 def check_clickhouse_connections(
     clusters: Sequence[ClickhouseCluster],
+    *,
+    max_attempts: int = 60,
+    retry_delay_seconds: float = 1.0,
 ) -> None:
     """
     Ensure that we can establish a connection with every cluster.
     """
-    attempts = 0
-
     for cluster in clusters:
         clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
 
-        while True:
+        for attempt in range(max_attempts):
             try:
                 logger.debug(
                     "Attempting to connect to Clickhouse cluster %s (attempt %d)",
                     cluster,
-                    attempts,
+                    attempt,
                 )
                 check_clickhouse(clickhouse)
                 break
@@ -93,16 +94,21 @@ def check_clickhouse_connections(
                 logger.error(e)
                 raise
             except Exception as e:
-                logger.error(
+                logger.debug(
                     "Connection to Clickhouse cluster %s failed (attempt %d)",
                     cluster,
-                    attempts,
+                    attempt,
                     exc_info=e,
                 )
-                attempts += 1
-                if attempts == 60:
+                if attempt + 1 >= max_attempts:
+                    logger.error(
+                        "Connection to Clickhouse cluster %s failed after %d attempts",
+                        cluster,
+                        max_attempts,
+                        exc_info=e,
+                    )
                     raise
-                time.sleep(1)
+                time.sleep(retry_delay_seconds)
 
 
 def check_clickhouse(clickhouse: ClickhousePool) -> None:

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -207,6 +207,7 @@ def test_operational_error_mapped_without_extra_retries() -> None:
 
     assert client.query.call_count == 1
     client.close_connections.assert_called_once()
+    client.close.assert_not_called()
 
 
 def test_generic_clickhouse_error_wrapped() -> None:
@@ -942,6 +943,7 @@ def test_execute_surfaces_native_stream_desync_without_retry() -> None:
     assert "Unrecognized ClickHouse type" in str(excinfo.value)
     assert client.query.call_count == 1
     client.close_connections.assert_called_once()
+    client.close.assert_not_called()
 
 
 def test_stream_failure_error_is_translated_to_clickhouse_error() -> None:
@@ -960,3 +962,4 @@ def test_stream_failure_error_is_translated_to_clickhouse_error() -> None:
     assert "Stream ended unexpectedly" in str(excinfo.value)
     assert client.query.call_count == 1
     client.close_connections.assert_called_once()
+    client.close.assert_not_called()

--- a/tests/migrations/test_connect.py
+++ b/tests/migrations/test_connect.py
@@ -2,16 +2,21 @@ from __future__ import annotations
 
 from functools import reduce
 from typing import Any
+from unittest import mock
 
 import pytest
 
+from snuba.clickhouse.errors import ClickhouseError
+from snuba.clickhouse.native import ClickhouseResult
 from snuba.clusters import cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.readiness_state import ReadinessState
 from snuba.migrations.connect import (
+    check_clickhouse_connections,
     get_clickhouse_clusters_for_migration_group,
     get_clusters_for_readiness_states,
 )
+from snuba.migrations.errors import InvalidClickhouseVersion
 from snuba.migrations.groups import MigrationGroup
 
 _ALL_STORAGE_SET_KEYS = {s.value for s in StorageSetKey}
@@ -133,3 +138,78 @@ def test_get_clusters_for_readiness_states(
         reduce(set.union, [rc.get_storage_set_keys() for rc in result_clusters])
         == expected_storage_set_keys
     )
+
+
+def _cluster_with_pool(pool: mock.Mock) -> mock.Mock:
+    cluster_mock = mock.Mock()
+    cluster_mock.get_query_connection.return_value = pool
+    return cluster_mock
+
+
+def _pool_returning_version(version: str = "23.8.11.29") -> mock.Mock:
+    pool = mock.Mock()
+    pool.execute.return_value = ClickhouseResult(results=[[version]])
+    return pool
+
+
+def test_check_clickhouse_connections_retries_transient_errors_then_succeeds() -> None:
+    pool = mock.Mock()
+    pool.execute.side_effect = [
+        ClickhouseError("connection reset by peer", code=-1),
+        ClickhouseResult(results=[["23.8.11.29"]]),
+    ]
+
+    with mock.patch("snuba.migrations.connect.time.sleep") as sleep:
+        check_clickhouse_connections(
+            [_cluster_with_pool(pool)], max_attempts=3, retry_delay_seconds=0
+        )
+
+    assert pool.execute.call_count == 2
+    sleep.assert_called_once_with(0)
+
+
+def test_check_clickhouse_connections_retries_are_per_cluster() -> None:
+    flaky = mock.Mock()
+    flaky.execute.side_effect = [
+        ClickhouseError("connection reset by peer", code=-1),
+        ClickhouseResult(results=[["23.8.11.29"]]),
+    ]
+
+    with mock.patch("snuba.migrations.connect.time.sleep"):
+        check_clickhouse_connections(
+            [_cluster_with_pool(flaky), _cluster_with_pool(_pool_returning_version())],
+            max_attempts=2,
+            retry_delay_seconds=0,
+        )
+
+    assert flaky.execute.call_count == 2
+
+
+def test_check_clickhouse_connections_raises_after_max_attempts() -> None:
+    pool = mock.Mock()
+    pool.execute.side_effect = ClickhouseError("connection reset by peer", code=-1)
+
+    with (
+        mock.patch("snuba.migrations.connect.time.sleep"),
+        pytest.raises(ClickhouseError, match="connection reset by peer"),
+    ):
+        check_clickhouse_connections(
+            [_cluster_with_pool(pool)], max_attempts=3, retry_delay_seconds=0
+        )
+
+    assert pool.execute.call_count == 3
+
+
+def test_check_clickhouse_connections_does_not_retry_invalid_version() -> None:
+    pool = _pool_returning_version("10.0.0.0")
+
+    with (
+        mock.patch("snuba.migrations.connect.time.sleep") as sleep,
+        pytest.raises(InvalidClickhouseVersion),
+    ):
+        check_clickhouse_connections(
+            [_cluster_with_pool(pool)], max_attempts=5, retry_delay_seconds=0
+        )
+
+    assert pool.execute.call_count == 1
+    sleep.assert_not_called()


### PR DESCRIPTION
Migration connection preflight already retries transient ClickHouse failures, but each intermediate attempt was logged at ERROR with `exc_info`, so expected startup noise became Sentry issues. Log retries at debug and only ERROR after the budget is exhausted; give each cluster its own attempt budget.
