### PR TITLE
ref(replacements): remove logger.error, update info messages

### DIFF
--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -579,10 +579,10 @@ class ReplacerWorker:
         )
         projects_exceeding_limit = self.__processing_time_counter.get_projects_exceeding_limit()
         set_config_auto_replacements_bypass_projects(projects_exceeding_limit, end_time)
-        logger.info(
-            "projects_exceeding_limit = {}".format(
-                ",".join(str(project_id) for project_id in projects_exceeding_limit)
-            )
-        )
         for _project_id in projects_exceeding_limit:
+            logger.info(
+                "projects_exceeding_limit = {}".format(
+                    ",".join(str(project_id) for project_id in projects_exceeding_limit)
+                )
+            )
             self.metrics.increment("project_processing_time_exceeded_time_limit")

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -579,10 +579,13 @@ class ReplacerWorker:
         )
         projects_exceeding_limit = self.__processing_time_counter.get_projects_exceeding_limit()
         set_config_auto_replacements_bypass_projects(projects_exceeding_limit, end_time)
-        for _project_id in projects_exceeding_limit:
+
+        if projects_exceeding_limit:
             logger.info(
                 "projects_exceeding_limit = {}".format(
                     ",".join(str(project_id) for project_id in projects_exceeding_limit)
                 )
             )
-            self.metrics.increment("project_processing_time_exceeded_time_limit")
+            self.metrics.increment(
+                "project_processing_time_exceeded_time_limit", len(projects_exceeding_limit)
+            )

--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -194,12 +194,7 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
             if processed.get_project_id() in projects_to_skip:
                 # For a persistent non rate limited logger
                 logger.info(
-                    f"Skipping replacement for project. Data {message}, Partition: {message.metadata.partition_index}, Offset: {message.metadata.offset}",
-                )
-                # For sentry tracking
-                logger.error(
-                    "Skipping replacement for project",
-                    extra={"project_id": processed.get_project_id(), "data": message},
+                    f"Skipping replacement for project {processed.get_project_id()}. Data {message}, Partition: {message.metadata.partition_index}, Offset: {message.metadata.offset}",
                 )
                 metrics.increment(
                     "replacement_message_skipped",


### PR DESCRIPTION
Removes the `logger.error` since we have the metrics and `logger.info` and we don't need this to count towards SLO. Also the `"projects_exceeding_limit ="` info message was being logged even if there were no projects exceeding the limit so that was unnecessary 