### PR TITLE
ref(admin): Remove migration status overwrite route

### DIFF
--- a/snuba/admin/audit_log/action.py
+++ b/snuba/admin/audit_log/action.py
@@ -10,7 +10,6 @@ class AuditLogAction(Enum):
     REVERSED_MIGRATION_COMPLETED = "reversed.migration.completed"
     RAN_MIGRATION_FAILED = "ran.migration.failed"
     REVERSED_MIGRATION_FAILED = "reversed.migration.failed"
-    FORCE_MIGRATION_OVERWRITE = "force.migration.overwrite"
     RAN_SUDO_SYSTEM_QUERY = "ran.sudo.system.query"
     RAN_CLUSTERLESS_SYSTEM_QUERY = "ran.clusterless.system.query"
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -248,12 +248,20 @@ def reverse_migration(group: str, migration_id: str) -> Response:
     methods=["POST"],
 )
 @check_tool_perms(tools=[AdminTools.MIGRATIONS])
+@check_migration_perms
 def force_overwrite_migration_status(group: str, migration_id: str, new_status: str) -> Response:
     try:
         migration_group = MigrationGroup(group)
     except ValueError as err:
         logger.error(err, exc_info=True)
         return make_response(jsonify({"error": "Group not found"}), 400)
+
+    migration_key = MigrationKey(migration_group, migration_id)
+    policies = get_migration_group_policies(g.user)[group]
+    if not any(
+        policy.can_run(migration_key) and policy.can_reverse(migration_key) for policy in policies
+    ):
+        return make_response(jsonify({"error": "Group not allowed overwrite policy"}), 403)
 
     runner.force_overwrite_status(migration_group, migration_id, Status(new_status))
     user = request.headers.get(USER_HEADER_KEY)

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -71,7 +71,6 @@ from snuba.manual_jobs.runner import (
 from snuba.migrations.errors import InactiveClickhouseReplica, MigrationError
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.runner import MigrationKey, Runner
-from snuba.migrations.status import Status
 from snuba.query.exceptions import InvalidQueryException
 from snuba.replacers.replacements_and_expiry import (
     get_config_auto_replacements_bypass_projects,
@@ -241,40 +240,6 @@ def run_migration(group: str, migration_id: str) -> Response:
 @check_tool_perms(tools=[AdminTools.MIGRATIONS])
 def reverse_migration(group: str, migration_id: str) -> Response:
     return run_or_reverse_migration(group=group, action="reverse", migration_id=migration_id)
-
-
-@application.route(
-    "/migrations/<group>/overwrite/<migration_id>/status/<new_status>",
-    methods=["POST"],
-)
-@check_tool_perms(tools=[AdminTools.MIGRATIONS])
-@check_migration_perms
-def force_overwrite_migration_status(group: str, migration_id: str, new_status: str) -> Response:
-    try:
-        migration_group = MigrationGroup(group)
-    except ValueError as err:
-        logger.error(err, exc_info=True)
-        return make_response(jsonify({"error": "Group not found"}), 400)
-
-    migration_key = MigrationKey(migration_group, migration_id)
-    policies = get_migration_group_policies(g.user)[group]
-    if not any(
-        policy.can_run(migration_key) and policy.can_reverse(migration_key) for policy in policies
-    ):
-        return make_response(jsonify({"error": "Group not allowed overwrite policy"}), 403)
-
-    runner.force_overwrite_status(migration_group, migration_id, Status(new_status))
-    user = request.headers.get(USER_HEADER_KEY)
-
-    audit_log.record(
-        user or "",
-        AuditLogAction.FORCE_MIGRATION_OVERWRITE,
-        {"group": group, "migration": migration_id, "new_status": new_status},
-        notify=True,
-    )
-
-    res = {"status": "OK"}
-    return make_response(jsonify(res), 200)
 
 
 @check_migration_perms

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -297,27 +297,6 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
 
 
 @pytest.mark.redis_db
-def test_force_overwrite_requires_run_and_reverse_policy(
-    admin_api: FlaskClient,
-) -> None:
-    migration_id = "0001_migrations"
-    with (
-        patch(
-            "snuba.admin.auth.DEFAULT_ROLES",
-            [
-                generate_migration_test_role("system", "none"),
-                generate_tool_test_role("all"),
-            ],
-        ),
-        patch.object(Runner, "force_overwrite_status") as mock_overwrite,
-    ):
-        response = admin_api.post(f"/migrations/system/overwrite/{migration_id}/status/not_started")
-        assert response.status_code == 403
-        assert json.loads(response.data) == {"error": "Group not allowed overwrite policy"}
-        assert mock_overwrite.call_count == 0
-
-
-@pytest.mark.redis_db
 def test_get_iam_roles(caplog: Any) -> None:
     system_role = generate_migration_test_role("system", "all")
     tool_role = generate_tool_test_role("snql-to-sql")

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -297,6 +297,27 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
 
 
 @pytest.mark.redis_db
+def test_force_overwrite_requires_run_and_reverse_policy(
+    admin_api: FlaskClient,
+) -> None:
+    migration_id = "0001_migrations"
+    with (
+        patch(
+            "snuba.admin.auth.DEFAULT_ROLES",
+            [
+                generate_migration_test_role("system", "none"),
+                generate_tool_test_role("all"),
+            ],
+        ),
+        patch.object(Runner, "force_overwrite_status") as mock_overwrite,
+    ):
+        response = admin_api.post(f"/migrations/system/overwrite/{migration_id}/status/not_started")
+        assert response.status_code == 403
+        assert json.loads(response.data) == {"error": "Group not allowed overwrite policy"}
+        assert mock_overwrite.call_count == 0
+
+
+@pytest.mark.redis_db
 def test_get_iam_roles(caplog: Any) -> None:
     system_role = generate_migration_test_role("system", "all")
     tool_role = generate_tool_test_role("snql-to-sql")

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -396,15 +396,6 @@ def test_prod_snql_query_invalid_query(admin_api: FlaskClient) -> None:
 
 
 @pytest.mark.redis_db
-def test_force_overwrite_route_removed(admin_api: FlaskClient) -> None:
-    response = admin_api.post(
-        "/migrations/search_issues/overwrite/0012_add_group_id_bloom_filter_index/status/not_started",
-        headers={"Referer": "https://snuba-admin.getsentry.net/"},
-    )
-    assert response.status_code == 404
-
-
-@pytest.mark.redis_db
 @pytest.mark.events_db
 def test_prod_snql_query_valid_query(admin_api: FlaskClient) -> None:
     snql_query = """

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -396,21 +396,12 @@ def test_prod_snql_query_invalid_query(admin_api: FlaskClient) -> None:
 
 
 @pytest.mark.redis_db
-@pytest.mark.events_db
-def test_force_overwrite(admin_api: FlaskClient) -> None:
-    migration_id = "0012_add_group_id_bloom_filter_index"
-    migrations = json.loads(admin_api.get("/migrations/search_issues/list").data)
-    downgraded_migration = [m for m in migrations if m.get("migration_id") == migration_id][0]
-    assert downgraded_migration["status"] == "completed"
-
+def test_force_overwrite_route_removed(admin_api: FlaskClient) -> None:
     response = admin_api.post(
-        f"/migrations/search_issues/overwrite/{migration_id}/status/not_started",
+        "/migrations/search_issues/overwrite/0012_add_group_id_bloom_filter_index/status/not_started",
         headers={"Referer": "https://snuba-admin.getsentry.net/"},
     )
-    assert response.status_code == 200
-    migrations = json.loads(admin_api.get("/migrations/search_issues/list").data)
-    downgraded_migration = [m for m in migrations if m.get("migration_id") == migration_id][0]
-    assert downgraded_migration["status"] == "not_started"
+    assert response.status_code == 404
 
 
 @pytest.mark.redis_db


### PR DESCRIPTION
`POST /migrations/<group>/overwrite/...` is gone. The ClickHouse migrations UI never called it; run and reverse stay. Status repairs go through `UpdateMigrationStatus`, which requires the current status and inserts a versioned row instead of mutating the tracker in place.

Fixes #8322
