### PR TITLE
feat(security): require service auth on delete endpoints

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -81,6 +81,14 @@ MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS = 24
 
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)
 
+# Destructive-endpoint service AuthN. Empty secret fails closed outside tests.
+# Mesh / mTLS should replace the JWT verifier later; keep the ServiceIdentity
+# interface stable.
+DELETE_SERVICE_AUTH_SECRET = os.environ.get("SNUBA_DELETE_SERVICE_AUTH_SECRET", "")
+DELETE_SERVICE_AUTH_ALLOWED_PRINCIPALS: Sequence[str] = ("sentry-delete",)
+DELETE_SERVICE_AUTH_MAX_TTL_SECONDS = 120
+
+
 ALLOCATION_POLICY_ENABLED = True
 DEFAULT_DATASET_NAME = "events"
 DISABLED_ENTITIES: set[str] = set()

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -66,3 +66,6 @@ REDIS_CLUSTERS = {
 VALIDATE_DATASET_YAMLS_ON_STARTUP = True
 
 LOG_MIGRATIONS = False
+
+# Fixture secret for delete AuthN tests. Not a production credential.
+DELETE_SERVICE_AUTH_SECRET = "snuba-test-delete-service-auth-secret"

--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -39,6 +39,7 @@ from snuba.web.delete_query import (
     _get_attribution_info,
     deletes_are_enabled,
 )
+from snuba.web.service_auth import require_delete_identity, service_auth_is_enforced
 
 metrics = MetricsWrapper(environment.metrics, "snuba.delete")
 logger = logging.getLogger(__name__)
@@ -203,6 +204,9 @@ def delete_from_storage(
     * column types are valid
     * attribute names are valid (allowed_attributes_by_item_type storage setting)
     """
+    if service_auth_is_enforced():
+        require_delete_identity()
+
     if not deletes_are_enabled():
         raise DeletesNotEnabledError("Deletes not enabled in this region")
 

--- a/snuba/web/service_auth.py
+++ b/snuba/web/service_auth.py
@@ -1,0 +1,200 @@
+"""Service AuthN for destructive Snuba endpoints.
+
+Near-term: short-lived HS256 JWT, audience-bound to snuba deletes.
+Long-term: replace ``authenticate_service_request`` with mesh / mTLS
+workload identity. AuthZ (predicate ids) consumes ``ServiceIdentity``
+and must not be rewritten when the verifier changes.
+
+Never take the principal or tenant ids from the request body.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import jwt
+from jwt import InvalidTokenError
+
+from snuba import environment, settings
+from snuba.utils.metrics.wrapper import MetricsWrapper
+
+logger = logging.getLogger("snuba.service_auth")
+metrics = MetricsWrapper(environment.metrics, "snuba.delete.auth")
+
+DELETE_JWT_AUDIENCE = "snuba-deletes"
+DELETE_JWT_ALGORITHM = "HS256"
+SENTRY_DELETE_PRINCIPAL = "sentry-delete"
+
+
+class ServiceAuthError(Exception):
+    """Unauthenticated or misconfigured delete AuthN. Maps to HTTP 401."""
+
+    status_code = 401
+
+
+class ServiceAuthzError(Exception):
+    """Authenticated but not allowed to delete. Maps to HTTP 403."""
+
+    status_code = 403
+
+
+@dataclass(frozen=True)
+class ServiceIdentity:
+    """Verified caller. Tenant id sets are empty until a delegated claim is present."""
+
+    principal: str
+    source: str
+    authorized_project_ids: frozenset[int]
+    authorized_organization_ids: frozenset[int]
+
+
+_active_identity: ContextVar[ServiceIdentity | None] = ContextVar(
+    "snuba_delete_service_identity", default=None
+)
+
+
+def _auth_secret() -> str:
+    return str(getattr(settings, "DELETE_SERVICE_AUTH_SECRET", "") or "")
+
+
+def _allowed_principals() -> frozenset[str]:
+    raw = getattr(settings, "DELETE_SERVICE_AUTH_ALLOWED_PRINCIPALS", (SENTRY_DELETE_PRINCIPAL,))
+    return frozenset(raw)
+
+
+def _max_ttl_seconds() -> int:
+    return int(getattr(settings, "DELETE_SERVICE_AUTH_MAX_TTL_SECONDS", 120))
+
+
+def service_auth_is_enforced() -> bool:
+    """Fail closed outside tests when the secret is missing."""
+    if _auth_secret():
+        return True
+    return not bool(getattr(settings, "TESTING", False))
+
+
+def authenticate_service_request(headers: Mapping[str, str]) -> ServiceIdentity:
+    """Verify service identity from request headers. Never reads the body."""
+    endpoint = headers.get("x-snuba-delete-endpoint", "unknown")
+    secret = _auth_secret()
+    if not secret:
+        metrics.increment("failure", tags={"reason": "missing_secret", "endpoint": endpoint})
+        logger.warning("delete_auth_misconfigured")
+        raise ServiceAuthError("delete service auth is not configured")
+
+    authorization = _header(headers, "Authorization")
+    if not authorization:
+        metrics.increment("failure", tags={"reason": "missing", "endpoint": endpoint})
+        raise ServiceAuthError("missing authorization")
+
+    scheme, _, credential = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not credential:
+        metrics.increment("failure", tags={"reason": "invalid_scheme", "endpoint": endpoint})
+        raise ServiceAuthError("invalid authorization")
+
+    try:
+        payload = jwt.decode(
+            credential,
+            secret,
+            algorithms=[DELETE_JWT_ALGORITHM],
+            audience=DELETE_JWT_AUDIENCE,
+            options={"require": ["exp", "iat", "sub", "aud"]},
+        )
+    except InvalidTokenError:
+        metrics.increment("failure", tags={"reason": "invalid_token", "endpoint": endpoint})
+        raise ServiceAuthError("invalid authorization") from None
+
+    principal = payload.get("sub")
+    if not isinstance(principal, str) or principal not in _allowed_principals():
+        metrics.increment("failure", tags={"reason": "invalid_principal", "endpoint": endpoint})
+        raise ServiceAuthError("invalid authorization")
+
+    iat = payload.get("iat")
+    exp = payload.get("exp")
+    if not isinstance(iat, int) or not isinstance(exp, int) or exp - iat > _max_ttl_seconds():
+        metrics.increment("failure", tags={"reason": "ttl", "endpoint": endpoint})
+        raise ServiceAuthError("invalid authorization")
+
+    identity = ServiceIdentity(
+        principal=principal,
+        source="jwt",
+        authorized_project_ids=_int_set(payload.get("project_ids")),
+        authorized_organization_ids=_int_set(payload.get("organization_ids")),
+    )
+    metrics.increment("success", tags={"principal": identity.principal, "endpoint": endpoint})
+    return identity
+
+
+def require_delete_identity() -> ServiceIdentity:
+    identity = _active_identity.get()
+    if identity is None:
+        raise ServiceAuthError("missing service identity")
+    return identity
+
+
+def bind_service_identity(identity: ServiceIdentity) -> Token[ServiceIdentity | None]:
+    return _active_identity.set(identity)
+
+
+def reset_service_identity(token: Token[ServiceIdentity | None]) -> None:
+    _active_identity.reset(token)
+
+
+@contextmanager
+def using_service_identity(identity: ServiceIdentity) -> Iterator[ServiceIdentity]:
+    token = bind_service_identity(identity)
+    try:
+        yield identity
+    finally:
+        reset_service_identity(token)
+
+
+def mint_delete_service_token(
+    *,
+    principal: str = SENTRY_DELETE_PRINCIPAL,
+    project_ids: Collection[int] = (),
+    organization_ids: Collection[int] = (),
+    ttl_seconds: int | None = None,
+    secret: str | None = None,
+) -> str:
+    """Test/caller helper. Production callers live in sentry."""
+    key = secret if secret is not None else _auth_secret()
+    if not key:
+        raise ServiceAuthError("delete service auth is not configured")
+    now = datetime.now(tz=UTC)
+    lifetime = ttl_seconds if ttl_seconds is not None else min(60, _max_ttl_seconds())
+    payload = {
+        "iss": "sentry",
+        "aud": DELETE_JWT_AUDIENCE,
+        "sub": principal,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=lifetime)).timestamp()),
+        "project_ids": [int(pid) for pid in project_ids],
+        "organization_ids": [int(oid) for oid in organization_ids],
+    }
+    return jwt.encode(payload, key, algorithm=DELETE_JWT_ALGORITHM)
+
+
+def _header(headers: Mapping[str, str], name: str) -> str:
+    target = name.lower()
+    for key, value in headers.items():
+        if key.lower() == target:
+            return value
+    return ""
+
+
+def _int_set(raw: Any) -> frozenset[int]:
+    if not isinstance(raw, list):
+        return frozenset()
+    values: set[int] = set()
+    for item in raw:
+        if isinstance(item, bool) or not isinstance(item, int):
+            raise ServiceAuthError("invalid authorization")
+        values.add(item)
+    return frozenset(values)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -69,6 +69,11 @@ from snuba.web.converters import DatasetConverter, EntityConverter, StorageConve
 from snuba.web.delete_query import DeletesNotEnabledError, TooManyOngoingMutationsError
 from snuba.web.query import parse_and_run_query
 from snuba.web.rpc import run_rpc_handler
