### PR TITLE
ci: Replace secrets: inherit with explicit secret in validate-sentry-options

### DIFF
--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -33,7 +33,8 @@ jobs:
     needs: cli-version
     name: Validate Schema Evolution
     uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@main
-    secrets: inherit
+    secrets:
+      SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:
       schemas-path: sentry-options/schemas
       cli-version: ${{ needs.cli-version.outputs.version }}


### PR DESCRIPTION
## Summary
- `validate-sentry-options.yml` used `secrets: inherit` when calling the reusable `getsentry/sentry-options/.github/workflows/validate-schema.yml`, exposing every repository secret to the called workflow.
- The called workflow declares exactly one optional secret under `workflow_call.secrets`: `SENTRY_INTERNAL_APP_PRIVATE_KEY`, used only when a schema deletion is detected (to check out `sentry-options-automator`).
- Replaced `secrets: inherit` with an explicit map passing only that secret.

## Test plan
- [x] Confirmed `getsentry/sentry-options/.github/workflows/validate-schema.yml` declares only `SENTRY_INTERNAL_APP_PRIVATE_KEY` under `workflow_call.secrets`
- [x] Validated workflow YAML parses correctly; pre-commit hooks passed
- [ ] Verify the Validate Schema Evolution check still runs correctly on this PR

Fixes VULN-2354

🤖 Generated with [Claude Code](https://claude.com/claude-code)