### PR TITLE
ref(EndpointTraceItemStats): add MAX_REQUEST_ATTRIBUTES cap

### DIFF
--- a/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
+++ b/snuba/web/rpc/v1/resolvers/R_eap_items/resolver_trace_item_stats.py
@@ -64,6 +64,8 @@ _DEFAULT_ROW_LIMIT = 10_000
 MAX_BUCKETS = 100
 DEFAULT_BUCKETS = 10
 
+MAX_REQUEST_ATTRIBUTES = 500
+
 COUNT_LABEL = "count()"
 LAST_SEEN_LABEL = "last_seen"
 
@@ -290,6 +292,11 @@ class ResolverTraceItemStatsEAPItems(ResolverTraceItemStats):
             if requested_type.HasField("attribute_distributions"):
                 if requested_type.attribute_distributions.max_buckets > MAX_BUCKETS:
                     raise BadSnubaRPCRequestException(f"Max allowed buckets is {MAX_BUCKETS}.")
+
+                if len(requested_type.attribute_distributions.attributes) > MAX_REQUEST_ATTRIBUTES:
+                    raise BadSnubaRPCRequestException(
+                        f"Max allowed attributes is {MAX_REQUEST_ATTRIBUTES}."
+                    )
 
                 query = _build_attr_distribution_query(
                     in_msg, requested_type.attribute_distributions

--- a/tests/web/rpc/v1/test_endpoint_trace_item_stats.py
+++ b/tests/web/rpc/v1/test_endpoint_trace_item_stats.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
@@ -20,6 +21,7 @@ from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue
 
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.endpoint_trace_item_stats import EndpointTraceItemStats
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
@@ -211,6 +213,36 @@ class TestTraceItemAttributesStats(BaseApiTest):
         assert bucket_matches(duration_dist.buckets[0], "30", 84)
         assert bucket_matches(duration_dist.buckets[1], "50", 18)
         assert bucket_matches(duration_dist.buckets[2], "10", 6)
+
+    @patch(
+        "snuba.web.rpc.v1.resolvers.R_eap_items.resolver_trace_item_stats.MAX_REQUEST_ATTRIBUTES", 2
+    )
+    def test_allow_list_too_many_attributes(self) -> None:
+        message = TraceItemStatsRequest(
+            meta=RequestMeta(
+                project_ids=[1],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=START_TIMESTAMP,
+                end_timestamp=END_TIMESTAMP,
+                trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            ),
+            stats_types=[
+                StatsType(
+                    attribute_distributions=AttributeDistributionsRequest(
+                        max_buckets=10,
+                        max_attributes=100,
+                        attributes=[
+                            AttributeKey(name=f"attr_{i}", type=AttributeKey.TYPE_STRING)
+                            for i in range(3)
+                        ],
+                    )
+                )
+            ],
+        )
+        with pytest.raises(BadSnubaRPCRequestException, match="Max allowed attributes is 2."):
+            EndpointTraceItemStats().execute(message)
 
     def test_with_filter(self, setup_teardown: Any) -> None:
         message = TraceItemStatsRequest(


### PR DESCRIPTION
We are hitting AST is too big errors in Clickhouse

`Code: 168. DB::Exception: Received from snuba-events-analytics-platform-arm-7-4:9000. DB::Exception: AST is too big. Maximum: 50000. Stack trace:`

So putting a limit on the requested attribute stats since it looks like the queries running into this are for this endpoint, with sentry referrer `api.spans.fields-stats.rpc`

REF [SENTRY-5SCQ](https://sentry.sentry.io/issues/7654882964/events/567cee221d13430f8e09dae137781cf7/)