### PR TITLE
fix(admin): Reject merge() in non-sudo system queries

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -223,11 +223,12 @@ def is_query_using_only_system_tables(
 
     for line in explain_query_tree_result.results:
         line = line[0].strip()
-        # We don't allow table functions (except clusterAllReplicas/merge) for now as the clickhouse analyzer isn't good enough yet to resolve those tables
+        # clusterAllReplicas is allowed only when EXPLAIN resolves its table
+        # argument to a system.* table below. merge() and other table functions
+        # can reach non-system tables the analyzer does not resolve here.
         if (
             line.startswith("TABLE_FUNCTION")
             and "table_function_name: clusterAllReplicas" not in line
-            and "table_function_name: merge" not in line
         ):
             return False
         if line.startswith("TABLE"):

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -55,7 +55,6 @@ from snuba.clusters.cluster import ClickhouseClientSettings
             memory DESC
         """,
         "SELECT hostname(), avg(query_duration_ms) FROM clusterAllReplicas('default', system.query_log) GROUP BY hostname()",
-        "SELECT count() FROM merge('system', '.*settings')",
     ],
 )
 @pytest.mark.events_db
@@ -75,6 +74,7 @@ def test_is_valid_system_query(sql_query: str) -> None:
         "SELECT 1; SELECT 2;"  # no multiple statements
         "SELECT * FROM system.clusters c INNER JOIN my_table m ON c.cluster == m.something",  # no join
         "SELECT * from system.as1",  # invalid system table format
+        "SELECT * FROM merge('default', 'errors.*')",  # merge() can reach non-system tables
         """SELECT
             count() as nb_query,
             user,

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -74,7 +74,6 @@ def test_is_valid_system_query(sql_query: str) -> None:
         "SELECT 1; SELECT 2;"  # no multiple statements
         "SELECT * FROM system.clusters c INNER JOIN my_table m ON c.cluster == m.something",  # no join
         "SELECT * from system.as1",  # invalid system table format
-        "SELECT * FROM merge('default', 'errors.*')",  # merge() can reach non-system tables
         """SELECT
             count() as nb_query,
             user,
@@ -110,6 +109,20 @@ def test_invalid_system_query(sql_query: str) -> None:
             sql_query,
             False,
         )
+
+
+@pytest.mark.events_db
+def test_merge_table_function_is_rejected() -> None:
+    # merge() is valid ClickHouse SQL. EXPLAIN succeeds, then
+    # is_query_using_only_system_tables returns False because the analyzer
+    # does not resolve merge() to system.* tables.
+    assert not is_valid_system_query(
+        settings.CLUSTERS[0]["host"],
+        int(settings.CLUSTERS[0]["port"]),
+        "errors",
+        "SELECT * FROM merge('default', 'errors.*')",
+        False,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Non-sudo admin system queries no longer treat `merge()` as a safe table function. The ClickHouse analyzer does not resolve those tables, so a query like `SELECT * FROM merge('default', 'errors.*')` could read non-system data.

`clusterAllReplicas` is still allowed when `EXPLAIN QUERY TREE` resolves its table argument to `system.*`, so `clusterAllReplicas('default', system.query_log)` continues to work.

Fixes #8318
