### PR TITLE
feat(eap): add received-at version test job

### DIFF
--- a/snuba/manual_jobs/create_eap_received_at_version_test.py
+++ b/snuba/manual_jobs/create_eap_received_at_version_test.py
@@ -8,6 +8,7 @@ from snuba.manual_jobs import Job, JobLogger
 from snuba.migrations.table_engines import ReplacingMergeTree
 
 _SOURCE_TABLE = "eap_items_1_local"
+_DISTRIBUTED_SOURCE_TABLE = "eap_items_1_dist"
 _SCHEMA_SOURCE_TABLE = "eap_items_1_downsample_8_local"
 _DESTINATION_TABLE = "eap_items_1_downsample_8_timestamp_versioned_test_local"
 _VIEW_NAME = "eap_items_1_downsample_8_timestamp_versioned_test_mv"
@@ -35,10 +36,14 @@ def _column_definition(column: ColumnDescription) -> str:
     return " ".join(clauses)
 
 
-def _on_cluster(cluster: ClickhouseCluster) -> str:
+def _on_cluster(cluster: ClickhouseCluster, *, distributed: bool = False) -> str:
     if cluster.is_single_node():
         return ""
-    cluster_name = cluster.get_clickhouse_cluster_name()
+    cluster_name = (
+        cluster.get_clickhouse_distributed_cluster_name()
+        if distributed
+        else cluster.get_clickhouse_cluster_name()
+    )
     assert cluster_name is not None
     return f" ON CLUSTER {escape_string(cluster_name)}"
 
@@ -68,9 +73,11 @@ def _get_columns(connection: ClickhousePool, table_name: str) -> list[ColumnDesc
     ]
 
 
-def _add_received_at_query(cluster: ClickhouseCluster) -> str:
+def _add_received_at_query(
+    cluster: ClickhouseCluster, table_name: str, *, distributed: bool = False
+) -> str:
     return (
-        f"ALTER TABLE {_SOURCE_TABLE}{_on_cluster(cluster)} "
+        f"ALTER TABLE {table_name}{_on_cluster(cluster, distributed=distributed)} "
         "ADD COLUMN IF NOT EXISTS received_at UInt64"
     )
 
@@ -122,9 +129,19 @@ class AddEAPReceivedAtColumn(Job):
 
     def execute(self, logger: JobLogger) -> None:
         cluster, connection = _get_connection()
-        query = _add_received_at_query(cluster)
+        query = _add_received_at_query(cluster, _SOURCE_TABLE)
         logger.info(f"Executing query: {query}")
         connection.execute(query=query)
+
+        if not cluster.is_single_node():
+            distributed_nodes = cluster.get_distributed_nodes()
+            assert distributed_nodes, "EAP distributed cluster has no nodes"
+            distributed_connection = cluster.get_node_connection(
+                ClickhouseClientSettings.MIGRATE, distributed_nodes[0]
+            )
+            query = _add_received_at_query(cluster, _DISTRIBUTED_SOURCE_TABLE, distributed=True)
+            logger.info(f"Executing query: {query}")
+            distributed_connection.execute(query=query)
         logger.info("complete")
 
 

