### PR TITLE
ref(genmetrics): remove sets,distributions,gauges from migration group

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/dataset.yaml
+++ b/snuba/datasets/configuration/generic_metrics/dataset.yaml
@@ -3,5 +3,8 @@ kind: dataset
 name: generic_metrics
 
 entities:
+  - generic_metrics_sets
+  - generic_metrics_distributions
   - generic_metrics_counters
   - generic_org_metrics_counters
+  - generic_metrics_gauges

--- a/snuba/datasets/configuration/generic_metrics/dataset.yaml
+++ b/snuba/datasets/configuration/generic_metrics/dataset.yaml
@@ -3,8 +3,5 @@ kind: dataset
 name: generic_metrics
 
 entities:
-  - generic_metrics_sets
-  - generic_metrics_distributions
   - generic_metrics_counters
   - generic_org_metrics_counters
-  - generic_metrics_gauges

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_distributions
 storage:
   key: generic_metrics_distributions
   set_key: generic_metrics_distributions
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_distributions
 storage:
   key: generic_metrics_distributions
   set_key: generic_metrics_distributions
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_distributions_raw
 storage:
   key: generic_metrics_distributions_raw
   set_key: generic_metrics_distributions
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_distributions_raw
 storage:
   key: generic_metrics_distributions_raw
   set_key: generic_metrics_distributions
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_meta.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_meta.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_distributions_meta
 storage:
   key: generic_metrics_distributions_meta
   set_key: generic_metrics_distributions
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_meta.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_meta.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_distributions_meta
 storage:
   key: generic_metrics_distributions_meta
   set_key: generic_metrics_distributions
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_gauges
 storage:
   key: generic_metrics_gauges
   set_key: generic_metrics_gauges
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_gauges
 storage:
   key: generic_metrics_gauges
   set_key: generic_metrics_gauges
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_gauges_raw
 storage:
   key: generic_metrics_gauges_raw
   set_key: generic_metrics_gauges
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_gauges_raw
 storage:
   key: generic_metrics_gauges_raw
   set_key: generic_metrics_gauges
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_meta.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_meta.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_gauges_meta
 storage:
   key: generic_metrics_gauges_meta
   set_key: generic_metrics_gauges
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_meta.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_meta.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_gauges_meta
 storage:
   key: generic_metrics_gauges_meta
   set_key: generic_metrics_gauges
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_meta_tag_values.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_gauges_meta_tag_values
 storage:
   key: generic_metrics_gauges_meta_tag_values
   set_key: generic_metrics_gauges
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_meta_tag_values.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_gauges_meta_tag_values
 storage:
   key: generic_metrics_gauges_meta_tag_values
   set_key: generic_metrics_gauges
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_sets
 storage:
   key: generic_metrics_sets
   set_key: generic_metrics_sets
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_sets
 storage:
   key: generic_metrics_sets
   set_key: generic_metrics_sets
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_sets_raw
 storage:
   key: generic_metrics_sets_raw
   set_key: generic_metrics_sets
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_sets_raw
 storage:
   key: generic_metrics_sets_raw
   set_key: generic_metrics_sets
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_meta.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_meta.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_sets_meta
 storage:
   key: generic_metrics_sets_meta
   set_key: generic_metrics_sets
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_meta.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_meta.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_sets_meta
 storage:
   key: generic_metrics_sets_meta
   set_key: generic_metrics_sets
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_meta_tag_values.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_sets_meta_tag_values
 storage:
   key: generic_metrics_sets_meta_tag_values
   set_key: generic_metrics_sets
-readiness_state: complete
+readiness_state: deprecate
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_meta_tag_values.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_meta_tag_values.yaml
@@ -6,7 +6,7 @@ name: generic_metrics_sets_meta_tag_values
 storage:
   key: generic_metrics_sets_meta_tag_values
   set_key: generic_metrics_sets
-readiness_state: deprecate
+readiness_state: limited
 schema:
   columns:
     [

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -141,12 +141,7 @@ _REGISTERED_MIGRATION_GROUPS: dict[MigrationGroup, _MigrationGroup] = {
     ),
     MigrationGroup.GENERIC_METRICS: _MigrationGroup(
         loader=GenericMetricsLoader(),
-        storage_sets_keys={
-            StorageSetKey.GENERIC_METRICS_SETS,
-            StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS,
-            StorageSetKey.GENERIC_METRICS_COUNTERS,
-            StorageSetKey.GENERIC_METRICS_GAUGES,
-        },
+        storage_sets_keys={StorageSetKey.GENERIC_METRICS_COUNTERS},
         readiness_state=ReadinessState.COMPLETE,
     ),
     MigrationGroup.TEST_MIGRATION: _MigrationGroup(

--- a/tests/migrations/test_groups.py
+++ b/tests/migrations/test_groups.py
@@ -18,11 +18,7 @@ def test_build_storage_set_to_group_mapping() -> None:
     try:
         storage_set_to_group_mapping = build_storage_set_to_group_mapping()
         assert (
-            storage_set_to_group_mapping[StorageSetKey.GENERIC_METRICS_SETS]
-            == MigrationGroup.GENERIC_METRICS
-        )
-        assert (
-            storage_set_to_group_mapping[StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS]
+            storage_set_to_group_mapping[StorageSetKey.GENERIC_METRICS_COUNTERS]
             == MigrationGroup.GENERIC_METRICS
         )
         assert storage_set_to_group_mapping[StorageSetKey.EVENTS] == MigrationGroup.EVENTS


### PR DESCRIPTION
Due to https://github.com/getsentry/ops/pull/22846/changes we are seeing `AttributeError: GENERIC_METRICS_SETS` when trying to load the storage sets for the migration groups since `MigrationGroup.GENERIC_METRICS` is still an active migration group