+from snuba.web.service_auth import (
+    ServiceAuthError,
+    authenticate_service_request,
+    using_service_identity,
+)
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
 
 logger = logging.getLogger("snuba.api")
@@ -293,7 +298,23 @@ def unqualified_query_view(*, timer: Timer) -> Response | str | WerkzeugResponse
 
 @application.route("/rpc/<name>/<version>", methods=["POST"])
 def rpc(*, name: str, version: str) -> Response:
-    result_proto = run_rpc_handler(name, version, http_request.data)
+    if name == "EndpointDeleteTraceItems":
+        try:
+            identity = authenticate_service_request(
+                {
+                    **{k: v for k, v in http_request.headers.items() if isinstance(v, str)},
+                    "x-snuba-delete-endpoint": name,
+                }
+            )
+        except ServiceAuthError as error:
+            return Response(
+                ErrorProto(code=error.status_code, message=str(error)).SerializeToString(),
+                status=error.status_code,
+            )
+        with using_service_identity(identity):
+            result_proto = run_rpc_handler(name, version, http_request.data)
+    else:
+        result_proto = run_rpc_handler(name, version, http_request.data)
     if isinstance(result_proto, ErrorProto):
         return Response(result_proto.SerializeToString(), status=result_proto.code)
     return Response(result_proto.SerializeToString(), status=200)
