### PR TITLE
fix(security): key lw delete killswitch on predicate project ids

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -180,7 +180,7 @@
         "type": "string"
       },
       "default": {},
-      "description": "Dict mapping storage name to a string of project ids; a lightweight delete is dropped when its project id appears in that storage's entry. Storages with no entry are not killswitched. Migrated from per-storage runtime config lw_deletes_killswitch_<storage>."
+      "description": "Dict mapping storage name to a string of project ids; a lightweight delete is dropped when any project_id in the delete predicate appears in that storage's entry. Mixed project lists fail closed. Attribution tenant_ids are not used. Storages with no entry are not killswitched. Migrated from per-storage runtime config lw_deletes_killswitch_<storage>."
     },
     "validate_schema_sample_rate": {
       "type": "object",

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -340,8 +340,10 @@ def delete_from_tables(
         return result
 
     storage_name = storage.get_storage_key().value
-    project_id = attribution_info.tenant_ids.get("project_id")
-    if project_id and should_use_killswitch(storage_name, str(project_id)):
+    # Killswitch is keyed on the delete predicate, not caller-controlled
+    # attribution. Mixed project lists fail closed: any killswitched id
+    # drops the entire request rather than deleting the rest.
+    if should_killswitch_delete(storage_name, conditions.column_conditions):
         return result
 
     delete_query: DeleteQueryMessage = {
@@ -373,6 +375,23 @@ def construct_or_conditions(
     return combine_or_conditions([_construct_condition(storage, cond) for cond in conditions])
 
 
+def _predicate_project_ids(column_conditions: Mapping[str, Any]) -> list[str]:
+    raw = column_conditions.get("project_id") or []
+    return [str(project_id) for project_id in raw]
+
+
 def should_use_killswitch(storage_name: str, project_id: str) -> bool:
     killswitch_config = get_mapped_option("lw_deletes_killswitch", storage_name, "")
     return project_id in killswitch_config if killswitch_config else False
+
+
+def should_killswitch_delete(storage_name: str, column_conditions: Mapping[str, Any]) -> bool:
+    """Drop the delete if any predicate project_id is killswitched.
+
+    Attribution tenant_ids are not consulted. A mixed list is dropped
+    entirely when any targeted project is killswitched.
+    """
+    return any(
+        should_use_killswitch(storage_name, project_id)
+        for project_id in _predicate_project_ids(column_conditions)
+    )

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -158,6 +158,18 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
             assert called_args["conditions"]["group_id"] == [4]
             assert called_args["rows_to_delete"] == 1
 
+    @patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+    @patch("snuba.web.bulk_delete_query.produce_delete_query")
+    @override_options("snuba", {"lw_deletes_killswitch": {"search_issues": "[3]"}})
+    def test_http_delete_killswitch_without_attribution_project_id(
+        self, mock_produce_delete: Mock, mock_enforce_rows: Mock
+    ) -> None:
+        # tenant_ids in delete_query omit project_id; killswitch must still
+        # apply to the predicate project_id.
+        response = self.delete_query(4)
+        assert response.status_code == 200
+        mock_produce_delete.assert_not_called()
+
     def test_bad_delete(self) -> None:
         res = self.app.delete(
             "/search_issues",

--- a/tests/web/rpc/v1/test_endpoint_delete_trace_items.py
+++ b/tests/web/rpc/v1/test_endpoint_delete_trace_items.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_options.testing import override_options
 from sentry_protos.snuba.v1.endpoint_delete_trace_items_pb2 import (
     DeleteTraceItemsRequest,
     DeleteTraceItemsResponse,
@@ -150,6 +151,32 @@ class TestEndpointDeleteTrace(BaseApiTest):
         assert called_args["conditions"]["organization_id"] == [1]
         assert called_args["conditions"]["trace_id"] == [_TRACE_ID]
         assert called_args["rows_to_delete"] == _SPAN_COUNT
+
+    @patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+    @patch("snuba.web.bulk_delete_query.produce_delete_query")
+    @override_options("snuba", {"lw_deletes_killswitch": {"eap_items": "[1]"}})
+    def test_killswitch_uses_predicate_without_tenant_project_id(
+        self, produce_delete_query_mock: Mock, mock_enforce_rows: Mock
+    ) -> None:
+        # RPC attribution never sets tenant_ids.project_id. Killswitch must
+        # still apply to meta.project_ids in the delete predicate.
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        message = DeleteTraceItemsRequest(
+            meta=RequestMeta(
+                project_ids=[1, 2, 3],
+                organization_id=1,
+                cogs_category="something",
+                referrer="something",
+                start_timestamp=ts,
+                end_timestamp=ts,
+                request_id=_REQUEST_ID,
+            ),
+            trace_ids=[_TRACE_ID],
+        )
+
+        EndpointDeleteTraceItems().execute(message)
+        produce_delete_query_mock.assert_not_called()
 
     # This should not yet produce a message to bulk_delete topic because
     # we haven't wired that behavior through yet (it should not error out,

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -122,6 +122,68 @@ def test_deletes_killswitch(mock_produce_query: Mock, mock_enforce_rows: Mock) -
 
 
 @pytest.mark.redis_db
+@patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+@patch("snuba.web.bulk_delete_query.produce_delete_query")
+@override_options("snuba", {"lw_deletes_killswitch": {"search_issues": "[1]"}})
+def test_killswitch_omitted_attribution_project_id(
+    mock_produce_query: Mock, mock_enforce_rows: Mock
+) -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
+    attr_info = get_attribution_info({"organization_id": 1})
+
+    delete_from_storage(storage, conditions, attr_info)
+    mock_produce_query.assert_not_called()
+
+
+@pytest.mark.redis_db
+@patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+@patch("snuba.web.bulk_delete_query.produce_delete_query")
+@override_options("snuba", {"lw_deletes_killswitch": {"search_issues": "[1]"}})
+def test_killswitch_ignores_attribution_project_id(
+    mock_produce_query: Mock, mock_enforce_rows: Mock
+) -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": [1], "group_id": [1, 2, 3, 4]}
+    # Attribution names a different project than the predicate. Killswitch
+    # must still fire on the predicate id.
+    attr_info = get_attribution_info({"project_id": 99, "organization_id": 1})
+
+    delete_from_storage(storage, conditions, attr_info)
+    mock_produce_query.assert_not_called()
+
+
+@pytest.mark.redis_db
+@patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+@patch("snuba.web.bulk_delete_query.produce_delete_query")
+@override_options("snuba", {"lw_deletes_killswitch": {"search_issues": "[1]"}})
+def test_killswitch_mixed_projects_fail_closed(
+    mock_produce_query: Mock, mock_enforce_rows: Mock
+) -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": [1, 2], "group_id": [1, 2, 3, 4]}
+    attr_info = get_attribution_info({"organization_id": 1})
+
+    delete_from_storage(storage, conditions, attr_info)
+    mock_produce_query.assert_not_called()
+
+
+@pytest.mark.redis_db
+@patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+@patch("snuba.web.bulk_delete_query.produce_delete_query")
+@override_options("snuba", {"lw_deletes_killswitch": {"search_issues": "[1]"}})
+def test_killswitch_does_not_drop_other_projects(
+    mock_produce_query: Mock, mock_enforce_rows: Mock
+) -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    conditions = {"project_id": [2], "group_id": [1, 2, 3, 4]}
+    attr_info = get_attribution_info({"organization_id": 1})
+
+    delete_from_storage(storage, conditions, attr_info)
+    mock_produce_query.assert_called_once()
+
+
+@pytest.mark.redis_db
 def test_delete_invalid_column_type() -> None:
     storage = get_writable_storage(StorageKey("search_issues"))
     conditions: dict[str, list[int | str]] = {


### PR DESCRIPTION
## summary

Operator killswitch `lw_deletes_killswitch` now keys off every `project_id` in the **delete predicate** (`conditions.column_conditions["project_id"]`), not `attribution_info.tenant_ids`.

HTTP DELETE and RPC `EndpointDeleteTraceItems` already share `delete_from_tables`. This is the single enforcement point.

Mixed project lists fail closed: if any targeted project is killswitched, the entire request is dropped (count result is still returned; nothing is produced).

## threat addressed

The killswitch was skipped whenever attribution omitted `project_id`. That is the HTTP default (`tenant_ids` need not include it) and the entire RPC path (attribution is built with `organization_id` + `referrer` only). An operator setting a project killswitch could not stop deletes on those entrypoints.

Attribution is caller-controlled. It is not a security input.

## non-goals

- Does not add AuthN or tenant AuthZ.
- Does not change matching syntax of the existing string option (`project_id in killswitch_config`).
- Does not add an org-level killswitch (option surface is project-id strings only).
- Does not change `storage_deletes_enabled` defaults (separate PR).

## rollout

Safe to land independently. No caller contract change. Legitimate deletes that are not killswitched behave as before.

After deploy, set `lw_deletes_killswitch` per storage to a string containing the project ids to drop, same as today.

## rollback

Revert this PR. Killswitch reverts to attribution `tenant_ids.project_id` (RPC remains unable to fire it).

## test plan

- `test_deletes_killswitch` — existing path still drops
- `test_killswitch_omitted_attribution_project_id` — HTTP-shaped attribution without `project_id`
- `test_killswitch_ignores_attribution_project_id` — spoofed attribution project does not bypass
- `test_killswitch_mixed_projects_fail_closed` — `[1, 2]` dropped when `1` is killswitched
- `test_killswitch_does_not_drop_other_projects` — unlisted project still enqueues
- `test_http_delete_killswitch_without_attribution_project_id` — Flask DELETE `/search_issues`
- `test_killswitch_uses_predicate_without_tenant_project_id` — RPC `EndpointDeleteTraceItems` (never sets `tenant_ids.project_id`)

## residual risk

- Unauthenticated callers can still invoke delete endpoints. AuthN is a follow-up PR.
- Authenticated callers can still delete arbitrary tenants. Predicate AuthZ is a follow-up PR.
- Deletes still default on unless the defaults-off PR lands. Production already sets `storage_deletes_enabled` explicitly.
- Empty `project_id` lists are not killswitched (HTTP schema requires the column; RPC copies `meta.project_ids`).
- Killswitch matching remains substring-in-string (`"1" in "[10]"`). Not changed here.
- Mesh still has no delete-specific identity. App-layer AuthN is required near-term.