### PR TITLE
fix(tracing): default to continue-only traces without local sampling

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -47,8 +47,9 @@ class SnubaCLI(click.MultiCommand):
         # by default. To mimic this behavior we have to do that here
         # since all of our infrastructure depends on this being the
         # case
-        # parent_span=None => service span. No stream-mode sampled=True; obeys
-        # SENTRY_TRACE_SAMPLE_RATE. snuba_init_time metric below is unaffected.
+        # parent_span=None => service span. Only emitted when
+        # SENTRY_TRACE_SAMPLE_RATE is explicitly set; default None is continue-only.
+        # snuba_init_time metric below is unaffected.
         with traces.start_span(
             name=f"[cli init] {name}",
             attributes={SENTRY_OP: "snuba_init"},

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -179,6 +179,10 @@ def setup_sentry() -> None:
         # the value for release is also computed in rust-snuba, please keep the
         # logic in sync
         release=os.getenv("SNUBA_RELEASE"),
+        # None (default) disables local root creation while still allowing
+        # continue-only participation in upstream-sampled traces under stream
+        # mode. A numeric 0 still enables tracing and floods Sample Rate
+        # client discards for every unsampled local root.
         traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
         profiles_sample_rate=settings.SNUBA_PROFILES_SAMPLE_RATE,
         # Stream spans as they finish. Disables the legacy tracing API

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -218,7 +218,14 @@ RECORD_COGS = False
 
 # Sentry Options
 SENTRY_DSN: str | None = None
-SENTRY_TRACE_SAMPLE_RATE = 0
+# None (default) keeps tracing disabled for local roots so we only continue
+# incoming sampled traces under trace_lifecycle="stream". A numeric 0 still
+# enables tracing and emits Sample Rate client discards for every unsampled
+# local root. Set via env only when intentionally enabling local sampling.
+_raw_trace_sample_rate = os.environ.get("SENTRY_TRACE_SAMPLE_RATE")
+SENTRY_TRACE_SAMPLE_RATE: float | None = (
+    float(_raw_trace_sample_rate) if _raw_trace_sample_rate else None
+)
 
 # Snuba Admin Options
 SLACK_API_TOKEN = os.environ.get("SLACK_API_TOKEN")


### PR DESCRIPTION
Default `SENTRY_TRACE_SAMPLE_RATE` to `None` instead of `0` so Snuba only continues upstream-sampled traces under stream mode, without creating unsampled local roots that flood Sample Rate client discards.

`0` still enables tracing (`traces_sample_rate is not None`) and reports every unsampled local root as a client discard. Unset/`None` disables local root creation while keeping continue-only participation.

### Deploy note
If prod sets `SENTRY_TRACE_SAMPLE_RATE=0`, remove that env var. Leaving it at `0` preserves the discard flood.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