@@ -332,16 +353,30 @@ def mql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Response | str:
 @util.time_request("delete_query")
 def storage_delete(*, storage: WritableTableStorage, timer: Timer) -> Response | str:
     if http_request.method == "DELETE":
+        try:
+            identity = authenticate_service_request(
+                {
+                    **{k: v for k, v in http_request.headers.items() if isinstance(v, str)},
+                    "x-snuba-delete-endpoint": "storage_delete",
+                }
+            )
+        except ServiceAuthError as error:
+            return make_response(
+                jsonify({"error": {"type": "authentication", "message": str(error)}}),
+                error.status_code,
+            )
+
         body = parse_request_body(http_request)
 
         try:
-            schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
-            request_parts = schema.validate(body)
-            payload = bulk_delete_from_storage(
-                storage,
-                request_parts.query["query"]["columns"],
-                request_parts.attribution_info,
-            )
+            with using_service_identity(identity):
+                schema = RequestSchema.build(HTTPQuerySettings, is_delete=True)
+                request_parts = schema.validate(body)
+                payload = bulk_delete_from_storage(
+                    storage,
+                    request_parts.query["query"]["columns"],
+                    request_parts.attribution_info,
+                )
         except (
             InvalidJsonRequestException,
             DeletesNotEnabledError,

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -94,7 +94,17 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         self,
         group_id: int,
         debug: bool = True,
+        headers: MutableMapping[str, str] | None = None,
     ) -> Any:
