### PR TITLE
fix(querylog): Drop illegal UUID SAMPLE BY from querylog_local

### DIFF
--- a/snuba/migrations/migration_utilities.py
+++ b/snuba/migrations/migration_utilities.py
@@ -18,18 +18,6 @@ def strip_sample_by_clause(create_table_statement: str) -> str:
     return _SAMPLE_BY_RE.sub("", create_table_statement, count=1)
 
 
-def replace_create_table_name(create_table_statement: str, old_name: str, new_name: str) -> str:
-    """Rename the table in a CREATE TABLE statement without rewriting ZooKeeper paths."""
-    pattern = re.compile(
-        rf"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?)((?:[`\w]+\.)?`?){re.escape(old_name)}(`?)",
-        re.IGNORECASE,
-    )
-    replaced, count = pattern.subn(rf"\g<1>\g<2>{new_name}\g<3>", create_table_statement, count=1)
-    if count != 1:
-        raise ValueError(f"Could not rename {old_name!r} to {new_name!r} in CREATE TABLE statement")
-    return replaced
-
-
 def get_clickhouse_version_for_storage_set(
     storage_set: StorageSetKey, clickhouse: ClickhousePool | None
 ) -> ClickhouseVersion:

--- a/snuba/migrations/migration_utilities.py
+++ b/snuba/migrations/migration_utilities.py
@@ -18,6 +18,18 @@ def strip_sample_by_clause(create_table_statement: str) -> str:
     return _SAMPLE_BY_RE.sub("", create_table_statement, count=1)
 
 
+def replace_create_table_name(create_table_statement: str, old_name: str, new_name: str) -> str:
+    """Rename the table in a CREATE TABLE statement without rewriting ZooKeeper paths."""
+    pattern = re.compile(
+        rf"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?)((?:[`\w]+\.)?`?){re.escape(old_name)}(`?)",
+        re.IGNORECASE,
+    )
+    replaced, count = pattern.subn(rf"\g<1>\g<2>{new_name}\g<3>", create_table_statement, count=1)
+    if count != 1:
+        raise ValueError(f"Could not rename {old_name!r} to {new_name!r} in CREATE TABLE statement")
+    return replaced
+
+
 def get_clickhouse_version_for_storage_set(
     storage_set: StorageSetKey, clickhouse: ClickhousePool | None
 ) -> ClickhouseVersion:

--- a/snuba/migrations/migration_utilities.py
+++ b/snuba/migrations/migration_utilities.py
@@ -1,8 +1,21 @@
+import re
+
 from snuba.clickhouse.pool import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 
 ClickhouseVersion = tuple[int, int]
+
+# SAMPLE BY <identifier> or SAMPLE BY <fn>(...)
+_SAMPLE_BY_RE = re.compile(
+    r"\s+SAMPLE BY\s+\S+(?:\([^)]*\))?",
+    re.IGNORECASE,
+)
+
+
+def strip_sample_by_clause(create_table_statement: str) -> str:
+    """Remove a SAMPLE BY clause from a ClickHouse SHOW CREATE TABLE statement."""
+    return _SAMPLE_BY_RE.sub("", create_table_statement, count=1)
 
 
 def get_clickhouse_version_for_storage_set(

--- a/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
+++ b/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
@@ -7,7 +7,10 @@ from snuba.clickhouse.pool import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
-from snuba.migrations.migration_utilities import strip_sample_by_clause
+from snuba.migrations.migration_utilities import (
+    replace_create_table_name,
+    strip_sample_by_clause,
+)
 
 TABLE_NAME = "querylog_local"
 TABLE_NAME_NEW = "querylog_local_new"
@@ -25,7 +28,9 @@ def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
         f"SELECT sampling_key, sorting_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     ).results
 
-    new_create_table_statement = curr_create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
+    new_create_table_statement = replace_create_table_name(
+        curr_create_table_statement, TABLE_NAME, TABLE_NAME_NEW
+    )
 
     # Switch the sorting key
     if curr_sorting_key != new_sorting_key:

--- a/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
+++ b/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
@@ -7,10 +7,7 @@ from snuba.clickhouse.pool import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
-from snuba.migrations.migration_utilities import (
-    replace_create_table_name,
-    strip_sample_by_clause,
-)
+from snuba.migrations.migration_utilities import strip_sample_by_clause
 
 TABLE_NAME = "querylog_local"
 TABLE_NAME_NEW = "querylog_local_new"
@@ -28,9 +25,7 @@ def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
         f"SELECT sampling_key, sorting_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     ).results
 
-    new_create_table_statement = replace_create_table_name(
-        curr_create_table_statement, TABLE_NAME, TABLE_NAME_NEW
-    )
+    new_create_table_statement = curr_create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
 
     # Switch the sorting key
     if curr_sorting_key != new_sorting_key:

--- a/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
+++ b/snuba/snuba_migrations/querylog/0006_sorting_key_change.py
@@ -34,10 +34,7 @@ def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
             curr_sorting_key, new_sorting_key
         )
 
-    # SAMPLE BY request_id is a UUID and is illegal on ClickHouse >= 21.9.
-    # Drop it while rebuilding so this migration can run on current ClickHouse.
-    # Remaining tables are cleaned up by 0008_drop_uuid_sample_by.
-    # See https://github.com/getsentry/snuba/issues/7216
+    # UUID SAMPLE BY is illegal on ClickHouse >= 21.9; drop it while rebuilding.
     if curr_sampling_key == "request_id":
         new_create_table_statement = strip_sample_by_clause(new_create_table_statement)
         assert "SAMPLE BY" not in new_create_table_statement.upper()

--- a/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
+++ b/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
@@ -13,49 +13,32 @@ TABLE_NAME = "querylog_local"
 TABLE_NAME_NEW = "querylog_local_new"
 TABLE_NAME_OLD = "querylog_local_old"
 
+# Pre-ClickHouse 21.9 allowed SAMPLE BY on UUID columns. querylog_local used
+# SAMPLE BY request_id (a UUID). ClickHouse now rejects that type, so SHOW CREATE
+# / cluster expansion fails with ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER.
+# See https://github.com/getsentry/snuba/issues/7216
+ILLEGAL_SAMPLE_BY = "request_id"
+
 
 def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
+    ((curr_sampling_key,),) = clickhouse.execute(
+        f"SELECT sampling_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
+    ).results
+
+    if curr_sampling_key != ILLEGAL_SAMPLE_BY:
+        return
+
     ((curr_create_table_statement,),) = clickhouse.execute(
         f"SHOW CREATE TABLE {database}.{TABLE_NAME}"
     ).results
 
-    new_sorting_key = "dataset, referrer, toStartOfDay(timestamp), request_id"
+    new_create_table_statement = strip_sample_by_clause(
+        curr_create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
+    )
+    assert "SAMPLE BY" not in new_create_table_statement.upper()
 
-    ((curr_sampling_key, curr_sorting_key),) = clickhouse.execute(
-        f"SELECT sampling_key, sorting_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
-    ).results
-
-    new_create_table_statement = curr_create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
-
-    # Switch the sorting key
-    if curr_sorting_key != new_sorting_key:
-        assert new_create_table_statement.count(curr_sorting_key) == 1
-        new_create_table_statement = new_create_table_statement.replace(
-            curr_sorting_key, new_sorting_key
-        )
-
-    # SAMPLE BY request_id is a UUID and is illegal on ClickHouse >= 21.9.
-    # Drop it while rebuilding so this migration can run on current ClickHouse.
-    # Remaining tables are cleaned up by 0008_drop_uuid_sample_by.
-    # See https://github.com/getsentry/snuba/issues/7216
-    if curr_sampling_key == "request_id":
-        new_create_table_statement = strip_sample_by_clause(new_create_table_statement)
-        assert "SAMPLE BY" not in new_create_table_statement.upper()
-
-    # Update the timestamp column
-    # Clickhouse 20 does not support altering a column in the primary key so we need to do it here
-    new_timestamp_type = "`timestamp` DateTime CODEC(T64, ZSTD(1))"
-    if new_create_table_statement.count(new_timestamp_type) == 0:
-        assert new_create_table_statement.count("`timestamp` DateTime") == 1
-        new_create_table_statement = new_create_table_statement.replace(
-            "`timestamp` DateTime", new_timestamp_type
-        )
-    assert new_timestamp_type in new_create_table_statement
-
-    # Create the new table
     clickhouse.execute(new_create_table_statement)
 
-    # Copy the data over
     [(row_count,)] = clickhouse.execute(f"SELECT count() FROM {TABLE_NAME}").results
     batch_size = 100000
     batch_count = math.ceil(row_count / batch_size)
@@ -67,9 +50,9 @@ def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
         insert_op = operations.InsertIntoSelect(
             storage_set=StorageSetKey.QUERYLOG,
             dest_table_name=TABLE_NAME_NEW,
-            dest_columns=["*"],  # All columns
+            dest_columns=["*"],
             src_table_name=TABLE_NAME,
-            src_columns=["*"],  # All columns
+            src_columns=["*"],
             order_by=orderby,
             limit=batch_size,
             offset=skip,
@@ -77,21 +60,21 @@ def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
         )
         clickhouse.execute(insert_op.format_sql())
 
