### PR TITLE
fix(subscriptions): Unstall combined scheduler when ticks have no work

### DIFF
--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -71,12 +71,8 @@ impl PythonTransformStep {
                 offsets,
             ) = py_message;
 
-            // Populate received_p99 from the processor's origin_timestamp so
-            // subscription schedulers configured with received_p99 can form ticks.
-            // Leaving this empty produces commit-log messages with received_p99=null,
-            // which previously stalled the tick consumer.
+            // origin_timestamp feeds received_p99 so schedulers can form ticks.
             let received_p99: Vec<_> = origin_timestamp.iter().copied().collect();
-
             let commit_log_offsets = offsets
                 .iter()
                 .map(|((_t, p), o)| {

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -71,7 +71,6 @@ impl PythonTransformStep {
                 offsets,
             ) = py_message;
 
-            // origin_timestamp feeds received_p99 so schedulers can form ticks.
             let received_p99: Vec<_> = origin_timestamp.iter().copied().collect();
             let commit_log_offsets = offsets
                 .iter()

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -71,6 +71,12 @@ impl PythonTransformStep {
                 offsets,
             ) = py_message;
 
+            // Populate received_p99 from the processor's origin_timestamp so
+            // subscription schedulers configured with received_p99 can form ticks.
+            // Leaving this empty produces commit-log messages with received_p99=null,
+            // which previously stalled the tick consumer.
+            let received_p99: Vec<_> = origin_timestamp.iter().copied().collect();
+
             let commit_log_offsets = offsets
                 .iter()
                 .map(|((_t, p), o)| {
@@ -79,7 +85,7 @@ impl PythonTransformStep {
                         CommitLogEntry {
                             offset: *o,
                             orig_message_ts: message_timestamp,
-                            received_p99: Vec::new(),
+                            received_p99: received_p99.clone(),
                         },
                     )
                 })

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -273,8 +273,6 @@ class ForwardToExecutor(ProcessingStrategy[Tick]):
         assert tick.partition is not None
 
         encoded_tasks: list[KafkaPayload] = []
-        # Stale ticks intentionally produce no work, but still need a commit so
-        # the commit-log consumer can advance (same as the separate scheduler).
         if (
             self.__stale_threshold_seconds is None
             or time.time() - tick.timestamps.lower <= self.__stale_threshold_seconds

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -11,7 +11,7 @@ from arroyo.commit import ONCE_PER_SECOND
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
-from arroyo.types import BrokerValue, Commit
+from arroyo.types import Commit
 
 from snuba import settings
 from snuba.datasets.dataset import Dataset
@@ -268,35 +268,28 @@ class ForwardToExecutor(ProcessingStrategy[Tick]):
 
     def submit(self, message: Message[Tick]) -> None:
         assert not self.__closed
-        assert isinstance(message.value, BrokerValue)
 
         tick = message.payload
         assert tick.partition is not None
 
-        # Mirror ProduceScheduledSubscriptionMessage: stale ticks produce no work
-        # and must still advance the commit-log consumer offset.
+        encoded_tasks: list[KafkaPayload] = []
+        # Stale ticks intentionally produce no work, but still need a commit so
+        # the commit-log consumer can advance (same as the separate scheduler).
         if (
-            self.__stale_threshold_seconds is not None
-            and time.time() - tick.timestamps.lower > self.__stale_threshold_seconds
+            self.__stale_threshold_seconds is None
+            or time.time() - tick.timestamps.lower <= self.__stale_threshold_seconds
         ):
-            encoded_tasks: list[KafkaPayload] = []
-        else:
-            tasks = []
             for entity_scheduler in self.__schedulers:
-                tasks.extend(list(entity_scheduler[tick.partition].find(tick)))
-            encoded_tasks = [self.__encoder.encode(task) for task in tasks]
+                for task in entity_scheduler[tick.partition].find(tick):
+                    encoded_tasks.append(self.__encoder.encode(task))
 
-        # If there is nothing to execute, commit immediately. Otherwise the
-        # combined scheduler-executor never stages offsets (ExecuteQuery only
-        # commits after producing a result) and the consumer appears stuck
-        # with CURRENT-OFFSET=- while lag stays non-zero.
-        if len(encoded_tasks) == 0:
+        if not encoded_tasks:
             logger.info("Committing offset - no subscriptions: %r", message.committable)
             self.__commit(message.committable)
             return
 
-        for task in encoded_tasks:
-            self.__next_step.submit(message.replace(task))
+        for encoded_task in encoded_tasks:
+            self.__next_step.submit(message.replace(encoded_task))
 
     def close(self) -> None:
         self.__closed = True

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
 from typing import NamedTuple
@@ -9,7 +11,7 @@ from arroyo.commit import ONCE_PER_SECOND
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
-from arroyo.types import Commit
+from arroyo.types import BrokerValue, Commit
 
 from snuba import settings
 from snuba.datasets.dataset import Dataset
@@ -29,6 +31,7 @@ from snuba.subscriptions.utils import SchedulingWatermarkMode, Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.configuration_builder import build_kafka_consumer_configuration
 
+logger = logging.getLogger(__name__)
 redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
 
 
@@ -165,6 +168,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         self.__partitions = partitions
         self.__entity_names = entity_names
         self.__metrics = metrics
+        self.__stale_threshold_seconds = stale_threshold_seconds
 
         entity_keys = [EntityKey(entity_name) for entity_name in self.__entity_names]
 
@@ -232,7 +236,12 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
             self.__mode,
             self.__partitions,
             self.__buffer_size,
-            ForwardToExecutor(self.__schedulers, execute_step),
+            ForwardToExecutor(
+                self.__schedulers,
+                execute_step,
+                commit,
+                self.__stale_threshold_seconds,
+            ),
             self.__metrics,
         )
 
@@ -242,8 +251,12 @@ class ForwardToExecutor(ProcessingStrategy[Tick]):
         self,
         schedulers: Sequence[Mapping[int, SubscriptionScheduler]],
         next_step: ProcessingStrategy[KafkaPayload],
+        commit: Commit,
+        stale_threshold_seconds: int | None = None,
     ) -> None:
         self.__next_step = next_step
+        self.__commit = commit
+        self.__stale_threshold_seconds = stale_threshold_seconds
 
         self.__schedulers = schedulers
         self.__encoder = SubscriptionScheduledTaskEncoder()
@@ -255,15 +268,32 @@ class ForwardToExecutor(ProcessingStrategy[Tick]):
 
     def submit(self, message: Message[Tick]) -> None:
         assert not self.__closed
+        assert isinstance(message.value, BrokerValue)
 
         tick = message.payload
         assert tick.partition is not None
 
-        tasks = []
-        for entity_scheduler in self.__schedulers:
-            tasks.extend(list(entity_scheduler[tick.partition].find(tick)))
+        # Mirror ProduceScheduledSubscriptionMessage: stale ticks produce no work
+        # and must still advance the commit-log consumer offset.
+        if (
+            self.__stale_threshold_seconds is not None
+            and time.time() - tick.timestamps.lower > self.__stale_threshold_seconds
+        ):
+            encoded_tasks: list[KafkaPayload] = []
+        else:
+            tasks = []
+            for entity_scheduler in self.__schedulers:
+                tasks.extend(list(entity_scheduler[tick.partition].find(tick)))
+            encoded_tasks = [self.__encoder.encode(task) for task in tasks]
 
-        encoded_tasks = [self.__encoder.encode(task) for task in tasks]
+        # If there is nothing to execute, commit immediately. Otherwise the
+        # combined scheduler-executor never stages offsets (ExecuteQuery only
+        # commits after producing a result) and the consumer appears stuck
+        # with CURRENT-OFFSET=- while lag stays non-zero.
+        if len(encoded_tasks) == 0:
+            logger.info("Committing offset - no subscriptions: %r", message.committable)
+            self.__commit(message.committable)
+            return
 
         for task in encoded_tasks:
             self.__next_step.submit(message.replace(task))

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
@@ -11,7 +10,7 @@ from arroyo.commit import ONCE_PER_SECOND
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
-from arroyo.types import Commit
+from arroyo.types import Commit, FilteredPayload
 
 from snuba import settings
 from snuba.datasets.dataset import Dataset
@@ -31,7 +30,6 @@ from snuba.subscriptions.utils import SchedulingWatermarkMode, Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.configuration_builder import build_kafka_consumer_configuration
 
-logger = logging.getLogger(__name__)
 redis_client = get_redis_client(RedisClientKey.SUBSCRIPTION_STORE)
 
 
@@ -239,7 +237,6 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
             ForwardToExecutor(
                 self.__schedulers,
                 execute_step,
-                commit,
                 self.__stale_threshold_seconds,
             ),
             self.__metrics,
@@ -250,12 +247,10 @@ class ForwardToExecutor(ProcessingStrategy[Tick]):
     def __init__(
         self,
         schedulers: Sequence[Mapping[int, SubscriptionScheduler]],
-        next_step: ProcessingStrategy[KafkaPayload],
-        commit: Commit,
+        next_step: ProcessingStrategy[FilteredPayload | KafkaPayload],
         stale_threshold_seconds: int | None = None,
     ) -> None:
         self.__next_step = next_step
-        self.__commit = commit
         self.__stale_threshold_seconds = stale_threshold_seconds
 
         self.__schedulers = schedulers
@@ -281,9 +276,10 @@ class ForwardToExecutor(ProcessingStrategy[Tick]):
                 for task in entity_scheduler[tick.partition].find(tick):
                     encoded_tasks.append(self.__encoder.encode(task))
 
+        # Route empty ticks through the executor as FilteredPayload so commits
+        # stay ordered behind any in-flight subscription queries.
         if not encoded_tasks:
-            logger.info("Committing offset - no subscriptions: %r", message.committable)
-            self.__commit(message.committable)
+            self.__next_step.submit(message.replace(FilteredPayload()))
             return
 
         for encoded_task in encoded_tasks:

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -19,7 +19,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.healthcheck import Healthcheck
 from arroyo.processing.strategies.produce import Produce
-from arroyo.types import Commit
+from arroyo.types import Commit, FilteredPayload
 
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.consumers.utils import get_partition_count
@@ -189,7 +189,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
         self,
         commit: Commit,
         partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[KafkaPayload]:
+    ) -> ProcessingStrategy[FilteredPayload | KafkaPayload]:
         calculated_max_concurrent_queries = calculate_max_concurrent_queries(
             len(partitions),
             self.__total_partition_count,
@@ -197,7 +197,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
         )
         self.__metrics.gauge("calculated_max_concurrent_queries", calculated_max_concurrent_queries)
 