--- a/snuba/manual_jobs/create_eap_received_at_version_test.py
+++ b/snuba/manual_jobs/create_eap_received_at_version_test.py
@@ -1,0 +1,132 @@
+from collections.abc import Sequence
+
+from snuba.clickhouse.escaping import escape_identifier, escape_string
+from snuba.clickhouse.native import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseCluster, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.manual_jobs import Job, JobLogger
+from snuba.migrations.table_engines import ReplacingMergeTree
+
+_SOURCE_TABLE = "eap_items_1_local"
+_SCHEMA_SOURCE_TABLE = "eap_items_1_downsample_8_local"
+_DESTINATION_TABLE = "eap_items_1_downsample_8_timestamp_versioned_test_local"
+_VIEW_NAME = "eap_items_1_downsample_8_timestamp_versioned_test_mv"
+
+ColumnDescription = tuple[str, str, str, str, str, str, str]
+
+
+def _escape_identifier(identifier: str) -> str:
+    escaped = escape_identifier(identifier)
+    assert escaped is not None
+    return escaped
+
+
+def _column_definition(column: ColumnDescription) -> str:
+    name, column_type, default_type, default_expression, comment, codec, ttl = column
+    clauses = [f"{_escape_identifier(name)} {column_type}"]
+    if default_type:
+        clauses.append(f"{default_type} {default_expression}")
+    if comment:
+        clauses.append(f"COMMENT {escape_string(comment)}")
+    if codec:
+        clauses.append(f"CODEC({codec})")
+    if ttl:
+        clauses.append(f"TTL {ttl}")
+    return " ".join(clauses)
+
+
+class CreateEAPReceivedAtVersionTest(Job):
+    """Create the S4S2 received_at-versioned EAP downsample experiment."""
+
+    def _on_cluster(self, cluster: ClickhouseCluster) -> str:
+        if cluster.is_single_node():
+            return ""
+        cluster_name = cluster.get_clickhouse_cluster_name()
+        assert cluster_name is not None
+        return f" ON CLUSTER {escape_string(cluster_name)}"
+
+    def _add_received_at_query(self, cluster: ClickhouseCluster) -> str:
+        return (
+            f"ALTER TABLE {_SOURCE_TABLE}{self._on_cluster(cluster)} "
+            "ADD COLUMN IF NOT EXISTS received_at UInt64"
+        )
+
+    def _get_columns_query(self) -> str:
+        return f"DESCRIBE TABLE {_SCHEMA_SOURCE_TABLE} SETTINGS describe_include_subcolumns = 0"
+
+    def _create_table_query(
+        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
+    ) -> str:
+        assert columns, f"{_SCHEMA_SOURCE_TABLE} has no columns"
+        column_definitions = ", ".join(_column_definition(column) for column in columns)
+        column_definitions += ", received_at UInt64"
+        engine = ReplacingMergeTree(
+            storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+            version_column="received_at",
+            primary_key="(organization_id, project_id, item_type, timestamp)",
+            order_by=("(organization_id, project_id, item_type, timestamp, trace_id, item_id)"),
+            partition_by="(retention_days, toMonday(timestamp))",
+            ttl="timestamp + toIntervalDay(retention_days)",
+            settings={
+                "index_granularity": "8192",
+                "enable_block_number_column": "1",
+                "enable_block_offset_column": "1",
+            },
+        ).get_sql(cluster, _DESTINATION_TABLE)
+        return (
+            f"CREATE TABLE IF NOT EXISTS {_DESTINATION_TABLE}{self._on_cluster(cluster)} "
+            f"({column_definitions}) ENGINE = {engine}"
+        )
+
+    def _create_view_query(
+        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
+    ) -> str:
+        projections = {
+            "retention_days": "downsampled_retention_days AS retention_days",
+            "sampling_weight": "sampling_weight * 8 AS sampling_weight",
+            "sampling_factor": "sampling_factor / 8 AS sampling_factor",
+            "client_sample_rate": "client_sample_rate / 8 AS client_sample_rate",
+            "server_sample_rate": "server_sample_rate / 8 AS server_sample_rate",
+        }
+        select_columns = [
+            projections.get(column[0], _escape_identifier(column[0])) for column in columns
+        ]
+        select_columns.append("received_at")
+        return (
+            f"CREATE MATERIALIZED VIEW IF NOT EXISTS {_VIEW_NAME}{self._on_cluster(cluster)} "
+            f"TO {_DESTINATION_TABLE} AS SELECT {', '.join(select_columns)} "
+            f"FROM {_SOURCE_TABLE} WHERE (cityHash64(item_id) % 8) = 0"
+        )
+
+    def execute(self, logger: JobLogger) -> None:
+        cluster = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM)
+        connection = cluster.get_node_connection(
+            ClickhouseClientSettings.MIGRATE, cluster.get_local_nodes()[0]
+        )
+
+        add_column_query = self._add_received_at_query(cluster)
+        logger.info(f"Executing query: {add_column_query}")
+        connection.execute(query=add_column_query)
+
+        columns_result: ClickhouseResult = connection.execute(query=self._get_columns_query())
+        columns = [
+            (
+                str(name),
+                str(column_type),
+                str(default_type),
+                str(default_expression),
+                str(comment),
+                str(codec),
+                str(ttl),
+            )
+            for name, column_type, default_type, default_expression, comment, codec, ttl in columns_result.results
+        ]
+        queries = [
+            self._create_table_query(cluster, columns),
+            self._create_view_query(cluster, columns),
+        ]
+        for query in queries:
+            logger.info(f"Executing query: {query}")
+            connection.execute(query=query)
+
+        logger.info("complete")

--- a/snuba/manual_jobs/create_eap_received_at_version_test.py
+++ b/snuba/manual_jobs/create_eap_received_at_version_test.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
 from snuba.clickhouse.escaping import escape_identifier, escape_string
-from snuba.clickhouse.native import ClickhouseResult
+from snuba.clickhouse.native import ClickhousePool, ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseCluster, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.manual_jobs import Job, JobLogger
@@ -35,98 +35,118 @@ def _column_definition(column: ColumnDescription) -> str:
     return " ".join(clauses)
 
 
