### PR TITLE
feat(gocd): Run distroless image for migration jobs

### DIFF
--- a/gocd/templates/bash/migrate-reverse.sh
+++ b/gocd/templates/bash/migrate-reverse.sh
@@ -3,10 +3,12 @@
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/get-cluster-credentials
 
+IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
+
 k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate-reverse" \
-  "us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  "us-docker.pkg.dev/sentryio/snuba-mr/image:${IMAGE_TAG}" \
   -- \
   snuba migrations reverse-in-progress

--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -9,10 +9,12 @@
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/get-cluster-credentials
 
+IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
+
 k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate" \
-  "us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  "us-docker.pkg.dev/sentryio/snuba-mr/image:${IMAGE_TAG}" \
   -- \
   snuba migrations migrate --check-dangerous

--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -3,10 +3,12 @@
 eval $(regions-project-env-vars --region="${SENTRY_REGION}")
 /devinfra/scripts/get-cluster-credentials
 
+IMAGE_TAG="${GO_REVISION_SNUBA_REPO}-distroless"
+
 k8s-spawn-job \
   --label-selector="service=${SNUBA_SERVICE_NAME}" \
   --container-name="${SNUBA_SERVICE_NAME}" \
   "snuba-migrate" \
-  "us-docker.pkg.dev/sentryio/snuba-mr/image:${GO_REVISION_SNUBA_REPO}" \
+  "us-docker.pkg.dev/sentryio/snuba-mr/image:${IMAGE_TAG}" \
   -- \
   snuba migrations migrate --check-dangerous -r complete -r partial


### PR DESCRIPTION
Point the migration jobs at the `-distroless` image tag, matching the deploy scripts:

- `migrate.sh` — SaaS migrations (`snuba migrations migrate`)
- `migrate-st.sh` — single-tenant migrations
- `migrate-reverse.sh` — migration rollback (`snuba migrations reverse-in-progress`)

These were the last gocd steps still pulling the non-distroless image. With this change, every image reference in `gocd/templates/bash/` uses `-distroless`, which unblocks eventually dropping the non-distroless build entirely.

### Why this is safe

- The migration commands run entirely in-process. ClickHouse access goes through the pure-Python `clickhouse_driver` (native protocol), not an external `clickhouse-client` binary.
- Neither `migrate` nor `reverse-in-progress` shells out. The only `subprocess` user in the migrations code is `autogeneration` (`snuba migrations generate`), a dev-time command these jobs never run.
- The distroless image uses a Python entrypoint (`docker_entrypoint.py`) instead of the bash one, since it has no shell. These jobs pass an explicit `snuba migrations ...` command, which the Python entrypoint `execvp`s directly via the `snuba` console script on the venv PATH — same behavior as the bash entrypoint.
- The `-distroless` tag is published on every master build and is already gated by `check-github.sh`, so the tag is guaranteed present for both forward migrations and rollbacks.

### Note for reviewers

Migration jobs run the same venv/code as the serving workloads that have been on distroless for 3+ weeks, so no new runtime deps. The one operational difference: if a migration job pod needs interactive debugging, the distroless image has no shell — use the `-debug` distroless variant (busybox) for that.