### PR TITLE
refactor(eap): clean up trace_item_table aggregation construction

### DIFF
--- a/snuba/web/rpc/proto_visitor.py
+++ b/snuba/web/rpc/proto_visitor.py
@@ -171,52 +171,35 @@ class ProtoVisitor(ABC):  # noqa: B024 dynamic visit dispatch via __getattr__; A
 def _convert_aggregation_to_conditional_aggregation(
     input: Column | AggregationComparisonFilter | TimeSeriesExpression,
 ) -> None:
-    if input.HasField("aggregation"):
-        aggregation = input.aggregation
-        input.ClearField("aggregation")
-        ranked_by = (
-            {"ranked_by": aggregation.ranked_by} if aggregation.HasField("ranked_by") else {}
-        )
-        match aggregation.WhichOneof("default_value"):
-            case None:
-                input.conditional_aggregation.CopyFrom(
-                    AttributeConditionalAggregation(
-                        aggregate=aggregation.aggregate,
-                        key=aggregation.key,
-                        label=aggregation.label,
-                        extrapolation_mode=aggregation.extrapolation_mode,
-                        # mypy can't type-check **unpack of an kwarg dict
-                        **ranked_by,  # type: ignore[arg-type]
-                    )
-                )
-            case "default_value_double":
-                input.conditional_aggregation.CopyFrom(
-                    AttributeConditionalAggregation(
-                        aggregate=aggregation.aggregate,
-                        key=aggregation.key,
-                        label=aggregation.label,
-                        extrapolation_mode=aggregation.extrapolation_mode,
-                        default_value_double=aggregation.default_value_double,
-                        # mypy can't type-check **unpack of an kwarg dict
-                        **ranked_by,  # type: ignore[arg-type]
-                    )
-                )
-            case "default_value_int64":
-                input.conditional_aggregation.CopyFrom(
-                    AttributeConditionalAggregation(
-                        aggregate=aggregation.aggregate,
-                        key=aggregation.key,
-                        label=aggregation.label,
-                        extrapolation_mode=aggregation.extrapolation_mode,
-                        default_value_int64=aggregation.default_value_int64,
-                        # mypy can't type-check **unpack of an kwarg dict
-                        **ranked_by,  # type: ignore[arg-type]
-                    )
-                )
-            case default:
-                raise BadSnubaRPCRequestException(
-                    f"Unknown default_value in formula. Expected default_value_double or default_value_int64 but got {default}"
-                )
+    if not input.HasField("aggregation"):
+        return
+
+    input_agg = input.aggregation
+    input.ClearField("aggregation")
+
+    conditional_aggregation = AttributeConditionalAggregation(
+        aggregate=input_agg.aggregate,
+        key=input_agg.key,
+        label=input_agg.label,
+        extrapolation_mode=input_agg.extrapolation_mode,
+    )
+
+    if input_agg.HasField("ranked_by"):
+        conditional_aggregation.ranked_by.CopyFrom(input_agg.ranked_by)
+
+    match input_agg.WhichOneof("default_value"):
+        case None:
+            pass
+        case "default_value_double":
+            conditional_aggregation.default_value_double = input_agg.default_value_double
+        case "default_value_int64":
+            conditional_aggregation.default_value_int64 = input_agg.default_value_int64
+        case default:
+            raise BadSnubaRPCRequestException(
+                f"Unknown default_value in formula. Expected default_value_double or default_value_int64 but got {default}"
+            )
+
+    input.conditional_aggregation.CopyFrom(conditional_aggregation)
 
 
 class AggregationToConditionalAggregationVisitor(ProtoVisitor):