-        strategy: ProcessingStrategy[KafkaPayload] = ExecuteQuery(
+        strategy: ProcessingStrategy[FilteredPayload | KafkaPayload] = ExecuteQuery(
             self.__dataset,
             self.__entity_names,
             calculated_max_concurrent_queries,
@@ -212,7 +212,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
         return strategy
 
 
-class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
+class ExecuteQuery(ProcessingStrategy[FilteredPayload | KafkaPayload]):
     """
     Decodes a scheduled subscription task from the Kafka payload, builds
     the request and executes the ClickHouse query.
@@ -225,7 +225,7 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
         max_concurrent_queries: int,
         stale_threshold_seconds: int | None,
         metrics: MetricsBackend,
-        next_step: ProcessingStrategy[KafkaPayload],
+        next_step: ProcessingStrategy[FilteredPayload | KafkaPayload],
     ) -> None:
         self.__dataset = dataset
         self.__entity_names = set(entity_names)
@@ -238,7 +238,12 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
         self.__encoder = SubscriptionScheduledTaskEncoder()
         self.__result_encoder = SubscriptionTaskResultEncoder()
 
-        self.__queue: deque[tuple[Message[KafkaPayload], SubscriptionTaskResultFuture]] = deque()
+        self.__queue: deque[
+            tuple[
+                Message[FilteredPayload | KafkaPayload],
+                SubscriptionTaskResultFuture | None,
+            ]
+        ] = deque()
 
         self.__closed = False
 
@@ -279,10 +284,17 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
     def poll(self) -> None:
         while self.__queue:
-            if not self.__queue[0][1].future.done():
+            message, result_future = self.__queue[0]
+
+            if result_future is None:
+                self.__queue.popleft()
+                self.__next_step.submit(message)
+                continue
+
+            if not result_future.future.done():
                 break
 
-            message, result_future = self.__queue.popleft()
+            self.__queue.popleft()
 
             try:
                 transformed_message = message.replace(
@@ -318,7 +330,7 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
         self.__next_step.poll()
 
-    def submit(self, message: Message[KafkaPayload]) -> None:
+    def submit(self, message: Message[FilteredPayload | KafkaPayload]) -> None:
         assert not self.__closed
 
         # If there are max_concurrent_queries + 10 pending futures in the queue,
@@ -331,6 +343,12 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
         # the queue
         if len(self.__queue) >= max_queue_size:
             raise MessageRejected
+
+        # Empty ticks are forwarded as FilteredPayload so CommitOffsets still
+        # advances, but only after earlier in-flight queries complete.
+        if isinstance(message.payload, FilteredPayload):
+            self.__queue.append((message, None))
+            return
 
         task = self.__encoder.decode(message.payload)
 
@@ -381,6 +399,10 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
                 break
 
             message, result_future = self.__queue.popleft()
+
+            if result_future is None:
+                self.__next_step.submit(message)
+                continue
 
             try:
                 result = result_future.future.result(remaining)

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -186,7 +186,6 @@ class CommitLogTickConsumer(Consumer[Tick]):
         return result
 
     def __sync_timestamp(self, orig_message_ts: float, received_p99: float | None) -> float:
-        """Return the scheduling clock ts, falling back when received_p99 is null."""
         if self.__synchronization_timestamp == "orig_message_ts":
             return orig_message_ts
         if received_p99 is None:

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -186,22 +186,12 @@ class CommitLogTickConsumer(Consumer[Tick]):
         return result
 
     def __sync_timestamp(self, orig_message_ts: float, received_p99: float | None) -> float:
-        """
-        Resolve the timestamp used as the subscription scheduling clock.
-
-        Prefer the configured synchronization timestamp, but fall back to
-        orig_message_ts when received_p99 is missing. Several commit-log
-        producers historically emit received_p99=null; treating that as a hard
-        failure permanently stalls the tick consumer because the previous
-        message is left with a null lower bound.
-        """
+        """Return the scheduling clock ts, falling back when received_p99 is null."""
         if self.__synchronization_timestamp == "orig_message_ts":
             return orig_message_ts
-
         if received_p99 is None:
             self.__metrics.increment("subscriptions.scheduler.sync_ts_fallback")
             return orig_message_ts
-
         return received_p99
 
     def pause(self, partitions: Sequence[Partition]) -> None:

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -155,8 +155,10 @@ class CommitLogTickConsumer(Consumer[Tick]):
         if previous_message is not None:
             try:
                 time_interval = Interval(
-                    getattr(previous_message, self.__synchronization_timestamp),
-                    getattr(commit, self.__synchronization_timestamp),
+                    self.__sync_timestamp(
+                        previous_message.orig_message_ts, previous_message.received_p99
+                    ),
+                    self.__sync_timestamp(commit.orig_message_ts, commit.received_p99),
                 )
                 offset_interval = Interval(previous_message.offset, commit.offset)
             except InvalidRangeError:
@@ -182,6 +184,25 @@ class CommitLogTickConsumer(Consumer[Tick]):
         )
 
         return result
+
+    def __sync_timestamp(self, orig_message_ts: float, received_p99: float | None) -> float:
+        """
+        Resolve the timestamp used as the subscription scheduling clock.
+
+        Prefer the configured synchronization timestamp, but fall back to
+        orig_message_ts when received_p99 is missing. Several commit-log
+        producers historically emit received_p99=null; treating that as a hard
+        failure permanently stalls the tick consumer because the previous
+        message is left with a null lower bound.
+        """
+        if self.__synchronization_timestamp == "orig_message_ts":
+            return orig_message_ts
+
+        if received_p99 is None:
+            self.__metrics.increment("subscriptions.scheduler.sync_ts_fallback")
+            return orig_message_ts
+
+        return received_p99
 
     def pause(self, partitions: Sequence[Partition]) -> None:
         self.__consumer.pause(partitions)

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -102,10 +102,6 @@ def test_combined_scheduler_and_executor(tmpdir: Path) -> None:
 
 @pytest.mark.redis_db
 def test_combined_scheduler_commits_when_no_subscriptions() -> None:
-    """
-    With no matching subscriptions the combined consumer must still commit the
-    commit-log offset. Otherwise CURRENT-OFFSET stays unset and lag never drains.
-    """
     epoch = datetime.now()
 
     topic = Topic("snuba-commit-log")

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -98,3 +98,51 @@ def test_combined_scheduler_and_executor(tmpdir: Path) -> None:
         assert (tmpdir / "health.txt").exists()
         strategy.close()
         strategy.join()
+
+
+@pytest.mark.redis_db
+def test_combined_scheduler_commits_when_no_subscriptions() -> None:
+    """
+    With no matching subscriptions the combined consumer must still commit the
+    commit-log offset. Otherwise CURRENT-OFFSET stays unset and lag never drains.
+    """
+    epoch = datetime.now()
+
+    topic = Topic("snuba-commit-log")
+    partitions = {Partition(topic, 0): 0}
+    partition = Partition(topic, 0)
+    commit = mock.Mock()
+
+    factory = CombinedSchedulerExecutorFactory(
+        dataset=get_dataset("events"),
+        entity_names=["events"],
+        partitions=1,
+        total_concurrent_queries=2,
+        producer=mock.Mock(),
+        metrics=TestingMetricsBackend(),
+        stale_threshold_seconds=None,
+        result_topic="events-subscription-results",
+        schedule_ttl=60,
+    )
+
+    strategy = factory.create_with_partitions(commit, partitions)
+
+    message = Message(
+        BrokerValue(
+            Tick(
+                0,
+                offsets=Interval(1, 3),
+                timestamps=Interval(epoch.timestamp(), epoch.timestamp() + 60),
+            ),
+            partition,
+            4,
+            epoch,
+        )
+    )
+    strategy.submit(message)
+
+    assert commit.call_count == 1
+    assert commit.call_args.args[0] == {partition: 5}
+
+    strategy.close()
+    strategy.join()

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -137,8 +137,14 @@ def test_combined_scheduler_commits_when_no_subscriptions() -> None:
     )
     strategy.submit(message)
 
-    assert commit.call_count == 1
-    assert commit.call_args.args[0] == {partition: 5}
+    # Empty ticks commit through the executor chain on poll so they stay ordered
+    # behind any in-flight subscription queries.
+    for _ in range(5):
+        strategy.poll()
+        if any(call.args and call.args[0] == {partition: 5} for call in commit.call_args_list):
+            break
+
+    assert any(call.args and call.args[0] == {partition: 5} for call in commit.call_args_list)
 
     strategy.close()
     strategy.join()

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -52,7 +52,7 @@ from snuba.utils.streams.configuration_builder import (
 from snuba.utils.streams.topics import Topic as SnubaTopic
 from snuba.web.rpc.v1.create_subscription import CreateSubscriptionRequest
 from tests.assertions import assert_changes
-from tests.backends.metrics import TestingMetricsBackend
+from tests.backends.metrics import Increment, TestingMetricsBackend
 
 commit_codec = CommitCodec()
 
@@ -634,6 +634,79 @@ def test_tick_consumer_non_monotonic() -> None:
             3,
             epoch + timedelta(seconds=2),
         )
+
+
+def test_tick_consumer_falls_back_when_received_p99_missing() -> None:
+    """
+    Commit-log messages may omit received_p99 (null). When the entity is
+    configured to synchronize on received_p99, fall back to orig_message_ts so
+    the scheduler keeps forming ticks instead of stalling forever.
+    """
+    clock = MockedClock()
+    broker: Broker[KafkaPayload] = Broker(MemoryMessageStorage(), clock)
+
+    epoch = datetime.fromtimestamp(clock.time())
+
+    topic = Topic("messages")
+    followed_consumer_group = "events"
+    partition = Partition(topic, 0)
+
+    broker.create_topic(topic, partitions=1)
+
+    producer = broker.get_producer()
+    metrics = TestingMetricsBackend()
+
+    consumer = CommitLogTickConsumer(
+        broker.get_consumer("group"),
+        followed_consumer_group,
+        metrics,
+        "received_p99",
+    )
+
+    consumer.subscribe([topic])
+
+    # received_p99 deliberately left as None on both messages
+    producer.produce(
+        partition,
+        commit_codec.encode(
+            Commit(
+                followed_consumer_group,
+                partition,
+                0,
+                epoch.timestamp(),
+                None,
+            )
+        ),
+    ).result()
+
+    clock.sleep(1)
+
+    producer.produce(
+        partition,
+        commit_codec.encode(
+            Commit(
+                followed_consumer_group,
+                partition,
+                1,
+                epoch.timestamp() + 1,
+                None,
+            )
+        ),
+    ).result()
+
+    # First message seeds previous state and does not yield a tick
+    assert consumer.poll() is None
+
+    tick_message = consumer.poll()
+    assert tick_message is not None
+    assert tick_message.payload == Tick(
+        0,
+        offsets=Interval(0, 1),
+        timestamps=Interval(epoch.timestamp(), epoch.timestamp() + 1),
+    )
+
+    # One fallback per side of the interval (previous + current message)
+    assert metrics.calls.count(Increment("subscriptions.scheduler.sync_ts_fallback", 1, None)) == 2
 
 
 def test_invalid_commit_log_message(caplog: Any) -> None:

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -637,22 +637,13 @@ def test_tick_consumer_non_monotonic() -> None:
 
 
 def test_tick_consumer_falls_back_when_received_p99_missing() -> None:
-    """
-    Commit-log messages may omit received_p99 (null). When the entity is
-    configured to synchronize on received_p99, fall back to orig_message_ts so
-    the scheduler keeps forming ticks instead of stalling forever.
-    """
     clock = MockedClock()
     broker: Broker[KafkaPayload] = Broker(MemoryMessageStorage(), clock)
-
     epoch = datetime.fromtimestamp(clock.time())
-
     topic = Topic("messages")
     followed_consumer_group = "events"
     partition = Partition(topic, 0)
-
     broker.create_topic(topic, partitions=1)
-
     producer = broker.get_producer()
     metrics = TestingMetricsBackend()
 
@@ -662,40 +653,17 @@ def test_tick_consumer_falls_back_when_received_p99_missing() -> None:
         metrics,
         "received_p99",
     )
-
     consumer.subscribe([topic])
 
-    # received_p99 deliberately left as None on both messages
-    producer.produce(
-        partition,
-        commit_codec.encode(
-            Commit(
-                followed_consumer_group,
-                partition,
-                0,
-                epoch.timestamp(),
-                None,
-            )
-        ),
-    ).result()
+    for offset, ts in ((0, epoch.timestamp()), (1, epoch.timestamp() + 1)):
+        producer.produce(
+            partition,
+            commit_codec.encode(Commit(followed_consumer_group, partition, offset, ts, None)),
+        ).result()
+        if offset == 0:
+            clock.sleep(1)
 
-    clock.sleep(1)
-
-    producer.produce(
-        partition,
-        commit_codec.encode(
-            Commit(
-                followed_consumer_group,
-                partition,
-                1,
-                epoch.timestamp() + 1,
-                None,
-            )
-        ),
-    ).result()
-
-    # First message seeds previous state and does not yield a tick
-    assert consumer.poll() is None
+    assert consumer.poll() is None  # seeds previous state only
 
     tick_message = consumer.poll()
     assert tick_message is not None
@@ -704,8 +672,7 @@ def test_tick_consumer_falls_back_when_received_p99_missing() -> None:
         offsets=Interval(0, 1),
         timestamps=Interval(epoch.timestamp(), epoch.timestamp() + 1),
     )
-
-    # One fallback per side of the interval (previous + current message)
+    # Fallback once per side of the interval (previous + current).
     assert metrics.calls.count(Increment("subscriptions.scheduler.sync_ts_fallback", 1, None)) == 2
 
 

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -663,7 +663,7 @@ def test_tick_consumer_falls_back_when_received_p99_missing() -> None:
         if offset == 0:
             clock.sleep(1)
 
-    assert consumer.poll() is None  # seeds previous state only
+    assert consumer.poll() is None
 
     tick_message = consumer.poll()
     assert tick_message is not None
@@ -672,7 +672,6 @@ def test_tick_consumer_falls_back_when_received_p99_missing() -> None:
         offsets=Interval(0, 1),
         timestamps=Interval(epoch.timestamp(), epoch.timestamp() + 1),
     )
-    # Fallback once per side of the interval (previous + current).
     assert metrics.calls.count(Increment("subscriptions.scheduler.sync_ts_fallback", 1, None)) == 2
 
 


### PR DESCRIPTION
The combined `subscriptions-scheduler-executor` (used by self-hosted for events/transactions metric alerts) could sit assigned to `snuba-commit-log` forever without advancing offsets. Commit-log messages with `received_p99: null` never formed ticks, and empty ticks never committed, so `CURRENT-OFFSET` stayed `-` and alerts never fired.

This falls back to `orig_message_ts` when `received_p99` is missing, commits immediately when a tick has no (or only stale) work, and fills `received_p99` from `origin_timestamp` on the hybrid Rust/Python consumer path so new commit-log traffic is complete.

Fixes EAP-104
Fixes getsentry/snuba#7204
