### PR TITLE
feat(consumer): harden KIP-345 static membership for multi-Deployment rollouts

### DIFF
--- a/docs/source/architecture/consumer.rst
+++ b/docs/source/architecture/consumer.rst
@@ -162,6 +162,39 @@ Since the consumer is launched from the Python CLI, it will find the Python
 interpreter already initialized, and does not have to re-import Snuba again
 (except in subprocesses)
 
+Static membership (KIP-345)
+---------------------------
+
+Both ``snuba consumer`` and ``snuba rust-consumer`` accept
+``--group-instance-id``. When set, Snuba passes ``group.instance.id`` into the
+librdkafka consumer config. Kafka then treats the process as a **static
+member**: after a restart it rejoins with the same id and keeps the same
+partitions as long as it returns within ``session.timeout.ms`` (no stop-the-world
+rebalance for that bounce).
+
+This is the application-side half of multi-Deployment (or StatefulSet) rollouts
+where each pod has a fixed identity, e.g. ops ``static_membership`` for
+``eap-items-consumer`` (one single-replica Deployment per member, Recreate
+strategy, ``--group-instance-id snuba-eap-items-consumer-<idx>``).
+
+Requirements / caveats:
+
+* **Uniqueness.** Two live members of the same consumer group must never share
+  an id (broker returns ``FENCED_INSTANCE_ID``). Deployments that keep a fixed
+  id must use ``Recreate`` (or equivalent terminate-before-create), not a rolling
+  surge.
+* **session.timeout.ms.** Controls how long a member can be gone before its
+  partitions are reassigned. Snuba does not expose a dedicated CLI flag; set it
+  via Kafka broker/topic consumer config (and keep
+  ``max.poll.interval.ms >= session.timeout.ms``). ``--max-poll-interval-ms`` on
+  the CLI only lowers session timeout when it is under 45s (librdkafka default).
+* **Concurrency.** ``--concurrency`` on ``rust-consumer`` is in-process worker
+  threads for message processing, not multiple Kafka members. One process still
+  equals one ``group.instance.id``.
+* **Observability.** When static membership is enabled the Rust consumer logs
+  the resolved ``group.instance.id`` at startup.
+
+
 Signal-handling is a bit tricky. Since no Python code runs for the majority of
 the consumer's lifetime, Python's signal handlers cannot run. This also means
 that the Rust consumer has to register its own handler for ``Ctrl-C``, but

--- a/rust_snuba/benches/processors.rs
+++ b/rust_snuba/benches/processors.rs
@@ -103,6 +103,7 @@ fn create_factory(
         join_timeout_ms: None,
         health_check: "arroyo".to_string(),
         use_row_binary: false,
+        skip_write: false,
         dlq_configured: false,
     };
     Box::new(factory)

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -175,6 +175,18 @@ pub fn consumer_impl(
         first_storage.name,
     );
 