+        from snuba.web.service_auth import mint_delete_service_token
+
+        request_headers = {"referer": "test"}
+        if headers is None:
+            request_headers["Authorization"] = (
+                f"Bearer {mint_delete_service_token(project_ids=[3], organization_ids=[1])}"
+            )
+        else:
+            request_headers.update(headers)
         return self.app.delete(
             "/search_issues",
             data=json.dumps(
@@ -104,7 +114,7 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
                     "tenant_ids": {"referrer": "test", "organization_id": 1},
                 }
             ),
-            headers={"referer": "test"},
+            headers=request_headers,
         )
 
     @patch("snuba.web.bulk_delete_query.produce_delete_query")
@@ -159,6 +169,9 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
             assert called_args["rows_to_delete"] == 1
 
     def test_bad_delete(self) -> None:
+        from snuba.web.service_auth import mint_delete_service_token
+
+        auth = {"referer": "test", "Authorization": f"Bearer {mint_delete_service_token()}"}
         res = self.app.delete(
             "/search_issues",
             data=json.dumps(
@@ -167,7 +180,7 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
                     "tenant_ids": {"referrer": "test", "organization_id": 1},
                 }
             ),
-            headers={"referer": "test"},
+            headers=auth,
         )
         assert int(res.status_code / 100) == 4  # 400 status code
         assert "'query' is a required property" in res.get_json()["error"]["message"]
@@ -187,7 +200,7 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
                     "tenant_ids": {"referrer": "test", "organization_id": 1},
                 }
             ),
-            headers={"referer": "test"},
+            headers=auth,
         )
         assert res.status_code == 400
         data = json.loads(res.data)
@@ -195,6 +208,16 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
             data["error"]["message"]
             == "Invalid value invalid_id for column type schemas.UInt(64, modifiers=None)"
         )
+
+    def test_http_delete_rejects_missing_auth(self) -> None:
+        response = self.delete_query(4, headers={"referer": "test"})
+        assert response.status_code == 401
+
+    def test_http_delete_rejects_invalid_auth(self) -> None:
+        response = self.delete_query(
+            4, headers={"referer": "test", "Authorization": "Bearer not-a-jwt"}
+        )
+        assert response.status_code == 401
 
     def test_simple_search_query(self) -> None:
         now = datetime.now().replace(minute=0, second=0, microsecond=0)

--- a/tests/web/rpc/v1/test_endpoint_delete_trace_items.py
+++ b/tests/web/rpc/v1/test_endpoint_delete_trace_items.py
@@ -31,6 +31,11 @@ from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
 from snuba.web.rpc.v1.endpoint_delete_trace_items import EndpointDeleteTraceItems
+from snuba.web.service_auth import (
+    SENTRY_DELETE_PRINCIPAL,
+    ServiceIdentity,
+    using_service_identity,
+)
 from tests.base import BaseApiTest
 from tests.helpers import write_raw_unprocessed_events
 from tests.web.rpc.v1.test_utils import gen_item_message
@@ -75,6 +80,17 @@ def setup_teardown(eap: None, redis_db: None) -> None:
 @pytest.mark.eap
 @pytest.mark.redis_db
 class TestEndpointDeleteTrace(BaseApiTest):
+    @pytest.fixture(autouse=True)
+    def bind_delete_identity(self) -> Any:
+        identity = ServiceIdentity(
+            principal=SENTRY_DELETE_PRINCIPAL,
+            source="test",
+            authorized_project_ids=frozenset({1, 2, 3}),
+            authorized_organization_ids=frozenset({1}),
+        )
+        with using_service_identity(identity):
+            yield identity
+
     def test_missing_trace_id_raises_exception(self) -> None:
         ts = Timestamp()
         ts.GetCurrentTime()

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -23,6 +23,12 @@ from snuba.utils.streams.configuration_builder import get_default_kafka_configur
 from snuba.utils.streams.topics import Topic
 from snuba.web.bulk_delete_query import delete_from_storage
 from snuba.web.delete_query import DeletesNotEnabledError
