### PR TITLE
fix(admin): Hide uncaught exception text from clients

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -121,7 +121,7 @@ def handle_http_exception(exception: HTTPException) -> HTTPException:
 def handle_uncaught_exception(exception: Exception) -> Response:
     logger.error(exception, exc_info=True)
     return Response(
-        json.dumps({"error": {"type": "unknown", "message": str(exception)}}),
+        json.dumps({"error": {"type": "unknown", "message": "Internal error"}}),
         500,
         {"Content-Type": "application/json"},
     )

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -606,7 +606,7 @@ def test_uncaught_exception_returns_json_500(admin_api: FlaskClient) -> None:
 
     assert response.status_code == 500
     assert response.headers["Content-Type"] == "application/json"
-    assert json.loads(response.data) == {"error": {"type": "unknown", "message": "boom"}}
+    assert json.loads(response.data) == {"error": {"type": "unknown", "message": "Internal error"}}
 
 
 @pytest.mark.redis_db


### PR DESCRIPTION
Uncaught exceptions in the Snuba admin UI no longer echo `str(exception)` back to the client. The catch-all handler still logs the original exception, but the JSON 500 now returns a generic `Internal error` message so internal details stay off the wire.

Fixes #8330
