### PR TITLE
fix(querylog): Redact DangerousRawSQL and reused aliases

### DIFF
--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -238,15 +238,19 @@ class ExpressionFormatterAnonymized(ClickhouseExpressionFormatter):
         # if they are input by the user, but that is better than leaking PII
         return _BETWEEN_SQUARE_BRACKETS_REGEX.sub("$A", alias)
 
+    def visit_dangerous_raw_sql(self, exp: DangerousRawSQL) -> str:
+        # Literals inside optimizer-built SQL still have to be redacted before
+        # the string is recorded as sql_anonymized.
+        anonymized = re.sub(r"'(?:\\.|[^'\\])*'", "'$S'", exp.sql)
+        anonymized = re.sub(r"\b\d+\b", str(_gen_random_number()), anonymized)
+        return self._alias(anonymized, exp.alias)
+
     def _alias(self, formatted_exp: str, alias: str | None) -> str:
         if not alias:
             return formatted_exp
+        anonymized_alias = escape_alias(self._anonimize_alias(alias))
+        assert anonymized_alias is not None
         if self._parsing_context.is_alias_present(alias):
-            ret = escape_alias(alias)
-            # This is for the type checker. escape_alias can return None if
-            # we pass None. But here we do not pass None so a None return value
-            # is not valid.
-            assert ret is not None
-            return ret
+            return anonymized_alias
         self._parsing_context.add_alias(alias)
-        return f"({formatted_exp} AS {escape_alias(self._anonimize_alias(alias))})"
+        return f"({formatted_exp} AS {anonymized_alias})"

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -234,12 +234,12 @@ test_expressions = [
     (
         DangerousRawSQL(None, "arrayReduce('sumIf', arr, cond)"),
         "arrayReduce('sumIf', arr, cond)",
-        "arrayReduce('sumIf', arr, cond)",
+        "arrayReduce('$S', arr, cond)",
     ),  # DangerousRawSQL with ClickHouse-specific syntax
     (
         DangerousRawSQL(None, "field->'key'"),
         "field->'key'",
-        "field->'key'",
+        "field->'$S'",
     ),  # DangerousRawSQL with special characters (not escaped)
     (
         FunctionCall(
@@ -252,7 +252,7 @@ test_expressions = [
             ),
         ),
         "if(condition > 0, t1.col1, 0)",
-        "if(condition > 0, t1.col1, -1337)",
+        "if(condition > -1337, t1.col1, -1337)",
     ),  # DangerousRawSQL in function call
     (DangerousRawSQL(None, ""), "", ""),  # Empty DangerousRawSQL (edge case)
 ]
@@ -294,6 +294,19 @@ def test_aliases() -> None:
 
     expected = "f1((tag(table1.column1) AS `tag[something]`), `tag[something]`, `tag[something]`)"
     assert f.accept(ClickhouseExpressionFormatter()) == expected
+
+
+def test_anonymized_alias_reuse_redacts_tag_key() -> None:
+    # Reused aliases must stay anonymized; otherwise later references re-emit
+    # the original tag key (e.g. email) into sql_anonymized.
+    col1 = Column("tags[email]", "table1", "column1")
+    col2 = Column("tags[email]", "table1", "column1")
+
+    pc = ParsingContext()
+    visitor = ExpressionFormatterAnonymized(pc)
+
+    assert col1.accept(visitor) == "(table1.column1 AS `tags[$A]`)"
+    assert col2.accept(visitor) == "`tags[$A]`"
 
 
 test_escaped = [


### PR DESCRIPTION
`sql_anonymized` still leaked user literals and tag keys in two formatter paths. Optimizer-built `DangerousRawSQL` was passed through unchanged, so predicates such as `user_id = '...'` landed in querylog metadata. Reused aliases also skipped `_anonimize_alias`, so a later `tags[email]` reference re-emitted the original key after the first occurrence had been redacted.

This redacts quoted strings and numbers inside `DangerousRawSQL` before recording, and always formats reused aliases through `_anonimize_alias`. ClickHouse SQL is unchanged; only the anonymized form used by querylog is affected.

Fixes #8333
Fixes #8334