+from snuba.web.service_auth import (
+    SENTRY_DELETE_PRINCIPAL,
+    ServiceAuthError,
+    ServiceIdentity,
+    using_service_identity,
+)
 
 # TraceItemType values from sentry_protos
 TRACE_ITEM_TYPE_SPAN = 1
@@ -48,6 +54,34 @@ def get_attribution_info(tenant_ids: Mapping[str, int | str] | None = None) -> M
         "parent_api": "test",
         "feature": "test",
     }
+
+
+@pytest.fixture(autouse=True)
+def bind_delete_identity() -> Any:
+    identity = ServiceIdentity(
+        principal=SENTRY_DELETE_PRINCIPAL,
+        source="test",
+        authorized_project_ids=frozenset({1, 2, 3}),
+        authorized_organization_ids=frozenset({1}),
+    )
+    with using_service_identity(identity):
+        yield identity
+
+
+def test_delete_from_storage_requires_identity() -> None:
+    from snuba.web.service_auth import _active_identity
+
+    token = _active_identity.set(None)
+    try:
+        storage = get_writable_storage(StorageKey("search_issues"))
+        with pytest.raises(ServiceAuthError, match="missing service identity"):
+            delete_from_storage(
+                storage,
+                {"project_id": [1], "group_id": [1]},
+                get_attribution_info(),
+            )
+    finally:
+        _active_identity.reset(token)
 
 
 @patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)

--- a/tests/web/test_service_auth.py
+++ b/tests/web/test_service_auth.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+
+from snuba.web.service_auth import (
+    DELETE_JWT_ALGORITHM,
+    DELETE_JWT_AUDIENCE,
+    SENTRY_DELETE_PRINCIPAL,
+    ServiceAuthError,
+    authenticate_service_request,
+    mint_delete_service_token,
+)
+from tests.base import BaseApiTest
+
+
+def test_authenticate_missing_header() -> None:
+    with pytest.raises(ServiceAuthError, match="missing authorization"):
+        authenticate_service_request({})
+
+
+def test_authenticate_invalid_scheme() -> None:
+    with pytest.raises(ServiceAuthError, match="invalid authorization"):
+        authenticate_service_request({"Authorization": "Basic abc"})
+
+
+def test_authenticate_invalid_token() -> None:
+    with pytest.raises(ServiceAuthError, match="invalid authorization"):
+        authenticate_service_request({"Authorization": "Bearer not-a-jwt"})
+
+
+def test_authenticate_wrong_audience() -> None:
+    token = jwt.encode(
+        {
+            "sub": SENTRY_DELETE_PRINCIPAL,
+            "aud": "someone-else",
+            "iat": int(datetime.now(tz=UTC).timestamp()),
+            "exp": int((datetime.now(tz=UTC) + timedelta(seconds=30)).timestamp()),
+        },
+        "snuba-test-delete-service-auth-secret",
+        algorithm=DELETE_JWT_ALGORITHM,
+    )
+    with pytest.raises(ServiceAuthError, match="invalid authorization"):
+        authenticate_service_request({"Authorization": f"Bearer {token}"})
+
+
+def test_authenticate_wrong_principal() -> None:
+    token = mint_delete_service_token(principal="sentry-query")
+    with pytest.raises(ServiceAuthError, match="invalid authorization"):
+        authenticate_service_request({"Authorization": f"Bearer {token}"})
+
+
+def test_authenticate_valid_token() -> None:
+    token = mint_delete_service_token(project_ids=[1, 2], organization_ids=[9])
+    identity = authenticate_service_request({"Authorization": f"Bearer {token}"})
+    assert identity.principal == SENTRY_DELETE_PRINCIPAL
+    assert identity.source == "jwt"
+    assert identity.authorized_project_ids == frozenset({1, 2})
+    assert identity.authorized_organization_ids == frozenset({9})
+
+
+def test_authenticate_ignores_body_like_headers() -> None:
+    token = mint_delete_service_token(principal=SENTRY_DELETE_PRINCIPAL)
+    identity = authenticate_service_request(
+        {
+            "Authorization": f"Bearer {token}",
+            "X-Principal": "attacker",
+            "tenant_ids": "nope",
+        }
+    )
+    assert identity.principal == SENTRY_DELETE_PRINCIPAL
+    assert DELETE_JWT_AUDIENCE == "snuba-deletes"
+
+
+class TestDeleteServiceAuthHTTP(BaseApiTest):
+    def test_rpc_delete_rejects_missing_auth(self) -> None:
+        response = self.app.post(
+            "/rpc/EndpointDeleteTraceItems/v1",
+            data=b"",
+            headers={"referer": "test"},
+        )
+        assert response.status_code == 401
+
+    def test_rpc_delete_rejects_invalid_auth(self) -> None:
+        response = self.app.post(
+            "/rpc/EndpointDeleteTraceItems/v1",
+            data=b"",
+            headers={"referer": "test", "Authorization": "Bearer not-a-jwt"},
+        )
+        assert response.status_code == 401
+
+    def test_rpc_delete_accepts_valid_auth_before_parse(self) -> None:
+        token = mint_delete_service_token()
+        response = self.app.post(
+            "/rpc/EndpointDeleteTraceItems/v1",
+            data=b"not-valid-protobuf",
+            headers={"referer": "test", "Authorization": f"Bearer {token}"},
+        )
+        # Auth passed; protobuf decode fails closed as 400.
+        assert response.status_code == 400


