### PR TITLE
fix(consumers): Pass retention config into RustCompatProcessor

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -359,7 +359,7 @@ type PyInsert = PyObject;
 /// replacement: (key/project_id, value)
 type PyReplacement = (PyObject, PyObject);
 
-#[pyfunction(signature = (name, value, partition, offset, millis_since_epoch, eap_items_emit_received_at=false))]
+#[pyfunction(signature = (name, value, partition, offset, millis_since_epoch, eap_items_emit_received_at=false, env_config=None))]
 pub fn process_message(
     py: Python,
     name: &str,
@@ -368,6 +368,7 @@ pub fn process_message(
     offset: u64,
     millis_since_epoch: i64,
     eap_items_emit_received_at: bool,
+    env_config: Option<&str>,
 ) -> PyResult<(Option<PyInsert>, Option<PyReplacement>)> {
     // XXX: Currently only takes the message payload and metadata. This assumes
     // key and headers are not used for message processing
@@ -382,7 +383,13 @@ pub fn process_message(
         offset,
         timestamp,
     };
+    let env_config = match env_config {
+        Some(raw) => serde_json::from_str(raw)
+            .map_err(|e| SnubaRustError::new_err(format!("invalid env_config: {e:?}")))?,
+        None => config::EnvConfig::default(),
+    };
     let processor_config = config::ProcessorConfig {
+        env_config,
         eap_items_emit_received_at: name == "EAPItemsProcessor" && eap_items_emit_received_at,
         ..Default::default()
     };

--- a/snuba/datasets/processors/rust_compat_processor.py
+++ b/snuba/datasets/processors/rust_compat_processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from datetime import UTC
 from typing import Any
 
@@ -28,6 +29,10 @@ class RustCompatProcessor(DatasetMessageProcessor):
             payload = message
         else:
             payload = json.dumps(message).encode("utf8")
+        # Imported lazily: consumer_config imports WritableTableStorage, which
+        # imports DatasetMessageProcessor and would otherwise cycle at import time.
+        from snuba.consumers.consumer_config import _resolve_env_config
+
         insert_payload, replacement_payload = self.__process_message(
             self.__processor_name,
             payload,
@@ -36,6 +41,7 @@ class RustCompatProcessor(DatasetMessageProcessor):
             int(metadata.timestamp.replace(tzinfo=UTC).timestamp() * 1000),
             self.__processor_name == "EAPItemsProcessor"
             and get_option("eap_items_emit_received_at", False),
+            json.dumps(asdict(_resolve_env_config())),
         )
 
         if insert_payload is not None:

--- a/tests/consumers/test_message_processors.py
+++ b/tests/consumers/test_message_processors.py
@@ -146,6 +146,31 @@ def test_replays_message_processor() -> None:
             assert parsed_rust_message | parsed_python_message == parsed_rust_message
 
 
+@patch("snuba.settings.DEFAULT_RETENTION_DAYS", 100)
+@patch("snuba.settings.VALID_RETENTION_DAYS", {30, 60, 100})
+def test_rust_compat_processor_honors_retention_settings() -> None:
+    """Python retention settings must reach RustCompatProcessor via process_message."""
+    example = next(
+        data
+        for ex in sentry_kafka_schemas.iter_examples("events")
+        if isinstance((data := ex.load()), list) and len(data) >= 3 and data[1] == "insert"
+    )
+    example[2]["retention_days"] = 100
+
+    processed = ErrorsProcessor().process_message(
+        example,
+        KafkaMessageMetadata(
+            offset=1,
+            partition=0,
+            timestamp=datetime.utcfromtimestamp(int(time.time())),
+        ),
+    )
+
+    assert isinstance(processed, InsertBatch)
+    assert processed.rows
+    assert processed.rows[0]["retention_days"] == 100
+
+
 def test_eap_items_received_at_from_broker_timestamp() -> None:
     payload = next(iter(sentry_kafka_schemas.iter_examples("snuba-items"))).load()
     broker_timestamp = datetime.fromtimestamp(1_745_562_493.123, tz=UTC)


### PR DESCRIPTION
`snuba consumer` / `RustCompatProcessor` now pass Python `EnvConfig` into `rust_snuba.process_message`, so `DEFAULT_RETENTION_DAYS`, `VALID_RETENTION_DAYS`, and `LOWER_RETENTION_DAYS` apply on the Python-consumer and HTTP insert path. Custom values such as `100` are no longer rewritten to the Rust default of `90`.

`process_message` previously always built `ProcessorConfig { ..Default::default() }`. `EnvConfig::default()` hardcodes 90-day retention, so Rust `enforce_retention` ignored Snuba settings on this FFI. Native `snuba rust-consumer --use-rust-processor` already threads `EnvConfig` correctly and is unchanged. Existing `process_message` callers can omit the new argument.

Fixes #8189

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
