### PR TITLE
fix(gocd): drop deleted Datadog monitor from SaaS health check

### DIFF
--- a/gocd/templates/bash/saas-ddog-health-check.sh
+++ b/gocd/templates/bash/saas-ddog-health-check.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 checks-datadog-monitor-status --dry-run=true \
-  113296727 \
   42722121
 
 
 # Above monitor IDs map to following monitors respectively:
-# Snuba - SLO - High API error rate
 # Snuba - Too many restarts on Snuba pods


### PR DESCRIPTION
## Summary
- Remove deleted Datadog monitor `113296727` (`Snuba - SLO - High API error rate`) from the SaaS deploy health check.
- Keeps the remaining monitor `42722121` (`Snuba - Too many restarts on Snuba pods`) so the gate no longer 404s and fails deploys.

## Testing
- Not run (not requested)
