### PR TITLE
fix(admin): Ignore caller-supplied tracing query_id

### DIFF
--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ from uuid import UUID
 import structlog
 
 from snuba.admin.clickhouse.common import (
+    InvalidCustomQuery,
     get_ro_query_node_connection,
     validate_ro_query,
 )
@@ -90,6 +92,13 @@ def run_query_and_get_trace(
     sql_settings.pop("query_id", None)
     execute_settings.update(sql_settings)
     execute_settings.pop("query_id", None)
+    # The SETTINGS splitter does not respect quoted commas. If extraction failed
+    # and leftover SQL still names query_id, refuse rather than let ClickHouse
+    # honor the caller-chosen id.
+    if not apply_query_limit and re.search(
+        r"\bquery_id\b", query_without_settings, flags=re.IGNORECASE
+    ):
+        raise InvalidCustomQuery("query_id is not allowed in SETTINGS")
 
     connection = get_ro_query_node_connection(storage_name, ClickhouseClientSettings.TRACING)
     # Prefer clickhouse-connect's client-side query_limit. Pass it per execute so

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -85,8 +85,11 @@ def run_query_and_get_trace(
     query_without_settings, sql_settings, apply_query_limit = _extract_settings_clause(query)
 
     execute_settings: dict[str, Any] = dict(settings or {})
-    # SQL SETTINGS win over request defaults for the same key.
+    # SQL SETTINGS win over request defaults for the same key, except query_id:
+    # a caller-chosen id can point summarize_from_query_log at another query.
+    sql_settings.pop("query_id", None)
     execute_settings.update(sql_settings)
+    execute_settings.pop("query_id", None)
 
     connection = get_ro_query_node_connection(storage_name, ClickhouseClientSettings.TRACING)
     # Prefer clickhouse-connect's client-side query_limit. Pass it per execute so

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -1,5 +1,8 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from snuba.admin.clickhouse.common import InvalidCustomQuery
 from snuba.admin.clickhouse.trace_log_parsing import ExecuteSummary, QuerySummary, TracingSummary
 from snuba.admin.clickhouse.tracing import (
     MAX_TRACING_QUERY_LIMIT,
@@ -33,6 +36,13 @@ def test_extract_settings_clause_moves_settings() -> None:
     # Malformed trailing SETTINGS: leave SQL alone and disable driver LIMIT append.
     body, settings, apply_limit = _extract_settings_clause("SELECT 1 SETTINGS max_threads")
     assert body == "SELECT 1 SETTINGS max_threads"
+    assert settings == {}
+    assert apply_limit is False
+
+    # Quoted commas are not treated as setting separators, so extraction fails closed.
+    quoted = "SELECT 1 SETTINGS query_id = 'foo,bar'"
+    body, settings, apply_limit = _extract_settings_clause(quoted)
+    assert body == quoted
     assert settings == {}
     assert apply_limit is False
 
@@ -441,6 +451,34 @@ def test_run_query_and_get_trace_drops_caller_query_id() -> None:
     assert "query_id" not in execute_settings
     assert execute_settings == {"log_profile_events": 1, "max_threads": "4"}
     assert connection.execute.call_args.kwargs["query"] == "SELECT 1"
+
+
+def test_run_query_and_get_trace_rejects_unparsed_query_id_settings() -> None:
+    # A quoted comma breaks the SETTINGS splitter, so query_id would otherwise
+    # remain in the SQL sent to ClickHouse.
+    connection = MagicMock()
+    connection.query_limit = 0
+    connection.execute.return_value = ClickhouseResult(
+        results=[(1,)],
+        meta=[("count()", "UInt64")],
+        trace_output="",
+        query_id="server-assigned",
+    )
+
+    with (
+        patch(
+            "snuba.admin.clickhouse.tracing.get_ro_query_node_connection",
+            return_value=connection,
+        ),
+        patch("snuba.admin.clickhouse.tracing.validate_ro_query"),
+        pytest.raises(InvalidCustomQuery, match="query_id is not allowed in SETTINGS"),
+    ):
+        run_query_and_get_trace(
+            "errors_ro",
+            "SELECT 1 SETTINGS join_algorithm = 'hash,parallel_hash', query_id = 'foo,bar'",
+        )
+
+    connection.execute.assert_not_called()
 
 
 def test_run_query_and_get_trace_disables_query_limit_when_settings_remain() -> None:

--- a/tests/admin/clickhouse/test_tracing.py
+++ b/tests/admin/clickhouse/test_tracing.py
@@ -408,6 +408,41 @@ def test_run_query_and_get_trace_uses_query_log_when_wire_trace_empty() -> None:
     assert output.executed_query == "SELECT 1 LIMIT 10000"
 
 
+def test_run_query_and_get_trace_drops_caller_query_id() -> None:
+    # A SETTINGS query_id would otherwise make summarize_from_query_log read
+    # another query's system.query_log rows.
+    connection = MagicMock()
+    connection.query_limit = 0
+    connection.execute.return_value = ClickhouseResult(
+        results=[(1,)],
+        meta=[("count()", "UInt64")],
+        trace_output="",
+        query_id="server-assigned",
+    )
+
+    with (
+        patch(
+            "snuba.admin.clickhouse.tracing.get_ro_query_node_connection",
+            return_value=connection,
+        ),
+        patch("snuba.admin.clickhouse.tracing.validate_ro_query"),
+        patch(
+            "snuba.admin.clickhouse.tracing.summarize_from_query_log",
+            return_value=TracingSummary({}),
+        ),
+    ):
+        run_query_and_get_trace(
+            "errors_ro",
+            "SELECT 1 SETTINGS query_id='attacker', max_threads = 4",
+            settings={"query_id": "also-attacker", "log_profile_events": 1},
+        )
+
+    execute_settings = connection.execute.call_args.kwargs["settings"]
+    assert "query_id" not in execute_settings
+    assert execute_settings == {"log_profile_events": 1, "max_threads": "4"}
+    assert connection.execute.call_args.kwargs["query"] == "SELECT 1"
+
+
 def test_run_query_and_get_trace_disables_query_limit_when_settings_remain() -> None:
     connection = MagicMock()
     # Simulate a connect pool (has query_limit attr) without mutating it.


### PR DESCRIPTION
Admin tracing no longer honors a caller-supplied `query_id`. `SETTINGS query_id='...'` in the SQL and `query_id` in execute settings are dropped before the query runs, so `summarize_from_query_log` can only read the server-assigned query.

Without this, a crafted tracing request can point query-log lookup at another query and return its SQL.

Fixes #8319.
