### PR TITLE
fix(jobs): Stop mass-assigning untrusted job params

### DIFF
--- a/snuba/manual_jobs/__init__.py
+++ b/snuba/manual_jobs/__init__.py
@@ -53,9 +53,6 @@ class Job(ABC, metaclass=RegisteredClass):
         self.job_spec = job_spec
         self.is_async = job_spec.is_async
         _set_job_type(job_spec.job_id, job_spec.job_type)
-        if job_spec.params:
-            for k, v in job_spec.params.items():
-                setattr(self, k, v)
 
     @abstractmethod
     def execute(self, logger: JobLogger) -> None:

--- a/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
+++ b/tests/manual_jobs/test_set_eap_downsampled_table_settings.py
@@ -82,6 +82,28 @@ def test_rejects_non_downsampled_eap_local_table(
         _build_job(monkeypatch, table_name)
 
 
+def test_untrusted_table_name_param_does_not_overwrite_validated_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("snuba.manual_jobs._set_job_type", Mock())
+    job = SetEAPDownsampledTableSettings(
+        JobSpec(
+            job_id="set-eap-settings",
+            job_type="SetEAPDownsampledTableSettings",
+            params={
+                "table_name": "eap_items_1_downsample_8_local",
+                "_table_name": "events_local",
+            },
+        )
+    )
+
+    assert job._table_name == "eap_items_1_downsample_8_local"
+    assert job._get_query(None) == (
+        "ALTER TABLE eap_items_1_downsample_8_local MODIFY SETTING "
+        "enable_block_number_column = 1, enable_block_offset_column = 1;"
+    )
+
+
 def test_execute_uses_eap_local_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
     job = _build_job(monkeypatch, "eap_items_1_downsample_64_local")
     connection = Mock()


### PR DESCRIPTION
`Job.__init__` no longer mass-assigns caller-supplied params onto the job instance. `SetEAPDownsampledTableSettings` (and other jobs) already copy validated fields themselves, so a `MANUAL_JOBS` caller cannot send `_table_name` after a valid `table_name` and run `MIGRATE` `ALTER`s on an arbitrary ClickHouse table.

ToyJob already reads `job_spec.params` directly. A regression test keeps `_table_name` as the validated downsampled table when both keys are present.

Fixes #8323
