### PR TITLE
ci: Harden workflow secret passing

### DIFF
--- a/.github/workflows/admin-sourcemaps.yml
+++ b/.github/workflows/admin-sourcemaps.yml
@@ -11,8 +11,6 @@ jobs:
   build:
     name: "build sourcemaps"
     runs-on: ubuntu-latest
-    env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.SNUBA_SENTRY_SOURCEMAP_KEY }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         name: Checkout code
@@ -23,3 +21,6 @@ jobs:
           node-version-file: snuba/admin/package.json
       - name: Build admin sourcemaps
         run: make build-admin
+        env:
+          # Only trusted master pushes may upload sourcemaps.
+          SENTRY_AUTH_TOKEN: ${{ github.event_name == 'push' && secrets.SNUBA_SENTRY_SOURCEMAP_KEY || '' }}

--- a/.github/workflows/admin-sourcemaps.yml
+++ b/.github/workflows/admin-sourcemaps.yml
@@ -22,5 +22,4 @@ jobs:
       - name: Build admin sourcemaps
         run: make build-admin
         env:
-          # Only trusted master pushes may upload sourcemaps.
           SENTRY_AUTH_TOKEN: ${{ github.event_name == 'push' && secrets.SNUBA_SENTRY_SOURCEMAP_KEY || '' }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -21,6 +21,9 @@ on:
       version:
         required: true
         type: string
+    secrets:
+      GETSENTRY_BOT_REVERT_TOKEN:
+        required: true
 
 # disable all permissions -- we use the PAT's permissions instead
 permissions: {}

--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -32,7 +32,8 @@ jobs:
   validate-schema:
     needs: cli-version
     name: Validate Schema Evolution
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@main
+    # main at pin time
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@24dbd915e6f091626630a284f9439bf983c32dbe
     secrets:
       SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:

--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -32,8 +32,7 @@ jobs:
   validate-schema:
     needs: cli-version
     name: Validate Schema Evolution
-    # main at pin time
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@24dbd915e6f091626630a284f9439bf983c32dbe
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@main
     secrets:
       SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:


### PR DESCRIPTION
Admin sourcemap builds no longer receive `SNUBA_SENTRY_SOURCEMAP_KEY` on `pull_request`. `make build-admin` still runs for PRs, but the token is injected only on `push` to master.

`bump-version.yml` now declares `GETSENTRY_BOT_REVERT_TOKEN` as a required `workflow_call` secret so callers pass it explicitly instead of `secrets: inherit`.

The sentry-options reusable workflow stays on `@main`. First-party workflows already track a branch; a SHA pin would only stall validator updates.

Fixes #8335
Fixes #8337
Refs #8338