-    # Ensure each table has the same number of rows before deleting the old one
     [(new_row_count,)] = clickhouse.execute(f"SELECT count() FROM {TABLE_NAME_NEW}").results
     assert row_count == new_row_count
 
     clickhouse.command(f"RENAME TABLE {TABLE_NAME} TO {TABLE_NAME_OLD};")
     clickhouse.command(f"RENAME TABLE {TABLE_NAME_NEW} TO {TABLE_NAME};")
     clickhouse.command(f"DROP TABLE {TABLE_NAME_OLD};")
-    return
 
 
 def forwards(logger: logging.Logger) -> None:
     """
-    This migration is a bit complicated because we need to change the sorting key.
-    We can't do it inplace so we need to create a new table with the modified keys,
-    copy the data over, then drop the old table.
+    Recreate querylog_local without SAMPLE BY request_id on every local node.
+
+    ClickHouse cannot ALTER SAMPLE BY, so this copies data into a new table.
+    Clusters whose querylog_local has no sampling key (or a non-UUID one) are
+    left unchanged.
     """
     cluster = get_cluster(StorageSetKey.QUERYLOG)
 
@@ -103,9 +86,8 @@ def forwards(logger: logging.Logger) -> None:
 
 def backwards(logger: logging.Logger) -> None:
     """
-    This method cleans up the temporary tables used by the forwards methods and
-    returns us to the original state if the forwards method has failed somewhere
-    in the middle. Otherwise it's a no-op.
+    Clean up temporary tables if forwards failed mid-way. Does not restore
+    SAMPLE BY request_id — that schema is illegal on current ClickHouse.
     """
     cluster = get_cluster(StorageSetKey.QUERYLOG)
 
@@ -136,18 +118,20 @@ def cleanup(clickhouse: ClickhousePool, logger: logging.Logger) -> None:
 
 class Migration(migration.CodeMigration):
     """
-    Change the sorting key to dataset, referrer, timestamp, request_id, to match SaaS.
-    This is a code migration because we can't change the sorting key in a single step.
+    Drop the illegal UUID SAMPLE BY request_id from querylog_local.
 
+    Fresh installs after 0001 no longer create this clause (#4842). Existing
+    clusters that still have it cannot dump or recreate the table on
+    ClickHouse >= 21.9 (https://github.com/getsentry/snuba/issues/7216).
     """
 
-    blocking = True  # This migration may take some time if there is data to migrate
+    blocking = True  # Recreating the table may take time if there is data to copy
 
     def forwards_global(self) -> Sequence[operations.RunPython]:
         return [
             operations.RunPython(
                 func=forwards,
-                description="Sync sample by and sorting key",
+                description="Drop UUID SAMPLE BY request_id from querylog_local",
             ),
         ]
 

--- a/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
+++ b/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
@@ -1,6 +1,5 @@
 from collections.abc import Sequence
 
-from snuba.clickhouse.pool import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
@@ -14,42 +13,6 @@ TABLE_NAME = "querylog_local"
 ILLEGAL_SAMPLE_BY = "request_id"
 
 
-def _local_connection() -> ClickhousePool | None:
-    cluster = get_cluster(StorageSetKey.QUERYLOG)
-    nodes = cluster.get_local_nodes()
-    if not nodes:
-        return None
-    return cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, nodes[0])
-
-
-def drop_sample_by_ops() -> Sequence[operations.SqlOperation]:
-    """Return REMOVE SAMPLE BY, or [] if the clause is already gone / table missing."""
-    clickhouse = _local_connection()
-    if clickhouse is None:
-        return []
-
-    database = get_cluster(StorageSetKey.QUERYLOG).get_database()
-    sampling_key_rows = clickhouse.execute(
-        f"SELECT sampling_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
-    ).results
-    if not sampling_key_rows:
-        return []
-    ((sampling_key,),) = sampling_key_rows
-    if sampling_key != ILLEGAL_SAMPLE_BY:
-        return []
-
-    return [RemoveSampleBy()]
-
-
-class RemoveSampleBy(operations.SqlOperation):
-    def __init__(self) -> None:
-        super().__init__(StorageSetKey.QUERYLOG, target=operations.OperationTarget.LOCAL)
-
-    def format_sql(self) -> str:
-        on_cluster = self._get_on_cluster_clause()
-        return f"ALTER TABLE {TABLE_NAME}{on_cluster} REMOVE SAMPLE BY;"
-
-
 class DropUuidSampleBy(operations.SqlOperation):
     """Inspects ClickHouse at execute time, then removes SAMPLE BY if it is illegal."""
 
@@ -57,11 +20,24 @@ class DropUuidSampleBy(operations.SqlOperation):
         super().__init__(StorageSetKey.QUERYLOG, target=operations.OperationTarget.LOCAL)
 
     def format_sql(self) -> str:
-        return "ALTER TABLE querylog_local REMOVE SAMPLE BY if sampling_key is request_id"
+        on_cluster = self._get_on_cluster_clause()
+        return f"ALTER TABLE {TABLE_NAME}{on_cluster} REMOVE SAMPLE BY;"
 
     def execute(self) -> None:
-        for op in drop_sample_by_ops():
-            op.execute()
+        cluster = get_cluster(StorageSetKey.QUERYLOG)
+        nodes = cluster.get_local_nodes()
+        if not nodes:
+            return
+
+        clickhouse = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, nodes[0])
+        sampling_key_rows = clickhouse.execute(
+            "SELECT sampling_key FROM system.tables "
+            f"WHERE name = '{TABLE_NAME}' AND database = '{cluster.get_database()}'"
+        ).results
+        if not sampling_key_rows or sampling_key_rows[0][0] != ILLEGAL_SAMPLE_BY:
+            return
+
+        super().execute()
 
 
 class Migration(migration.ClickhouseNodeMigration):

--- a/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
+++ b/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
@@ -1,8 +1,5 @@
-import logging
-import time
 from collections.abc import Sequence
 
-from snuba.clickhouse.pool import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
@@ -19,90 +16,79 @@ TABLE_NAME_OLD = "querylog_local_old"
 ILLEGAL_SAMPLE_BY = "request_id"
 
 
-def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
+def _forwards_ops() -> Sequence[operations.SqlOperation]:
+    cluster = get_cluster(StorageSetKey.QUERYLOG)
+    nodes = cluster.get_local_nodes()
+    if not nodes:
+        return []
+
+    clickhouse = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, nodes[0])
+    database = cluster.get_database()
     ((sampling_key,),) = clickhouse.execute(
         f"SELECT sampling_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     ).results
-
     if sampling_key != ILLEGAL_SAMPLE_BY:
-        return
+        return []
 
     ((create_table_statement,),) = clickhouse.execute(
         f"SHOW CREATE TABLE {database}.{TABLE_NAME}"
     ).results
-
     new_create_table_statement = strip_sample_by_clause(
         create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
     )
     assert "SAMPLE BY" not in new_create_table_statement.upper()
-    clickhouse.execute(new_create_table_statement)
 
-    [(row_count,)] = clickhouse.execute(f"SELECT count() FROM {TABLE_NAME}").results
-    batch_size = 100000
-    for offset in range(0, row_count, batch_size):
-        insert_op = operations.InsertIntoSelect(
+    return [
+        operations.RunSql(
+            StorageSetKey.QUERYLOG,
+            new_create_table_statement,
+            target=operations.OperationTarget.LOCAL,
+        ),
+        operations.InsertIntoSelect(
             storage_set=StorageSetKey.QUERYLOG,
             dest_table_name=TABLE_NAME_NEW,
             dest_columns=["*"],
             src_table_name=TABLE_NAME,
             src_columns=["*"],
-            order_by="toStartOfDay(timestamp), request_id",
-            limit=batch_size,
-            offset=offset,
             target=operations.OperationTarget.LOCAL,
-        )
-        clickhouse.execute(insert_op.format_sql())
-
-    [(new_row_count,)] = clickhouse.execute(f"SELECT count() FROM {TABLE_NAME_NEW}").results
-    assert row_count == new_row_count
-
-    clickhouse.command(f"RENAME TABLE {TABLE_NAME} TO {TABLE_NAME_OLD};")
-    clickhouse.command(f"RENAME TABLE {TABLE_NAME_NEW} TO {TABLE_NAME};")
-    clickhouse.command(f"DROP TABLE {TABLE_NAME_OLD};")
-
-
-def forwards(logger: logging.Logger) -> None:
-    cluster = get_cluster(StorageSetKey.QUERYLOG)
-
-    for node in cluster.get_local_nodes():
-        connection = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, node)
-        database = cluster.get_database()
-        update_querylog_table(connection, database)
-
-
-def backwards(logger: logging.Logger) -> None:
-    """
-    Clean up temporary tables if forwards failed mid-way. Does not restore
-    SAMPLE BY request_id — that schema is illegal on current ClickHouse.
-    """
-    cluster = get_cluster(StorageSetKey.QUERYLOG)
-
-    if not cluster.is_single_node():
-        return
-
-    clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
-    cleanup(clickhouse, logger)
+        ),
+        operations.RenameTable(
+            StorageSetKey.QUERYLOG,
+            TABLE_NAME,
+            TABLE_NAME_OLD,
+            target=operations.OperationTarget.LOCAL,
+        ),
+        operations.RenameTable(
+            StorageSetKey.QUERYLOG,
+            TABLE_NAME_NEW,
+            TABLE_NAME,
+            target=operations.OperationTarget.LOCAL,
+        ),
+        operations.DropTable(
+            StorageSetKey.QUERYLOG,
+            TABLE_NAME_OLD,
+            target=operations.OperationTarget.LOCAL,
+        ),
+    ]
 
 
-def cleanup(clickhouse: ClickhousePool, logger: logging.Logger) -> None:
-    def table_exists(table_name: str) -> bool:
-        return clickhouse.execute(f"EXISTS TABLE {table_name};").results == [(1,)]
-
-    if not table_exists(TABLE_NAME):
-        raise Exception(f"Table {TABLE_NAME} is missing")
-
-    if table_exists(TABLE_NAME_NEW):
-        logger.info(f"Dropping table {TABLE_NAME_NEW}")
-        time.sleep(1)
-        clickhouse.command(f"DROP TABLE {TABLE_NAME_NEW};")
-
-    if table_exists(TABLE_NAME_OLD):
-        logger.info(f"Dropping table {TABLE_NAME_OLD}")
-        time.sleep(1)
-        clickhouse.command(f"DROP TABLE {TABLE_NAME_OLD};")
+def _backwards_ops() -> Sequence[operations.SqlOperation]:
+    # Temporary tables only. SAMPLE BY request_id cannot be restored on current ClickHouse.
+    return [
+        operations.DropTable(
+            StorageSetKey.QUERYLOG,
+            TABLE_NAME_NEW,
+            target=operations.OperationTarget.LOCAL,
+        ),
+        operations.DropTable(
+            StorageSetKey.QUERYLOG,
+            TABLE_NAME_OLD,
+            target=operations.OperationTarget.LOCAL,
+        ),
+    ]
 
 
-class Migration(migration.CodeMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Drop the illegal UUID SAMPLE BY request_id from querylog_local.
 
@@ -113,13 +99,8 @@ class Migration(migration.CodeMigration):
 
     blocking = True  # Recreating the table may take time if there is data to copy
 
-    def forwards_global(self) -> Sequence[operations.RunPython]:
-        return [
-            operations.RunPython(
-                func=forwards,
-                description="Drop UUID SAMPLE BY request_id from querylog_local",
-            ),
-        ]
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return _forwards_ops()
 
-    def backwards_global(self) -> Sequence[operations.RunPython]:
-        return [operations.RunPython(func=backwards)]
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return _backwards_ops()

--- a/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
+++ b/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 
+from snuba.clickhouse.pool import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
@@ -16,14 +17,32 @@ TABLE_NAME_OLD = "querylog_local_old"
 ILLEGAL_SAMPLE_BY = "request_id"
 
 
-def _forwards_ops() -> Sequence[operations.SqlOperation]:
+def _local_connection() -> ClickhousePool | None:
     cluster = get_cluster(StorageSetKey.QUERYLOG)
     nodes = cluster.get_local_nodes()
     if not nodes:
+        return None
+    return cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, nodes[0])
+
+
+def _table_exists(clickhouse: ClickhousePool, table_name: str) -> bool:
+    return clickhouse.execute(f"EXISTS TABLE {table_name};").results == [(1,)]
+
+
+def _drop_local(table_name: str) -> operations.DropTable:
+    return operations.DropTable(
+        StorageSetKey.QUERYLOG,
+        table_name,
+        target=operations.OperationTarget.LOCAL,
+    )
+
+
+def _forwards_ops() -> Sequence[operations.SqlOperation]:
+    clickhouse = _local_connection()
+    if clickhouse is None:
         return []
 