--- a/snuba/web/rpc/v1/resolvers/common/aggregation.py
+++ b/snuba/web/rpc/v1/resolvers/common/aggregation.py
@@ -588,6 +588,53 @@ def get_extrapolated_function(
     return function_map_sample_weighted.get(aggregation.aggregate)
 
 
+def get_non_extrapolated_function(
+    aggregation: AttributeConditionalAggregation,
+    field: Expression,
+    field_exists: Expression,
+    condition_in_aggregation: Expression,
+    alias_dict: dict[str, str],
+    max_array_size: int,
+    attribute_key_to_expression: Callable[[AttributeKey], Expression],
+) -> CurriedFunctionCall | FunctionCall | None:
+    function_map: dict[Function.ValueType, Callable[..., CurriedFunctionCall | FunctionCall]] = {
+        Function.FUNCTION_SUM: f.sumIfOrNull,
+        Function.FUNCTION_AVERAGE: f.avgIfOrNull,
+        Function.FUNCTION_COUNT: f.countIfOrNull,
+        Function.FUNCTION_P50: cf.quantileIfOrNull(0.5),
+        Function.FUNCTION_P75: cf.quantileIfOrNull(0.75),
+        Function.FUNCTION_P90: cf.quantileIfOrNull(0.9),
+        Function.FUNCTION_P95: cf.quantileIfOrNull(0.95),
+        Function.FUNCTION_P99: cf.quantileIfOrNull(0.99),
+        Function.FUNCTION_AVG: f.avgIfOrNull,
+        Function.FUNCTION_MAX: f.maxIfOrNull,
+        Function.FUNCTION_MIN: f.minIfOrNull,
+        Function.FUNCTION_UNIQ: f.uniqIfOrNull,
+        Function.FUNCTION_ANY: f.anyIfOrNull,
+        Function.FUNCTION_COLLECT_UNIQUE: cf.groupUniqArrayIf(max_array_size),
+        Function.FUNCTION_FIRST: f.argMinIfOrNull,
+        Function.FUNCTION_LAST: f.argMaxIfOrNull,
+    }
+
+    agg_func = function_map.get(aggregation.aggregate)
+    if agg_func is None:
+        return None
+
+    ordered_agg_sort_key = _build_ordered_agg_sort_key(aggregation, attribute_key_to_expression)
+    if ordered_agg_sort_key:
+        ranked_by_exists = get_field_existence_expression(
+            attribute_key_to_expression(aggregation.ranked_by.key)
+        )
+        condition = and_cond(field_exists, ranked_by_exists, condition_in_aggregation)
+        return agg_func(field, ordered_agg_sort_key, condition, **alias_dict)
+
+    condition = and_cond(field_exists, condition_in_aggregation)
+    if aggregation.aggregate in (Function.FUNCTION_ANY, Function.FUNCTION_COLLECT_UNIQUE):
+        return agg_func(field, condition, **alias_dict)
+
+    return f.round(agg_func(field, condition), _FLOATING_POINT_PRECISION, **alias_dict)
+
+
 def _get_ci_count(
     aggregation: AttributeConditionalAggregation,
     attribute_key_to_expression: Callable[[AttributeKey], Expression],
@@ -919,86 +966,6 @@ def aggregation_to_expression(
             aggregation, field, condition_in_aggregation, alias_dict
         )
 
-    # FUNCTION_FIRST / FUNCTION_LAST return the value of `field` at the row that ranks
-    # first / last by the aggregation's ranked_by. FIRST maps to argMin; LAST maps to
-    # argMax. Sort key is only built for those aggregates (None otherwise).
-    ordered_agg_sort_key = _build_ordered_agg_sort_key(aggregation, attribute_key_to_expression)
-    ordered_agg_condition = None
-    if ordered_agg_sort_key is not None:
-        ranked_by_exists = get_field_existence_expression(
-            attribute_key_to_expression(aggregation.ranked_by.key)
-        )
-        ordered_agg_condition = and_cond(field_exists, ranked_by_exists, condition_in_aggregation)
-
-    function_map: dict[Function.ValueType, CurriedFunctionCall | FunctionCall] = {
-        Function.FUNCTION_SUM: f.sumIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_AVERAGE: f.avgIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_COUNT: f.countIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_P50: cf.quantileIfOrNull(0.5)(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_P75: cf.quantileIfOrNull(0.75)(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_P90: cf.quantileIfOrNull(0.9)(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_P95: cf.quantileIfOrNull(0.95)(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_P99: cf.quantileIfOrNull(0.99)(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_AVG: f.avgIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_MAX: f.maxIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_MIN: f.minIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_UNIQ: f.uniqIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_ANY: f.anyIfOrNull(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_COLLECT_UNIQUE: cf.groupUniqArrayIf(max_array_size)(
-            field,
-            and_cond(field_exists, condition_in_aggregation),
-        ),
-        Function.FUNCTION_FIRST: f.argMinIfOrNull(
-            field,
-            ordered_agg_sort_key,
-            ordered_agg_condition,
-        ),
-        Function.FUNCTION_LAST: f.argMaxIfOrNull(
-            field,
-            ordered_agg_sort_key,
-            ordered_agg_condition,
-        ),
-    }
-
     if aggregation.extrapolation_mode in [
         ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
         ExtrapolationMode.EXTRAPOLATION_MODE_CLIENT_ONLY,
@@ -1012,32 +979,15 @@ def aggregation_to_expression(
             use_sampling_factor,
         )
     else:
-        agg_func_expr = function_map.get(aggregation.aggregate)
-        if agg_func_expr is not None:
-            if aggregation.aggregate == Function.FUNCTION_ANY:
-                agg_func_expr = f.anyIfOrNull(
-                    field, and_cond(field_exists, condition_in_aggregation), **alias_dict
-                )
-            elif aggregation.aggregate == Function.FUNCTION_COLLECT_UNIQUE:
-                agg_func_expr = cf.groupUniqArrayIf(max_array_size)(
-                    field, and_cond(field_exists, condition_in_aggregation), **alias_dict
-                )
-            elif aggregation.aggregate == Function.FUNCTION_FIRST:
-                agg_func_expr = f.argMinIfOrNull(
-                    field,
-                    ordered_agg_sort_key,
-                    ordered_agg_condition,
-                    **alias_dict,
-                )
-            elif aggregation.aggregate == Function.FUNCTION_LAST:
-                agg_func_expr = f.argMaxIfOrNull(
-                    field,
-                    ordered_agg_sort_key,
-                    ordered_agg_condition,
-                    **alias_dict,
-                )
-            else:
-                agg_func_expr = f.round(agg_func_expr, _FLOATING_POINT_PRECISION, **alias_dict)
+        agg_func_expr = get_non_extrapolated_function(
+            aggregation,
+            field,
+            field_exists,
+            condition_in_aggregation,
+            alias_dict,
+            max_array_size,
+            attribute_key_to_expression,
+        )
 
     if agg_func_expr is None:
         raise BadSnubaRPCRequestException(f"Aggregation not specified for {aggregation.key.name}")


### PR DESCRIPTION
Pure refactoring of the code paths touched by the FUNCTION_FIRST work, no behavior change:

- **`_convert_aggregation_to_conditional_aggregation`** (`proto_visitor.py`): collapse the near-identical per-`default_value` branches into a single construction site (shared kwargs, early return).
- **`aggregation_to_expression`** (`resolvers/common/aggregation.py`): hoist the non-extrapolated aggregate path into `get_non_extrapolated_function`. Its `function_map` now stores the uncalled callables and applies `field`/`condition`/alias once at the single call site, instead of pre-building every expression.

Covered by the existing `test_endpoint_trace_item_table.py` suite (129 module tests pass).