### PR TITLE
feat(eap): emit Kafka broker timestamp as received_at

### DIFF
--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 pub struct ProcessorConfig {
     pub env_config: EnvConfig,
     pub storage_name: String,
+    pub eap_items_emit_received_at: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -329,7 +329,7 @@ type PyInsert = PyObject;
 /// replacement: (key/project_id, value)
 type PyReplacement = (PyObject, PyObject);
 
-#[pyfunction]
+#[pyfunction(signature = (name, value, partition, offset, millis_since_epoch, eap_items_emit_received_at=false))]
 pub fn process_message(
     py: Python,
     name: &str,
@@ -337,6 +337,7 @@ pub fn process_message(
     partition: u16,
     offset: u64,
     millis_since_epoch: i64,
+    eap_items_emit_received_at: bool,
 ) -> PyResult<(Option<PyInsert>, Option<PyReplacement>)> {
     // XXX: Currently only takes the message payload and metadata. This assumes
     // key and headers are not used for message processing
@@ -351,10 +352,14 @@ pub fn process_message(
         offset,
         timestamp,
     };
+    let processor_config = config::ProcessorConfig {
+        eap_items_emit_received_at: name == "EAPItemsProcessor" && eap_items_emit_received_at,
+        ..Default::default()
+    };
 
     match func {
         processors::ProcessingFunctionType::ProcessingFunction(f) => {
-            let res = f(payload, meta, &config::ProcessorConfig::default())
+            let res = f(payload, meta, &processor_config)
                 .map_err(|e| SnubaRustError::new_err(format!("invalid message: {e:?}")))?;
 
             let payload = PyBytes::new(py, &res.rows.into_encoded_rows()).into();
@@ -362,7 +367,7 @@ pub fn process_message(
             Ok((Some(payload), None))
         }
         processors::ProcessingFunctionType::ProcessingFunctionWithReplacements(f) => {
-            let res = f(payload, meta, &config::ProcessorConfig::default())
+            let res = f(payload, meta, &processor_config)
                 .map_err(|e| SnubaRustError::new_err(format!("invalid message: {e:?}")))?;
 
             match res {

--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -90,6 +90,14 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
     }
 
     fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
+        let processor_name = self
+            .storage_config
+            .message_processor
+            .python_class_name
+            .as_str();
+        let eap_items_emit_received_at = processor_name == "EAPItemsProcessor"
+            && crate::processors::eap_items::emit_received_at();
+
         // RowBinary storages: the processor swap (JSON → RowBinary sibling) and
         // the column list the RowBinary writer needs, both used below.
         let (process_fn_override, insert_columns): (
@@ -97,18 +105,15 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
             Option<&'static [&'static str]>,
         ) = if self.use_row_binary {
             tracing::info!("Using RowBinary wire format");
-            let processor_name = self
-                .storage_config
-                .message_processor
-                .python_class_name
-                .as_str();
             let (func, columns): (
                 crate::processors::ProcessingFunction,
                 &'static [&'static str],
             ) = match processor_name {
                 "EAPItemsProcessor" => (
                     crate::processors::eap_items::process_message_row_binary,
-                    crate::processors::eap_items::EAPItemRow::COLUMN_NAMES,
+                    crate::processors::eap_items::EAPItemRow::column_names(
+                        eap_items_emit_received_at,
+                    ),
                 ),
                 name => panic!("RowBinary not supported for processor: {name}"),
             };
@@ -251,6 +256,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                     config::ProcessorConfig {
                         env_config: self.env_config.clone(),
                         storage_name: self.storage_config.name.clone(),
+                        eap_items_emit_received_at,
                     },
                     self.stop_at_timestamp,
                 )
@@ -269,6 +275,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                     config::ProcessorConfig {
                         env_config: self.env_config.clone(),
                         storage_name: self.storage_config.name.clone(),
+                        eap_items_emit_received_at,
                     },
                     self.stop_at_timestamp,
                 )

--- a/rust_snuba/src/processors/eap_items.rs
+++ b/rust_snuba/src/processors/eap_items.rs
@@ -4,7 +4,7 @@ use chrono::Datelike;
 use chrono::Utc;
 use prost::Message;
 use seq_macro::seq;
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap};
 use uuid::Uuid;
 
@@ -34,6 +34,7 @@ use crate::types::{item_type_name, InsertBatch, ItemTypeMetrics, KafkaMessageMet
 /// messages after a grace window prevents that pressure without
 /// over-eagerly dropping current-week stragglers.
 const DLQ_GRACE_PERIOD_MIN_KEY: &str = "eap_items_dlq_grace_period_min";
+const EMIT_RECEIVED_AT_KEY: &str = "eap_items_emit_received_at";
 
 /// Precision factor for sampling_factor calculations to compensate for floating point errors
 const SAMPLING_FACTOR_PRECISION: f64 = 1e6;
@@ -47,7 +48,11 @@ struct ProcessedItem {
     cogs_data: CogsData,
 }
 
-fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Result<ProcessedItem> {
+fn process_eap_item(
+    msg: KafkaPayload,
+    metadata: &KafkaMessageMetadata,
+    config: &ProcessorConfig,
+) -> anyhow::Result<ProcessedItem> {
     let payload: &[u8] = msg.payload().context("Expected payload")?;
     let trace_item = TraceItem::decode(payload)?;
     let origin_timestamp = trace_item
@@ -92,6 +97,15 @@ fn process_eap_item(msg: KafkaPayload, config: &ProcessorConfig) -> anyhow::Resu
 
     eap_item.retention_days = retention_days;
     eap_item.downsampled_retention_days = downsampled_retention_days;
+    if config.eap_items_emit_received_at {
+        eap_item.received_at = Some(
+            metadata
+                .timestamp
+                .timestamp_millis()
+                .try_into()
+                .context("Kafka broker timestamp must be non-negative")?,
+        );
+    }
     eap_item.attributes.insert_int(
         "sentry._internal.ingested_at".into(),
         Utc::now().timestamp_millis(),
@@ -149,6 +163,14 @@ fn get_dlq_grace_period_min(storage_name: &str) -> Option<i64> {
         .filter(|&n| n >= 0)
 }
 
+pub(crate) fn emit_received_at() -> bool {
+    options("snuba")
+        .ok()
+        .and_then(|o| o.get(EMIT_RECEIVED_AT_KEY).ok())
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
 /// Most recent Monday 00:00 UTC at or before `now` — the active weekly
 /// partition boundary used by `toMonday(timestamp)` in ClickHouse.
 fn prior_partition_boundary(now: DateTime<Utc>) -> DateTime<Utc> {
@@ -182,10 +204,10 @@ fn should_dlq(event_ts: DateTime<Utc>, now: DateTime<Utc>, grace_min: i64) -> Op
 
 pub fn process_message(
     msg: KafkaPayload,
-    _metadata: KafkaMessageMetadata,
+    metadata: KafkaMessageMetadata,
     config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
-    let processed = process_eap_item(msg, config)?;
+    let processed = process_eap_item(msg, &metadata, config)?;
     let mut batch = InsertBatch::from_rows([processed.eap_item], processed.origin_timestamp)?;
     batch.item_type_metrics = Some(processed.item_type_metrics);
     batch.cogs_data = Some(processed.cogs_data);
@@ -194,10 +216,10 @@ pub fn process_message(
 
 pub fn process_message_row_binary(
     msg: KafkaPayload,
-    _metadata: KafkaMessageMetadata,
+    metadata: KafkaMessageMetadata,
     config: &ProcessorConfig,
 ) -> anyhow::Result<InsertBatch> {
-    let processed = process_eap_item(msg, config)?;
+    let processed = process_eap_item(msg, &metadata, config)?;
     let row = EAPItemRow::try_from(processed.eap_item)?;
 
     // Encode the row to RowBinary bytes inline so the wide typed struct (~80
@@ -227,10 +249,10 @@ pub(crate) struct EAPItemRowBatch {
 #[cfg(test)]
 pub(crate) fn process_message_row_binary_typed(
     msg: KafkaPayload,
-    _metadata: KafkaMessageMetadata,
+    metadata: KafkaMessageMetadata,
     config: &ProcessorConfig,
 ) -> anyhow::Result<EAPItemRowBatch> {
-    let processed = process_eap_item(msg, config)?;
+    let processed = process_eap_item(msg, &metadata, config)?;
     Ok(EAPItemRowBatch {
         rows: vec![EAPItemRow::try_from(processed.eap_item)?],
         cogs_data: Some(processed.cogs_data),
@@ -266,6 +288,9 @@ struct EAPItem {
 
     retention_days: Option<u16>,
     downsampled_retention_days: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    received_at: Option<u64>,
 }
 
 impl TryFrom<TraceItem> for EAPItem {
@@ -309,6 +334,7 @@ impl TryFrom<TraceItem> for EAPItem {
             sampling_weight: 1,
             client_sample_rate: 1.0,
             server_sample_rate: 1.0,
+            received_at: None,
         };
 
         for (key, value) in from.attributes {
@@ -548,7 +574,20 @@ pub struct EAPItemRow {
     attributes_array_int: Vec<(String, Vec<i64>)>,
     attributes_array_float: Vec<(String, Vec<f64>)>,
     attributes_array_bool: Vec<(String, Vec<bool>)>,
+
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_u64"
+    )]
+    received_at: Option<u64>,
 }
+}
+
+fn serialize_optional_u64<S>(value: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_u64(value.unwrap_or_default())
 }
 
 seq_attrs! {
@@ -595,6 +634,43 @@ impl EAPItemRow {
         "attributes_array_float",
         "attributes_array_bool",
     ];
+
+    pub(crate) const COLUMN_NAMES_WITH_RECEIVED_AT: &'static [&'static str] = &[
+        "organization_id",
+        "project_id",
+        "item_type",
+        "timestamp",
+        "trace_id",
+        "session_id",
+        "ai_conversation_id",
+        "item_id",
+        "indexed_name",
+        "sampling_weight",
+        "sampling_factor",
+        "client_sample_rate",
+        "server_sample_rate",
+        "retention_days",
+        "downsampled_retention_days",
+        "attributes_bool",
+        "attributes_int",
+        #(
+        concat!("attributes_string_", stringify!(N)),
+        concat!("attributes_float_", stringify!(N)),
+        )*
+        "attributes_array_string",
+        "attributes_array_int",
+        "attributes_array_float",
+        "attributes_array_bool",
+        "received_at",
+    ];
+
+    pub(crate) fn column_names(emit_received_at: bool) -> &'static [&'static str] {
+        if emit_received_at {
+            Self::COLUMN_NAMES_WITH_RECEIVED_AT
+        } else {
+            Self::COLUMN_NAMES
+        }
+    }
 }
 }
 
@@ -640,6 +716,7 @@ impl TryFrom<EAPItem> for EAPItemRow {
                     .into_iter()
                     .collect(),
                 attributes_array_bool: item.attributes.attributes_array_bool.into_iter().collect(),
+                received_at: item.received_at,
             });
         }
     }
@@ -650,6 +727,7 @@ impl TryFrom<EAPItem> for EAPItemRow {
 mod tests {
     use std::time::SystemTime;
 
+    use chrono::TimeZone;
     use prost_types::Timestamp;
     use sentry_options::testing::override_options;
     use sentry_protos::snuba::v1::any_value::Value;
@@ -1093,6 +1171,90 @@ mod tests {
         assert_eq!(names[98], "attributes_array_int");
         assert_eq!(names[99], "attributes_array_float");
         assert_eq!(names[100], "attributes_array_bool");
+
+        let names_with_received_at = EAPItemRow::COLUMN_NAMES_WITH_RECEIVED_AT;
+        assert_eq!(names_with_received_at.len(), 102);
+        assert_eq!(&names_with_received_at[..101], names);
+        assert_eq!(names_with_received_at[101], "received_at");
+        assert_eq!(EAPItemRow::column_names(false), names);
+        assert_eq!(EAPItemRow::column_names(true), names_with_received_at);
+    }
+
+    #[test]
+    fn test_emit_received_at_option_defaults_off() {
+        init_options();
+        assert!(!emit_received_at());
+
+        let _guard = override_options(&[("snuba", EMIT_RECEIVED_AT_KEY, json!(true))]).unwrap();
+        assert!(emit_received_at());
+    }
+
+    #[test]
+    fn test_received_at_is_omitted_by_default() {
+        let trace_item = generate_trace_item(Uuid::new_v4());
+        let mut payload_bytes = Vec::new();
+        trace_item.encode(&mut payload_bytes).unwrap();
+        let metadata = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: Utc.timestamp_millis_opt(1_745_562_493_123).unwrap(),
+        };
+
+        let json_batch = process_message(
+            KafkaPayload::new(None, None, Some(payload_bytes.clone())),
+            metadata.clone(),
+            &ProcessorConfig::default(),
+        )
+        .unwrap();
+        let json_row: serde_json::Value =
+            serde_json::from_slice(&json_batch.rows.encoded_rows).unwrap();
+        assert!(json_row.get("received_at").is_none());
+
+        let row_binary_batch = process_message_row_binary_typed(
+            KafkaPayload::new(None, None, Some(payload_bytes)),
+            metadata,
+            &ProcessorConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(row_binary_batch.rows[0].received_at, None);
+    }
+
+    #[test]
+    fn test_received_at_row_binary_is_raw_uint64() {
+        let trace_item = generate_trace_item(Uuid::new_v4());
+        let mut payload_bytes = Vec::new();
+        trace_item.encode(&mut payload_bytes).unwrap();
+        let metadata = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: Utc.timestamp_millis_opt(1_745_562_493_123).unwrap(),
+        };
+        let enabled_config = ProcessorConfig {
+            eap_items_emit_received_at: true,
+            ..Default::default()
+        };
+
+        let disabled = process_message_row_binary(
+            KafkaPayload::new(None, None, Some(payload_bytes.clone())),
+            metadata.clone(),
+            &ProcessorConfig::default(),
+        )
+        .unwrap();
+        let enabled = process_message_row_binary(
+            KafkaPayload::new(None, None, Some(payload_bytes)),
+            metadata,
+            &enabled_config,
+        )
+        .unwrap();
+
+        assert_eq!(
+            enabled.rows.encoded_rows.len(),
+            disabled.rows.encoded_rows.len() + std::mem::size_of::<u64>()
+        );
+        assert_eq!(
+            enabled.rows.encoded_rows[enabled.rows.encoded_rows.len() - 8..],
+            1_745_562_493_123_u64.to_le_bytes()
+        );
     }
 
     #[test]
@@ -1683,19 +1845,22 @@ mod tests {
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
-            timestamp: DateTime::from(SystemTime::now()),
+            timestamp: Utc.timestamp_millis_opt(1_745_562_493_123).unwrap(),
+        };
+        let config = ProcessorConfig {
+            eap_items_emit_received_at: true,
+            ..Default::default()
         };
 
         // Process through JSON path
         let json_payload = KafkaPayload::new(None, None, Some(payload_bytes.clone()));
-        let json_batch = process_message(json_payload, meta.clone(), &ProcessorConfig::default())
-            .expect("JSON path should succeed");
+        let json_batch =
+            process_message(json_payload, meta.clone(), &config).expect("JSON path should succeed");
 
         // Process through RowBinary path
         let rb_payload = KafkaPayload::new(None, None, Some(payload_bytes));
-        let rb_batch =
-            process_message_row_binary_typed(rb_payload, meta, &ProcessorConfig::default())
-                .expect("RowBinary path should succeed");
+        let rb_batch = process_message_row_binary_typed(rb_payload, meta, &config)
+            .expect("RowBinary path should succeed");
 
         // Parse the JSON output
         let json_str =
@@ -1745,6 +1910,12 @@ mod tests {
             rb_row.downsampled_retention_days,
             "downsampled_retention_days mismatch"
         );
+        assert_eq!(
+            json_row["received_at"].as_u64(),
+            rb_row.received_at,
+            "received_at mismatch"
+        );
+        assert_eq!(rb_row.received_at, Some(1_745_562_493_123));
 
         // Compare trace_id (JSON serializes as hyphenated UUID string)
         let json_trace_id = Uuid::parse_str(json_row["trace_id"].as_str().unwrap()).unwrap();

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -67,6 +67,11 @@
       "default": {},
       "description": "Dict mapping storage name to a grace period in minutes; eap-items messages from before the current partition older than this are routed to the DLQ. Storages with no entry have no grace-period dropping. Migrated from per-storage runtime config eap_items_dlq_grace_period_min:<storage>."
     },
+    "eap_items_emit_received_at": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the EAP items consumer writes the Kafka broker timestamp in epoch milliseconds to the received_at column."
+    },
     "quantized_rebalance_consumer_group_delay_secs": {
       "type": "object",
       "additionalProperties": {

--- a/snuba/datasets/processors/rust_compat_processor.py
+++ b/snuba/datasets/processors/rust_compat_processor.py
@@ -9,6 +9,7 @@ import simplejson as json
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.processor import InsertBatch, ProcessedMessage, ReplacementBatch
+from snuba.state.sentry_options import get_option
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,8 @@ class RustCompatProcessor(DatasetMessageProcessor):
             metadata.partition,
             metadata.offset,
             int(metadata.timestamp.replace(tzinfo=UTC).timestamp() * 1000),
+            self.__processor_name == "EAPItemsProcessor"
+            and get_option("eap_items_emit_received_at", False),
         )
 
         if insert_payload is not None:

--- a/snuba/manual_jobs/create_eap_received_at_version_test.py
+++ b/snuba/manual_jobs/create_eap_received_at_version_test.py
@@ -8,6 +8,7 @@ from snuba.manual_jobs import Job, JobLogger
 from snuba.migrations.table_engines import ReplacingMergeTree
 
 _SOURCE_TABLE = "eap_items_1_local"
+_DISTRIBUTED_SOURCE_TABLE = "eap_items_1_dist"
 _SCHEMA_SOURCE_TABLE = "eap_items_1_downsample_8_local"
 _DESTINATION_TABLE = "eap_items_1_downsample_8_timestamp_versioned_test_local"
 _VIEW_NAME = "eap_items_1_downsample_8_timestamp_versioned_test_mv"
@@ -35,10 +36,14 @@ def _column_definition(column: ColumnDescription) -> str:
     return " ".join(clauses)
 
 
-def _on_cluster(cluster: ClickhouseCluster) -> str:
+def _on_cluster(cluster: ClickhouseCluster, *, distributed: bool = False) -> str:
     if cluster.is_single_node():
         return ""
-    cluster_name = cluster.get_clickhouse_cluster_name()
+    cluster_name = (
+        cluster.get_clickhouse_distributed_cluster_name()
+        if distributed
+        else cluster.get_clickhouse_cluster_name()
+    )
     assert cluster_name is not None
     return f" ON CLUSTER {escape_string(cluster_name)}"
 
@@ -68,9 +73,11 @@ def _get_columns(connection: ClickhousePool, table_name: str) -> list[ColumnDesc
     ]
 
 
-def _add_received_at_query(cluster: ClickhouseCluster) -> str:
+def _add_received_at_query(
+    cluster: ClickhouseCluster, table_name: str, *, distributed: bool = False
+) -> str:
     return (
-        f"ALTER TABLE {_SOURCE_TABLE}{_on_cluster(cluster)} "
+        f"ALTER TABLE {table_name}{_on_cluster(cluster, distributed=distributed)} "
         "ADD COLUMN IF NOT EXISTS received_at UInt64"
     )
 
@@ -122,9 +129,19 @@ class AddEAPReceivedAtColumn(Job):
 
     def execute(self, logger: JobLogger) -> None:
         cluster, connection = _get_connection()
-        query = _add_received_at_query(cluster)
+        query = _add_received_at_query(cluster, _SOURCE_TABLE)
         logger.info(f"Executing query: {query}")
         connection.execute(query=query)
+
+        if not cluster.is_single_node():
+            distributed_nodes = cluster.get_distributed_nodes()
+            assert distributed_nodes, "EAP distributed cluster has no nodes"
+            distributed_connection = cluster.get_node_connection(
+                ClickhouseClientSettings.MIGRATE, distributed_nodes[0]
+            )
+            query = _add_received_at_query(cluster, _DISTRIBUTED_SOURCE_TABLE, distributed=True)
+            logger.info(f"Executing query: {query}")
+            distributed_connection.execute(query=query)
         logger.info("complete")
 
 

--- a/snuba/manual_jobs/create_eap_received_at_version_test.py
+++ b/snuba/manual_jobs/create_eap_received_at_version_test.py
@@ -1,0 +1,132 @@
+from collections.abc import Sequence
+
+from snuba.clickhouse.escaping import escape_identifier, escape_string
+from snuba.clickhouse.native import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseCluster, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.manual_jobs import Job, JobLogger
+from snuba.migrations.table_engines import ReplacingMergeTree
+
+_SOURCE_TABLE = "eap_items_1_local"
+_SCHEMA_SOURCE_TABLE = "eap_items_1_downsample_8_local"
+_DESTINATION_TABLE = "eap_items_1_downsample_8_timestamp_versioned_test_local"
+_VIEW_NAME = "eap_items_1_downsample_8_timestamp_versioned_test_mv"
+
+ColumnDescription = tuple[str, str, str, str, str, str, str]
+
+
+def _escape_identifier(identifier: str) -> str:
+    escaped = escape_identifier(identifier)
+    assert escaped is not None
+    return escaped
+
+
+def _column_definition(column: ColumnDescription) -> str:
+    name, column_type, default_type, default_expression, comment, codec, ttl = column
+    clauses = [f"{_escape_identifier(name)} {column_type}"]
+    if default_type:
+        clauses.append(f"{default_type} {default_expression}")
+    if comment:
+        clauses.append(f"COMMENT {escape_string(comment)}")
+    if codec:
+        clauses.append(f"CODEC({codec})")
+    if ttl:
+        clauses.append(f"TTL {ttl}")
+    return " ".join(clauses)
+
+
+class CreateEAPReceivedAtVersionTest(Job):
+    """Create the S4S2 received_at-versioned EAP downsample experiment."""
+
+    def _on_cluster(self, cluster: ClickhouseCluster) -> str:
+        if cluster.is_single_node():
+            return ""
+        cluster_name = cluster.get_clickhouse_cluster_name()
+        assert cluster_name is not None
+        return f" ON CLUSTER {escape_string(cluster_name)}"
+
+    def _add_received_at_query(self, cluster: ClickhouseCluster) -> str:
+        return (
+            f"ALTER TABLE {_SOURCE_TABLE}{self._on_cluster(cluster)} "
+            "ADD COLUMN IF NOT EXISTS received_at UInt64"
+        )
+
+    def _get_columns_query(self) -> str:
+        return f"DESCRIBE TABLE {_SCHEMA_SOURCE_TABLE} SETTINGS describe_include_subcolumns = 0"
+
+    def _create_table_query(
+        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
+    ) -> str:
+        assert columns, f"{_SCHEMA_SOURCE_TABLE} has no columns"
+        column_definitions = ", ".join(_column_definition(column) for column in columns)
+        column_definitions += ", received_at UInt64"
+        engine = ReplacingMergeTree(
+            storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+            version_column="received_at",
+            primary_key="(organization_id, project_id, item_type, timestamp)",
+            order_by=("(organization_id, project_id, item_type, timestamp, trace_id, item_id)"),
+            partition_by="(retention_days, toMonday(timestamp))",
+            ttl="timestamp + toIntervalDay(retention_days)",
+            settings={
+                "index_granularity": "8192",
+                "enable_block_number_column": "1",
+                "enable_block_offset_column": "1",
+            },
+        ).get_sql(cluster, _DESTINATION_TABLE)
+        return (
+            f"CREATE TABLE IF NOT EXISTS {_DESTINATION_TABLE}{self._on_cluster(cluster)} "
+            f"({column_definitions}) ENGINE = {engine}"
+        )
+
+    def _create_view_query(
+        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
+    ) -> str:
+        projections = {
+            "retention_days": "downsampled_retention_days AS retention_days",
+            "sampling_weight": "sampling_weight * 8 AS sampling_weight",
+            "sampling_factor": "sampling_factor / 8 AS sampling_factor",
+            "client_sample_rate": "client_sample_rate / 8 AS client_sample_rate",
+            "server_sample_rate": "server_sample_rate / 8 AS server_sample_rate",
+        }
+        select_columns = [
+            projections.get(column[0], _escape_identifier(column[0])) for column in columns
+        ]
+        select_columns.append("received_at")
+        return (
+            f"CREATE MATERIALIZED VIEW IF NOT EXISTS {_VIEW_NAME}{self._on_cluster(cluster)} "
+            f"TO {_DESTINATION_TABLE} AS SELECT {', '.join(select_columns)} "
+            f"FROM {_SOURCE_TABLE} WHERE (cityHash64(item_id) % 8) = 0"
+        )
+
+    def execute(self, logger: JobLogger) -> None:
+        cluster = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM)
+        connection = cluster.get_node_connection(
+            ClickhouseClientSettings.MIGRATE, cluster.get_local_nodes()[0]
+        )
+
+        add_column_query = self._add_received_at_query(cluster)
+        logger.info(f"Executing query: {add_column_query}")
+        connection.execute(query=add_column_query)
+
+        columns_result: ClickhouseResult = connection.execute(query=self._get_columns_query())
+        columns = [
+            (
+                str(name),
+                str(column_type),
+                str(default_type),
+                str(default_expression),
+                str(comment),
+                str(codec),
+                str(ttl),
+            )
+            for name, column_type, default_type, default_expression, comment, codec, ttl in columns_result.results
+        ]
+        queries = [
+            self._create_table_query(cluster, columns),
+            self._create_view_query(cluster, columns),
+        ]
+        for query in queries:
+            logger.info(f"Executing query: {query}")
+            connection.execute(query=query)
+
+        logger.info("complete")

--- a/snuba/manual_jobs/create_eap_received_at_version_test.py
+++ b/snuba/manual_jobs/create_eap_received_at_version_test.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
 from snuba.clickhouse.escaping import escape_identifier, escape_string
-from snuba.clickhouse.native import ClickhouseResult
+from snuba.clickhouse.native import ClickhousePool, ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseCluster, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.manual_jobs import Job, JobLogger
@@ -35,98 +35,118 @@ def _column_definition(column: ColumnDescription) -> str:
     return " ".join(clauses)
 
 
-class CreateEAPReceivedAtVersionTest(Job):
-    """Create the S4S2 received_at-versioned EAP downsample experiment."""
+def _on_cluster(cluster: ClickhouseCluster) -> str:
+    if cluster.is_single_node():
+        return ""
+    cluster_name = cluster.get_clickhouse_cluster_name()
+    assert cluster_name is not None
+    return f" ON CLUSTER {escape_string(cluster_name)}"
 
-    def _on_cluster(self, cluster: ClickhouseCluster) -> str:
-        if cluster.is_single_node():
-            return ""
-        cluster_name = cluster.get_clickhouse_cluster_name()
-        assert cluster_name is not None
-        return f" ON CLUSTER {escape_string(cluster_name)}"
 
-    def _add_received_at_query(self, cluster: ClickhouseCluster) -> str:
-        return (
-            f"ALTER TABLE {_SOURCE_TABLE}{self._on_cluster(cluster)} "
-            "ADD COLUMN IF NOT EXISTS received_at UInt64"
+def _get_connection() -> tuple[ClickhouseCluster, ClickhousePool]:
+    cluster = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM)
+    connection = cluster.get_node_connection(
+        ClickhouseClientSettings.MIGRATE, cluster.get_local_nodes()[0]
+    )
+    return cluster, connection
+
+
+def _get_columns(connection: ClickhousePool, table_name: str) -> list[ColumnDescription]:
+    query = f"DESCRIBE TABLE {table_name} SETTINGS describe_include_subcolumns = 0"
+    columns_result: ClickhouseResult = connection.execute(query=query)
+    return [
+        (
+            str(name),
+            str(column_type),
+            str(default_type),
+            str(default_expression),
+            str(comment),
+            str(codec),
+            str(ttl),
         )
+        for name, column_type, default_type, default_expression, comment, codec, ttl in columns_result.results
+    ]
 
-    def _get_columns_query(self) -> str:
-        return f"DESCRIBE TABLE {_SCHEMA_SOURCE_TABLE} SETTINGS describe_include_subcolumns = 0"
 
-    def _create_table_query(
-        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
-    ) -> str:
-        assert columns, f"{_SCHEMA_SOURCE_TABLE} has no columns"
-        column_definitions = ", ".join(_column_definition(column) for column in columns)
-        column_definitions += ", received_at UInt64"
-        engine = ReplacingMergeTree(
-            storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
-            version_column="received_at",
-            primary_key="(organization_id, project_id, item_type, timestamp)",
-            order_by=("(organization_id, project_id, item_type, timestamp, trace_id, item_id)"),
-            partition_by="(retention_days, toMonday(timestamp))",
-            ttl="timestamp + toIntervalDay(retention_days)",
-            settings={
-                "index_granularity": "8192",
-                "enable_block_number_column": "1",
-                "enable_block_offset_column": "1",
-            },
-        ).get_sql(cluster, _DESTINATION_TABLE)
-        return (
-            f"CREATE TABLE IF NOT EXISTS {_DESTINATION_TABLE}{self._on_cluster(cluster)} "
-            f"({column_definitions}) ENGINE = {engine}"
-        )
+def _add_received_at_query(cluster: ClickhouseCluster) -> str:
+    return (
+        f"ALTER TABLE {_SOURCE_TABLE}{_on_cluster(cluster)} "
+        "ADD COLUMN IF NOT EXISTS received_at UInt64"
+    )
 
-    def _create_view_query(
-        self, cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]
-    ) -> str:
-        projections = {
-            "retention_days": "downsampled_retention_days AS retention_days",
-            "sampling_weight": "sampling_weight * 8 AS sampling_weight",
-            "sampling_factor": "sampling_factor / 8 AS sampling_factor",
-            "client_sample_rate": "client_sample_rate / 8 AS client_sample_rate",
-            "server_sample_rate": "server_sample_rate / 8 AS server_sample_rate",
-        }
-        select_columns = [
-            projections.get(column[0], _escape_identifier(column[0])) for column in columns
-        ]
-        select_columns.append("received_at")
-        return (
-            f"CREATE MATERIALIZED VIEW IF NOT EXISTS {_VIEW_NAME}{self._on_cluster(cluster)} "
-            f"TO {_DESTINATION_TABLE} AS SELECT {', '.join(select_columns)} "
-            f"FROM {_SOURCE_TABLE} WHERE (cityHash64(item_id) % 8) = 0"
-        )
+
+def _create_table_query(cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]) -> str:
+    assert columns, f"{_SCHEMA_SOURCE_TABLE} has no columns"
+    column_definitions = ", ".join(_column_definition(column) for column in columns)
+    column_definitions += ", received_at UInt64"
+    engine = ReplacingMergeTree(
+        storage_set=StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+        version_column="received_at",
+        primary_key="(organization_id, project_id, item_type, timestamp)",
+        order_by=("(organization_id, project_id, item_type, timestamp, trace_id, item_id)"),
+        partition_by="(retention_days, toMonday(timestamp))",
+        ttl="timestamp + toIntervalDay(retention_days)",
+        settings={
+            "index_granularity": "8192",
+            "enable_block_number_column": "1",
+            "enable_block_offset_column": "1",
+        },
+    ).get_sql(cluster, _DESTINATION_TABLE)
+    return (
+        f"CREATE TABLE IF NOT EXISTS {_DESTINATION_TABLE}{_on_cluster(cluster)} "
+        f"({column_definitions}) ENGINE = {engine}"
+    )
+
+
+def _create_view_query(cluster: ClickhouseCluster, columns: Sequence[ColumnDescription]) -> str:
+    assert columns, f"{_DESTINATION_TABLE} has no columns"
+    projections = {
+        "retention_days": "downsampled_retention_days AS retention_days",
+        "sampling_weight": "sampling_weight * 8 AS sampling_weight",
+        "sampling_factor": "sampling_factor / 8 AS sampling_factor",
+        "client_sample_rate": "client_sample_rate / 8 AS client_sample_rate",
+        "server_sample_rate": "server_sample_rate / 8 AS server_sample_rate",
+    }
+    select_columns = [
+        projections.get(column[0], _escape_identifier(column[0])) for column in columns
+    ]
+    return (
+        f"CREATE MATERIALIZED VIEW IF NOT EXISTS {_VIEW_NAME}{_on_cluster(cluster)} "
+        f"TO {_DESTINATION_TABLE} AS SELECT {', '.join(select_columns)} "
+        f"FROM {_SOURCE_TABLE} WHERE received_at != 0 AND (cityHash64(item_id) % 8) = 0"
+    )
+
+
+class AddEAPReceivedAtColumn(Job):
+    """Add the received_at source column before consumer deployment."""
 
     def execute(self, logger: JobLogger) -> None:
-        cluster = get_cluster(StorageSetKey.EVENTS_ANALYTICS_PLATFORM)
-        connection = cluster.get_node_connection(
-            ClickhouseClientSettings.MIGRATE, cluster.get_local_nodes()[0]
-        )
+        cluster, connection = _get_connection()
+        query = _add_received_at_query(cluster)
+        logger.info(f"Executing query: {query}")
+        connection.execute(query=query)
+        logger.info("complete")
 
-        add_column_query = self._add_received_at_query(cluster)
-        logger.info(f"Executing query: {add_column_query}")
-        connection.execute(query=add_column_query)
 
-        columns_result: ClickhouseResult = connection.execute(query=self._get_columns_query())
-        columns = [
-            (
-                str(name),
-                str(column_type),
-                str(default_type),
-                str(default_expression),
-                str(comment),
-                str(codec),
-                str(ttl),
-            )
-            for name, column_type, default_type, default_expression, comment, codec, ttl in columns_result.results
-        ]
-        queries = [
-            self._create_table_query(cluster, columns),
-            self._create_view_query(cluster, columns),
-        ]
-        for query in queries:
-            logger.info(f"Executing query: {query}")
-            connection.execute(query=query)
+class CreateEAPReceivedAtVersionTestTable(Job):
+    """Create the empty received_at-versioned treatment table."""
 
+    def execute(self, logger: JobLogger) -> None:
+        cluster, connection = _get_connection()
+        columns = _get_columns(connection, _SCHEMA_SOURCE_TABLE)
+        query = _create_table_query(cluster, columns)
+        logger.info(f"Executing query: {query}")
+        connection.execute(query=query)
+        logger.info("complete")
+
+
+class CreateEAPReceivedAtVersionTestMaterializedView(Job):
+    """Start treatment inserts after received_at population is enabled."""
+
+    def execute(self, logger: JobLogger) -> None:
+        cluster, connection = _get_connection()
+        columns = _get_columns(connection, _DESTINATION_TABLE)
+        query = _create_view_query(cluster, columns)
+        logger.info(f"Executing query: {query}")
+        connection.execute(query=query)
         logger.info("complete")

--- a/tests/consumers/test_message_processors.py
+++ b/tests/consumers/test_message_processors.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import json
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 import sentry_kafka_schemas
+from sentry_options.testing import override_options
 
 import rust_snuba
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.processors import DatasetMessageProcessor
+from snuba.datasets.processors.eap_items_processor import EAPItemsProcessor
 from snuba.datasets.processors.errors_processor import ErrorsProcessor
 from snuba.datasets.processors.metrics_bucket_processor import (
     PolymorphicMetricsProcessor,
@@ -142,3 +144,17 @@ def test_replays_message_processor() -> None:
             # rust message and overly the python message. This fill in the gaps of the python
             # message.
             assert parsed_rust_message | parsed_python_message == parsed_rust_message
+
+
+def test_eap_items_received_at_from_broker_timestamp() -> None:
+    payload = next(iter(sentry_kafka_schemas.iter_examples("snuba-items"))).load()
+    broker_timestamp = datetime.fromtimestamp(1_745_562_493.123, tz=UTC)
+
+    with override_options("snuba", {"eap_items_emit_received_at": True}):
+        processed = EAPItemsProcessor().process_message(
+            payload,
+            KafkaMessageMetadata(offset=1, partition=0, timestamp=broker_timestamp),
+        )
+
+    assert isinstance(processed, InsertBatch)
+    assert processed.rows[0]["received_at"] == 1_745_562_493_123

--- a/tests/manual_jobs/test_create_eap_received_at_version_test.py
+++ b/tests/manual_jobs/test_create_eap_received_at_version_test.py
@@ -45,8 +45,10 @@ def _build_cluster(*, single_node: bool) -> Mock:
     cluster = Mock()
     cluster.is_single_node.return_value = single_node
     cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
+    cluster.get_clickhouse_distributed_cluster_name.return_value = "eap_dist_cluster"
     cluster.get_database.return_value = "default"
     cluster.get_local_nodes.return_value = ["local-node"]
+    cluster.get_distributed_nodes.return_value = ["distributed-node"]
     return cluster
 
 
@@ -75,8 +77,12 @@ def test_jobs_require_manifest(job_type: type[Job]) -> None:
 def test_multi_node_queries() -> None:
     cluster = _build_cluster(single_node=False)
 
-    assert _add_received_at_query(cluster) == (
+    assert _add_received_at_query(cluster, "eap_items_1_local") == (
         "ALTER TABLE eap_items_1_local ON CLUSTER 'eap_cluster' "
+        "ADD COLUMN IF NOT EXISTS received_at UInt64"
+    )
+    assert _add_received_at_query(cluster, "eap_items_1_dist", distributed=True) == (
+        "ALTER TABLE eap_items_1_dist ON CLUSTER 'eap_dist_cluster' "
         "ADD COLUMN IF NOT EXISTS received_at UInt64"
     )
 
@@ -127,17 +133,49 @@ def test_single_node_uses_non_replicated_engine() -> None:
     assert "ReplicatedReplacingMergeTree" not in create_table
 
 
-def test_add_column_job_executes_only_source_alter(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_add_column_job_alters_local_and_distributed_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = _build_job(monkeypatch, AddEAPReceivedAtColumn)
+    local_connection = Mock()
+    distributed_connection = Mock()
+    cluster = _patch_cluster(monkeypatch, local_connection)
+    cluster.get_node_connection.side_effect = [local_connection, distributed_connection]
+
+    job.execute(Mock())
+
+    assert cluster.get_node_connection.call_args_list == [
+        call(ClickhouseClientSettings.MIGRATE, "local-node"),
+        call(ClickhouseClientSettings.MIGRATE, "distributed-node"),
+    ]
+    local_connection.execute.assert_called_once_with(
+        query=_add_received_at_query(cluster, "eap_items_1_local")
+    )
+    distributed_connection.execute.assert_called_once_with(
+        query=_add_received_at_query(cluster, "eap_items_1_dist", distributed=True)
+    )
+
+
+def test_add_column_job_skips_dist_table_on_single_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     job = _build_job(monkeypatch, AddEAPReceivedAtColumn)
     connection = Mock()
-    cluster = _patch_cluster(monkeypatch, connection)
+    cluster = _build_cluster(single_node=True)
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
+        Mock(return_value=cluster),
+    )
 
     job.execute(Mock())
 
     cluster.get_node_connection.assert_called_once_with(
         ClickhouseClientSettings.MIGRATE, "local-node"
     )
-    connection.execute.assert_called_once_with(query=_add_received_at_query(cluster))
+    connection.execute.assert_called_once_with(
+        query=_add_received_at_query(cluster, "eap_items_1_local")
+    )
 
 
 def test_create_table_job_does_not_create_view(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/manual_jobs/test_create_eap_received_at_version_test.py
+++ b/tests/manual_jobs/test_create_eap_received_at_version_test.py
@@ -1,0 +1,144 @@
+from unittest.mock import Mock, call
+
+import pytest
+
+from snuba.clickhouse.native import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs.create_eap_received_at_version_test import (
+    CreateEAPReceivedAtVersionTest,
+)
+
+_COLUMNS = [
+    ("organization_id", "UInt64", "", "", "", "", ""),
+    ("project_id", "UInt64", "", "", "", "", ""),
+    ("item_type", "UInt8", "", "", "", "", ""),
+    ("timestamp", "DateTime", "", "", "event time", "DoubleDelta, ZSTD(1)", ""),
+    ("trace_id", "UUID", "", "", "", "", ""),
+    ("item_id", "UInt128", "", "", "", "", ""),
+    ("sampling_weight", "UInt64", "", "", "", "ZSTD(1)", ""),
+    ("sampling_factor", "Float64", "", "", "", "ZSTD(1)", ""),
+    ("retention_days", "UInt16", "DEFAULT", "30", "", "T64, ZSTD(1)", ""),
+    ("client_sample_rate", "Float64", "", "", "", "", ""),
+    ("server_sample_rate", "Float64", "", "", "", "", ""),
+    ("attributes_string_0", "Map(String, String)", "", "", "", "ZSTD(1)", ""),
+]
+
+
+def _build_job(monkeypatch: pytest.MonkeyPatch) -> CreateEAPReceivedAtVersionTest:
+    monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
+    return CreateEAPReceivedAtVersionTest(
+        JobSpec(
+            job_id="create-eap-received-at-version-test",
+            job_type="CreateEAPReceivedAtVersionTest",
+        )
+    )
+
+
+def _build_cluster(*, single_node: bool) -> Mock:
+    cluster = Mock()
+    cluster.is_single_node.return_value = single_node
+    cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
+    cluster.get_database.return_value = "default"
+    return cluster
+
+
+def test_job_requires_manifest() -> None:
+    assert not CreateEAPReceivedAtVersionTest.allow_adhoc_run
+
+
+def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+    cluster = _build_cluster(single_node=False)
+
+    assert job._add_received_at_query(cluster) == (
+        "ALTER TABLE eap_items_1_local ON CLUSTER 'eap_cluster' "
+        "ADD COLUMN IF NOT EXISTS received_at UInt64"
+    )
+
+    create_table = job._create_table_query(cluster, _COLUMNS)
+    assert create_table.startswith(
+        "CREATE TABLE IF NOT EXISTS "
+        "eap_items_1_downsample_8_timestamp_versioned_test_local "
+        "ON CLUSTER 'eap_cluster' (organization_id UInt64"
+    )
+    assert "timestamp DateTime COMMENT 'event time' CODEC(DoubleDelta, ZSTD(1))" in create_table
+    assert "retention_days UInt16 DEFAULT 30 CODEC(T64, ZSTD(1))" in create_table
+    assert (
+        "attributes_string_0 Map(String, String) CODEC(ZSTD(1)), received_at UInt64" in create_table
+    )
+    assert (
+        "ReplicatedReplacingMergeTree("
+        "'/clickhouse/tables/events_analytics_platform/{shard}/default/"
+        "eap_items_1_downsample_8_timestamp_versioned_test_local', "
+        "'{replica}', received_at)"
+    ) in create_table
+    assert "PARTITION BY (retention_days, toMonday(timestamp))" in create_table
+    assert "TTL timestamp + toIntervalDay(retention_days)" in create_table
+    assert (
+        "SETTINGS index_granularity=8192, enable_block_number_column=1, "
+        "enable_block_offset_column=1"
+    ) in create_table
+
+    create_view = job._create_view_query(cluster, _COLUMNS)
+    assert create_view.startswith(
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS "
+        "eap_items_1_downsample_8_timestamp_versioned_test_mv "
+        "ON CLUSTER 'eap_cluster' TO "
+        "eap_items_1_downsample_8_timestamp_versioned_test_local AS SELECT "
+    )
+    assert "sampling_weight * 8 AS sampling_weight" in create_view
+    assert "sampling_factor / 8 AS sampling_factor" in create_view
+    assert "downsampled_retention_days AS retention_days" in create_view
+    assert "server_sample_rate / 8 AS server_sample_rate" in create_view
+    assert "attributes_string_0, received_at FROM eap_items_1_local" in create_view
+    assert create_view.endswith("WHERE (cityHash64(item_id) % 8) = 0")
+
+
+def test_single_node_uses_non_replicated_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+    cluster = _build_cluster(single_node=True)
+
+    create_table = job._create_table_query(cluster, _COLUMNS)
+    assert "ON CLUSTER" not in create_table
+    assert "ENGINE = ReplacingMergeTree(received_at)" in create_table
+    assert "ReplicatedReplacingMergeTree" not in create_table
+
+
+def test_execute_uses_eap_local_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+    connection = Mock()
+    connection.execute.side_effect = [
+        ClickhouseResult(),
+        ClickhouseResult(results=_COLUMNS),
+        ClickhouseResult(),
+        ClickhouseResult(),
+    ]
+    cluster = _build_cluster(single_node=False)
+    cluster.get_local_nodes.return_value = ["local-node"]
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
+        Mock(return_value=cluster),
+    )
+
+    job.execute(Mock())
+
+    cluster.get_node_connection.assert_called_once_with(
+        ClickhouseClientSettings.MIGRATE, "local-node"
+    )
+    assert connection.execute.call_args_list[0] == call(query=job._add_received_at_query(cluster))
+    assert connection.execute.call_args_list[1] == call(query=job._get_columns_query())
+    assert connection.execute.call_args_list[2] == call(
+        query=job._create_table_query(cluster, _COLUMNS)
+    )
+    assert connection.execute.call_args_list[3] == call(
+        query=job._create_view_query(cluster, _COLUMNS)
+    )
+
+
+def test_rejects_empty_source_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch)
+
+    with pytest.raises(AssertionError, match="has no columns"):
+        job._create_table_query(_build_cluster(single_node=True), [])

--- a/tests/manual_jobs/test_create_eap_received_at_version_test.py
+++ b/tests/manual_jobs/test_create_eap_received_at_version_test.py
@@ -4,9 +4,14 @@ import pytest
 
 from snuba.clickhouse.native import ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings
-from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs import Job, JobSpec
 from snuba.manual_jobs.create_eap_received_at_version_test import (
-    CreateEAPReceivedAtVersionTest,
+    AddEAPReceivedAtColumn,
+    CreateEAPReceivedAtVersionTestMaterializedView,
+    CreateEAPReceivedAtVersionTestTable,
+    _add_received_at_query,
+    _create_table_query,
+    _create_view_query,
 )
 
 _COLUMNS = [
@@ -23,14 +28,15 @@ _COLUMNS = [
     ("server_sample_rate", "Float64", "", "", "", "", ""),
     ("attributes_string_0", "Map(String, String)", "", "", "", "ZSTD(1)", ""),
 ]
+_DESTINATION_COLUMNS = [*_COLUMNS, ("received_at", "UInt64", "", "", "", "", "")]
 
 
-def _build_job(monkeypatch: pytest.MonkeyPatch) -> CreateEAPReceivedAtVersionTest:
+def _build_job(monkeypatch: pytest.MonkeyPatch, job_type: type[Job]) -> Job:
     monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
-    return CreateEAPReceivedAtVersionTest(
+    return job_type(
         JobSpec(
-            job_id="create-eap-received-at-version-test",
-            job_type="CreateEAPReceivedAtVersionTest",
+            job_id="eap-received-at-version-test",
+            job_type=job_type.__name__,
         )
     )
 
@@ -40,23 +46,41 @@ def _build_cluster(*, single_node: bool) -> Mock:
     cluster.is_single_node.return_value = single_node
     cluster.get_clickhouse_cluster_name.return_value = "eap_cluster"
     cluster.get_database.return_value = "default"
+    cluster.get_local_nodes.return_value = ["local-node"]
     return cluster
 
 
-def test_job_requires_manifest() -> None:
-    assert not CreateEAPReceivedAtVersionTest.allow_adhoc_run
+def _patch_cluster(monkeypatch: pytest.MonkeyPatch, connection: Mock) -> Mock:
+    cluster = _build_cluster(single_node=False)
+    cluster.get_node_connection.return_value = connection
+    monkeypatch.setattr(
+        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
+        Mock(return_value=cluster),
+    )
+    return cluster
 
 
-def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
+@pytest.mark.parametrize(
+    "job_type",
+    [
+        AddEAPReceivedAtColumn,
+        CreateEAPReceivedAtVersionTestTable,
+        CreateEAPReceivedAtVersionTestMaterializedView,
+    ],
+)
+def test_jobs_require_manifest(job_type: type[Job]) -> None:
+    assert not job_type.allow_adhoc_run
+
+
+def test_multi_node_queries() -> None:
     cluster = _build_cluster(single_node=False)
 
-    assert job._add_received_at_query(cluster) == (
+    assert _add_received_at_query(cluster) == (
         "ALTER TABLE eap_items_1_local ON CLUSTER 'eap_cluster' "
         "ADD COLUMN IF NOT EXISTS received_at UInt64"
     )
 
-    create_table = job._create_table_query(cluster, _COLUMNS)
+    create_table = _create_table_query(cluster, _COLUMNS)
     assert create_table.startswith(
         "CREATE TABLE IF NOT EXISTS "
         "eap_items_1_downsample_8_timestamp_versioned_test_local "
@@ -80,7 +104,7 @@ def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
         "enable_block_offset_column=1"
     ) in create_table
 
-    create_view = job._create_view_query(cluster, _COLUMNS)
+    create_view = _create_view_query(cluster, _DESTINATION_COLUMNS)
     assert create_view.startswith(
         "CREATE MATERIALIZED VIEW IF NOT EXISTS "
         "eap_items_1_downsample_8_timestamp_versioned_test_mv "
@@ -92,53 +116,71 @@ def test_multi_node_queries(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "downsampled_retention_days AS retention_days" in create_view
     assert "server_sample_rate / 8 AS server_sample_rate" in create_view
     assert "attributes_string_0, received_at FROM eap_items_1_local" in create_view
-    assert create_view.endswith("WHERE (cityHash64(item_id) % 8) = 0")
+    assert create_view.endswith("WHERE received_at != 0 AND (cityHash64(item_id) % 8) = 0")
 
 
-def test_single_node_uses_non_replicated_engine(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
-    cluster = _build_cluster(single_node=True)
+def test_single_node_uses_non_replicated_engine() -> None:
+    create_table = _create_table_query(_build_cluster(single_node=True), _COLUMNS)
 
-    create_table = job._create_table_query(cluster, _COLUMNS)
     assert "ON CLUSTER" not in create_table
     assert "ENGINE = ReplacingMergeTree(received_at)" in create_table
     assert "ReplicatedReplacingMergeTree" not in create_table
 
 
-def test_execute_uses_eap_local_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
+def test_add_column_job_executes_only_source_alter(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, AddEAPReceivedAtColumn)
     connection = Mock()
-    connection.execute.side_effect = [
-        ClickhouseResult(),
-        ClickhouseResult(results=_COLUMNS),
-        ClickhouseResult(),
-        ClickhouseResult(),
-    ]
-    cluster = _build_cluster(single_node=False)
-    cluster.get_local_nodes.return_value = ["local-node"]
-    cluster.get_node_connection.return_value = connection
-    monkeypatch.setattr(
-        "snuba.manual_jobs.create_eap_received_at_version_test.get_cluster",
-        Mock(return_value=cluster),
-    )
+    cluster = _patch_cluster(monkeypatch, connection)
 
     job.execute(Mock())
 
     cluster.get_node_connection.assert_called_once_with(
         ClickhouseClientSettings.MIGRATE, "local-node"
     )
-    assert connection.execute.call_args_list[0] == call(query=job._add_received_at_query(cluster))
-    assert connection.execute.call_args_list[1] == call(query=job._get_columns_query())
-    assert connection.execute.call_args_list[2] == call(
-        query=job._create_table_query(cluster, _COLUMNS)
-    )
-    assert connection.execute.call_args_list[3] == call(
-        query=job._create_view_query(cluster, _COLUMNS)
-    )
+    connection.execute.assert_called_once_with(query=_add_received_at_query(cluster))
 
 
-def test_rejects_empty_source_schema(monkeypatch: pytest.MonkeyPatch) -> None:
-    job = _build_job(monkeypatch)
+def test_create_table_job_does_not_create_view(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, CreateEAPReceivedAtVersionTestTable)
+    connection = Mock()
+    connection.execute.side_effect = [ClickhouseResult(results=_COLUMNS), ClickhouseResult()]
+    cluster = _patch_cluster(monkeypatch, connection)
 
-    with pytest.raises(AssertionError, match="has no columns"):
-        job._create_table_query(_build_cluster(single_node=True), [])
+    job.execute(Mock())
+
+    assert connection.execute.call_args_list == [
+        call(
+            query="DESCRIBE TABLE eap_items_1_downsample_8_local "
+            "SETTINGS describe_include_subcolumns = 0"
+        ),
+        call(query=_create_table_query(cluster, _COLUMNS)),
+    ]
+
+
+def test_create_view_job_uses_destination_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = _build_job(monkeypatch, CreateEAPReceivedAtVersionTestMaterializedView)
+    connection = Mock()
+    connection.execute.side_effect = [
+        ClickhouseResult(results=_DESTINATION_COLUMNS),
+        ClickhouseResult(),
+    ]
+    cluster = _patch_cluster(monkeypatch, connection)
+
+    job.execute(Mock())
+
+    assert connection.execute.call_args_list == [
+        call(
+            query="DESCRIBE TABLE eap_items_1_downsample_8_timestamp_versioned_test_local "
+            "SETTINGS describe_include_subcolumns = 0"
+        ),
+        call(query=_create_view_query(cluster, _DESTINATION_COLUMNS)),
+    ]
+
+
+def test_rejects_empty_schemas() -> None:
+    cluster = _build_cluster(single_node=True)
+
+    with pytest.raises(AssertionError, match="downsample_8_local has no columns"):
+        _create_table_query(cluster, [])
+    with pytest.raises(AssertionError, match="versioned_test_local has no columns"):
+        _create_view_query(cluster, [])


### PR DESCRIPTION
## Summary

- add the `eap_items_emit_received_at` sentry-option, defaulting to `false`
- emit the Kafka broker timestamp as epoch milliseconds in the top-level `received_at` field when enabled
- support native JSONEachRow, Python compatibility JSONEachRow, and native RowBinary consumers
- keep disabled payloads and RowBinary column lists unchanged

## Stack

- depends on #8270, which adds the `received_at UInt64` source column and versioned experiment table
- this PR targets the #8270 branch so its diff contains only consumer changes

## Test plan

- `cargo test --lib`
- `cargo clippy --all-targets -- -D warnings`
- `pytest -q tests/consumers/test_message_processors.py`
- `pre-commit run --files rust_snuba/src/config.rs rust_snuba/src/consumer.rs rust_snuba/src/factory_v2.rs rust_snuba/src/processors/eap_items.rs sentry-options/schemas/snuba/schema.json snuba/datasets/processors/rust_compat_processor.py tests/consumers/test_message_processors.py`