-    clickhouse = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, nodes[0])
-    database = cluster.get_database()
+    database = get_cluster(StorageSetKey.QUERYLOG).get_database()
     ((sampling_key,),) = clickhouse.execute(
         f"SELECT sampling_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     ).results
@@ -73,19 +92,46 @@ def _forwards_ops() -> Sequence[operations.SqlOperation]:
 
 
 def _backwards_ops() -> Sequence[operations.SqlOperation]:
-    # Temporary tables only. SAMPLE BY request_id cannot be restored on current ClickHouse.
-    return [
-        operations.DropTable(
-            StorageSetKey.QUERYLOG,
-            TABLE_NAME_NEW,
-            target=operations.OperationTarget.LOCAL,
-        ),
-        operations.DropTable(
-            StorageSetKey.QUERYLOG,
-            TABLE_NAME_OLD,
-            target=operations.OperationTarget.LOCAL,
-        ),
-    ]
+    # Recovery only: restore querylog_local if the swap was interrupted, then drop temps.
+    # SAMPLE BY request_id cannot be restored on current ClickHouse.
+    clickhouse = _local_connection()
+    if clickhouse is None:
+        return []
+
+    has_local = _table_exists(clickhouse, TABLE_NAME)
+    has_new = _table_exists(clickhouse, TABLE_NAME_NEW)
+    has_old = _table_exists(clickhouse, TABLE_NAME_OLD)
+    ops: list[operations.SqlOperation] = []
+
+    if not has_local:
+        if has_old:
+            ops.append(
+                operations.RenameTable(
+                    StorageSetKey.QUERYLOG,
+                    TABLE_NAME_OLD,
+                    TABLE_NAME,
+                    target=operations.OperationTarget.LOCAL,
+                )
+            )
+            has_old = False
+        elif has_new:
+            ops.append(
+                operations.RenameTable(
+                    StorageSetKey.QUERYLOG,
+                    TABLE_NAME_NEW,
+                    TABLE_NAME,
+                    target=operations.OperationTarget.LOCAL,
+                )
+            )
+            has_new = False
+        else:
+            raise Exception(f"Table {TABLE_NAME} is missing")
+
+    if has_new:
+        ops.append(_drop_local(TABLE_NAME_NEW))
+    if has_old:
+        ops.append(_drop_local(TABLE_NAME_OLD))
+    return ops
 
 
 class Migration(migration.ClickhouseNodeMigration):

--- a/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
+++ b/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
@@ -4,11 +4,8 @@ from snuba.clickhouse.pool import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
-from snuba.migrations.migration_utilities import strip_sample_by_clause
 
 TABLE_NAME = "querylog_local"
-TABLE_NAME_NEW = "querylog_local_new"
-TABLE_NAME_OLD = "querylog_local_old"
 
 # Pre-ClickHouse 21.9 allowed SAMPLE BY on UUID columns. querylog_local used
 # SAMPLE BY request_id (a UUID). ClickHouse now rejects that type, so SHOW CREATE
@@ -25,162 +22,62 @@ def _local_connection() -> ClickhousePool | None:
     return cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, nodes[0])
 
 
-def _table_exists(clickhouse: ClickhousePool, table_name: str) -> bool:
-    return clickhouse.execute(f"EXISTS TABLE {table_name};").results == [(1,)]
-
-
-def _drop_local(table_name: str) -> operations.DropTable:
-    return operations.DropTable(
-        StorageSetKey.QUERYLOG,
-        table_name,
-        target=operations.OperationTarget.LOCAL,
-    )
-
-
-def rebuild_ops() -> Sequence[operations.SqlOperation]:
-    """Inspect querylog_local and return rebuild ops, or [] if SAMPLE BY is already valid."""
+def drop_sample_by_ops() -> Sequence[operations.SqlOperation]:
+    """Return REMOVE SAMPLE BY, or [] if the clause is already gone / table missing."""
     clickhouse = _local_connection()
     if clickhouse is None:
         return []
 
     database = get_cluster(StorageSetKey.QUERYLOG).get_database()
