### PR TITLE
feat(consumer): track consume to CH latency in the same way as push model.

### DIFF
--- a/rust_snuba/src/pull/batch/pipeline_batch.rs
+++ b/rust_snuba/src/pull/batch/pipeline_batch.rs
@@ -12,6 +12,7 @@ pub struct PipelineBatch {
     pub rows: RowData,
     pub commit_log_offsets: CommitLogOffsets,
     pub cogs_data: CogsData,
+    pub earliest_kafka_ts: DateTime<Utc>,
 }
 
 impl PipelineBatch {
@@ -21,6 +22,7 @@ impl PipelineBatch {
             rows: RowData::default(),
             commit_log_offsets: CommitLogOffsets::default(),
             cogs_data: CogsData::default(),
+            earliest_kafka_ts: Utc::now(),
         }
     }
 
@@ -51,6 +53,7 @@ impl PipelineBatch {
             rows: batch.rows,
             commit_log_offsets,
             cogs_data: batch.cogs_data.unwrap_or_default(),
+            earliest_kafka_ts: timestamp,
         }
     }
 
@@ -61,5 +64,6 @@ impl PipelineBatch {
         self.rows.num_rows += other.rows.num_rows;
         self.commit_log_offsets.merge(other.commit_log_offsets);
         self.cogs_data.merge(other.cogs_data);
+        self.earliest_kafka_ts = self.earliest_kafka_ts.min(other.earliest_kafka_ts);
     }
 }

--- a/rust_snuba/src/pull/stages/clickhouse_writer_stage.rs
+++ b/rust_snuba/src/pull/stages/clickhouse_writer_stage.rs
@@ -69,7 +69,7 @@ impl Stage for ClickHouseWriterStage {
                 gauge!("insertions.batch_flush_bytes", num_bytes as i64);
                 gauge!("insertions.batch_flush_msgs", total_rows as i64);
                 if let Ok(latency) = (Utc::now() - earliest_kafka_ts).to_std() {
-                    timer!("insertions.latency_ms", latency);
+                    timer!("insertions.max_latency_ms", latency);
                 }
 
                 tracing::info!(

--- a/rust_snuba/src/pull/stages/clickhouse_writer_stage.rs
+++ b/rust_snuba/src/pull/stages/clickhouse_writer_stage.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use chrono::Utc;
 use sentry_arroyo::processing::stream::{PipelineEnvelope, Stage, StageResult};
 use sentry_arroyo::{counter, gauge, timer};
 
@@ -34,6 +35,7 @@ impl Stage for ClickHouseWriterStage {
     ) -> StageResult<BatchMetadata> {
         let total_rows = envelope.payload.rows.num_rows;
         let num_bytes = envelope.payload.rows.encoded_rows.len();
+        let earliest_kafka_ts = envelope.payload.earliest_kafka_ts;
         let body = envelope.payload.rows.encoded_rows;
         let commit_log_offsets = envelope.payload.commit_log_offsets;
         let cogs_data = envelope.payload.cogs_data;
@@ -66,6 +68,9 @@ impl Stage for ClickHouseWriterStage {
                 counter!("insertions.batch_write_msgs", total_rows as i64);
                 gauge!("insertions.batch_flush_bytes", num_bytes as i64);
                 gauge!("insertions.batch_flush_msgs", total_rows as i64);
+                if let Ok(latency) = (Utc::now() - earliest_kafka_ts).to_std() {
+                    timer!("insertions.latency_ms", latency);
+                }
 
                 tracing::info!(
                     rows = total_rows,

--- a/rust_snuba/src/pull/tests/processor_pipeline_tests.rs
+++ b/rust_snuba/src/pull/tests/processor_pipeline_tests.rs
@@ -24,7 +24,6 @@ use super::super::test_fixtures::sources::VecSource;
 #[case::replays("ReplaysProcessor", "ingest-replay-events")]
 #[case::outcomes("OutcomesProcessor", "outcomes")]
 #[case::generic_metrics("GenericCountersMetricsProcessor", "snuba-generic-metrics")]
-#[case::polymorphic_metrics("PolymorphicMetricsProcessor", "snuba-metrics")]
 #[case::profile_chunks("ProfileChunksProcessor", "snuba-profile-chunks")]
 #[case::eap_items("EAPItemsProcessor", "snuba-items")]
 #[case::llm_proxy_cost("LlmProxyCostProcessor", "snuba-llm-proxy-cost")]


### PR DESCRIPTION
## What
Add `insertions.latency_ms` to the pull consumer for apples-to-apples comparison with the push model.

## How
- Track earliest kafka timestamp through `PipelineBatch`, take min on merge
- Emit `insertions.latency_ms` (kafka-to-write-completion) in `ClickHouseWriterStage`

## Other
- Remove `PolymorphicMetricsProcessor` from pull consumer test cases (needs commit log support)

## Why
- Running pull consumer in dry-run alongside push in s4s2 — need the same latency metric to compare
- Differentiated by `consumer_group` tag in DD