+    if let Some(group_instance_id) = consumer_config
+        .raw_topic
+        .broker_config
+        .get("group.instance.id")
+    {
+        tracing::info!(
+            group_instance_id = %group_instance_id,
+            consumer_group = %consumer_group,
+            "Static membership enabled (KIP-345 group.instance.id)"
+        );
+    }
+
     let config = KafkaConfig::new_consumer_config(
         vec![],
         consumer_group.to_owned(),

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -46,6 +46,7 @@ pub fn consumer(
     max_dlq_buffer_length: Option<usize>,
     join_timeout_ms: Option<u64>,
     use_row_binary: bool,
+    skip_write: bool,
 ) -> usize {
     py.allow_threads(|| {
         consumer_impl(
@@ -67,6 +68,7 @@ pub fn consumer(
             join_timeout_ms,
             health_check,
             use_row_binary,
+            skip_write,
         )
     })
 }
@@ -91,6 +93,7 @@ pub fn consumer_impl(
     join_timeout_ms: Option<u64>,
     health_check: &str,
     use_row_binary: bool,
+    skip_write: bool,
 ) -> usize {
     setup_logging();
     crate::init_sentry_options().expect("failed to initialize sentry-options");
@@ -187,6 +190,13 @@ pub fn consumer_impl(
         );
     }
 
+    if skip_write {
+        tracing::warn!(
+            consumer_group = %consumer_group,
+            "ClickHouse writes disabled (--skip-write); offsets still commit"
+        );
+    }
+
     let config = KafkaConfig::new_consumer_config(
         vec![],
         consumer_group.to_owned(),
@@ -235,7 +245,11 @@ pub fn consumer_impl(
         )
     });
 
-    let commit_log_producer = if let Some(topic_config) = consumer_config.commit_log_topic {
+    // Shadow consumers (--skip-write) must not produce commit log either; that
+    // stream drives post-processing against written rows.
+    let commit_log_producer = if skip_write {
+        None
+    } else if let Some(topic_config) = consumer_config.commit_log_topic {
         let producer_config =
             KafkaConfig::new_producer_config(vec![], Some(topic_config.broker_config));
         let producer = KafkaProducer::new(producer_config);
@@ -297,6 +311,7 @@ pub fn consumer_impl(
         join_timeout_ms,
         health_check: health_check.to_string(),
         use_row_binary,
+        skip_write,
         dlq_configured,
     };
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -216,34 +216,34 @@ pub fn consumer_impl(
     let dlq_concurrency_config = ConcurrencyConfig::new(10);
 
     // DLQ policy applies only if we are not skipping writes, otherwise we don't want to be
-    // writing to the DLQ topics in prod.
+    // writing to the DLQ topics in prod. DlqByAge is keyed off the same flag.
+    let dlq_policy = if skip_write {
+        None
+    } else {
+        consumer_config.dlq_topic.map(|dlq_topic_config| {
+            let producer = KafkaProducer::new(KafkaConfig::new_producer_config(
+                vec![],
+                Some(dlq_topic_config.broker_config),
+            ));
 
-    // Whether a DLQ topic is configured. The DLQ-by-age strategy relies on the
-    // DLQ policy, so it is only wired into the factory when this is true.
-    let dlq_configured = consumer_config.dlq_topic.is_some();
+            let kafka_dlq_producer = Box::new(KafkaDlqProducer::new(
+                producer,
+                Topic::new(&dlq_topic_config.physical_topic_name),
+            ));
 
-    let dlq_policy = consumer_config.dlq_topic.map(|dlq_topic_config| {
-        let producer = KafkaProducer::new(KafkaConfig::new_producer_config(
-            vec![],
-            Some(dlq_topic_config.broker_config),
-        ));
-
-        let kafka_dlq_producer = Box::new(KafkaDlqProducer::new(
-            producer,
-            Topic::new(&dlq_topic_config.physical_topic_name),
-        ));
-
-        let handle = dlq_concurrency_config.handle();
-        DlqPolicy::new(
-            handle,
-            kafka_dlq_producer,
-            DlqLimit {
-                max_invalid_ratio: None,
-                max_consecutive_count: None,
-            },
-            max_dlq_buffer_length,
-        )
-    });
+            let handle = dlq_concurrency_config.handle();
+            DlqPolicy::new(
+                handle,
+                kafka_dlq_producer,
+                DlqLimit {
+                    max_invalid_ratio: None,
+                    max_consecutive_count: None,
+                },
+                max_dlq_buffer_length,
+            )
+        })
+    };
+    let dlq_configured = dlq_policy.is_some();
 
     // Shadow consumers (--skip-write) must not produce commit log either; that
     // stream drives post-processing against written rows.

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -261,7 +261,11 @@ pub fn consumer_impl(
         None
     };
 
-    let replacements_config = if let Some(topic_config) = consumer_config.replacements_topic {
+    // Shadow consumers must not produce replacements either; those mutate
+    // ClickHouse via the replacements consumer.
+    let replacements_config = if skip_write {
+        None
+    } else if let Some(topic_config) = consumer_config.replacements_topic {
         let producer_config =
             KafkaConfig::new_producer_config(vec![], Some(topic_config.broker_config));
         Some((

--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -63,6 +63,8 @@ pub struct ConsumerStrategyFactoryV2 {
     pub join_timeout_ms: Option<u64>,
     pub health_check: String,
     pub use_row_binary: bool,
+    /// When true, process messages but do not INSERT into ClickHouse.
+    pub skip_write: bool,
     // Whether this consumer has a DLQ topic configured. The DLQ-by-age strategy
     // is only inserted when true, since without a DLQ policy an InvalidMessage
     // is logged and silently dropped by arroyo (losing data).
@@ -167,7 +169,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                     next_step,
                     self.storage_config.clickhouse_cluster.clone(),
                     self.storage_config.clickhouse_table_name.clone(),
-                    false,
+                    self.skip_write,
                     &self.clickhouse_concurrency,
                     self.storage_config.name.clone(),
                     columns,
@@ -177,7 +179,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                     next_step,
                     self.storage_config.clickhouse_cluster.clone(),
                     self.storage_config.clickhouse_table_name.clone(),
-                    false,
+                    self.skip_write,
                     &self.clickhouse_concurrency,
                     self.storage_config.name.clone(),
                 ))

--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -146,8 +146,8 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
 
         // Produce cogs if generic metrics AND we are not skipping writes AND record_cogs is true
         let next_step: Box<dyn ProcessingStrategy<BytesInsertBatch<()>>> =
-            match (self.env_config.record_cogs, cogs_label) {
-                (true, Some(resource_id)) => Box::new(RecordCogs::new(
+            match (self.env_config.record_cogs, self.skip_write, cogs_label) {
+                (true, false, Some(resource_id)) => Box::new(RecordCogs::new(
                     next_step,
                     resource_id,
                     self.accountant_topic_config.broker_config.clone(),
@@ -237,17 +237,22 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                 true,
                 Some(processors::ProcessingFunctionType::ProcessingFunctionWithReplacements(func)),
             ) => {
-                let (replacements_config, replacements_destination) =
-                    self.replacements_config.clone().unwrap();
-
-                let producer = KafkaProducer::new(replacements_config);
-                let replacements_step = ProduceReplacements::new(
-                    next_step,
-                    producer,
-                    replacements_destination,
-                    &self.replacements_concurrency,
-                    false,
-                );
+                let replacements_step = if self.skip_write {
+                    ProduceReplacements::skipping(next_step)
+                } else {
+                    let (replacements_config, replacements_destination) =
+                        self.replacements_config.clone().expect(
+                            "replacements topic required for processors that emit replacements",
+                        );
+                    let producer = KafkaProducer::new(replacements_config);
+                    ProduceReplacements::new(
+                        next_step,
+                        producer,
+                        replacements_destination,
+                        &self.replacements_concurrency,
+                        false,
+                    )
+                };
 
                 make_rust_processor_with_replacements(
                     replacements_step,

--- a/rust_snuba/src/strategies/replacements.rs
+++ b/rust_snuba/src/strategies/replacements.rs
@@ -48,6 +48,19 @@ impl ProduceReplacements {
             skip_produce,
         }
     }
+
+    /// Drop replacements without constructing a Kafka producer.
+    /// Used by `--skip-write` shadow consumers.
+    pub fn skipping<N>(next_step: N) -> Self
+    where
+        N: ProcessingStrategy<BytesInsertBatch<RowData>> + 'static,
+    {
+        ProduceReplacements {
+            next_step: Box::new(next_step),
+            inner: Box::new(Noop {}),
+            skip_produce: true,
+        }
+    }
 }
 
 impl ProcessingStrategy<InsertOrReplacement<BytesInsertBatch<RowData>>> for ProduceReplacements {
@@ -172,5 +185,52 @@ mod tests {
         strategy.join(None).unwrap();
 
         assert_eq!(produced_payloads.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn skip_produce_drops_replacements() {
+        let next_step = TestStrategy::new();
+        let produced_payloads = Arc::new(Mutex::new(vec![]));
+        let producer = MockProducer {
+            payloads: produced_payloads.clone(),
+        };
+        let destination = Topic::new("test");
+        let concurrency = ConcurrencyConfig::new(10);
+        let mut strategy =
+            ProduceReplacements::new(next_step, producer, destination, &concurrency, true);
+
+        strategy
+            .submit(Message::new_any_message(
+                InsertOrReplacement::Replacement(ReplacementData {
+                    key: "1".as_bytes().to_vec(),
+                    value: "{\"project_id\":1}".as_bytes().to_vec(),
+                }),
+                BTreeMap::new(),
+            ))
+            .unwrap();
+
+        strategy.poll().unwrap();
+        strategy.join(None).unwrap();
+
+        assert_eq!(produced_payloads.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn skipping_constructor_drops_replacements() {
+        let next_step = TestStrategy::new();
+        let mut strategy = ProduceReplacements::skipping(next_step);
+
+        strategy
+            .submit(Message::new_any_message(
+                InsertOrReplacement::Replacement(ReplacementData {
+                    key: "1".as_bytes().to_vec(),
+                    value: "{\"project_id\":1}".as_bytes().to_vec(),
+                }),
+                BTreeMap::new(),
+            ))
+            .unwrap();
+
+        strategy.poll().unwrap();
+        strategy.join(None).unwrap();
     }
 }

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -165,7 +165,12 @@ logger = logging.getLogger(__name__)
     "--group-instance-id",
     type=str,
     default=None,
-    help="Kafka group instance id. passing a value here will run kafka with static membership.",
+    help=(
+        "Kafka group.instance.id (KIP-345 static membership). When set, this "
+        "member keeps its partition assignment across restarts as long as it "
+        "rejoins within session.timeout.ms. Must be unique per live member of "
+        "the consumer group."
+    ),
 )
 def consumer(
     *,
@@ -243,6 +248,12 @@ def consumer(
         group_instance_id=group_instance_id,
         quantized_rebalance_consumer_group_delay_secs=quantized_rebalance_consumer_group_delay_secs,
     )
+
+    if group_instance_id is not None:
+        logger.info(
+            "Static membership enabled (KIP-345 group.instance.id=%s)",
+            group_instance_id,
+        )
 
     consumer_builder = ConsumerBuilder(
         consumer_config=consumer_config,

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -204,9 +204,9 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     is_flag=True,
     default=False,
     help=(
-        "Skip ClickHouse inserts, commit-log produce, replacements produce, and "
-        "COGS. Still consumes Kafka and commits offsets. Use for shadow / soak "
-        "consumers that must not write production tables."
+        "Skip ClickHouse inserts, commit-log produce, replacements produce, "
+        "COGS, and DLQ produce. Still consumes Kafka and commits offsets. Use "
+        "for shadow / soak consumers that must not write production tables."
     ),
 )
 @click.option(

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -199,6 +199,17 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     help="Use RowBinary format for ClickHouse inserts instead of JSONEachRow. Currently only supported for EAPItemsProcessor.",
 )
 @click.option(
+    "--skip-write/--no-skip-write",
+    "skip_write",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip ClickHouse inserts (and commit-log produce). Still consumes Kafka "
+        "and commits offsets. Use for shadow / soak consumers that must not "
+        "write production tables."
+    ),
+)
+@click.option(
     "--consumer-version",
     default="v2",
     type=click.Choice(["v1", "v2"]),
@@ -238,6 +249,7 @@ def rust_consumer(
     quantized_rebalance_consumer_group_delay_secs: int | None,
     join_timeout_ms: int | None,
     use_row_binary: bool,
+    skip_write: bool,
     consumer_version: str | None,
 ) -> None:
     """
@@ -295,6 +307,7 @@ def rust_consumer(
         max_dlq_buffer_length,
         join_timeout_ms,
         use_row_binary,
+        skip_write,
     )
 
     sys.exit(exitcode)

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -119,7 +119,13 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     "--group-instance-id",
     type=str,
     default=None,
-    help="Kafka group instance id. passing a value here will run kafka with static membership.",
+    help=(
+        "Kafka group.instance.id (KIP-345 static membership). When set, this "
+        "member keeps its partition assignment across restarts as long as it "
+        "rejoins within session.timeout.ms. Must be unique per live member of "
+        "the consumer group (e.g. one id per single-replica Deployment). "
+        "Tune session.timeout.ms via Kafka broker/topic consumer config."
+    ),
 )
 @click.option(
     "--python-max-queue-depth",

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -204,9 +204,9 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     is_flag=True,
     default=False,
     help=(
-        "Skip ClickHouse inserts (and commit-log produce). Still consumes Kafka "
-        "and commits offsets. Use for shadow / soak consumers that must not "
-        "write production tables."
+        "Skip ClickHouse inserts, commit-log produce, replacements produce, and "
+        "COGS. Still consumes Kafka and commits offsets. Use for shadow / soak "
+        "consumers that must not write production tables."
     ),
 )
 @click.option(

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -199,6 +199,10 @@ def resolve_consumer_config(
         )
 
     if group_instance_id is not None:
+        # KIP-345 static membership: unique per consumer process. Empty values
+        # would still enable static membership with a useless id and risk fencing.
+        if not str(group_instance_id).strip():
+            raise ValueError("group_instance_id must be non-empty when provided")
         resolved_raw_topic = _add_to_topic_broker_config(
             resolved_raw_topic, "group.instance.id", group_instance_id
         )

--- a/tests/cli/test_rust_consumer.py
+++ b/tests/cli/test_rust_consumer.py
@@ -1,0 +1,37 @@
+import sys
+from collections.abc import Sequence
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from snuba.cli.rust_consumer import rust_consumer
+
+
+@patch("snuba.cli.rust_consumer.asdict", return_value={})
+@patch("snuba.cli.rust_consumer.resolve_consumer_config")
+def test_rust_consumer_passes_group_instance_id(
+    resolve_config: Mock, *_mocks: Sequence[Mock]
+) -> None:
+    """ops static_membership deployments pass --group-instance-id to rust-consumer."""
+    resolve_config.return_value = Mock()
+    mock_rust = Mock()
+    mock_rust.consumer.return_value = 0
+
+    runner = CliRunner()
+    with patch.dict(sys.modules, {"rust_snuba": mock_rust}):
+        result = runner.invoke(
+            rust_consumer,
+            [
+                "--storage",
+                "eap_items",
+                "--consumer-group",
+                "snuba-eap-items-consumers",
+                "--group-instance-id",
+                "snuba-eap-items-consumer-0",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    resolve_config.assert_called_once()
+    assert resolve_config.call_args.kwargs["group_instance_id"] == "snuba-eap-items-consumer-0"
+    mock_rust.consumer.assert_called_once()

--- a/tests/cli/test_rust_consumer.py
+++ b/tests/cli/test_rust_consumer.py
@@ -35,3 +35,29 @@ def test_rust_consumer_passes_group_instance_id(
     resolve_config.assert_called_once()
     assert resolve_config.call_args.kwargs["group_instance_id"] == "snuba-eap-items-consumer-0"
     mock_rust.consumer.assert_called_once()
+
+
+@patch("snuba.cli.rust_consumer.asdict", return_value={})
+@patch("snuba.cli.rust_consumer.resolve_consumer_config")
+def test_rust_consumer_passes_skip_write(resolve_config: Mock, *_mocks: Sequence[Mock]) -> None:
+    """Shadow soak consumers pass --skip-write so rust-consumer does not insert."""
+    resolve_config.return_value = Mock()
+    mock_rust = Mock()
+    mock_rust.consumer.return_value = 0
+
+    runner = CliRunner()
+    with patch.dict(sys.modules, {"rust_snuba": mock_rust}):
+        result = runner.invoke(
+            rust_consumer,
+            [
+                "--storage",
+                "eap_items",
+                "--consumer-group",
+                "snuba-eap-items-consumers",
+                "--skip-write",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_rust.consumer.assert_called_once()
+    assert mock_rust.consumer.call_args.args[-1] is True

--- a/tests/consumers/test_consumer_config.py
+++ b/tests/consumers/test_consumer_config.py
@@ -46,3 +46,39 @@ def test_consumer_config() -> None:
             max_batch_size=1,
             max_batch_time_ms=1000,
         )
+
+
+def test_group_instance_id_in_broker_config() -> None:
+    """Static membership: --group-instance-id lands in librdkafka broker config."""
+    resolved = resolve_consumer_config(
+        storage_names=["errors"],
+        raw_topic=None,
+        commit_log_topic=None,
+        replacements_topic=None,
+        slice_id=None,
+        bootstrap_servers=["some_server:9092"],
+        commit_log_bootstrap_servers=[],
+        replacement_bootstrap_servers=[],
+        max_batch_size=1,
+        max_batch_time_ms=1000,
+        group_instance_id="snuba-eap-items-consumer-0",
+    )
+
+    assert resolved.raw_topic.broker_config["group.instance.id"] == "snuba-eap-items-consumer-0"
+
+
+def test_group_instance_id_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="group_instance_id must be non-empty"):
+        resolve_consumer_config(
+            storage_names=["errors"],
+            raw_topic=None,
+            commit_log_topic=None,
+            replacements_topic=None,
+            slice_id=None,
+            bootstrap_servers=["some_server:9092"],
+            commit_log_bootstrap_servers=[],
+            replacement_bootstrap_servers=[],
+            max_batch_size=1,
+            max_batch_time_ms=1000,
+            group_instance_id="   ",
+        )


### PR DESCRIPTION
## Summary

Companion to [getsentry/ops#21808](https://github.com/getsentry/ops/pull/21808) (s4s2 `eap-items-consumer` static membership).

`--group-instance-id` already exists on `snuba consumer` and `snuba rust-consumer` and is passed through to librdkafka as `group.instance.id` (KIP-345). This PR hardens that path so multi-Deployment rollouts are clearly supported and observable:

- **Validate** non-empty `group_instance_id` in `resolve_consumer_config`
- **Log** the resolved id at startup (Python consumer + Rust consumer)
- **Document** the contract in `docs/source/architecture/consumer.rst` (unique ids, `Recreate`, `session.timeout.ms` via Kafka config, concurrency ≠ multiple members)
- **Tests** for broker-config injection, empty rejection, and rust-consumer CLI wiring

No new CLI flags. Ops continues to pass `--group-instance-id snuba-eap-items-consumer-<idx>` per single-replica Deployment.

## Test plan

- [x] `pytest tests/consumers/test_consumer_config.py tests/cli/test_rust_consumer.py tests/cli/test_consumer.py`
- [ ] CI green
- [ ] After merge + deploy: confirm s4s2 eap-items member pods log `Static membership enabled (KIP-345 group.instance.id=...)` on start