-class CreateEAPReceivedAtVersionTest(Job):
-    """Create the S4S2 received_at-versioned EAP downsample experiment."""
+def _on_cluster(cluster: ClickhouseCluster) -> str:
+    if cluster.is_single_node():
+        return ""
+    cluster_name = cluster.get_clickhouse_cluster_name()
+    assert cluster_name is not None
+    return f" ON CLUSTER {escape_string(cluster_name)}"
 
-    def _on_cluster(self, cluster: ClickhouseCluster) -> str:
-        if cluster.is_single_node():
-            return ""
-        cluster_name = cluster.get_clickhouse_cluster_name()
-        assert cluster_name is not None
-        return f" ON CLUSTER {escape_string(cluster_name)}"
 
-    def _add_received_at_query(self, cluster: ClickhouseCluster) -> str:
-        return (
-            f"ALTER TABLE {_SOURCE_TABLE}{self._on_cluster(cluster)} "
-            "ADD COLUMN IF NOT EXISTS received_at UInt64"
+def _get_connection() -> tuple[ClickhouseCluster, ClickhousePool]:
+    cluster = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM)
+    connection = cluster.get_node_connection(
+        ClickhouseClientSettings.MIGRATE, cluster.get_local_nodes()[0]
+    )
+    return cluster, connection
+
+
+def _get_columns(connection: ClickhousePool, table_name: str) -> list[ColumnDescription]:
+    query = f"DESCRIBE TABLE {table_name} SETTINGS describe_include_subcolumns = 0"
+    columns_result: ClickhouseResult = connection.execute(query=query)
+    return [
+        (
+            str(name),
+            str(column_type),
+            str(default_type),
+            str(default_expression),
+            str(comment),
+            str(codec),
+            str(ttl),
         )
+        for name, column_type, default_type, default_expression, comment, codec, ttl in columns_result.results
+    ]
 
-    def _get_columns_query(self) -> str:
-        return f"DESCRIBE TABLE {_SCHEMA_SOURCE_TABLE} SETTINGS describe_include_subcolumns = 0"
 
-    def _create_table_query(
-        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
-    ) -> str:
-        assert columns, f"{_SCHEMA_SOURCE_TABLE} has no columns"
-        column_definitions = ", ".join(_column_definition(column) for column in columns)
-        column_definitions += ", received_at UInt64"
-        engine = ReplacingMergeTree(
-            storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
-            version_column="received_at",
-            primary_key="(organization_id, project_id, item_type, timestamp)",
-            order_by=("(organization_id, project_id, item_type, timestamp, trace_id, item_id)"),
-            partition_by="(retention_days, toMonday(timestamp))",
-            ttl="timestamp + toIntervalDay(retention_days)",
-            settings={
-                "index_granularity": "8192",
-                "enable_block_number_column": "1",
-                "enable_block_offset_column": "1",
-            },
-        ).get_sql(cluster, _DESTINATION_TABLE)
-        return (
-            f"CREATE TABLE IF NOT EXISTS {_DESTINATION_TABLE}{self._on_cluster(cluster)} "
-            f"({column_definitions}) ENGINE = {engine}"
-        )
+def _add_received_at_query(cluster: ClickhouseCluster) -> str:
+    return (
+        f"ALTER TABLE {_SOURCE_TABLE}{_on_cluster(cluster)} "
+        "ADD COLUMN IF NOT EXISTS received_at UInt64"
+    )
 
