### PR TITLE
fix(admin): close the SQL injection paths in PF-75

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -453,7 +453,7 @@ def _normalize_for_scanning(sql_query: str) -> str:
 # sql_metadata does not report table functions in Parser.tables, so a query
 # sourced only from one reaches the allowed_tables check with an empty table set
 # and passes it. ARRAY JOIN is excluded: it takes an expression list, not a table.
-_TABLE_POSITION_CALL_RE = re.compile(r"(?<!array )\b(?:from|join)\s+(\w+)\s*\(")
+_TABLE_POSITION_CALL_RE = re.compile(r"\b(?:from|join)\s+(\w+)\s*\(")
 
 # Fanning a read out across replicas is normal in these tools, so cluster and
 # clusterAllReplicas stay allowed -- as they already are in the system-queries
@@ -470,6 +470,8 @@ _DISALLOWED_TABLE_FUNCTIONS = (
     "azureBlobStorage",
     "azureBlobStorageCluster",
     "deltaLake",
+    "deltaLakeAzure",
+    "deltaLakeCluster",
     "dictionary",
     "executable",
     "file",
@@ -478,8 +480,11 @@ _DISALLOWED_TABLE_FUNCTIONS = (
     "hdfs",
     "hdfsCluster",
     "hudi",
+    "hudiCluster",
     "iceberg",
+    "icebergCluster",
     "icebergS3",
+    "icebergS3Cluster",
     "jdbc",
     "loop",
     "merge",
@@ -487,6 +492,8 @@ _DISALLOWED_TABLE_FUNCTIONS = (
     "mongodb",
     "mysql",
     "odbc",
+    "paimon",
+    "paimonCluster",
     "postgresql",
     "redis",
     "remote",
@@ -517,8 +524,16 @@ def _reject_table_functions(normalized_query: str) -> None:
     # anything ClickHouse adds later) sitting where a table belongs.
     for match in _TABLE_POSITION_CALL_RE.finditer(normalized_query):
         name = match.group(1)
-        if name not in _ALLOWED_TABLE_FUNCTIONS:
-            raise InvalidCustomQuery(f"table function {name} is not allowed in the query")
+        if name in _ALLOWED_TABLE_FUNCTIONS:
+            continue
+        # ARRAY JOIN takes an expression list rather than a table, so a call
+        # there is an ordinary one. Checked here rather than as a lookbehind on
+        # "array " because that also skipped a real JOIN after an alias named
+        # `array` -- `FROM t AS array JOIN f(...)`.
+        before = normalized_query[: match.start()]
+        if before.endswith("array ") and not before.endswith("as array "):
+            continue
+        raise InvalidCustomQuery(f"table function {name} is not allowed in the query")
 
 
 def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) -> None:

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -411,13 +411,17 @@ _TABLE_POSITION_CALL_RE = re.compile(r"(?<!array )\b(?:from|join)\s+(\w+)\s*\(")
 # validator. Note this leaves allowed_tables reachable through them.
 _ALLOWED_TABLE_FUNCTIONS = frozenset({"cluster", "clusterallreplicas"})
 
-# Table functions reaching off the node: network and filesystem. Rejected
-# anywhere rather than only in a table position, so they cannot hide in a
-# comma-joined source or a subquery. None collide with a scalar function.
-_EXTERNAL_TABLE_FUNCTIONS = (
+# Table functions that can read data allowed_tables never authorized: off the
+# node (network, filesystem) or across local tables. Matched anywhere rather
+# than only in a table position, since a FROM list can reach them past a comma
+# -- `FROM allowed, merge('default', '.*')` -- or from inside a subquery. None
+# collide with a scalar function name; `format` and `values` are left out
+# because they do.
+_DISALLOWED_TABLE_FUNCTIONS = (
     "azureBlobStorage",
     "azureBlobStorageCluster",
     "deltaLake",
+    "dictionary",
     "executable",
     "file",
     "fileCluster",
@@ -428,6 +432,9 @@ _EXTERNAL_TABLE_FUNCTIONS = (
     "iceberg",
     "icebergS3",
     "jdbc",
+    "loop",
+    "merge",
+    "mergeTreeIndex",
     "mongodb",
     "mysql",
     "odbc",
@@ -440,21 +447,25 @@ _EXTERNAL_TABLE_FUNCTIONS = (
     "sqlite",
     "url",
     "urlCluster",
+    "view",
+    "viewIfPermitted",
 )
-_EXTERNAL_TABLE_FUNCTION_RE = re.compile(
-    r"\b(?:" + "|".join(fn.lower() for fn in _EXTERNAL_TABLE_FUNCTIONS) + r")\s*\("
+_DISALLOWED_TABLE_FUNCTION_RE = re.compile(
+    r"\b(?:" + "|".join(fn.lower() for fn in _DISALLOWED_TABLE_FUNCTIONS) + r")\s*\("
 )
 
 
 def _reject_table_functions(normalized_query: str) -> None:
     """Reject table functions. Query must be lower cased, literal stripped and
     whitespace collapsed for the patterns above to match reliably."""
-    external = _EXTERNAL_TABLE_FUNCTION_RE.search(normalized_query)
-    if external:
+    disallowed = _DISALLOWED_TABLE_FUNCTION_RE.search(normalized_query)
+    if disallowed:
         raise InvalidCustomQuery(
-            f"table function {external.group().rstrip('( ')} is not allowed in the query"
+            f"table function {disallowed.group().rstrip('( ')} is not allowed in the query"
         )
 
+    # Backstop for table functions not named above (synthetic generators, and
+    # anything ClickHouse adds later) sitting where a table belongs.
     for match in _TABLE_POSITION_CALL_RE.finditer(normalized_query):
         name = match.group(1)
         if name not in _ALLOWED_TABLE_FUNCTIONS:

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -401,6 +401,55 @@ def _strip_sql_string_literals(sql_query: str) -> str:
     return "".join(out)
 
 
+def _normalize_for_scanning(sql_query: str) -> str:
+    """Lower cased SQL with literals emptied and identifier quoting removed.
+
+    ClickHouse quotes strings with ``'`` and identifiers with ``"`` or a
+    backtick, and the table-function scan below needs all three handled in one
+    pass. Treating ``"`` as a string delimiter erases `"url"` from the scan
+    outright; treating it as ordinary text lets the apostrophe in `"a'b"` open a
+    literal that swallows a following `url(`. Either way a table function slips
+    past.
+
+    String literals collapse to ''; identifiers keep their contents but lose
+    their quoting, which is what makes `url`(...) normalize to url(...).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(sql_query)
+    while i < n:
+        ch = sql_query[i]
+        if ch in ("'", '"', "`"):
+            end = _end_of_sql_string_literal(sql_query, i)
+            if end is None:
+                # Unterminated. Keep the remainder minus the opener so nothing
+                # hides behind it; _sql_quotes_are_balanced rejects it anyway.
+                out.append(sql_query[i + 1 :])
+                break
+            out.append("''" if ch == "'" else sql_query[i + 1 : end - 1])
+            i = end
+            continue
+        # Comments are removed rather than kept, because ClickHouse removes them
+        # too: `url#c<newline>(...)` runs as url(...), so a scan that leaves the
+        # comment in place sees `url# c (` and matches nothing. ClickHouse
+        # documents five forms -- `--`, `#`, `#!`, `//` ("or more than 2 /
+        # characters") and `/* */` -- and all of them are handled here. Matching
+        # a bare `#` also covers `#!`, and a `//` prefix covers `///`.
+        if ch == "#" or sql_query.startswith("--", i) or sql_query.startswith("//", i):
+            newline = sql_query.find("\n", i)
+            i = n if newline == -1 else newline + 1
+            continue
+        if sql_query.startswith("/*", i):
+            # ClickHouse nests these; closing at the first */ only ever leaves
+            # more text in the scan than it should, never less.
+            close = sql_query.find("*/", i + 2)
+            i = n if close == -1 else close + 2
+            continue
+        out.append(ch)
+        i += 1
+    return " ".join("".join(out).lower().split())
+
+
 # sql_metadata does not report table functions in Parser.tables, so a query
 # sourced only from one reaches the allowed_tables check with an empty table set
 # and passes it. ARRAY JOIN is excluded: it takes an expression list, not a table.
@@ -499,6 +548,8 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
         "replace",
         ";",  # Prevent query chaining
         "--",  # Prevent comment-based injection
+        "#",  # ClickHouse line comment, and covers #!
+        "//",  # ClickHouse C-style line comment, and covers ///
         "/*",  # Prevent multi-line comment injection
         "*/",
         "exec",
@@ -513,8 +564,9 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
         elif kw in lowered:
             raise InvalidCustomQuery(f"{kw} is not allowed in the query")
 
+    normalized = _normalize_for_scanning(sql_query)
     # Must run before the allowed_tables check below, which cannot see them.
-    _reject_table_functions(" ".join(lowered.split()))
+    _reject_table_functions(normalized)
 
     parsed = Parser(sql_query.lower())
 

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -457,7 +457,13 @@ _TABLE_POSITION_CALL_RE = re.compile(r"\b(?:from|join)\s+(\w+)\s*\(")
 
 # Fanning a read out across replicas is normal in these tools, so cluster and
 # clusterAllReplicas stay allowed -- as they already are in the system-queries
-# validator. Note this leaves allowed_tables reachable through them.
+# validator.
+#
+# Their table argument is not inspected here, which does not open a hole on the
+# pinned sql-metadata 2.11.0: that version reports both the function and its
+# table in Parser.tables, so allowed_tables still rejects a read outside the
+# allowlist. 3.x stops reporting them, so the upgrade to it has to add an
+# explicit check on that argument in the same change.
 _ALLOWED_TABLE_FUNCTIONS = frozenset({"cluster", "clusterallreplicas"})
 
 # Table functions that can read data allowed_tables never authorized: off the

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -401,6 +401,66 @@ def _strip_sql_string_literals(sql_query: str) -> str:
     return "".join(out)
 
 
+# sql_metadata does not report table functions in Parser.tables, so a query
+# sourced only from one reaches the allowed_tables check with an empty table set
+# and passes it. ARRAY JOIN is excluded: it takes an expression list, not a table.
+_TABLE_POSITION_CALL_RE = re.compile(r"(?<!array )\b(?:from|join)\s+(\w+)\s*\(")
+
+# Fanning a read out across replicas is normal in these tools, so cluster and
+# clusterAllReplicas stay allowed -- as they already are in the system-queries
+# validator. Note this leaves allowed_tables reachable through them.
+_ALLOWED_TABLE_FUNCTIONS = frozenset({"cluster", "clusterallreplicas"})
+
+# Table functions reaching off the node: network and filesystem. Rejected
+# anywhere rather than only in a table position, so they cannot hide in a
+# comma-joined source or a subquery. None collide with a scalar function.
+_EXTERNAL_TABLE_FUNCTIONS = (
+    "azureBlobStorage",
+    "azureBlobStorageCluster",
+    "deltaLake",
+    "executable",
+    "file",
+    "fileCluster",
+    "gcs",
+    "hdfs",
+    "hdfsCluster",
+    "hudi",
+    "iceberg",
+    "icebergS3",
+    "jdbc",
+    "mongodb",
+    "mysql",
+    "odbc",
+    "postgresql",
+    "redis",
+    "remote",
+    "remoteSecure",
+    "s3",
+    "s3Cluster",
+    "sqlite",
+    "url",
+    "urlCluster",
+)
+_EXTERNAL_TABLE_FUNCTION_RE = re.compile(
+    r"\b(?:" + "|".join(fn.lower() for fn in _EXTERNAL_TABLE_FUNCTIONS) + r")\s*\("
+)
+
+
+def _reject_table_functions(normalized_query: str) -> None:
+    """Reject table functions. Query must be lower cased, literal stripped and
+    whitespace collapsed for the patterns above to match reliably."""
+    external = _EXTERNAL_TABLE_FUNCTION_RE.search(normalized_query)
+    if external:
+        raise InvalidCustomQuery(
+            f"table function {external.group().rstrip('( ')} is not allowed in the query"
+        )
+
+    for match in _TABLE_POSITION_CALL_RE.finditer(normalized_query):
+        name = match.group(1)
+        if name not in _ALLOWED_TABLE_FUNCTIONS:
+            raise InvalidCustomQuery(f"table function {name} is not allowed in the query")
+
+
 def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) -> None:
     """
     Validates that the query is a safe read-only query.
@@ -441,6 +501,9 @@ def validate_ro_query(sql_query: str, allowed_tables: set[str] | None = None) ->
                 raise InvalidCustomQuery(f"{kw} is not allowed in the query")
         elif kw in lowered:
             raise InvalidCustomQuery(f"{kw} is not allowed in the query")
+
+    # Must run before the allowed_tables check below, which cannot see them.
+    _reject_table_functions(" ".join(lowered.split()))
 
     parsed = Parser(sql_query.lower())
 

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -1,10 +1,33 @@
+import re
 from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
 from typing import TypedDict
 
 from snuba.admin.clickhouse.common import _get_storage, get_clusterless_node_connection
+from snuba.clickhouse.escaping import escape_string
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.utils.serializable_exception import SerializableException
+
+
+class InvalidClusterName(SerializableException):
+    pass
+
+
+# The caller-supplied cluster name is interpolated into DDL this module executes
+# and into clusterAllReplicas(), on connections holding full cluster credentials.
+# No real cluster name falls outside this shape, so reject rather than lean on
+# the escaping downstream.
+CLUSTER_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+
+
+def validate_cluster_name(cluster_name: str) -> str:
+    if not CLUSTER_NAME_RE.match(cluster_name):
+        raise InvalidClusterName(
+            "cluster name must be 1-128 characters of letters, digits, underscores or dashes",
+            extra_data={"cluster_name": cluster_name},
+        )
+    return cluster_name
 
 
 @dataclass
@@ -60,7 +83,7 @@ def get_create_table_statements(
 
         if cluster_name:
             table_statement = table_statement.replace(
-                db_table, f"{db_table} ON CLUSTER '{cluster_name}'"
+                db_table, f"{db_table} ON CLUSTER {escape_string(cluster_name)}"
             )
 
         table_statements.append(
@@ -89,7 +112,7 @@ def verify_tables_on_replicas(
     if the expected created tables are missing.
     """
     if cluster_name:
-        from_clause = f"FROM clusterAllReplicas('{cluster_name}', system.tables)"
+        from_clause = f"FROM clusterAllReplicas({escape_string(cluster_name)}, system.tables)"
     else:
         from_clause = "FROM system.tables"
 
@@ -98,7 +121,7 @@ def verify_tables_on_replicas(
         hostName() as host,
         groupArray(name) as table_name
     {from_clause}
-    WHERE database = '{database_name}'
+    WHERE database = {escape_string(database_name)}
     GROUP BY host
     ORDER BY host
     """
@@ -143,7 +166,8 @@ def copy_tables(
     if skip_on_cluster:
         cluster_name = None
     elif cluster_name_override:
-        cluster_name = cluster_name_override
+        # Only the override needs validating; the names below come from settings.
+        cluster_name = validate_cluster_name(cluster_name_override)
     elif not cluster.is_single_node():
         cluster_name = storage.get_cluster().get_clickhouse_cluster_name()
         assert cluster_name, "Missing cluster name for ON CLUSTER create statement"

--- a/snuba/admin/eap_query_analysis/analysis.py
+++ b/snuba/admin/eap_query_analysis/analysis.py
@@ -21,6 +21,7 @@ from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableR
 
 from snuba.admin.clickhouse.common import get_ro_query_node_connection
 from snuba.admin.clickhouse.querylog import run_querylog_query
+from snuba.clickhouse.escaping import escape_string
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.schemas.tables import TableSchema
@@ -104,12 +105,16 @@ class EapQueryAnalysisRequest:
 
         include_profile_events = bool(data.get("include_profile_events", True))
 
+        # Both fields end up in a SQL string literal, so keep them str.
+        referrer = data.get("referrer") or None
+        referrer_contains = data.get("referrer_contains") or None
+
         return cls(
             hours=hours,
             max_rows=max_rows,
-            referrer=data.get("referrer") or None,
+            referrer=str(referrer) if referrer is not None else None,
             organization_id=organization_id,
-            referrer_contains=data.get("referrer_contains") or None,
+            referrer_contains=(str(referrer_contains) if referrer_contains is not None else None),
             include_profile_events=include_profile_events,
         )
 
@@ -256,11 +261,6 @@ def _schema_table_name() -> str:
     return schema.get_table_name()
 
 
-def _escape_literal(value: str) -> str:
-    """Escape a string for safe inclusion in a single-quoted SQL literal."""
-    return value.replace("\\", "\\\\").replace("'", "\\'")
-
-
 def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
     table = _schema_table_name()
     dataset_list = ", ".join(f"'{d}'" for d in _EAP_DATASETS)
@@ -269,13 +269,13 @@ def _build_fetch_sql(req: EapQueryAnalysisRequest) -> str:
         f"dataset IN ({dataset_list})",
     ]
     if req.referrer:
-        where.append(f"referrer = '{_escape_literal(req.referrer)}'")
+        where.append(f"referrer = {escape_string(req.referrer)}")
     if req.referrer_contains:
         # Use positionCaseInsensitive for literal substring matching. ClickHouse
         # 25.x does not support LIKE ... ESCAPE, and LIKE would treat _/% as
         # wildcards for inputs like "eap_items".
         where.append(
-            f"positionCaseInsensitive(referrer, '{_escape_literal(req.referrer_contains)}') > 0"
+            f"positionCaseInsensitive(referrer, {escape_string(req.referrer_contains)}) > 0"
         )
     if req.organization_id is not None:
         where.append(f"organization = {int(req.organization_id)}")
@@ -432,7 +432,7 @@ def _fetch_profile_events(query_ids: list[str], hours: int) -> dict[str, dict[st
         if len(raw) == 32:
             dashed.append(f"{raw[0:8]}-{raw[8:12]}-{raw[12:16]}-{raw[16:20]}-{raw[20:32]}")
     all_ids = list({*normalized, *dashed})
-    id_list = ", ".join(f"'{_escape_literal(qid)}'" for qid in all_ids)
+    id_list = ", ".join(escape_string(qid) for qid in all_ids)
 
     cluster_name = _eap_profile_cluster_name()
     sql_cluster = None
@@ -441,7 +441,7 @@ def _fetch_profile_events(query_ids: list[str], hours: int) -> dict[str, dict[st
             SELECT
                 replaceAll(toString(query_id), '-', '') AS qid,
                 ProfileEvents
-            FROM clusterAllReplicas('{_escape_literal(cluster_name)}', system.query_log)
+            FROM clusterAllReplicas({escape_string(cluster_name)}, system.query_log)
             WHERE type = 'QueryFinish'
               AND event_time > now() - INTERVAL {int(hours)} HOUR
               AND replaceAll(toString(query_id), '-', '') IN ({id_list})

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -24,7 +24,7 @@ from snuba.admin.auth import USER_HEADER_KEY, UnauthorizedException, authorize_r
 from snuba.admin.cardinality_analyzer.cardinality_analyzer import run_metrics_query
 from snuba.admin.clickhouse.clusters import get_cluster_info
 from snuba.admin.clickhouse.common import InvalidCustomQuery, InvalidNodeError
-from snuba.admin.clickhouse.copy_tables import copy_tables
+from snuba.admin.clickhouse.copy_tables import InvalidClusterName, copy_tables
 from snuba.admin.clickhouse.migration_checks import run_migration_checks_and_policies
 from snuba.admin.clickhouse.nodes import get_storage_info
 from snuba.admin.clickhouse.predefined_cardinality_analyzer_queries import (
@@ -505,6 +505,18 @@ def copy_table_query() -> Response:
                     "error": {
                         "type": "request",
                         "message": f"Target host is invalid: {err.args[0]}",
+                    }
+                }
+            ),
+            400,
+        )
+    except InvalidClusterName as err:
+        return make_response(
+            jsonify(
+                {
+                    "error": {
+                        "type": "request",
+                        "message": err.message or "Invalid cluster name",
                     }
                 }
             ),

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -1,13 +1,17 @@
 import os
+from typing import Any, cast
 
 import pytest
 
 from snuba.admin.clickhouse.common import _get_storage, get_clusterless_node_connection
 from snuba.admin.clickhouse.copy_tables import (
+    InvalidClusterName,
     copy_tables,
     get_create_table_statements,
+    validate_cluster_name,
     verify_tables_on_replicas,
 )
+from snuba.clickhouse.native import ClickhousePool, ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.migrations import table_engines
 from snuba.migrations.groups import MigrationGroup
@@ -97,6 +101,74 @@ def run_migrations() -> None:
 
     migration_group = MigrationGroup("outcomes")
     Runner().run_all(force=True, group=migration_group)
+
+
+class FakeConnection:
+    """Records the SQL it is handed instead of talking to ClickHouse."""
+
+    def __init__(self, results: list[list[Any]]) -> None:
+        self.queries: list[str] = []
+        self.results = results
+
+    def execute(self, query: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
+        self.queries.append(query)
+        return ClickhouseResult(self.results)
+
+    def as_pool(self) -> ClickhousePool:
+        return cast(ClickhousePool, self)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "test_cluster",
+        "cluster_one_sh",
+        "my-cluster-1",
+        "c" * 128,
+    ],
+)
+def test_validate_cluster_name_accepts_identifiers(name: str) -> None:
+    assert validate_cluster_name(name) == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Rewrites the verify query and the ON CLUSTER clause respectively.
+        "x', system.tables) WHERE 1=1 UNION ALL SELECT hostName(), groupArray(name) "
+        "FROM clusterAllReplicas('c', system.users) GROUP BY 1 --",
+        "c' AS SELECT * FROM system.users --",
+        "",
+        "c" * 129,
+        "has space",
+        "quote'",
+        "back\\slash",
+        "semi;colon",
+    ],
+)
+def test_validate_cluster_name_rejects_injection(name: str) -> None:
+    with pytest.raises(InvalidClusterName):
+        validate_cluster_name(name)
+
+
+def test_verify_tables_on_replicas_escapes_identifiers() -> None:
+    connection = FakeConnection([["host1", ["t"]]])
+    verify_tables_on_replicas(connection.as_pool(), "test_cluster", "my'db", ["t"])
+
+    query = connection.queries[0]
+    assert "clusterAllReplicas('test_cluster', system.tables)" in query
+    assert "WHERE database = 'my\\'db'" in query
+
+
+def test_create_table_statements_escape_cluster_name() -> None:
+    connection = FakeConnection([["CREATE TABLE db.t (a UInt64) ENGINE = MergeTree"]])
+    statements = get_create_table_statements(
+        tables=["t"],
+        source_connection=connection.as_pool(),
+        source_database="db",
+        cluster_name="test_cluster",
+    )
+    assert "ON CLUSTER 'test_cluster'" in statements[0].statement
 
 
 @pytest.mark.parametrize("table, storage_name, statement, is_mergetree", TABLE_DATA)

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -85,6 +85,15 @@ def test_comment_tokens_outside_literals_rejected() -> None:
         validate_ro_query("SELECT * FROM my_table -- drop everything")
     with pytest.raises(InvalidCustomQuery):
         validate_ro_query("SELECT * FROM my_table /* bad */")
+    # ClickHouse also treats # as a line comment.
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query("SELECT * FROM my_table # drop everything")
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query("SELECT * FROM my_table // drop everything")
+    # ...but inside a literal they are just data. A URL is the case that matters:
+    # // in a filter value must not read as a comment.
+    validate_ro_query("SELECT * FROM my_table WHERE referrer = 'a#b'")
+    validate_ro_query("SELECT * FROM my_table WHERE u = 'http://example.com/x'")
 
 
 @pytest.mark.parametrize(
@@ -104,6 +113,27 @@ def test_comment_tokens_outside_literals_rejected() -> None:
         "SELECT * FROM my_table WHERE x IN (SELECT * FROM merge('default', '.*'))",
         "SELECT * FROM my_table WHERE x IN (SELECT * FROM remote('h:9000', system.users))",
         "SELECT * FROM\n  URL('http://evil/x', CSV, 'a String')",
+        # Quoted identifiers: ClickHouse quotes strings with ' and identifiers
+        # with ` or ", so neither form may hide the function name.
+        "SELECT * FROM `url`('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM \"url\"('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM `remote`('h:9000', system.users)",
+        # An apostrophe inside a quoted identifier must not open a literal that
+        # swallows the function name that follows it.
+        """SELECT * FROM "a'b", url('http://evil/x', CSV, 'a String')""",
+        """SELECT * FROM `a'b`, url('http://evil/x', CSV, 'a String')""",
+        """SELECT * FROM "a'b", `remote`('h:9000', system.users)""",
+        # ClickHouse strips comments before parsing, so one between the name and
+        # its ( must not hide the call. It documents five forms: -- # #! // /* */
+        # ("or more than 2 / characters"), and all of them are covered here.
+        "SELECT * FROM url--c\n('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM url#c\n('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM url#!c\n('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM url//c\n('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM url///c\n('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM url/*c*/('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM remote//c\n('h:9000', system.users)",
+        "SELECT * FROM \"merge\"('default', '.*')",
         # Following an allowed one must not end the scan.
         "SELECT * FROM clusterAllReplicas('c', my_table) JOIN merge('default', '.*') USING x",
     ],
@@ -122,6 +152,9 @@ def test_table_functions_rejected(query: str) -> None:
         "SELECT * FROM (SELECT * FROM my_table) sub",
         "SELECT count() FROM my_table WHERE referrer IN ('a', 'b')",
         "SELECT * FROM my_table WHERE referrer = 'url(http://x)'",
+        # A quoted table name is still just a table.
+        "SELECT * FROM `my_table`",
+        'SELECT * FROM "my_table"',
     ],
 )
 def test_legitimate_queries_still_allowed(query: str) -> None:
@@ -141,10 +174,8 @@ def test_legitimate_queries_still_allowed(query: str) -> None:
 def test_allowed_without_a_table_allowlist(query: str) -> None:
     """Legitimate for tracing, which passes no allowed_tables.
 
-    The scoped tools reject these on sql_metadata 2.11.0 for an unrelated
-    reason: it reports `arraymap`, `clusterallreplicas` and friends in
-    Parser.tables, so they fail the allowlist as unknown table names. That is
-    pre-existing behaviour and version-specific -- 3.x drops them from
-    Parser.tables -- so it is not asserted here.
+    Whether the scoped tools accept these depends on how the parser reports
+    function sources in Parser.tables, which differs across sql_metadata
+    versions, so it is not asserted here.
     """
     validate_ro_query(query)

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -119,15 +119,32 @@ def test_table_functions_rejected(query: str) -> None:
 @pytest.mark.parametrize(
     "query",
     [
-        "SELECT * FROM my_table ARRAY JOIN arrayMap(x -> x + 1, nums) AS n",
-        "SELECT * FROM my_table LEFT ARRAY JOIN arrayZip(a, b) AS z",
         "SELECT * FROM (SELECT * FROM my_table) sub",
         "SELECT count() FROM my_table WHERE referrer IN ('a', 'b')",
         "SELECT * FROM my_table WHERE referrer = 'url(http://x)'",
-        # Fanning out across replicas stays available to the admin tools.
-        "SELECT * FROM clusterAllReplicas('c', my_table)",
-        "SELECT * FROM cluster('c', my_table)",
     ],
 )
 def test_legitimate_queries_still_allowed(query: str) -> None:
     validate_ro_query(query, allowed_tables={"my_table"})
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # ARRAY JOIN over an expression, and fanning a read out across replicas.
+        "SELECT * FROM my_table ARRAY JOIN arrayMap(x -> x + 1, nums) AS n",
+        "SELECT * FROM my_table LEFT ARRAY JOIN arrayZip(a, b) AS z",
+        "SELECT * FROM clusterAllReplicas('c', my_table)",
+        "SELECT * FROM cluster('c', my_table)",
+    ],
+)
+def test_allowed_without_a_table_allowlist(query: str) -> None:
+    """Legitimate for tracing, which passes no allowed_tables.
+
+    The scoped tools reject these on sql_metadata 2.11.0 for an unrelated
+    reason: it reports `arraymap`, `clusterallreplicas` and friends in
+    Parser.tables, so they fail the allowlist as unknown table names. That is
+    pre-existing behaviour and version-specific -- 3.x drops them from
+    Parser.tables -- so it is not asserted here.
+    """
+    validate_ro_query(query)

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -98,6 +98,10 @@ def test_comment_tokens_outside_literals_rejected() -> None:
         "SELECT * FROM numbers(10)",
         # Not sitting directly after FROM.
         "SELECT * FROM my_table, url('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM my_table, merge('default', '.*')",
+        "SELECT * FROM my_table, dictionary('d')",
+        "SELECT * FROM my_table, view(SELECT * FROM system.users)",
+        "SELECT * FROM my_table WHERE x IN (SELECT * FROM merge('default', '.*'))",
         "SELECT * FROM my_table WHERE x IN (SELECT * FROM remote('h:9000', system.users))",
         "SELECT * FROM\n  URL('http://evil/x', CSV, 'a String')",
         # Following an allowed one must not end the scan.

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -85,3 +85,45 @@ def test_comment_tokens_outside_literals_rejected() -> None:
         validate_ro_query("SELECT * FROM my_table -- drop everything")
     with pytest.raises(InvalidCustomQuery):
         validate_ro_query("SELECT * FROM my_table /* bad */")
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM url('http://169.254.169.254/latest/meta-data/', CSV, 'a String')",
+        "SELECT * FROM remote('other-host:9000', system.users)",
+        "SELECT * FROM mysql('host:3306', 'db', 'table', 'user', 'password')",
+        "SELECT * FROM s3('http://host/key', 'CSV', 'a String')",
+        "SELECT * FROM merge('default', '.*')",
+        "SELECT * FROM numbers(10)",
+        # Not sitting directly after FROM.
+        "SELECT * FROM my_table, url('http://evil/x', CSV, 'a String')",
+        "SELECT * FROM my_table WHERE x IN (SELECT * FROM remote('h:9000', system.users))",
+        "SELECT * FROM\n  URL('http://evil/x', CSV, 'a String')",
+        # Following an allowed one must not end the scan.
+        "SELECT * FROM clusterAllReplicas('c', my_table) JOIN merge('default', '.*') USING x",
+    ],
+)
+def test_table_functions_rejected(query: str) -> None:
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query(query, allowed_tables={"my_table"})
+    # Rejected for the unscoped tools (tracing) too, not just the scoped ones.
+    with pytest.raises(InvalidCustomQuery):
+        validate_ro_query(query)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM my_table ARRAY JOIN arrayMap(x -> x + 1, nums) AS n",
+        "SELECT * FROM my_table LEFT ARRAY JOIN arrayZip(a, b) AS z",
+        "SELECT * FROM (SELECT * FROM my_table) sub",
+        "SELECT count() FROM my_table WHERE referrer IN ('a', 'b')",
+        "SELECT * FROM my_table WHERE referrer = 'url(http://x)'",
+        # Fanning out across replicas stays available to the admin tools.
+        "SELECT * FROM clusterAllReplicas('c', my_table)",
+        "SELECT * FROM cluster('c', my_table)",
+    ],
+)
+def test_legitimate_queries_still_allowed(query: str) -> None:
+    validate_ro_query(query, allowed_tables={"my_table"})

--- a/tests/admin/clickhouse/test_query_validation.py
+++ b/tests/admin/clickhouse/test_query_validation.py
@@ -133,6 +133,13 @@ def test_comment_tokens_outside_literals_rejected() -> None:
         "SELECT * FROM url///c\n('http://evil/x', CSV, 'a String')",
         "SELECT * FROM url/*c*/('http://evil/x', CSV, 'a String')",
         "SELECT * FROM remote//c\n('h:9000', system.users)",
+        # Data-lake and *Cluster families sit beside names already listed.
+        "SELECT * FROM icebergCluster('c', 'http://host/x')",
+        "SELECT * FROM my_table, paimon('http://host/x')",
+        "SELECT * FROM deltaLakeAzure('x')",
+        # A real JOIN after an alias named `array` is not an ARRAY JOIN, so the
+        # backstop must still see the call after it.
+        "SELECT * FROM my_table AS array JOIN somefunc(1) USING x",
         "SELECT * FROM \"merge\"('default', '.*')",
         # Following an allowed one must not end the scan.
         "SELECT * FROM clusterAllReplicas('c', my_table) JOIN merge('default', '.*') USING x",

--- a/tests/admin/eap_query_analysis/test_analysis.py
+++ b/tests/admin/eap_query_analysis/test_analysis.py
@@ -25,7 +25,6 @@ from snuba.admin.eap_query_analysis.analysis import (
     EapQueryAnalysisRequest,
     ResourceTotals,
     _build_fetch_sql,
-    _escape_literal,
     _infer_request_class,
     _parse_request_body,
     analyze_eap_queries,
@@ -374,4 +373,36 @@ def test_build_fetch_sql_filters_estimation_and_duplicates() -> None:
     assert "positionCaseInsensitive(referrer, 'eap_items') > 0" in sql
     assert "LIKE" not in sql
     assert "ESCAPE" not in sql
-    assert _escape_literal("a'b\\c") == "a\\'b\\\\c"
+
+
+def test_build_fetch_sql_escapes_referrer_filters() -> None:
+    req = EapQueryAnalysisRequest.from_dict(
+        {
+            "hours": 1,
+            "referrer": "a' OR 1=1 --",
+            "referrer_contains": "b'\\c",
+        }
+    )
+    with patch(
+        "snuba.admin.eap_query_analysis.analysis._schema_table_name",
+        return_value="querylog_local",
+    ):
+        sql = _build_fetch_sql(req)
+
+    assert "referrer = 'a\\' OR 1=1 --'" in sql
+    assert "positionCaseInsensitive(referrer, 'b\\'\\\\c')" in sql
+    # The injected quote never terminates the literal it sits in.
+    assert "OR 1=1" not in sql.replace("'a\\' OR 1=1 --'", "")
+
+
+def test_request_coerces_non_string_referrers() -> None:
+    req = EapQueryAnalysisRequest.from_dict(
+        {"referrer": ["a"], "referrer_contains": {"b": 1}},
+    )
+    assert isinstance(req.referrer, str)
+    assert isinstance(req.referrer_contains, str)
+    with patch(
+        "snuba.admin.eap_query_analysis.analysis._schema_table_name",
+        return_value="querylog_local",
+    ):
+        _build_fetch_sql(req)


### PR DESCRIPTION
Closes [PF-75](https://linear.app/getsentry/issue/PF-75/sql-injection-vulnerabilities-in-getsentrysnuba-in-3-locations) (Semgrep `python.flask.db.generic-sql-flask`, request data reaching a SQL sink).

Split out of #8289, which had grown well past the ticket. This branch is PF-75 only; two follow-ups stack on it (see the bottom).

## The three locations

**1. `/run_copy_table_query` interpolated an unvalidated `cluster_name`.** The request field went straight into `clusterAllReplicas('…', system.tables)` and the `ON CLUSTER` clause of executed `CREATE` statements, on connections holding full cluster credentials. A quote rewrote whichever statement it landed in. Now validated against the identifier shape a real cluster name has, with every cluster/database interpolation going through `escape_string`, and `InvalidClusterName` → HTTP 400.

**2. The tracing tool ran any table function.** `run_query_and_get_trace` calls `validate_ro_query(query)` with no `allowed_tables`, so nothing stopped `SELECT * FROM url('http://…', CSV, 'a String')` — SSRF from inside the ClickHouse network — or `remote()` reading any table on any reachable node. `validate_ro_query` now rejects table functions: those reaching off the node (`url`, `remote`, `s3`, `mysql`, `file`, …) or across local tables (`merge`, `dictionary`, `view`, `loop`) anywhere in the query, and anything else in a table position as a backstop. `ARRAY JOIN` is exempt — it takes an expression list, not a table.

**3. EAP Stats escaped referrer filters by hand** rather than using `escape_string`. Behaviour was equivalent — I could not break out of the literal — so this was the flagged pattern rather than a live hole. Both referrer fields are also pinned to `str` so a JSON list or object cannot reach the escaping.

## On the scan being lexical

The scan went through several rounds of bypasses during review — past a comma, as a quoted identifier (`` `url`(...) ``, `"url"(...)`), through an apostrophe inside a quoted identifier, and behind `#` and `//` comments. All are covered with regression tests, and they are squashed into one commit here rather than left as a trail.

The underlying reason was that the scan inspected text that did not match what ClickHouse parses. `_normalize_for_scanning` does one left-to-right pass over everything that can hide a call — `'` literals emptied, `"` and `` ` `` identifiers unquoted, and all five documented comment forms removed — so the scan sees the same tokens the server will.

Two things reviewers should weigh:

- **This is a text approximation of a parse.** The system-queries tool solves the same problem properly, by asking ClickHouse via `EXPLAIN QUERY TREE` what the query resolves to. Routing `validate_ro_query` through that would end this class of finding outright. It costs a round trip per validation and changes the failure mode when ClickHouse is unreachable, so it is not in this PR — but it is the better long-term shape.
- **In Sentry's deployment this is now defence in depth**, since `SOURCES` is revoked from the admin ClickHouse users, so `url`/`remote`/`s3` and the rest are refused server-side regardless. It stays in the code because self-hosted deployments get no such revoke, and because `merge`/`dictionary`/`view`/`loop` and `cluster`/`clusterAllReplicas` are not `SOURCES` members and so are not covered by it.

## Not covered here

`CLICKHOUSE_READONLY_USER` and `CLICKHOUSE_TRACE_USER` both default to `"default"` (`settings/__init__.py:150-153`), so unless a deployment overrides them the "read-only" admin connections authenticate as a full-privilege user. Worth its own ticket.

## Testing

`tests/admin` passes against the currently pinned `sql-metadata` 2.11.0. New tests cover each rejected table function in the direct, comma-joined and subquery positions, each quoting and comment form that could hide one, and the queries that must keep working (`` `my_table` ``, `'a#b'` and `'http://…'` as data, `quantilesMerge`, ARRAY JOIN over an expression).

## Stacked follow-ups

- `claude/snuba-sql-metadata-3` — sql-metadata 3.0.1 + bounding the cluster table functions (coupled: the upgrade is what makes that gap live)
- `claude/snuba-admin-sql-cleanup` — driver-bound params, shared SQL fragments, job removal

https://claude.ai/code/session_01JAWCwVv23LnmaGADQSuQgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAWCwVv23LnmaGADQSuQgV)_