### PR TITLE
feat(security): authorize delete predicates server-side

### DIFF
--- a/snuba/web/bulk_delete_query.py
+++ b/snuba/web/bulk_delete_query.py
@@ -39,7 +39,11 @@ from snuba.web.delete_query import (
     _get_attribution_info,
     deletes_are_enabled,
 )
-from snuba.web.service_auth import require_delete_identity, service_auth_is_enforced
+from snuba.web.service_auth import (
+    authorize_delete_predicate,
+    require_delete_identity,
+    service_auth_is_enforced,
+)
 
 metrics = MetricsWrapper(environment.metrics, "snuba.delete")
 logger = logging.getLogger(__name__)
@@ -205,7 +209,17 @@ def delete_from_storage(
     * attribute names are valid (allowed_attributes_by_item_type storage setting)
     """
     if service_auth_is_enforced():
-        require_delete_identity()
+        identity = require_delete_identity()
+        authorize_delete_predicate(identity, column_conditions)
+        logger.info(
+            "delete_authorized",
+            extra={
+                "principal": identity.principal,
+                "storage": storage.get_storage_key().value,
+                "project_ids": list(column_conditions.get("project_id") or []),
+                "organization_ids": list(column_conditions.get("organization_id") or []),
+            },
+        )
 
     if not deletes_are_enabled():
         raise DeletesNotEnabledError("Deletes not enabled in this region")

--- a/snuba/web/rpc/v1/endpoint_delete_trace_items.py
+++ b/snuba/web/rpc/v1/endpoint_delete_trace_items.py
@@ -16,7 +16,8 @@ from snuba.lw_deletions.types import AttributeConditions
 from snuba.web.bulk_delete_query import delete_from_storage
 from snuba.web.rpc import RPCEndpoint
 from snuba.web.rpc.common.common import _scalar_value
-from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException
+from snuba.web.rpc.common.exceptions import BadSnubaRPCRequestException, RPCRequestException
+from snuba.web.service_auth import ServiceAuthzError
 
 
 def _extract_attribute_value(comparison_filter: ComparisonFilter) -> Any:
@@ -157,12 +158,15 @@ class EndpointDeleteTraceItems(RPCEndpoint[DeleteTraceItemsRequest, DeleteTraceI
             # Add item_type to conditions for the delete query
             conditions["item_type"] = [attribute_conditions.item_type]
 
-        delete_result = delete_from_storage(
-            get_writable_storage(StorageKey.EAP_ITEMS),
-            conditions,
-            attribution_info,
-            attribute_conditions,
-        )
+        try:
+            delete_result = delete_from_storage(
+                get_writable_storage(StorageKey.EAP_ITEMS),
+                conditions,
+                attribution_info,
+                attribute_conditions,
+            )
+        except ServiceAuthzError as error:
+            raise RPCRequestException(error.status_code, str(error)) from error
 
         response = DeleteTraceItemsResponse()
         # TODO: fix how we pass this data around, this is too coupled

--- a/snuba/web/service_auth.py
+++ b/snuba/web/service_auth.py
@@ -54,6 +54,20 @@ class ServiceIdentity:
     authorized_organization_ids: frozenset[int]
 
 
+def authorize_delete_predicate(
+    identity: ServiceIdentity, column_conditions: Mapping[str, Any]
+) -> None:
+    """Authorize every tenant id in the delete predicate. Never uses attribution."""
+    predicate_projects = _condition_ids(column_conditions.get("project_id"))
+    predicate_orgs = _condition_ids(column_conditions.get("organization_id"))
+    if not predicate_projects:
+        raise ServiceAuthzError("delete predicate is not authorized")
+    if not predicate_projects.issubset(identity.authorized_project_ids):
+        raise ServiceAuthzError("delete predicate is not authorized")
+    if predicate_orgs and not predicate_orgs.issubset(identity.authorized_organization_ids):
+        raise ServiceAuthzError("delete predicate is not authorized")
+
+
 _active_identity: ContextVar[ServiceIdentity | None] = ContextVar(
     "snuba_delete_service_identity", default=None
 )
@@ -187,6 +201,19 @@ def _header(headers: Mapping[str, str], name: str) -> str:
         if key.lower() == target:
             return value
     return ""
+
+
+def _condition_ids(raw: Any) -> set[int]:
+    if raw is None:
+        return set()
+    if not isinstance(raw, list):
+        raise ServiceAuthzError("delete predicate is not authorized")
+    values: set[int] = set()
+    for item in raw:
+        if isinstance(item, bool) or not isinstance(item, int):
+            raise ServiceAuthzError("delete predicate is not authorized")
+        values.add(item)
+    return values
 
 
 def _int_set(raw: Any) -> frozenset[int]:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -71,6 +71,7 @@ from snuba.web.query import parse_and_run_query
 from snuba.web.rpc import run_rpc_handler
 from snuba.web.service_auth import (
     ServiceAuthError,
+    ServiceAuthzError,
     authenticate_service_request,
     using_service_identity,
 )
@@ -377,6 +378,11 @@ def storage_delete(*, storage: WritableTableStorage, timer: Timer) -> Response |
                     request_parts.query["query"]["columns"],
                     request_parts.attribution_info,
                 )
+        except ServiceAuthzError as error:
+            return make_response(
+                jsonify({"error": {"type": "authorization", "message": str(error)}}),
+                error.status_code,
+            )
         except (
             InvalidJsonRequestException,
             DeletesNotEnabledError,

--- a/tests/web/test_bulk_delete_query.py
+++ b/tests/web/test_bulk_delete_query.py
@@ -26,6 +26,7 @@ from snuba.web.delete_query import DeletesNotEnabledError
 from snuba.web.service_auth import (
     SENTRY_DELETE_PRINCIPAL,
     ServiceAuthError,
+    ServiceAuthzError,
     ServiceIdentity,
     using_service_identity,
 )
@@ -82,6 +83,64 @@ def test_delete_from_storage_requires_identity() -> None:
             )
     finally:
         _active_identity.reset(token)
+
+
+def test_delete_rejects_project_outside_authorized_set() -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    from snuba.web.service_auth import _active_identity
+
+    identity = ServiceIdentity(
+        principal=SENTRY_DELETE_PRINCIPAL,
+        source="test",
+        authorized_project_ids=frozenset({1}),
+        authorized_organization_ids=frozenset({1}),
+    )
+    token = _active_identity.set(identity)
+    try:
+        with pytest.raises(ServiceAuthzError):
+            delete_from_storage(
+                storage,
+                {"project_id": [99], "group_id": [1]},
+                get_attribution_info({"organization_id": 1}),
+            )
+    finally:
+        _active_identity.reset(token)
+
+
+def test_delete_rejects_missing_authorized_projects() -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    from snuba.web.service_auth import _active_identity
+
+    identity = ServiceIdentity(
+        principal=SENTRY_DELETE_PRINCIPAL,
+        source="test",
+        authorized_project_ids=frozenset(),
+        authorized_organization_ids=frozenset({1}),
+    )
+    token = _active_identity.set(identity)
+    try:
+        with pytest.raises(ServiceAuthzError):
+            delete_from_storage(
+                storage,
+                {"project_id": [1], "group_id": [1]},
+                get_attribution_info(),
+            )
+    finally:
+        _active_identity.reset(token)
+
+
+@patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)
+@patch("snuba.web.bulk_delete_query.produce_delete_query")
+def test_delete_allows_authorized_same_tenant(
+    mock_produce_query: Mock, mock_enforce_rows: Mock
+) -> None:
+    storage = get_writable_storage(StorageKey("search_issues"))
+    delete_from_storage(
+        storage,
+        {"project_id": [1], "group_id": [1]},
+        get_attribution_info(),
+    )
+    mock_produce_query.assert_called_once()
 
 
 @patch("snuba.web.bulk_delete_query._enforce_max_rows", return_value=10)

--- a/tests/web/test_service_auth.py
+++ b/tests/web/test_service_auth.py
@@ -10,7 +10,10 @@ from snuba.web.service_auth import (
     DELETE_JWT_AUDIENCE,
     SENTRY_DELETE_PRINCIPAL,
     ServiceAuthError,
+    ServiceAuthzError,
+    ServiceIdentity,
     authenticate_service_request,
+    authorize_delete_predicate,
     mint_delete_service_token,
 )
 from tests.base import BaseApiTest
@@ -72,6 +75,39 @@ def test_authenticate_ignores_body_like_headers() -> None:
     )
     assert identity.principal == SENTRY_DELETE_PRINCIPAL
     assert DELETE_JWT_AUDIENCE == "snuba-deletes"
+
+
+def _identity(**kwargs: object) -> ServiceIdentity:
+    defaults = {
+        "principal": SENTRY_DELETE_PRINCIPAL,
+        "source": "test",
+        "authorized_project_ids": frozenset({1}),
+        "authorized_organization_ids": frozenset({9}),
+    }
+    defaults.update(kwargs)
+    return ServiceIdentity(**defaults)  # type: ignore[arg-type]
+
+
+def test_authorize_same_tenant_allowed() -> None:
+    authorize_delete_predicate(_identity(), {"project_id": [1], "organization_id": [9]})
+
+
+def test_authorize_cross_tenant_project_denied() -> None:
+    with pytest.raises(ServiceAuthzError):
+        authorize_delete_predicate(_identity(), {"project_id": [99]})
+
+
+def test_authorize_missing_project_id_denied() -> None:
+    with pytest.raises(ServiceAuthzError):
+        authorize_delete_predicate(_identity(), {"group_id": [1]})
+
+
+def test_authorize_ignores_attribution_spoof() -> None:
+    with pytest.raises(ServiceAuthzError):
+        authorize_delete_predicate(
+            _identity(),
+            {"project_id": [99]},
+        )
 
 
 class TestDeleteServiceAuthHTTP(BaseApiTest):


### PR DESCRIPTION
## summary

Delete AuthZ now runs in the shared sink against the **actual predicate**, not attribution.

- Every `project_id` in `column_conditions` must be in the verified `ServiceIdentity` claim set
- `organization_id` in the predicate, if present, must also be claimed
- Missing `project_id` or empty authorized set → 403
- Attribution `tenant_ids` are not consulted
- Accepted deletes are logged with principal + predicate ids (no secrets)

Depends on #8310 (`ServiceIdentity`).

## threat addressed

An authenticated delete-capable caller cannot delete arbitrary tenants by putting other project/org ids in the predicate (or by spoofing `tenant_ids`).

## non-goals

- Does not add mesh / mTLS identity (PR F)
- Does not add a god-mode maintenance principal
- Does not change query/read AuthZ
- Does not trust body `tenant_ids` for allow decisions

## rollout

Land after #8310 and the sentry caller PR (so JWTs include `project_ids` / `organization_ids`).

1. Deploy sentry caller so tokens carry the authorized id sets.
2. Deploy this PR. Cross-tenant predicates return 403.

## rollback

Revert this PR. AuthN from #8310 remains; tenant AuthZ is removed.

## test plan

- `test_authorize_same_tenant_allowed`
- `test_authorize_cross_tenant_project_denied`
- `test_authorize_missing_project_id_denied`
- `test_delete_rejects_project_outside_authorized_set`
- `test_delete_rejects_missing_authorized_projects`
- `test_delete_allows_authorized_same_tenant`

## residual risk

- A compromised `sentry-delete` principal that can mint tokens for any project/org can still delete those tenants. Sentry must only mint claims for ids it already authorized.
- Mesh still has one shared sentry identity.
- Killswitch matching remains substring-in-string.