### PR TITLE
security(clickhouse): keep client-side readonly off server-enforced reads

### DIFF
--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -944,3 +944,28 @@ def test_close_pools_releases_sockets() -> None:
     mgr.clear.assert_called_once()
     assert mgr not in all_managers
     assert connect_mod._pool_managers == {}
+
+
+def test_readonly_user_profiles_do_not_send_readonly() -> None:
+    """
+    VULN-2528: read-only on these paths is enforced by the ClickHouse user's own
+    server-side profile -- the API deployment's CLICKHOUSE_USER and the admin read
+    tools' CLICKHOUSE_READONLY_USER are both provisioned readonly=2. Sending
+    readonly as a client setting on top of that is not redundant, it is breaking:
+    a user already in readonly mode rejects the query with "Cannot modify
+    'readonly' setting in readonly mode", and a readonly=1 profile rejects any
+    setting at all.
+
+    TRACING and CARDINALITY_ANALYZER deliberately still send readonly=2: they
+    authenticate as CLICKHOUSE_TRACE_USER, which is not constrained server-side,
+    so for them the client-side setting is the only guard there is. If that user
+    is ever given a readonly profile, they have to drop the setting the same way.
+    """
+    for profile in (
+        ClickhouseClientSettings.QUERY,
+        ClickhouseClientSettings.QUERYLOG,
+    ):
+        assert "readonly" not in profile.value.settings, (
+            f"{profile.name} runs as a server-side read-only user; sending readonly "
+            "would make ClickHouse reject the query"
+        )


### PR DESCRIPTION
Ref VULN-2528.

**This PR changed direction.** It previously made Snuba send `readonly=2` on its read profiles. Now that the API deployment's `CLICKHOUSE_USER` is provisioned with a server-side `readonly=2` profile — as the admin read tools' `CLICKHOUSE_READONLY_USER` already is — that approach is not just redundant, it would break every read:

> Cannot modify 'readonly' setting in readonly mode

So the client-side work is reverted in full. What remains is a guard so it cannot come back, plus devservices support for the constrained user.

## Why server-side won

Read-only can be enforced two ways, and they are mutually exclusive on the same connection:

| | Enforced by | Can a query escape it? |
| --- | --- | --- |
| Client-side (`readonly=2` in query settings) | Snuba, per query | Yes — any read path built without the profile misses it |
| Server-side (the ClickHouse user's profile) | ClickHouse | No |

Server-side is strictly stronger, and it turned out to be available: the API process never writes to ClickHouse, so its `CLICKHOUSE_USER` can be read-only without affecting ingestion. Its `DELETE` endpoints (`views.py:340`, `endpoint_delete_trace_items.py:160`) produce to Kafka; the actual `DELETE FROM` runs in the separate `lw_deletions` consumer. Migrations, the replacer, `optimize` and `CLEANUP` are all separate deployments on the writable credential.

Note for provisioning: that user needs `readonly=2`, **not** `readonly=1`. Reads send per-query settings (`max_threads`, `load_balancing`, `query_id`) and `readonly=1` rejects any setting change.

## What is in this PR

- A test pinning that the `QUERY` and `QUERYLOG` profiles send no `readonly` setting, with the reasoning inline, so re-adding one fails in CI rather than in production. This is the durable part: the whole detour happened because nothing encoded which paths are server-enforced.
- `devservices/clickhouse/users.xml` gains a `readonly` user on a `readonly=2` profile, so the constrained path can be exercised locally and the expected production shape is documented.

## What was reverted

- `readonly=2` on `QUERY` and `QUERYLOG`
- The `ADMIN_READ` profile and the admin call-site changes, which existed only to shield the admin read paths from `QUERY`'s `readonly=2`
- The `ADMIN_SUDO` profile, which existed only to keep sudo statements off a readonly profile

`TRACING` and `CARDINALITY_ANALYZER` keep their pre-existing `readonly=2`. They authenticate as `CLICKHOUSE_TRACE_USER`, which is not constrained server-side, so for them the client-side setting is the only guard there is. If that user is ever given a readonly profile, they will need the same treatment — worth a follow-up.

## Known trade-off

Deployments that do not provision a read-only user for the API — self-hosted, most likely — no longer get the client-side `readonly=2` and so keep running reads at `readonly=0`. That is a deliberate cost of the two mechanisms being mutually exclusive: Snuba cannot know whether the user it authenticates as is already constrained, so it cannot safely send the setting "just in case". The actual injection VULN-2528 reported is fixed at its source in getsentry/sentry#121911, which applies to every deployment regardless.

## Testing

The suite passes locally (46 tests in `tests/clickhouse/test_connect.py`; the one error there is a pre-existing ClickHouse-dependent test, and no ClickHouse or Docker daemon was available in my environment). Nothing here exercises a real constrained user yet — wiring a CI job for that is follow-up, since the test suite writes to ClickHouse via migrations and fixtures and so cannot be pointed at a read-only user wholesale.

## Not included

The ClickHouse function allowlist from an earlier revision of this branch was dropped. The injection it backstopped is fixed in getsentry/sentry#121911, and `AllowedFunctionValidator` defaults to off, so the list had no runtime effect. Turning that validator on needs its own soak against the `invalid_funcs` metric. For whoever picks it up: of the five values Sentry now permits, only `identity` is missing from Snuba's list today.