### PR TITLE
fix(security): default storage deletes off

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -512,8 +512,8 @@
     },
     "storage_deletes_enabled": {
       "type": "boolean",
-      "default": true,
-      "description": "Master switch for storage delete (DELETE FROM) support; when false all delete requests are rejected."
+      "default": false,
+      "description": "Master switch for storage delete (DELETE FROM) support. Defaults off; deletes are rejected unless this option is explicitly set true for the environment. When false all delete requests are rejected."
     },
     "enforce_max_rows_to_delete": {
       "type": "boolean",

--- a/snuba/web/delete_query.py
+++ b/snuba/web/delete_query.py
@@ -224,7 +224,7 @@ WHERE metric = 'PartMutation'
 
 
 def deletes_are_enabled() -> bool:
-    return get_option("storage_deletes_enabled", True)
+    return bool(get_option("storage_deletes_enabled", False))
 
 
 def _get_rows_to_delete(storage_key: StorageKey, select_query_to_count_rows: Query) -> int:

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -51,6 +51,11 @@ def base_insert_event(
 
 
 class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
+    @pytest.fixture(autouse=True)
+    def enable_storage_deletes(self) -> Any:
+        with override_options("snuba", {"storage_deletes_enabled": True}):
+            yield
+
     @pytest.fixture
     def test_entity(self) -> str | tuple[str, str]:
         return "search_issues"

--- a/tests/web/rpc/v1/test_endpoint_delete_trace_items.py
+++ b/tests/web/rpc/v1/test_endpoint_delete_trace_items.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_options.testing import override_options
 from sentry_protos.snuba.v1.endpoint_delete_trace_items_pb2 import (
     DeleteTraceItemsRequest,
     DeleteTraceItemsResponse,
@@ -75,6 +76,11 @@ def setup_teardown(eap: None, redis_db: None) -> None:
 @pytest.mark.eap
 @pytest.mark.redis_db
 class TestEndpointDeleteTrace(BaseApiTest):
+    @pytest.fixture(autouse=True)
+    def enable_storage_deletes(self) -> Any:
+        with override_options("snuba", {"storage_deletes_enabled": True}):
+            yield
+
     def test_missing_trace_id_raises_exception(self) -> None:
         ts = Timestamp()
         ts.GetCurrentTime()

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -50,6 +50,13 @@ def get_attribution_info(tenant_ids: Mapping[str, int | str] | None = None) -> M
     }
 
 
+@pytest.fixture(autouse=True)
+def enable_storage_deletes() -> Any:
+    # Product tests opt in. Default-off is covered in test_delete_query.py.
+    with override_options("snuba", {"storage_deletes_enabled": True}):
+        yield
+
+
 @patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
 def test_delete_success(mock_enforce_max_row: Mock) -> None:
     admin_client = AdminClient(get_default_kafka_configuration())

--- a/tests/web/test_delete_query.py
+++ b/tests/web/test_delete_query.py
@@ -24,7 +24,30 @@ from snuba.query.data_source.simple import Table
 from snuba.query.dsl import and_cond, column, equals, literal
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.web import QueryException
-from snuba.web.delete_query import _execute_query
+from snuba.web.delete_query import DeletesNotEnabledError, _execute_query, deletes_are_enabled
+
+
+def test_deletes_are_enabled_defaults_false() -> None:
+    assert deletes_are_enabled() is False
+
+
+def test_delete_from_storage_rejected_when_disabled_by_default() -> None:
+    from snuba.web.bulk_delete_query import delete_from_storage
+
+    storage = get_writable_storage(StorageKey("search_issues"))
+    with pytest.raises(DeletesNotEnabledError, match="Deletes not enabled in this region"):
+        delete_from_storage(
+            storage,
+            {"project_id": [1], "group_id": [1]},
+            {
+                "tenant_ids": {"project_id": 1, "organization_id": 1},
+                "referrer": "test",
+                "app_id": "test",
+                "team": "test",
+                "parent_api": "test",
+                "feature": "test",
+            },
+        )
 
 
 @pytest.mark.eap


### PR DESCRIPTION
Unset environments now reject storage deletes. `storage_deletes_enabled` defaults **false** in the options schema and in the `deletes_are_enabled()` fallback, so a missing values mount, a new region, or an options-init failure no longer fail-opens into bulk DELETE.

Production is unchanged: sentry-options-automator already sets `storage_deletes_enabled: true` in `option-values/snuba/default/values.yaml`, and region files inherit it. Per-storage yaml `deletion_settings.is_enabled` is also unchanged (`search_issues` and `eap_items` stay the product allowlist). This PR only closes the global gate when the option is unset.

Product delete tests now opt in with `override_options(..., {"storage_deletes_enabled": True})`. Default-off is asserted directly. Self-hosted and local without an explicit `true` get `400 Deletes not enabled in this region`.

Sentry-options CI forbids changing schema defaults, so `validate-schema-changes` will fail until DevInfra grants an exception. Sentry's integrated CI talks to a live Snuba container with no automator values and will see the same 400 unless that environment sets the option. AuthN and tenant AuthZ are still follow-ups.