-    ((sampling_key,),) = clickhouse.execute(
+    sampling_key_rows = clickhouse.execute(
         f"SELECT sampling_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     ).results
+    if not sampling_key_rows:
+        return []
+    ((sampling_key,),) = sampling_key_rows
     if sampling_key != ILLEGAL_SAMPLE_BY:
         return []
 
-    ((create_table_statement,),) = clickhouse.execute(
-        f"SHOW CREATE TABLE {database}.{TABLE_NAME}"
-    ).results
-    new_create_table_statement = strip_sample_by_clause(
-        create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
-    )
-    assert "SAMPLE BY" not in new_create_table_statement.upper()
-
-    return [
-        operations.RunSql(
-            StorageSetKey.QUERYLOG,
-            new_create_table_statement,
-            target=operations.OperationTarget.LOCAL,
-        ),
-        operations.InsertIntoSelect(
-            storage_set=StorageSetKey.QUERYLOG,
-            dest_table_name=TABLE_NAME_NEW,
-            dest_columns=["*"],
-            src_table_name=TABLE_NAME,
-            src_columns=["*"],
-            target=operations.OperationTarget.LOCAL,
-        ),
-        operations.RenameTable(
-            StorageSetKey.QUERYLOG,
-            TABLE_NAME,
-            TABLE_NAME_OLD,
-            target=operations.OperationTarget.LOCAL,
-        ),
-        operations.RenameTable(
-            StorageSetKey.QUERYLOG,
-            TABLE_NAME_NEW,
-            TABLE_NAME,
-            target=operations.OperationTarget.LOCAL,
-        ),
-        operations.DropTable(
-            StorageSetKey.QUERYLOG,
-            TABLE_NAME_OLD,
-            target=operations.OperationTarget.LOCAL,
-        ),
-    ]
+    return [RemoveSampleBy()]
 
 
-def recover_ops() -> Sequence[operations.SqlOperation]:
-    """Restore querylog_local if the swap was interrupted, then drop leftover temps."""
-    clickhouse = _local_connection()
-    if clickhouse is None:
-        return []
-
-    has_local = _table_exists(clickhouse, TABLE_NAME)
-    has_new = _table_exists(clickhouse, TABLE_NAME_NEW)
-    has_old = _table_exists(clickhouse, TABLE_NAME_OLD)
-    ops: list[operations.SqlOperation] = []
-
-    if not has_local:
-        if has_old:
-            ops.append(
-                operations.RenameTable(
-                    StorageSetKey.QUERYLOG,
-                    TABLE_NAME_OLD,
-                    TABLE_NAME,
-                    target=operations.OperationTarget.LOCAL,
-                )
-            )
-            has_old = False
-        elif has_new:
-            ops.append(
-                operations.RenameTable(
-                    StorageSetKey.QUERYLOG,
-                    TABLE_NAME_NEW,
-                    TABLE_NAME,
-                    target=operations.OperationTarget.LOCAL,
-                )
-            )
-            has_new = False
-        else:
-            raise Exception(f"Table {TABLE_NAME} is missing")
-
-    if has_new:
-        ops.append(_drop_local(TABLE_NAME_NEW))
-    if has_old:
-        ops.append(_drop_local(TABLE_NAME_OLD))
-    return ops
-
-
-class _DeferredLocalOp(operations.SqlOperation):
-    """Inspects ClickHouse at execute time, then runs the returned SqlOperations."""
-
-    def __init__(self, description: str) -> None:
+class RemoveSampleBy(operations.SqlOperation):
+    def __init__(self) -> None:
         super().__init__(StorageSetKey.QUERYLOG, target=operations.OperationTarget.LOCAL)
-        self.__description = description
 
     def format_sql(self) -> str:
-        return self.__description
+        on_cluster = self._get_on_cluster_clause()
+        return f"ALTER TABLE {TABLE_NAME}{on_cluster} REMOVE SAMPLE BY;"
+
+
+class DropUuidSampleBy(operations.SqlOperation):
+    """Inspects ClickHouse at execute time, then removes SAMPLE BY if it is illegal."""
+
+    def __init__(self) -> None:
+        super().__init__(StorageSetKey.QUERYLOG, target=operations.OperationTarget.LOCAL)
+
+    def format_sql(self) -> str:
+        return "ALTER TABLE querylog_local REMOVE SAMPLE BY if sampling_key is request_id"
 
     def execute(self) -> None:
-        for op in self._ops():
+        for op in drop_sample_by_ops():
             op.execute()
-
-    def _ops(self) -> Sequence[operations.SqlOperation]:
-        raise NotImplementedError
-
-
-class DropUuidSampleBy(_DeferredLocalOp):
-    def __init__(self) -> None:
-        super().__init__("Rebuild querylog_local without SAMPLE BY request_id if present")
-
-    def _ops(self) -> Sequence[operations.SqlOperation]:
-        return rebuild_ops()
-
-
-class RecoverQuerylogLocal(_DeferredLocalOp):
-    def __init__(self) -> None:
-        super().__init__("Restore querylog_local from temp tables after a failed rebuild")
-
-    def _ops(self) -> Sequence[operations.SqlOperation]:
-        return recover_ops()
 
 
 class Migration(migration.ClickhouseNodeMigration):
     """
-    Drop the illegal UUID SAMPLE BY request_id from querylog_local.
+    Drop the illegal UUID SAMPLE BY request_id from querylog_local in place.
 
     Fresh installs after 0001 no longer create this clause (#4842). Existing
     clusters that still have it cannot dump or recreate the table on
     ClickHouse >= 21.9 (https://github.com/getsentry/snuba/issues/7216).
     """
 
-    blocking = True  # Recreating the table may take time if there is data to copy
+    blocking = False
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [DropUuidSampleBy()]
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
-        return [RecoverQuerylogLocal()]
+        # Do not restore the illegal SAMPLE BY clause.
+        return []

--- a/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
+++ b/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import time
 from collections.abc import Sequence
 
@@ -21,41 +20,35 @@ ILLEGAL_SAMPLE_BY = "request_id"
 
 
 def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
-    ((curr_sampling_key,),) = clickhouse.execute(
+    ((sampling_key,),) = clickhouse.execute(
         f"SELECT sampling_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     ).results
 
-    if curr_sampling_key != ILLEGAL_SAMPLE_BY:
+    if sampling_key != ILLEGAL_SAMPLE_BY:
         return
 
-    ((curr_create_table_statement,),) = clickhouse.execute(
+    ((create_table_statement,),) = clickhouse.execute(
         f"SHOW CREATE TABLE {database}.{TABLE_NAME}"
     ).results
 
     new_create_table_statement = strip_sample_by_clause(
-        curr_create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
+        create_table_statement.replace(TABLE_NAME, TABLE_NAME_NEW)
     )
     assert "SAMPLE BY" not in new_create_table_statement.upper()
-
     clickhouse.execute(new_create_table_statement)
 
     [(row_count,)] = clickhouse.execute(f"SELECT count() FROM {TABLE_NAME}").results
     batch_size = 100000
-    batch_count = math.ceil(row_count / batch_size)
-
-    orderby = "toStartOfDay(timestamp), request_id"
-
-    for i in range(batch_count):
-        skip = batch_size * i
+    for offset in range(0, row_count, batch_size):
         insert_op = operations.InsertIntoSelect(
             storage_set=StorageSetKey.QUERYLOG,
             dest_table_name=TABLE_NAME_NEW,
             dest_columns=["*"],
             src_table_name=TABLE_NAME,
             src_columns=["*"],
-            order_by=orderby,
+            order_by="toStartOfDay(timestamp), request_id",
             limit=batch_size,
-            offset=skip,
+            offset=offset,
             target=operations.OperationTarget.LOCAL,
         )
         clickhouse.execute(insert_op.format_sql())
@@ -69,13 +62,6 @@ def update_querylog_table(clickhouse: ClickhousePool, database: str) -> None:
 
 
 def forwards(logger: logging.Logger) -> None:
-    """
-    Recreate querylog_local without SAMPLE BY request_id on every local node.
-
-    ClickHouse cannot ALTER SAMPLE BY, so this copies data into a new table.
-    Clusters whose querylog_local has no sampling key (or a non-UUID one) are
-    left unchanged.
-    """
     cluster = get_cluster(StorageSetKey.QUERYLOG)
 
     for node in cluster.get_local_nodes():

--- a/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
+++ b/snuba/snuba_migrations/querylog/0008_drop_uuid_sample_by.py
@@ -37,7 +37,8 @@ def _drop_local(table_name: str) -> operations.DropTable:
     )
 
 
-def _forwards_ops() -> Sequence[operations.SqlOperation]:
+def rebuild_ops() -> Sequence[operations.SqlOperation]:
+    """Inspect querylog_local and return rebuild ops, or [] if SAMPLE BY is already valid."""
     clickhouse = _local_connection()
     if clickhouse is None:
         return []
@@ -91,9 +92,8 @@ def _forwards_ops() -> Sequence[operations.SqlOperation]:
     ]
 
 
-def _backwards_ops() -> Sequence[operations.SqlOperation]:
-    # Recovery only: restore querylog_local if the swap was interrupted, then drop temps.
-    # SAMPLE BY request_id cannot be restored on current ClickHouse.
+def recover_ops() -> Sequence[operations.SqlOperation]:
+    """Restore querylog_local if the swap was interrupted, then drop leftover temps."""
     clickhouse = _local_connection()
     if clickhouse is None:
         return []
@@ -134,6 +134,40 @@ def _backwards_ops() -> Sequence[operations.SqlOperation]:
     return ops
 
 
+class _DeferredLocalOp(operations.SqlOperation):
+    """Inspects ClickHouse at execute time, then runs the returned SqlOperations."""
+
+    def __init__(self, description: str) -> None:
+        super().__init__(StorageSetKey.QUERYLOG, target=operations.OperationTarget.LOCAL)
+        self.__description = description
+
+    def format_sql(self) -> str:
+        return self.__description
+
+    def execute(self) -> None:
+        for op in self._ops():
+            op.execute()
+
+    def _ops(self) -> Sequence[operations.SqlOperation]:
+        raise NotImplementedError
+
+
+class DropUuidSampleBy(_DeferredLocalOp):
+    def __init__(self) -> None:
+        super().__init__("Rebuild querylog_local without SAMPLE BY request_id if present")
+
+    def _ops(self) -> Sequence[operations.SqlOperation]:
+        return rebuild_ops()
+
+
+class RecoverQuerylogLocal(_DeferredLocalOp):
+    def __init__(self) -> None:
+        super().__init__("Restore querylog_local from temp tables after a failed rebuild")
+
+    def _ops(self) -> Sequence[operations.SqlOperation]:
+        return recover_ops()
+
+
 class Migration(migration.ClickhouseNodeMigration):
     """
     Drop the illegal UUID SAMPLE BY request_id from querylog_local.
@@ -146,7 +180,7 @@ class Migration(migration.ClickhouseNodeMigration):
     blocking = True  # Recreating the table may take time if there is data to copy
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:
-        return _forwards_ops()
+        return [DropUuidSampleBy()]
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
-        return _backwards_ops()
+        return [RecoverQuerylogLocal()]

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -16,7 +16,8 @@ from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 
 querylog_0008 = importlib.import_module("snuba.snuba_migrations.querylog.0008_drop_uuid_sample_by")
-forwards_ops = querylog_0008._forwards_ops
+rebuild_ops = querylog_0008.rebuild_ops
+recover_ops = querylog_0008.recover_ops
 
 SHOW_CREATE_MULTILINE = """CREATE TABLE default.querylog_local
 (
@@ -116,17 +117,17 @@ def _ops_for(sampling_key: str, create_sql: str) -> list[Any]:
     )
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
-        return list(forwards_ops())
+        return list(rebuild_ops())
 
 
-def _backwards_ops_for(existing_tables: set[str]) -> list[Any]:
+def _recover_ops_for(existing_tables: set[str]) -> list[Any]:
     mock_cluster = Mock()
     mock_cluster.get_local_nodes.return_value = [Mock()]
     mock_cluster.get_database.return_value = "default"
     mock_cluster.get_node_connection.return_value = _FakePool(existing_tables=existing_tables)
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
-        return list(querylog_0008._backwards_ops())
+        return list(recover_ops())
 
 
 @pytest.mark.parametrize("sampling_key", ["", "cityHash64(request_id)"])
@@ -154,21 +155,21 @@ def test_forwards_ops_rebuilds_when_sample_by_is_request_id() -> None:
     assert "DROP TABLE IF EXISTS querylog_local_old" in ops[4].format_sql()
 
 
-def test_backwards_ops_restores_old_table_when_local_missing() -> None:
-    ops = _backwards_ops_for({"querylog_local_old", "querylog_local_new"})
+def test_recover_ops_restores_old_table_when_local_missing() -> None:
+    ops = _recover_ops_for({"querylog_local_old", "querylog_local_new"})
     assert [type(op) for op in ops] == [RenameTable, DropTable]
     assert ops[0].format_sql().startswith("RENAME TABLE querylog_local_old TO querylog_local")
     assert "DROP TABLE IF EXISTS querylog_local_new" in ops[1].format_sql()
 
 
-def test_backwards_ops_does_not_drop_old_when_it_is_the_only_copy() -> None:
-    ops = _backwards_ops_for({"querylog_local_old"})
+def test_recover_ops_does_not_drop_old_when_it_is_the_only_copy() -> None:
+    ops = _recover_ops_for({"querylog_local_old"})
     assert [type(op) for op in ops] == [RenameTable]
     assert ops[0].format_sql().startswith("RENAME TABLE querylog_local_old TO querylog_local")
 
 
-def test_backwards_ops_drops_temps_when_local_exists() -> None:
-    ops = _backwards_ops_for({"querylog_local", "querylog_local_new", "querylog_local_old"})
+def test_recover_ops_drops_temps_when_local_exists() -> None:
+    ops = _recover_ops_for({"querylog_local", "querylog_local_new", "querylog_local_old"})
     assert [type(op) for op in ops] == [DropTable, DropTable]
     assert "DROP TABLE IF EXISTS querylog_local_new" in ops[0].format_sql()
     assert "DROP TABLE IF EXISTS querylog_local_old" in ops[1].format_sql()

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -10,14 +10,17 @@ from snuba.clickhouse.pool import ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.groups import MigrationGroup, get_group_loader
-from snuba.migrations.migration_utilities import strip_sample_by_clause
-from snuba.migrations.operations import DropTable, InsertIntoSelect, RenameTable, RunSql
+from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.migration_utilities import (
+    replace_create_table_name,
+    strip_sample_by_clause,
+)
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 
 querylog_0008 = importlib.import_module("snuba.snuba_migrations.querylog.0008_drop_uuid_sample_by")
-rebuild_ops = querylog_0008.rebuild_ops
-recover_ops = querylog_0008.recover_ops
+drop_sample_by_ops = querylog_0008.drop_sample_by_ops
+RemoveSampleBy = querylog_0008.RemoveSampleBy
 
 SHOW_CREATE_MULTILINE = """CREATE TABLE default.querylog_local
 (
@@ -85,101 +88,78 @@ def test_strip_sample_by_function_expression() -> None:
     assert "TTL ts + INTERVAL 1 DAY" in stripped
 
 
+def test_replace_create_table_name_preserves_replicated_zk_path() -> None:
+    renamed = replace_create_table_name(
+        SHOW_CREATE_REPLICATED, "querylog_local", "querylog_local_new"
+    )
+    assert "CREATE TABLE default.querylog_local_new" in renamed
+    assert (
+        "ReplicatedMergeTree('/clickhouse/tables/querylog/{shard}/default/querylog_local'"
+        in renamed
+    )
+    assert "querylog_local_new'" not in renamed
+
+
+def test_replace_create_table_name_rejects_missing_table() -> None:
+    with pytest.raises(ValueError, match="Could not rename"):
+        replace_create_table_name(SHOW_CREATE_NO_SAMPLE, "missing_table", "other")
+
+
 class _FakePool:
     def __init__(
         self,
         *,
         sampling_key: str = "",
-        create_sql: str = "",
-        existing_tables: set[str] | None = None,
+        missing_table: bool = False,
     ) -> None:
         self.sampling_key = sampling_key
-        self.create_sql = create_sql
-        self.existing_tables = existing_tables or set()
+        self.missing_table = missing_table
 
     def execute(self, query: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
         if query.startswith("SELECT sampling_key"):
+            if self.missing_table:
+                return ClickhouseResult(results=[])
             return ClickhouseResult(results=[(self.sampling_key,)])
-        if query.startswith("SHOW CREATE TABLE"):
-            return ClickhouseResult(results=[(self.create_sql,)])
-        if query.startswith("EXISTS TABLE"):
-            table_name = query.split()[-1].rstrip(";")
-            return ClickhouseResult(results=[(1 if table_name in self.existing_tables else 0,)])
         return ClickhouseResult(results=[])
 
 
-def _ops_for(sampling_key: str, create_sql: str) -> list[Any]:
+def _ops_for(sampling_key: str, *, missing_table: bool = False) -> list[Any]:
     mock_cluster = Mock()
     mock_cluster.get_local_nodes.return_value = [Mock()]
     mock_cluster.get_database.return_value = "default"
     mock_cluster.get_node_connection.return_value = _FakePool(
-        sampling_key=sampling_key, create_sql=create_sql
+        sampling_key=sampling_key, missing_table=missing_table
     )
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
-        return list(rebuild_ops())
-
-
-def _recover_ops_for(existing_tables: set[str]) -> list[Any]:
-    mock_cluster = Mock()
-    mock_cluster.get_local_nodes.return_value = [Mock()]
-    mock_cluster.get_database.return_value = "default"
-    mock_cluster.get_node_connection.return_value = _FakePool(existing_tables=existing_tables)
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
-        return list(recover_ops())
+        return list(drop_sample_by_ops())
 
 
 @pytest.mark.parametrize("sampling_key", ["", "cityHash64(request_id)"])
 def test_forwards_ops_noop(sampling_key: str) -> None:
-    assert _ops_for(sampling_key, SHOW_CREATE_NO_SAMPLE) == []
+    assert _ops_for(sampling_key) == []
 
 
-def test_forwards_ops_rebuilds_when_sample_by_is_request_id() -> None:
-    ops = _ops_for("request_id", SHOW_CREATE_MULTILINE)
-    assert [type(op) for op in ops] == [
-        RunSql,
-        InsertIntoSelect,
-        RenameTable,
-        RenameTable,
-        DropTable,
-    ]
-
-    create_sql = ops[0].format_sql()
-    assert "SAMPLE BY" not in create_sql.upper()
-    assert "querylog_local_new" in create_sql
-
-    assert "INSERT INTO querylog_local_new" in ops[1].format_sql()
-    assert ops[2].format_sql().startswith("RENAME TABLE querylog_local TO querylog_local_old")
-    assert ops[3].format_sql().startswith("RENAME TABLE querylog_local_new TO querylog_local")
-    assert "DROP TABLE IF EXISTS querylog_local_old" in ops[4].format_sql()
+def test_forwards_ops_noop_when_table_missing() -> None:
+    assert _ops_for("", missing_table=True) == []
 
 
-def test_recover_ops_restores_old_table_when_local_missing() -> None:
-    ops = _recover_ops_for({"querylog_local_old", "querylog_local_new"})
-    assert [type(op) for op in ops] == [RenameTable, DropTable]
-    assert ops[0].format_sql().startswith("RENAME TABLE querylog_local_old TO querylog_local")
-    assert "DROP TABLE IF EXISTS querylog_local_new" in ops[1].format_sql()
-
-
-def test_recover_ops_does_not_drop_old_when_it_is_the_only_copy() -> None:
-    ops = _recover_ops_for({"querylog_local_old"})
-    assert [type(op) for op in ops] == [RenameTable]
-    assert ops[0].format_sql().startswith("RENAME TABLE querylog_local_old TO querylog_local")
-
-
-def test_recover_ops_drops_temps_when_local_exists() -> None:
-    ops = _recover_ops_for({"querylog_local", "querylog_local_new", "querylog_local_old"})
-    assert [type(op) for op in ops] == [DropTable, DropTable]
-    assert "DROP TABLE IF EXISTS querylog_local_new" in ops[0].format_sql()
-    assert "DROP TABLE IF EXISTS querylog_local_old" in ops[1].format_sql()
+def test_forwards_ops_removes_sample_by_in_place() -> None:
+    ops = _ops_for("request_id")
+    assert [type(op) for op in ops] == [RemoveSampleBy]
+    sql = ops[0].format_sql()
+    assert sql.startswith("ALTER TABLE querylog_local")
+    assert "REMOVE SAMPLE BY" in sql
+    assert "querylog_local_new" not in sql
 
 
 def test_migration_is_registered() -> None:
     migrations = get_group_loader(MigrationGroup.QUERYLOG).get_migrations()
     assert "0008_drop_uuid_sample_by" in migrations
     loaded = get_group_loader(MigrationGroup.QUERYLOG).load_migration("0008_drop_uuid_sample_by")
-    assert loaded.blocking is True
+    assert isinstance(loaded, ClickhouseNodeMigration)
+    assert loaded.blocking is False
+    assert loaded.backwards_ops() == []
 
 
 @pytest.mark.custom_clickhouse_db

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -15,6 +15,7 @@ from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 
 querylog_0008 = importlib.import_module("snuba.snuba_migrations.querylog.0008_drop_uuid_sample_by")
+update_querylog_table = querylog_0008.update_querylog_table
 
 SHOW_CREATE_MULTILINE = """CREATE TABLE default.querylog_local
 (
@@ -57,19 +58,14 @@ SETTINGS index_granularity = 8192"""
 
 
 @pytest.mark.parametrize(
-    "original, unexpected_fragment",
-    [
-        pytest.param(SHOW_CREATE_MULTILINE, "SAMPLE BY request_id", id="multiline"),
-        pytest.param(SHOW_CREATE_INLINE, "SAMPLE BY request_id", id="inline"),
-        pytest.param(SHOW_CREATE_REPLICATED, "SAMPLE BY request_id", id="replicated"),
-    ],
+    "create_sql",
+    [SHOW_CREATE_MULTILINE, SHOW_CREATE_INLINE, SHOW_CREATE_REPLICATED],
+    ids=["multiline", "inline", "replicated"],
 )
-def test_strip_sample_by_clause(original: str, unexpected_fragment: str) -> None:
-    stripped = strip_sample_by_clause(original)
+def test_strip_sample_by_clause(create_sql: str) -> None:
+    stripped = strip_sample_by_clause(create_sql)
     assert "SAMPLE BY" not in stripped.upper()
-    assert unexpected_fragment not in stripped
     assert "ORDER BY" in stripped
-    assert "querylog_local" in stripped
 
 
 def test_strip_sample_by_preserves_statement_without_clause() -> None:
@@ -116,22 +112,22 @@ class _FakePool:
         return ClickhouseResult(results=[])
 
 
-def test_update_querylog_table_noop_without_sample_by() -> None:
-    pool = _FakePool(sampling_key="", create_sql=SHOW_CREATE_NO_SAMPLE)
-    querylog_0008.update_querylog_table(pool, "default")
+@pytest.mark.parametrize("sampling_key", ["", "cityHash64(request_id)"])
+def test_update_querylog_table_noop(sampling_key: str) -> None:
+    pool = _FakePool(sampling_key=sampling_key, create_sql=SHOW_CREATE_NO_SAMPLE)
+    update_querylog_table(pool, "default")
     assert pool.commands == []
     assert all(not q.startswith("SHOW CREATE") for q in pool.executed)
 
 
 def test_update_querylog_table_rebuilds_when_sample_by_is_request_id() -> None:
     pool = _FakePool(sampling_key="request_id", create_sql=SHOW_CREATE_MULTILINE, row_count=0)
-    querylog_0008.update_querylog_table(pool, "default")
+    update_querylog_table(pool, "default")
 
     create_statements = [q for q in pool.executed if q.startswith("CREATE TABLE")]
     assert len(create_statements) == 1
     assert "SAMPLE BY" not in create_statements[0].upper()
     assert "querylog_local_new" in create_statements[0]
-    assert "querylog_local," not in create_statements[0].split("\n")[0]
     assert pool.commands == [
         "RENAME TABLE querylog_local TO querylog_local_old;",
         "RENAME TABLE querylog_local_new TO querylog_local;",
@@ -141,19 +137,12 @@ def test_update_querylog_table_rebuilds_when_sample_by_is_request_id() -> None:
 
 def test_update_querylog_table_copies_rows() -> None:
     pool = _FakePool(sampling_key="request_id", create_sql=SHOW_CREATE_INLINE, row_count=1)
-    querylog_0008.update_querylog_table(pool, "default")
+    update_querylog_table(pool, "default")
 
     inserts = [q for q in pool.executed if q.startswith("INSERT INTO")]
     assert len(inserts) == 1
     assert "querylog_local_new" in inserts[0]
     assert "FROM querylog_local" in inserts[0]
-
-
-def test_update_querylog_table_ignores_other_sampling_keys() -> None:
-    pool = _FakePool(sampling_key="cityHash64(request_id)", create_sql=SHOW_CREATE_NO_SAMPLE)
-    querylog_0008.update_querylog_table(pool, "default")
-    assert pool.commands == []
-    assert all(not q.startswith("SHOW CREATE") for q in pool.executed)
 
 
 def test_migration_is_registered() -> None:

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -11,10 +11,7 @@ from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.groups import MigrationGroup, get_group_loader
 from snuba.migrations.migration import ClickhouseNodeMigration
-from snuba.migrations.migration_utilities import (
-    replace_create_table_name,
-    strip_sample_by_clause,
-)
+from snuba.migrations.migration_utilities import strip_sample_by_clause
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 
@@ -86,23 +83,6 @@ def test_strip_sample_by_function_expression() -> None:
     assert "SAMPLE BY" not in stripped.upper()
     assert "ORDER BY cityHash64(id)" in stripped
     assert "TTL ts + INTERVAL 1 DAY" in stripped
-
-
-def test_replace_create_table_name_preserves_replicated_zk_path() -> None:
-    renamed = replace_create_table_name(
-        SHOW_CREATE_REPLICATED, "querylog_local", "querylog_local_new"
-    )
-    assert "CREATE TABLE default.querylog_local_new" in renamed
-    assert (
-        "ReplicatedMergeTree('/clickhouse/tables/querylog/{shard}/default/querylog_local'"
-        in renamed
-    )
-    assert "querylog_local_new'" not in renamed
-
-
-def test_replace_create_table_name_rejects_missing_table() -> None:
-    with pytest.raises(ValueError, match="Could not rename"):
-        replace_create_table_name(SHOW_CREATE_NO_SAMPLE, "missing_table", "other")
 
 
 class _FakePool:

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -85,15 +85,25 @@ def test_strip_sample_by_function_expression() -> None:
 
 
 class _FakePool:
-    def __init__(self, *, sampling_key: str, create_sql: str) -> None:
+    def __init__(
+        self,
+        *,
+        sampling_key: str = "",
+        create_sql: str = "",
+        existing_tables: set[str] | None = None,
+    ) -> None:
         self.sampling_key = sampling_key
         self.create_sql = create_sql
+        self.existing_tables = existing_tables or set()
 
     def execute(self, query: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
         if query.startswith("SELECT sampling_key"):
             return ClickhouseResult(results=[(self.sampling_key,)])
         if query.startswith("SHOW CREATE TABLE"):
             return ClickhouseResult(results=[(self.create_sql,)])
+        if query.startswith("EXISTS TABLE"):
+            table_name = query.split()[-1].rstrip(";")
+            return ClickhouseResult(results=[(1 if table_name in self.existing_tables else 0,)])
         return ClickhouseResult(results=[])
 
 
@@ -107,6 +117,16 @@ def _ops_for(sampling_key: str, create_sql: str) -> list[Any]:
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
         return list(forwards_ops())
+
+
+def _backwards_ops_for(existing_tables: set[str]) -> list[Any]:
+    mock_cluster = Mock()
+    mock_cluster.get_local_nodes.return_value = [Mock()]
+    mock_cluster.get_database.return_value = "default"
+    mock_cluster.get_node_connection.return_value = _FakePool(existing_tables=existing_tables)
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
+        return list(querylog_0008._backwards_ops())
 
 
 @pytest.mark.parametrize("sampling_key", ["", "cityHash64(request_id)"])
@@ -132,6 +152,26 @@ def test_forwards_ops_rebuilds_when_sample_by_is_request_id() -> None:
     assert ops[2].format_sql().startswith("RENAME TABLE querylog_local TO querylog_local_old")
     assert ops[3].format_sql().startswith("RENAME TABLE querylog_local_new TO querylog_local")
     assert "DROP TABLE IF EXISTS querylog_local_old" in ops[4].format_sql()
+
+
+def test_backwards_ops_restores_old_table_when_local_missing() -> None:
+    ops = _backwards_ops_for({"querylog_local_old", "querylog_local_new"})
+    assert [type(op) for op in ops] == [RenameTable, DropTable]
+    assert ops[0].format_sql().startswith("RENAME TABLE querylog_local_old TO querylog_local")
+    assert "DROP TABLE IF EXISTS querylog_local_new" in ops[1].format_sql()
+
+
+def test_backwards_ops_does_not_drop_old_when_it_is_the_only_copy() -> None:
+    ops = _backwards_ops_for({"querylog_local_old"})
+    assert [type(op) for op in ops] == [RenameTable]
+    assert ops[0].format_sql().startswith("RENAME TABLE querylog_local_old TO querylog_local")
+
+
+def test_backwards_ops_drops_temps_when_local_exists() -> None:
+    ops = _backwards_ops_for({"querylog_local", "querylog_local_new", "querylog_local_old"})
+    assert [type(op) for op in ops] == [DropTable, DropTable]
+    assert "DROP TABLE IF EXISTS querylog_local_new" in ops[0].format_sql()
+    assert "DROP TABLE IF EXISTS querylog_local_old" in ops[1].format_sql()
 
 
 def test_migration_is_registered() -> None:

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -9,6 +9,7 @@ import pytest
 from snuba.clickhouse.pool import ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import operations as migration_operations
 from snuba.migrations.groups import MigrationGroup, get_group_loader
 from snuba.migrations.migration import ClickhouseNodeMigration
 from snuba.migrations.migration_utilities import strip_sample_by_clause
@@ -16,8 +17,7 @@ from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 
 querylog_0008 = importlib.import_module("snuba.snuba_migrations.querylog.0008_drop_uuid_sample_by")
-drop_sample_by_ops = querylog_0008.drop_sample_by_ops
-RemoveSampleBy = querylog_0008.RemoveSampleBy
+DropUuidSampleBy = querylog_0008.DropUuidSampleBy
 
 SHOW_CREATE_MULTILINE = """CREATE TABLE default.querylog_local
 (
@@ -94,6 +94,7 @@ class _FakePool:
     ) -> None:
         self.sampling_key = sampling_key
         self.missing_table = missing_table
+        self.commands: list[str] = []
 
     def execute(self, query: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
         if query.startswith("SELECT sampling_key"):
@@ -102,35 +103,40 @@ class _FakePool:
             return ClickhouseResult(results=[(self.sampling_key,)])
         return ClickhouseResult(results=[])
 
+    def command(self, sql: str, *args: Any, **kwargs: Any) -> None:
+        self.commands.append(sql)
 
-def _ops_for(sampling_key: str, *, missing_table: bool = False) -> list[Any]:
+
+def _execute(sampling_key: str, *, missing_table: bool = False) -> _FakePool:
+    pool = _FakePool(sampling_key=sampling_key, missing_table=missing_table)
+    node = Mock()
     mock_cluster = Mock()
-    mock_cluster.get_local_nodes.return_value = [Mock()]
+    mock_cluster.get_local_nodes.return_value = [node]
     mock_cluster.get_database.return_value = "default"
-    mock_cluster.get_node_connection.return_value = _FakePool(
-        sampling_key=sampling_key, missing_table=missing_table
-    )
+    mock_cluster.is_single_node.return_value = True
+    mock_cluster.get_node_connection.return_value = pool
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
-        return list(drop_sample_by_ops())
+        mp.setattr(migration_operations, "get_cluster", lambda storage_set: mock_cluster)
+        DropUuidSampleBy().execute()
+    return pool
 
 
 @pytest.mark.parametrize("sampling_key", ["", "cityHash64(request_id)"])
 def test_forwards_ops_noop(sampling_key: str) -> None:
-    assert _ops_for(sampling_key) == []
+    assert _execute(sampling_key).commands == []
 
 
 def test_forwards_ops_noop_when_table_missing() -> None:
-    assert _ops_for("", missing_table=True) == []
+    assert _execute("", missing_table=True).commands == []
 
 
 def test_forwards_ops_removes_sample_by_in_place() -> None:
-    ops = _ops_for("request_id")
-    assert [type(op) for op in ops] == [RemoveSampleBy]
-    sql = ops[0].format_sql()
+    pool = _execute("request_id")
+    assert len(pool.commands) == 1
+    sql = pool.commands[0]
     assert sql.startswith("ALTER TABLE querylog_local")
     assert "REMOVE SAMPLE BY" in sql
-    assert "querylog_local_new" not in sql
 
 
 def test_migration_is_registered() -> None:

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from snuba.clickhouse.pool import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.groups import MigrationGroup, get_group_loader
+from snuba.migrations.migration_utilities import strip_sample_by_clause
+from snuba.migrations.runner import MigrationKey, Runner
+from snuba.migrations.status import Status
+
+querylog_0008 = importlib.import_module("snuba.snuba_migrations.querylog.0008_drop_uuid_sample_by")
+
+SHOW_CREATE_MULTILINE = """CREATE TABLE default.querylog_local
+(
+    `request_id` UUID CODEC(NONE),
+    `request_body` String CODEC(LZ4HC(0)),
+    `referrer` LowCardinality(String),
+    `dataset` LowCardinality(String),
+    `timestamp` DateTime CODEC(T64, ZSTD(1))
+)
+ENGINE = MergeTree
+PARTITION BY toMonday(timestamp)
+ORDER BY (dataset, referrer, toStartOfDay(timestamp), request_id)
+SAMPLE BY request_id
+TTL timestamp + toIntervalDay(30)
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 10000000, ttl_only_drop_parts = 1"""
+
+SHOW_CREATE_INLINE = (
+    "CREATE TABLE default.querylog_local (`request_id` UUID, `timestamp` DateTime) "
+    "ENGINE = MergeTree() ORDER BY (toStartOfDay(timestamp), request_id) "
+    "PARTITION BY toMonday(timestamp) SAMPLE BY request_id "
+    "SETTINGS index_granularity = 8192"
+)
+
+SHOW_CREATE_REPLICATED = """CREATE TABLE default.querylog_local
+(
+    `request_id` UUID
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/querylog/{shard}/default/querylog_local', '{replica}')
+ORDER BY (toStartOfDay(timestamp), request_id)
+SAMPLE BY request_id
+SETTINGS index_granularity = 8192"""
+
+SHOW_CREATE_NO_SAMPLE = """CREATE TABLE default.querylog_local
+(
+    `request_id` UUID
+)
+ENGINE = MergeTree
+ORDER BY (toStartOfDay(timestamp), request_id)
+SETTINGS index_granularity = 8192"""
+
+
+@pytest.mark.parametrize(
+    "original, unexpected_fragment",
+    [
+        pytest.param(SHOW_CREATE_MULTILINE, "SAMPLE BY request_id", id="multiline"),
+        pytest.param(SHOW_CREATE_INLINE, "SAMPLE BY request_id", id="inline"),
+        pytest.param(SHOW_CREATE_REPLICATED, "SAMPLE BY request_id", id="replicated"),
+    ],
+)
+def test_strip_sample_by_clause(original: str, unexpected_fragment: str) -> None:
+    stripped = strip_sample_by_clause(original)
+    assert "SAMPLE BY" not in stripped.upper()
+    assert unexpected_fragment not in stripped
+    assert "ORDER BY" in stripped
+    assert "querylog_local" in stripped
+
+
+def test_strip_sample_by_preserves_statement_without_clause() -> None:
+    assert strip_sample_by_clause(SHOW_CREATE_NO_SAMPLE) == SHOW_CREATE_NO_SAMPLE
+
+
+def test_strip_sample_by_function_expression() -> None:
+    statement = (
+        "CREATE TABLE t (id UUID) ENGINE = MergeTree "
+        "ORDER BY cityHash64(id) SAMPLE BY cityHash64(id) TTL ts + INTERVAL 1 DAY"
+    )
+    stripped = strip_sample_by_clause(statement)
+    assert "SAMPLE BY" not in stripped.upper()
+    assert "ORDER BY cityHash64(id)" in stripped
+    assert "TTL ts + INTERVAL 1 DAY" in stripped
+
+
+class _FakePool:
+    def __init__(
+        self,
+        *,
+        sampling_key: str,
+        create_sql: str,
+        row_count: int = 0,
+    ) -> None:
+        self.sampling_key = sampling_key
+        self.create_sql = create_sql
+        self.row_count = row_count
+        self.executed: list[str] = []
+        self.commands: list[str] = []
+
+    def execute(self, query: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
+        self.executed.append(query)
+        if query.startswith("SELECT sampling_key"):
+            return ClickhouseResult(results=[(self.sampling_key,)])
+        if query.startswith("SHOW CREATE TABLE"):
+            return ClickhouseResult(results=[(self.create_sql,)])
+        if query.startswith("SELECT count()"):
+            return ClickhouseResult(results=[(self.row_count,)])
+        return ClickhouseResult(results=[])
+
+    def command(self, statement: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
+        self.commands.append(statement)
+        return ClickhouseResult(results=[])
+
+
+def test_update_querylog_table_noop_without_sample_by() -> None:
+    pool = _FakePool(sampling_key="", create_sql=SHOW_CREATE_NO_SAMPLE)
+    querylog_0008.update_querylog_table(pool, "default")
+    assert pool.commands == []
+    assert all(not q.startswith("SHOW CREATE") for q in pool.executed)
+
+
+def test_update_querylog_table_rebuilds_when_sample_by_is_request_id() -> None:
+    pool = _FakePool(sampling_key="request_id", create_sql=SHOW_CREATE_MULTILINE, row_count=0)
+    querylog_0008.update_querylog_table(pool, "default")
+
+    create_statements = [q for q in pool.executed if q.startswith("CREATE TABLE")]
+    assert len(create_statements) == 1
+    assert "SAMPLE BY" not in create_statements[0].upper()
+    assert "querylog_local_new" in create_statements[0]
+    assert "querylog_local," not in create_statements[0].split("\n")[0]
+    assert pool.commands == [
+        "RENAME TABLE querylog_local TO querylog_local_old;",
+        "RENAME TABLE querylog_local_new TO querylog_local;",
+        "DROP TABLE querylog_local_old;",
+    ]
+
+
+def test_update_querylog_table_copies_rows() -> None:
+    pool = _FakePool(sampling_key="request_id", create_sql=SHOW_CREATE_INLINE, row_count=1)
+    querylog_0008.update_querylog_table(pool, "default")
+
+    inserts = [q for q in pool.executed if q.startswith("INSERT INTO")]
+    assert len(inserts) == 1
+    assert "querylog_local_new" in inserts[0]
+    assert "FROM querylog_local" in inserts[0]
+
+
+def test_update_querylog_table_ignores_other_sampling_keys() -> None:
+    pool = _FakePool(sampling_key="cityHash64(request_id)", create_sql=SHOW_CREATE_NO_SAMPLE)
+    querylog_0008.update_querylog_table(pool, "default")
+    assert pool.commands == []
+    assert all(not q.startswith("SHOW CREATE") for q in pool.executed)
+
+
+def test_migration_is_registered() -> None:
+    migrations = get_group_loader(MigrationGroup.QUERYLOG).get_migrations()
+    assert "0008_drop_uuid_sample_by" in migrations
+    loaded = get_group_loader(MigrationGroup.QUERYLOG).load_migration("0008_drop_uuid_sample_by")
+    assert loaded.blocking is True
+
+
+def test_forwards_visits_local_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    updated: list[str] = []
+
+    def fake_update(clickhouse: Any, database: str) -> None:
+        updated.append(database)
+
+    monkeypatch.setattr(querylog_0008, "update_querylog_table", fake_update)
+
+    mock_cluster = Mock()
+    mock_cluster.get_local_nodes.return_value = [Mock(), Mock()]
+    mock_cluster.get_database.return_value = "default"
+    mock_cluster.get_node_connection.return_value = Mock()
+    monkeypatch.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
+
+    querylog_0008.forwards(Mock())
+    assert updated == ["default", "default"]
+
+
+@pytest.mark.custom_clickhouse_db
+def test_querylog_migration_noop_on_fresh_schema() -> None:
+    cluster = get_cluster(StorageSetKey.QUERYLOG)
+    if not cluster.is_single_node():
+        return
+
+    runner = Runner()
+    runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"), force=True)
+    for migration_id in get_group_loader(MigrationGroup.QUERYLOG).get_migrations():
+        runner.run_migration(
+            MigrationKey(MigrationGroup.QUERYLOG, migration_id),
+            force=True,
+        )
+
+    assert (
+        runner.get_status(MigrationKey(MigrationGroup.QUERYLOG, "0008_drop_uuid_sample_by"))[0]
+        == Status.COMPLETED
+    )
+
+    connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+    database = cluster.get_database()
+    ((sampling_key,),) = connection.execute(
+        "SELECT sampling_key FROM system.tables "
+        f"WHERE name = 'querylog_local' AND database = '{database}'"
+    ).results
+    assert sampling_key == ""
+    ((create_sql,),) = connection.execute(f"SHOW CREATE TABLE {database}.querylog_local").results
+    assert "SAMPLE BY" not in create_sql.upper()

--- a/tests/migrations/test_querylog_sample_by.py
+++ b/tests/migrations/test_querylog_sample_by.py
@@ -11,11 +11,12 @@ from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.groups import MigrationGroup, get_group_loader
 from snuba.migrations.migration_utilities import strip_sample_by_clause
+from snuba.migrations.operations import DropTable, InsertIntoSelect, RenameTable, RunSql
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 
 querylog_0008 = importlib.import_module("snuba.snuba_migrations.querylog.0008_drop_uuid_sample_by")
-update_querylog_table = querylog_0008.update_querylog_table
+forwards_ops = querylog_0008._forwards_ops
 
 SHOW_CREATE_MULTILINE = """CREATE TABLE default.querylog_local
 (
@@ -84,65 +85,53 @@ def test_strip_sample_by_function_expression() -> None:
 
 
 class _FakePool:
-    def __init__(
-        self,
-        *,
-        sampling_key: str,
-        create_sql: str,
-        row_count: int = 0,
-    ) -> None:
+    def __init__(self, *, sampling_key: str, create_sql: str) -> None:
         self.sampling_key = sampling_key
         self.create_sql = create_sql
-        self.row_count = row_count
-        self.executed: list[str] = []
-        self.commands: list[str] = []
 
     def execute(self, query: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
-        self.executed.append(query)
         if query.startswith("SELECT sampling_key"):
             return ClickhouseResult(results=[(self.sampling_key,)])
         if query.startswith("SHOW CREATE TABLE"):
             return ClickhouseResult(results=[(self.create_sql,)])
-        if query.startswith("SELECT count()"):
-            return ClickhouseResult(results=[(self.row_count,)])
         return ClickhouseResult(results=[])
 
-    def command(self, statement: str, *args: Any, **kwargs: Any) -> ClickhouseResult:
-        self.commands.append(statement)
-        return ClickhouseResult(results=[])
+
+def _ops_for(sampling_key: str, create_sql: str) -> list[Any]:
+    mock_cluster = Mock()
+    mock_cluster.get_local_nodes.return_value = [Mock()]
+    mock_cluster.get_database.return_value = "default"
+    mock_cluster.get_node_connection.return_value = _FakePool(
+        sampling_key=sampling_key, create_sql=create_sql
+    )
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
+        return list(forwards_ops())
 
 
 @pytest.mark.parametrize("sampling_key", ["", "cityHash64(request_id)"])
-def test_update_querylog_table_noop(sampling_key: str) -> None:
-    pool = _FakePool(sampling_key=sampling_key, create_sql=SHOW_CREATE_NO_SAMPLE)
-    update_querylog_table(pool, "default")
-    assert pool.commands == []
-    assert all(not q.startswith("SHOW CREATE") for q in pool.executed)
+def test_forwards_ops_noop(sampling_key: str) -> None:
+    assert _ops_for(sampling_key, SHOW_CREATE_NO_SAMPLE) == []
 
 
-def test_update_querylog_table_rebuilds_when_sample_by_is_request_id() -> None:
-    pool = _FakePool(sampling_key="request_id", create_sql=SHOW_CREATE_MULTILINE, row_count=0)
-    update_querylog_table(pool, "default")
-
-    create_statements = [q for q in pool.executed if q.startswith("CREATE TABLE")]
-    assert len(create_statements) == 1
-    assert "SAMPLE BY" not in create_statements[0].upper()
-    assert "querylog_local_new" in create_statements[0]
-    assert pool.commands == [
-        "RENAME TABLE querylog_local TO querylog_local_old;",
-        "RENAME TABLE querylog_local_new TO querylog_local;",
-        "DROP TABLE querylog_local_old;",
+def test_forwards_ops_rebuilds_when_sample_by_is_request_id() -> None:
+    ops = _ops_for("request_id", SHOW_CREATE_MULTILINE)
+    assert [type(op) for op in ops] == [
+        RunSql,
+        InsertIntoSelect,
+        RenameTable,
+        RenameTable,
+        DropTable,
     ]
 
+    create_sql = ops[0].format_sql()
+    assert "SAMPLE BY" not in create_sql.upper()
+    assert "querylog_local_new" in create_sql
 
-def test_update_querylog_table_copies_rows() -> None:
-    pool = _FakePool(sampling_key="request_id", create_sql=SHOW_CREATE_INLINE, row_count=1)
-    update_querylog_table(pool, "default")
-
-    inserts = [q for q in pool.executed if q.startswith("INSERT INTO")]
-    assert len(inserts) == 1
-    assert "querylog_local_new" in inserts[0]
-    assert "FROM querylog_local" in inserts[0]
+    assert "INSERT INTO querylog_local_new" in ops[1].format_sql()
+    assert ops[2].format_sql().startswith("RENAME TABLE querylog_local TO querylog_local_old")
+    assert ops[3].format_sql().startswith("RENAME TABLE querylog_local_new TO querylog_local")
+    assert "DROP TABLE IF EXISTS querylog_local_old" in ops[4].format_sql()
 
 
 def test_migration_is_registered() -> None:
@@ -150,24 +139,6 @@ def test_migration_is_registered() -> None:
     assert "0008_drop_uuid_sample_by" in migrations
     loaded = get_group_loader(MigrationGroup.QUERYLOG).load_migration("0008_drop_uuid_sample_by")
     assert loaded.blocking is True
-
-
-def test_forwards_visits_local_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
-    updated: list[str] = []
-
-    def fake_update(clickhouse: Any, database: str) -> None:
-        updated.append(database)
-
-    monkeypatch.setattr(querylog_0008, "update_querylog_table", fake_update)
-
-    mock_cluster = Mock()
-    mock_cluster.get_local_nodes.return_value = [Mock(), Mock()]
-    mock_cluster.get_database.return_value = "default"
-    mock_cluster.get_node_connection.return_value = Mock()
-    monkeypatch.setattr(querylog_0008, "get_cluster", lambda storage_set: mock_cluster)
-
-    querylog_0008.forwards(Mock())
-    assert updated == ["default", "default"]
 
 
 @pytest.mark.custom_clickhouse_db


### PR DESCRIPTION
`querylog_local` historically used `SAMPLE BY request_id` (a UUID). ClickHouse ≥ 21.9 rejects that, so dumping or recreating the table fails with `ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER`. Fresh installs already omit the clause (#4842), but existing clusters still have it, and `0006_sorting_key_change` copied it onto the rebuilt table.

This adds blocking `0008_drop_uuid_sample_by`, which rebuilds `querylog_local` without the sample key when `sampling_key == request_id` and is a no-op otherwise. `0006` also strips the clause while rebuilding so that migration can run on current ClickHouse.

Self-hosted / cluster expansion needs `--force` (0008 is blocking). After it runs, `SHOW CREATE TABLE querylog_local` no longer has `SAMPLE BY`. Backwards does not restore the illegal clause.

Fixes #7216

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