-    def _create_view_query(
-        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
-    ) -> str:
-        projections = {
-            "retention_days": "downsampled_retention_days AS retention_days",
-            "sampling_weight": "sampling_weight * 8 AS sampling_weight",
-            "sampling_factor": "sampling_factor / 8 AS sampling_factor",
-            "client_sample_rate": "client_sample_rate / 8 AS client_sample_rate",
-            "server_sample_rate": "server_sample_rate / 8 AS server_sample_rate",
-        }
-        select_columns = [
-            projections.get(column[0], _escape_identifier(column[0])) for column in columns
-        ]
-        select_columns.append("received_at")
-        return (
-            f"CREATE MATERIALIZED VIEW IF NOT EXISTS {_VIEW_NAME}{self._on_cluster(cluster)} "
-            f"TO {_DESTINATION_TABLE} AS SELECT {', '.join(select_columns)} "
-            f"FROM {_SOURCE_TABLE} WHERE (cityHash64(item_id) % 8) = 0"
-        )
+
+def _create_table_query(cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]) -> str:
+    assert columns, f"{_SCHEMA_SOURCE_TABLE} has no columns"
+    column_definitions = ", ".join(_column_definition(column) for column in columns)
+    column_definitions += ", received_at UInt64"
+    engine = ReplacingMergeTree(
+        storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+        version_column="received_at",
+        primary_key="(organization_id, project_id, item_type, timestamp)",
+        order_by=("(organization_id, project_id, item_type, timestamp, trace_id, item_id)"),
+        partition_by="(retention_days, toMonday(timestamp))",
+        ttl="timestamp + toIntervalDay(retention_days)",
+        settings={
+            "index_granularity": "8192",
+            "enable_block_number_column": "1",
+            "enable_block_offset_column": "1",
+        },
+    ).get_sql(cluster, _DESTINATION_TABLE)
+    return (
+        f"CREATE TABLE IF NOT EXISTS {_DESTINATION_TABLE}{_on_cluster(cluster)} "
+        f"({column_definitions}) ENGINE = {engine}"
+    )
+
+
+def _create_view_query(cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]) -> str:
+    assert columns, f"{_DESTINATION_TABLE} has no columns"
+    projections = {
+        "retention_days": "downsampled_retention_days AS retention_days",
+        "sampling_weight": "sampling_weight * 8 AS sampling_weight",
+        "sampling_factor": "sampling_factor / 8 AS sampling_factor",
+        "client_sample_rate": "client_sample_rate / 8 AS client_sample_rate",
+        "server_sample_rate": "server_sample_rate / 8 AS server_sample_rate",
+    }
+    select_columns = [
+        projections.get(column[0], _escape_identifier(column[0])) for column in columns
+    ]
+    return (
+        f"CREATE MATERIALIZED VIEW IF NOT EXISTS {_VIEW_NAME}{_on_cluster(cluster)} "
+        f"TO {_DESTINATION_TABLE} AS SELECT {', '.join(select_columns)} "
+        f"FROM {_SOURCE_TABLE} WHERE received_at != 0 AND (cityHash64(item_id) % 8) = 0"
+    )
+
+
+class AddEAPReceivedAtColumn(Job):
+    """Add the received_at source column before consumer deployment."""
 
     def execute(self, logger: JobLogger) -> None:
-        cluster = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM)
-        connection = cluster.get_node_connection(
-            ClickhouseClientSettings.MIGRATE, cluster.get_local_nodes()[0]
-        )
+        cluster, connection = _get_connection()
+        query = _add_received_at_query(cluster)
+        logger.info(f"Executing query: {query}")
+        connection.execute(query=query)
+        logger.info("complete")
 
-        add_column_query = self._add_received_at_query(cluster)
-        logger.info(f"Executing query: {add_column_query}")
-        connection.execute(query=add_column_query)
 
-        columns_result: ClickhouseResult = connection.execute(query=self._get_columns_query())
-        columns = [
-            (
-                str(name),
-                str(column_type),
-                str(default_type),
-                str(default_expression),
-                str(comment),
-                str(codec),
-                str(ttl),
-            )
-            for name, column_type, default_type, default_expression, comment, codec, ttl in columns_result.results
-        ]
-        queries = [
-            self._create_table_query(cluster, columns),
-            self._create_view_query(cluster, columns),
-        ]
-        for query in queries:
-            logger.info(f"Executing query: {query}")
-            connection.execute(query=query)
+class CreateEAPReceivedAtVersionTestTable(Job):
+    """Create the empty received_at-versioned treatment table."""
 
+    def execute(self, logger: JobLogger) -> None:
+        cluster, connection = _get_connection()
+        columns = _get_columns(connection, _SCHEMA_SOURCE_TABLE)
+        query = _create_table_query(cluster, columns)
+        logger.info(f"Executing query: {query}")
+        connection.execute(query=query)
+        logger.info("complete")
+
+
+class CreateEAPReceivedAtVersionTestMaterializedView(Job):
+    """Start treatment inserts after received_at population is enabled."""
+
+    def execute(self, logger: JobLogger) -> None:
+        cluster, connection = _get_connection()
+        columns = _get_columns(connection, _DESTINATION_TABLE)
+        query = _create_view_query(cluster, columns)
+        logger.info(f"Executing query: {query}")
+        connection.execute(query=query)
         logger.info("complete")

--- a/tests/manual_jobs/test_create_eap_received_at_version_test.py
+++ b/tests/manual_jobs/test_create_eap_received_at_version_test.py
@@ -45,8 +45,10 @@ def _build_cluster(*, single_node: bool) -> Mock:
     cluster = Mock()
     cluster.is_single_node.return_value = single_node
     cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
+    cluster.get_clickhouse_distributed_cluster_name.return_value = "eap_dist_cluster"
     cluster.get_database.return_value = "default"
     cluster.get_local_nodes.return_value = ["local-node"]
