### PR TITLE
feat(snuba): record gauge for batch size.

### DIFF
--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -66,8 +66,8 @@ fn clickhouse_task_runner(
 
             counter!("insertions.batch_write_bytes", num_bytes as i64);
             counter!("insertions.batch_write_msgs", batch_len as i64);
-            gauge!("insertions.batch_write_bytes", num_bytes as i64);
-            gauge!("insertions.batch_flush_rows", batch_len as i64);
+            gauge!("insertions.batch_flush_bytes", num_bytes as i64);
+            gauge!("insertions.batch_flush_msgs", batch_len as i64);
             empty_batch.record_message_latency();
             empty_batch.emit_item_type_metrics();
 

--- a/rust_snuba/src/strategies/clickhouse/writer_v2.rs
+++ b/rust_snuba/src/strategies/clickhouse/writer_v2.rs
@@ -10,7 +10,7 @@ use sentry_arroyo::processing::strategies::{
     CommitRequest, ProcessingStrategy, StrategyError, SubmitError,
 };
 use sentry_arroyo::types::Message;
-use sentry_arroyo::{counter, timer};
+use sentry_arroyo::{counter, gauge, timer};
 
 use crate::config::ClickhouseConfig;
 use crate::options::{
@@ -66,6 +66,8 @@ fn clickhouse_task_runner(
 
             counter!("insertions.batch_write_bytes", num_bytes as i64);
             counter!("insertions.batch_write_msgs", batch_len as i64);
+            gauge!("insertions.batch_write_bytes", num_bytes as i64);
+            gauge!("insertions.batch_flush_rows", batch_len as i64);
             empty_batch.record_message_latency();
             empty_batch.emit_item_type_metrics();
 


### PR DESCRIPTION
## What

Add gauge metrics for per-batch rows and bytes on ClickHouse inserts.

## How

- Emit new `gauge`s: `insertions.batch_flush_msgs` and `insertions.batch_flush_bytes` 

## Why
- We're tuning batch sizes for reduced merge pressure and I want to see how many messages we're actually sending per batch at a glance
- Existing counter metrics (`batch_write_msgs`, `batch_write_bytes`) get summed across aggregation intervals, making batch sizes look inflated at wider time windows
- Gauges report actual per-batch values at any zoom level

## Notes
- Keeps existing `counter`s for throughput

## Links
- [EAP-650](https://linear.app/getsentry/issue/EAP-650/enable-row-binary-on-eap-items-us)