### PR DESCRIPTION
## summary

Destructive Snuba endpoints now require a service identity.

- New `authenticate_service_request(headers) -> ServiceIdentity` interface
- Near-term verifier: short-lived HS256 JWT, `aud=snuba-deletes`, `sub` is the principal
- Principal is never taken from the request body
- `DELETE /<storage>` and `POST /rpc/EndpointDeleteTraceItems/v1` authenticate **before** predicate parsing
- Shared sink `delete_from_storage` fail-closes if no identity is bound
- Empty `DELETE_SERVICE_AUTH_SECRET` fails closed outside tests

Mesh / mTLS can replace the JWT verifier later without rewriting AuthZ.

## threat addressed

Unauthenticated network callers can no longer enqueue bulk deletes. Wrong service principals (`sentry-query`) are rejected.

## non-goals

- Does not authorize tenant ids in the predicate (follow-up PR D)
- Does not change read/query RPC AuthN
- Does not invent a permanent HMAC platform standard; JWT is a migration credential
- Does not land mesh identities (PR F)

## rollout

1. Provision `SNUBA_DELETE_SERVICE_AUTH_SECRET` on snuba-api (same value sentry will use).
2. Land sentry caller PR so legitimate deletes send `Authorization: Bearer <jwt>`.
3. Deploy this PR. Deletes without a valid token return 401.

Emergency: unset the secret **does not** fail open in production. To temporarily allow deletes you must revert this PR.

Test env uses a fixture secret in `settings_test.py`.

## rollback

Revert this PR. Delete endpoints become unauthenticated again.

## test plan

- `test_authenticate_missing_header` / `invalid_token` / `wrong_audience` / `wrong_principal`
- `test_authenticate_valid_token`
- `test_delete_from_storage_requires_identity`
- `test_http_delete_rejects_missing_auth` / `invalid_auth`
- `test_rpc_delete_rejects_missing_auth` / `invalid_auth` / valid-auth-before-parse

## residual risk

- A compromised `sentry-delete` principal can still delete any tenant until PR D (predicate AuthZ).
- Mesh still has one shared sentry identity; no query vs delete split (PR F).
- Direct pod/IP access to snuba-api still exists; app gate is the control until mesh allowlists delete routes.
- JWT is a shared secret, not workload identity. Rotate via env; do not log tokens.