+    cluster.get_distributed_nodes.return_value = ["distributed-node"]
     return cluster
 
 
@@ -75,8 +77,12 @@ def test_jobs_require_manifest(job_type: type[Job]) -> None:
 def test_multi_node_queries() -> None:
     cluster = _build_cluster(single_node=False)
 
-    assert _add_received_at_query(cluster) == (
+    assert _add_received_at_query(cluster, "eap_items_1_local") == (
         "ALTER TABLE eap_items_1_local ON CLUSTER 'eap_cluster' "
+        "ADD COLUMN IF NOT EXISTS received_at UInt64"
+    )
+    assert _add_received_at_query(cluster, "eap_items_1_dist", distributed=True) == (
+        "ALTER TABLE eap_items_1_dist ON CLUSTER 'eap_dist_cluster' "
         "ADD COLUMN IF NOT EXISTS received_at UInt64"
     )
 
@@ -127,17 +133,49 @@ def test_single_node_uses_non_replicated_engine() -> None:
     assert "ReplicatedReplacingMergeTree" not in create_table
 
 
-def test_add_column_job_executes_only_source_alter(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_add_column_job_alters_local_and_distributed_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = _build_job(monkeypatch, AddEAPReceivedAtColumn)
+    local_connection = Mock()
+    distributed_connection = Mock()
+    cluster = _patch_cluster(monkeypatch, local_connection)
+    cluster.get_node_connection.side_effect = [local_connection, distributed_connection]
+
+    job.execute(Mock())
+
+    assert cluster.get_node_connection.call_args_list == [
+        call(ClickhouseClientSettings.MIGRATE, "local-node"),
+        call(ClickhouseClientSettings.MIGRATE, "distributed-node"),
+    ]
+    local_connection.execute.assert_called_once_with(
+        query=_add_received_at_query(cluster, "eap_items_1_local")
+    )
+    distributed_connection.execute.assert_called_once_with(
+        query=_add_received_at_query(cluster, "eap_items_1_dist", distributed=True)
+    )
+
+
+def test_add_column_job_skips_dist_table_on_single_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     job = _build_job(monkeypatch, AddEAPReceivedAtColumn)
     connection = Mock()
-    cluster = _patch_cluster(monkeypatch, connection)
+    cluster = _build_cluster(single_node=True)
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
+        Mock(return_value=cluster),
+    )
 
     job.execute(Mock())
 
     cluster.get_node_connection.assert_called_once_with(
         ClickhouseClientSettings.MIGRATE, "local-node"
     )
-    connection.execute.assert_called_once_with(query=_add_received_at_query(cluster))
+    connection.execute.assert_called_once_with(
+        query=_add_received_at_query(cluster, "eap_items_1_local")
+    )
 
 
 def test_create_table_job_does_not_create_view(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/manual_jobs/test_create_eap_received_at_version_test.py
+++ b/tests/manual_jobs/test_create_eap_received_at_version_test.py
@@ -1,0 +1,144 @@
+from unittest.mock import Mock, call
+
+import pytest
+
+from snuba.clickhouse.native import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs.create_eap_received_at_version_test import (
+    CreateEAPReceivedAtVersionTest,
+)
+
+_COLUMNS = [
+    ("organization_id", "UInt64", "", "", "", "", ""),
+    ("project_id", "UInt64", "", "", "", "", ""),
+    ("item_type", "UInt8", "", "", "", "", ""),
+    ("timestamp", "DateTime", "", "", "event time", "DoubleDelta, ZSTD(1)", ""),
+    ("trace_id", "UUID", "", "", "", "", ""),
+    ("item_id", "UInt128", "", "", "", "", ""),
+    ("sampling_weight", "UInt64", "", "", "", "ZSTD(1)", ""),
+    ("sampling_factor", "Float64", "", "", "", "ZSTD(1)", ""),
+    ("retention_days", "UInt16", "DEFAULT", "30", "", "T64, ZSTD(1)", ""),
+    ("client_sample_rate", "Float64", "", "", "", "", ""),
+    ("server_sample_rate", "Float64", "", "", "", "", ""),
+    ("attributes_string_0", "Map(String, String)", "", "", "", "ZSTD(1)", ""),
+]
+
+
+def _build_job(monkeypatch: pytest.MonkeyPatch) -> CreateEAPReceivedAtVersionTest:
+    monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
+    return CreateEAPReceivedAtVersionTest(
+        JobSpec(
+            job_id="create-eap-received-at-version-test",
+            job_type="CreateEAPReceivedAtVersionTest",
+        )
+    )
+
+
+def _build_cluster(*, single_node: bool) -> Mock:
+    cluster = Mock()
+    cluster.is_single_node.return_value = single_node
+    cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
+    cluster.get_database.return_value = "default"
+    return cluster
+
+
+def test_job_requires_manifest() -> None:
+    assert not CreateEAPReceivedAtVersionTest.allow_adhoc_run
+
+
+def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+    cluster = _build_cluster(single_node=False)
+
+    assert job._add_received_at_query(cluster) == (
+        "ALTER TABLE eap_items_1_local ON CLUSTER 'eap_cluster' "
+        "ADD COLUMN IF NOT EXISTS received_at UInt64"
+    )
+
+    create_table = job._create_table_query(cluster, _COLUMNS)
+    assert create_table.startswith(
+        "CREATE TABLE IF NOT EXISTS "
+        "eap_items_1_downsample_8_timestamp_versioned_test_local "
+        "ON CLUSTER 'eap_cluster' (organization_id UInt64"
+    )
+    assert "timestamp DateTime COMMENT 'event time' CODEC(DoubleDelta, ZSTD(1))" in create_table
+    assert "retention_days UInt16 DEFAULT 30 CODEC(T64, ZSTD(1))" in create_table
+    assert (
+        "attributes_string_0 Map(String, String) CODEC(ZSTD(1)), received_at UInt64" in create_table
+    )
+    assert (
+        "ReplicatedReplacingMergeTree("
+        "'/clickhouse/tables/events_analytics_platform/{shard}/default/"
+        "eap_items_1_downsample_8_timestamp_versioned_test_local', "
+        "'{replica}', received_at)"
+    ) in create_table
+    assert "PARTITION BY (retention_days, toMonday(timestamp))" in create_table
+    assert "TTL timestamp + toIntervalDay(retention_days)" in create_table
+    assert (
+        "SETTINGS index_granularity=8192, enable_block_number_column=1, "
+        "enable_block_offset_column=1"
+    ) in create_table
+
+    create_view = job._create_view_query(cluster, _COLUMNS)
+    assert create_view.startswith(
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS "
+        "eap_items_1_downsample_8_timestamp_versioned_test_mv "
+        "ON CLUSTER 'eap_cluster' TO "
+        "eap_items_1_downsample_8_timestamp_versioned_test_local AS SELECT "
+    )
+    assert "sampling_weight * 8 AS sampling_weight" in create_view
+    assert "sampling_factor / 8 AS sampling_factor" in create_view
+    assert "downsampled_retention_days AS retention_days" in create_view
+    assert "server_sample_rate / 8 AS server_sample_rate" in create_view
+    assert "attributes_string_0, received_at FROM eap_items_1_local" in create_view
+    assert create_view.endswith("WHERE (cityHash64(item_id) % 8) = 0")
+
+
+def test_single_node_uses_non_replicated_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+    cluster = _build_cluster(single_node=True)
+
+    create_table = job._create_table_query(cluster, _COLUMNS)
+    assert "ON CLUSTER" not in create_table
+    assert "ENGINE = ReplacingMergeTree(received_at)" in create_table
+    assert "ReplicatedReplacingMergeTree" not in create_table
+
+
+def test_execute_uses_eap_local_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+    connection = Mock()
+    connection.execute.side_effect = [
+        ClickhouseResult(),
+        ClickhouseResult(results=_COLUMNS),
+        ClickhouseResult(),
+        ClickhouseResult(),
+    ]
+    cluster = _build_cluster(single_node=False)
+    cluster.get_local_nodes.return_value = ["local-node"]
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
+        Mock(return_value=cluster),
+    )
+
+    job.execute(Mock())
+
+    cluster.get_node_connection.assert_called_once_with(
+        ClickhouseClientSettings.MIGRATE, "local-node"
+    )
+    assert connection.execute.call_args_list[0] == call(query=job._add_received_at_query(cluster))
+    assert connection.execute.call_args_list[1] == call(query=job._get_columns_query())
+    assert connection.execute.call_args_list[2] == call(
+        query=job._create_table_query(cluster, _COLUMNS)
+    )
+    assert connection.execute.call_args_list[3] == call(
+        query=job._create_view_query(cluster, _COLUMNS)
+    )
+
+
+def test_rejects_empty_source_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+
+    with pytest.raises(AssertionError, match="has no columns"):
+        job._create_table_query(_build_cluster(single_node=True), [])

--- a/tests/manual_jobs/test_create_eap_received_at_version_test.py
+++ b/tests/manual_jobs/test_create_eap_received_at_version_test.py
@@ -4,9 +4,14 @@ import pytest
 
 from snuba.clickhouse.native import ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings
-from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs import Job, JobSpec
 from snuba.manual_jobs.create_eap_received_at_version_test import (
-    CreateEAPReceivedAtVersionTest,
+    AddEAPReceivedAtColumn,
+    CreateEAPReceivedAtVersionTestMaterializedView,
+    CreateEAPReceivedAtVersionTestTable,
+    _add_received_at_query,
+    _create_table_query,
+    _create_view_query,
 )
 
 _COLUMNS = [
@@ -23,14 +28,15 @@ _COLUMNS = [
     ("server_sample_rate", "Float64", "", "", "", "", ""),
     ("attributes_string_0", "Map(String, String)", "", "", "", "ZSTD(1)", ""),
 ]
+_DESTINATION_COLUMNS = [*_COLUMNS, ("received_at", "UInt64", "", "", "", "", "")]
 
 
-def _build_job(monkeypatch: pytest.MonkeyPatch) -> CreateEAPReceivedAtVersionTest:
+def _build_job(monkeypatch: pytest.MonkeyPatch, job_type: type[Job]) -> Job:
     monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
-    return CreateEAPReceivedAtVersionTest(
+    return job_type(
         JobSpec(
-            job_id="create-eap-received-at-version-test",
-            job_type="CreateEAPReceivedAtVersionTest",
+            job_id="eap-received-at-version-test",
+            job_type=job_type.__name__,
         )
     )
 
@@ -40,23 +46,41 @@ def _build_cluster(*, single_node: bool) -> Mock:
     cluster.is_single_node.return_value = single_node
     cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
     cluster.get_database.return_value = "default"
+    cluster.get_local_nodes.return_value = ["local-node"]
     return cluster
 
 
-def test_job_requires_manifest() -> None:
-    assert not CreateEAPReceivedAtVersionTest.allow_adhoc_run
+def _patch_cluster(monkeypatch: pytest.MonkeyPatch, connection: Mock) -> Mock:
+    cluster = _build_cluster(single_node=False)
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
+        Mock(return_value=cluster),
+    )
+    return cluster
 
 
-def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
+@pytest.mark.parametrize(
+    "job_type",
+    [
+        AddEAPReceivedAtColumn,
+        CreateEAPReceivedAtVersionTestTable,
+        CreateEAPReceivedAtVersionTestMaterializedView,
+    ],
+)
+def test_jobs_require_manifest(job_type: type[Job]) -> None:
+    assert not job_type.allow_adhoc_run
+
+
+def test_multi_node_queries() -> None:
     cluster = _build_cluster(single_node=False)
 
-    assert job._add_received_at_query(cluster) == (
+    assert _add_received_at_query(cluster) == (
         "ALTER TABLE eap_items_1_local ON CLUSTER 'eap_cluster' "
         "ADD COLUMN IF NOT EXISTS received_at UInt64"
     )
 
-    create_table = job._create_table_query(cluster, _COLUMNS)
+    create_table = _create_table_query(cluster, _COLUMNS)
     assert create_table.startswith(
         "CREATE TABLE IF NOT EXISTS "
         "eap_items_1_downsample_8_timestamp_versioned_test_local "
@@ -80,7 +104,7 @@ def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
         "enable_block_offset_column=1"
     ) in create_table
 
-    create_view = job._create_view_query(cluster, _COLUMNS)
+    create_view = _create_view_query(cluster, _DESTINATION_COLUMNS)
     assert create_view.startswith(
         "CREATE MATERIALIZED VIEW IF NOT EXISTS "
         "eap_items_1_downsample_8_timestamp_versioned_test_mv "
@@ -92,53 +116,71 @@ def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "downsampled_retention_days AS retention_days" in create_view
     assert "server_sample_rate / 8 AS server_sample_rate" in create_view
     assert "attributes_string_0, received_at FROM eap_items_1_local" in create_view
-    assert create_view.endswith("WHERE (cityHash64(item_id) % 8) = 0")
+    assert create_view.endswith("WHERE received_at != 0 AND (cityHash64(item_id) % 8) = 0")
 
 
-def test_single_node_uses_non_replicated_engine(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
-    cluster = _build_cluster(single_node=True)
+def test_single_node_uses_non_replicated_engine() -> None:
+    create_table = _create_table_query(_build_cluster(single_node=True), _COLUMNS)
 
-    create_table = job._create_table_query(cluster, _COLUMNS)
     assert "ON CLUSTER" not in create_table
     assert "ENGINE = ReplacingMergeTree(received_at)" in create_table
     assert "ReplicatedReplacingMergeTree" not in create_table
 
 
-def test_execute_uses_eap_local_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
+def test_add_column_job_executes_only_source_alter(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, AddEAPReceivedAtColumn)
     connection = Mock()
-    connection.execute.side_effect = [
-        ClickhouseResult(),
-        ClickhouseResult(results=_COLUMNS),
-        ClickhouseResult(),
-        ClickhouseResult(),
-    ]
-    cluster = _build_cluster(single_node=False)
-    cluster.get_local_nodes.return_value = ["local-node"]
-    cluster.get_node_connection.return_value = connection
-    monkeypatch.setattr(
-        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
-        Mock(return_value=cluster),
-    )
+    cluster = _patch_cluster(monkeypatch, connection)
 
     job.execute(Mock())
 
     cluster.get_node_connection.assert_called_once_with(
         ClickhouseClientSettings.MIGRATE, "local-node"
     )
-    assert connection.execute.call_args_list[0] == call(query=job._add_received_at_query(cluster))
-    assert connection.execute.call_args_list[1] == call(query=job._get_columns_query())
-    assert connection.execute.call_args_list[2] == call(
-        query=job._create_table_query(cluster, _COLUMNS)
-    )
-    assert connection.execute.call_args_list[3] == call(
-        query=job._create_view_query(cluster, _COLUMNS)
-    )
+    connection.execute.assert_called_once_with(query=_add_received_at_query(cluster))
 
 
-def test_rejects_empty_source_schema(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
+def test_create_table_job_does_not_create_view(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, CreateEAPReceivedAtVersionTestTable)
+    connection = Mock()
+    connection.execute.side_effect = [ClickhouseResult(results=_COLUMNS), ClickhouseResult()]
+    cluster = _patch_cluster(monkeypatch, connection)
 
-    with pytest.raises(AssertionError, match="has no columns"):
-        job._create_table_query(_build_cluster(single_node=True), [])
+    job.execute(Mock())
+
+    assert connection.execute.call_args_list == [
+        call(
+            query="DESCRIBE TABLE eap_items_1_downsample_8_local "
+            "SETTINGS describe_include_subcolumns = 0"
+        ),
+        call(query=_create_table_query(cluster, _COLUMNS)),
+    ]
+
+
+def test_create_view_job_uses_destination_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, CreateEAPReceivedAtVersionTestMaterializedView)
+    connection = Mock()
+    connection.execute.side_effect = [
+        ClickhouseResult(results=_DESTINATION_COLUMNS),
+        ClickhouseResult(),
+    ]
+    cluster = _patch_cluster(monkeypatch, connection)
+
+    job.execute(Mock())
+
+    assert connection.execute.call_args_list == [
+        call(
+            query="DESCRIBE TABLE eap_items_1_downsample_8_timestamp_versioned_test_local "
+            "SETTINGS describe_include_subcolumns = 0"
+        ),
+        call(query=_create_view_query(cluster, _DESTINATION_COLUMNS)),
+    ]
+
+
+def test_rejects_empty_schemas() -> None:
+    cluster = _build_cluster(single_node=True)
+
+    with pytest.raises(AssertionError, match="downsample_8_local has no columns"):
+        _create_table_query(cluster, [])
+    with pytest.raises(AssertionError, match="versioned_test_local has no columns"):
+        _create_view_query(cluster, [])


### PR DESCRIPTION
## Summary

- add `AddEAPReceivedAtColumn` to add `received_at UInt64` to `eap_items_1_local` and `eap_items_1_dist` independently
- target storage and query-node clusters separately for the local and distributed table alterations
- add `CreateEAPReceivedAtVersionTestTable` to create the empty tier-8 treatment table with `received_at` as its `ReplacingMergeTree` version
- add `CreateEAPReceivedAtVersionTestMaterializedView` to start treatment writes only after population is enabled
- preserve the live tier-8 schema, sampling behavior, and persisted block metadata settings
- filter `received_at = 0` from the treatment MV so unset versions can never create treatment parts

## Rollout order

1. Run `AddEAPReceivedAtColumn`.
2. Merge and deploy #8271 with `eap_items_emit_received_at` disabled by default.
3. Enable `eap_items_emit_received_at` and verify source rows have nonzero values.
4. Run `CreateEAPReceivedAtVersionTestTable`.
5. Run `CreateEAPReceivedAtVersionTestMaterializedView`.

## Test plan

- `pytest -q tests/manual_jobs/test_create_eap_received_at_version_test.py tests/manual_jobs/test_set_eap_downsampled_table_settings.py`
- `pre-commit run --files snuba/manual_jobs/create_eap_received_at_version_test.py tests/manual_jobs/test_create_eap_received_at_version_test.py`