### PR TITLE
fix(search-issues): handle explicit null data.request

### DIFF
--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -155,7 +155,7 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
     def _process_request_data(
         self, event_data: IssueEventData, processed: MutableMapping[str, Any]
     ) -> None:
-        request = event_data.get("request", {})
+        request = event_data.get("request") or {}
         http_data: MutableMapping[str, Any] = {}
         extract_http(http_data, request)
         processed["http_method"] = http_data["http_method"]

--- a/tests/datasets/test_search_issues_processor.py
+++ b/tests/datasets/test_search_issues_processor.py
@@ -238,6 +238,14 @@ class TestSearchIssuesMessageProcessor:
         assert "http_method" in insert_row and insert_row["http_method"] == "GET"
         assert "http_referer" in insert_row and insert_row["http_referer"] == "http://example.com"
 
+    def test_extract_http_null_request(self, message_base):
+        message_base["data"]["request"] = None
+        processed = self.process_message(message_base)
+        self.assert_required_columns(processed)
+        insert_row = processed.rows[0]
+        assert "http_method" in insert_row and insert_row["http_method"] is None
+        assert "http_referer" in insert_row and insert_row["http_referer"] is None
+
     def test_extract_sdk(self, message_base):
         message_base["data"]["sdk"] = {
             "version": "1.2.3",


### PR DESCRIPTION
`SearchIssuesMessageProcessor._process_request_data` used `event_data.get("request", {})`, which only falls back to `{}` when the `request` key is *absent*. When a producer sends `data.request` explicitly set to `null`, the default doesn't apply and `None` is passed straight into `extract_http`, which calls `request.get(...)` and raises `AttributeError`, failing the message.

Switching to `event_data.get("request") or {}` treats an explicit `null` (and any other falsy value) the same as a missing key, so `http_method` / `http_referer` / `http_url` are simply extracted as `None`.

