### PR TITLE
Cleanup types with aliases. Make noisy logs debug. Add upload jitter.…

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2553,7 +2553,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2922,21 +2922,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3455,7 +3445,7 @@ checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -3922,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "sentry_arroyo"
 version = "2.42.0"
-source = "git+https://github.com/getsentry/arroyo?branch=rbroughan%2Fpull-based-arroyo-part-2#6af7ed91134222f7ba3f7157237ca11aa55cfcb7"
+source = "git+https://github.com/getsentry/arroyo?branch=rbroughan%2Fpull-based-arroyo-part-2#7c5b1d7f453000cd1a8ebe4f5425a1df6e12701c"
 dependencies = [
  "async-stream",
  "chrono",
@@ -4578,12 +4568,6 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-
-[[package]]
-name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -4593,25 +4577,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.6.5",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -4620,7 +4593,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -5491,15 +5464,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/rust_snuba/src/pull/producers/dry_run.rs
+++ b/rust_snuba/src/pull/producers/dry_run.rs
@@ -16,7 +16,7 @@ impl Producer<KafkaPayload> for DryRunProducer {
         destination: &TopicOrPartition,
         payload: KafkaPayload,
     ) -> Result<(), ProducerError> {
-        tracing::info!(
+        tracing::debug!(
             destination = ?destination,
             key_bytes = payload.key().map(|k| k.len()),
             payload_bytes = payload.payload().map(|p| p.len()),

--- a/rust_snuba/src/pull/test_fixtures/sources.rs
+++ b/rust_snuba/src/pull/test_fixtures/sources.rs
@@ -1,7 +1,6 @@
-use std::pin::Pin;
 use std::sync::Mutex;
 
-use futures::stream::Stream;
+use futures::stream::BoxStream;
 use sentry_arroyo::backends::kafka::types::KafkaPayload;
 use sentry_arroyo::processing::stream::{
     MessageMetadata, OffsetCommitter, PipelineEnvelope, PullSource, StageResult,
@@ -39,7 +38,7 @@ impl VecSource {
 }
 
 impl PullSource for VecSource {
-    fn stream(&self) -> Pin<Box<dyn Stream<Item = StageResult<KafkaPayload>> + '_>> {
+    fn stream(&self) -> BoxStream<'_, StageResult<KafkaPayload>> {
         let messages: Vec<_> = self.messages.lock().unwrap().drain(..).collect();
         Box::pin(futures::stream::iter(messages))
     }

--- a/rust_snuba/src/pull/test_fixtures/writer.rs
+++ b/rust_snuba/src/pull/test_fixtures/writer.rs
@@ -1,6 +1,6 @@
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Mutex;
+
+use futures::future::BoxFuture;
 
 use crate::pull::writer::ClickHouseWriter;
 
@@ -28,10 +28,7 @@ impl MockWriter {
 }
 
 impl ClickHouseWriter for MockWriter {
-    fn write(
-        &self,
-        body: Vec<u8>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>> {
+    fn write(&self, body: Vec<u8>) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
             self.calls.lock().unwrap().push(WriteCall {
                 raw_bytes: body.len(),

--- a/rust_snuba/src/pull/writer/clickhouse_client_writer.rs
+++ b/rust_snuba/src/pull/writer/clickhouse_client_writer.rs
@@ -1,5 +1,4 @@
-use std::future::Future;
-use std::pin::Pin;
+use futures::future::BoxFuture;
 
 use crate::strategies::clickhouse::writer_v2::ClickhouseClient;
 
@@ -8,10 +7,7 @@ use super::clickhouse_writer::ClickHouseWriter;
 /// Live writer that delegates to the existing `ClickhouseClient`.
 /// Compression, retries, and HTTP transport are all handled by the client.
 impl ClickHouseWriter for ClickhouseClient {
-    fn write(
-        &self,
-        body: Vec<u8>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>> {
+    fn write(&self, body: Vec<u8>) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
             self.send(body).await?;
             Ok(())

--- a/rust_snuba/src/pull/writer/clickhouse_writer.rs
+++ b/rust_snuba/src/pull/writer/clickhouse_writer.rs
@@ -1,26 +1,21 @@
-use std::future::Future;
-use std::pin::Pin;
+use futures::future::BoxFuture;
 
 /// Trait for writing encoded rows to ClickHouse (or a test double).
 ///
 /// Object-safe — can be used as `Box<dyn ClickHouseWriter>`.
 /// The `write` method is called once per batch flush, so the
-/// `Pin<Box<dyn Future>>` allocation is negligible.
+/// `BoxFuture` allocation is negligible.
 ///
 /// The real `ClickhouseClient` implements this — it compresses, retries,
 /// and POSTs to ClickHouse over HTTP. `DryRunWriter` implements it for
 /// staging — it compresses (real CPU cost), sleeps (simulated
 /// network latency), and drops the data.
 pub trait ClickHouseWriter: Send + Sync {
-    fn write(&self, body: Vec<u8>)
-        -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>>;
+    fn write(&self, body: Vec<u8>) -> BoxFuture<'_, anyhow::Result<()>>;
 }
 
 impl<T: ClickHouseWriter> ClickHouseWriter for std::sync::Arc<T> {
-    fn write(
-        &self,
-        body: Vec<u8>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>> {
+    fn write(&self, body: Vec<u8>) -> BoxFuture<'_, anyhow::Result<()>> {
         (**self).write(body)
     }
 }

--- a/rust_snuba/src/pull/writer/dry_run_writer.rs
+++ b/rust_snuba/src/pull/writer/dry_run_writer.rs
@@ -1,6 +1,7 @@
-use std::future::Future;
-use std::pin::Pin;
 use std::time::Duration;
+
+use futures::future::BoxFuture;
+use rand::Rng;
 
 use crate::strategies::clickhouse::writer_v2::lz4_compress;
 
@@ -23,10 +24,7 @@ impl DryRunWriter {
 }
 
 impl ClickHouseWriter for DryRunWriter {
-    fn write(
-        &self,
-        body: Vec<u8>,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>> {
+    fn write(&self, body: Vec<u8>) -> BoxFuture<'_, anyhow::Result<()>> {
         Box::pin(async move {
             let raw_bytes = body.len();
 
@@ -35,10 +33,12 @@ impl ClickHouseWriter for DryRunWriter {
             drop(compressed);
 
             if !self.latency.is_zero() {
-                tokio::time::sleep(self.latency).await;
+                let jitter: i64 = rand::rng().random_range(-100..=100);
+                let adjusted = self.latency.as_millis() as i64 + jitter;
+                tokio::time::sleep(Duration::from_millis(adjusted.max(0) as u64)).await;
             }
 
-            tracing::info!(
+            tracing::debug!(
                 raw_bytes,
                 compressed_bytes,
                 "dry-run: would have written {} bytes ({} compressed) to ClickHouse",

--- a/rust_snuba/src/pull_consumer.rs
+++ b/rust_snuba/src/pull_consumer.rs
@@ -254,7 +254,7 @@ async fn run_fire_and_forget(
             clickhouse_concurrency,
         );
 
-        let mut tracker = OffsetTracker::new(Duration::from_secs(5), source.committer());
+        let mut tracker = OffsetTracker::new(Duration::from_secs(1), source.committer());
         match pipeline.stream(source.stream()).commit(&mut tracker).await {
             Ok(PipelineExit::Rebalance) => {
                 tracing::info!("Rebalance detected, restarting pipeline");
@@ -379,7 +379,7 @@ async fn run_eap(
             cogs,
         );
 
-        let mut tracker = OffsetTracker::new(Duration::from_secs(5), source.committer());
+        let mut tracker = OffsetTracker::new(Duration::from_secs(1), source.committer());
         match pipeline.stream(source.stream()).commit(&mut tracker).await {
             Ok(PipelineExit::Rebalance) => {
                 tracing::info!("Rebalance detected, restarting pipeline");


### PR DESCRIPTION
## What
Quiet down dry-run logging, add simulated IO jitter, match commit kafka offset, pick up latest arroyo (`BoxError`/`BoxStream` type aliases and rdkafka logging metrics).

## How
- `DryRunProducer` / `DryRunWriter`: `info!` → `debug!` (was logging every message/batch)
- `DryRunWriter`: ±100ms jitter around configured dry-run latency
- Bump `sentry_arroyo` to latest pushed commit, update writer trait signatures to match new `BoxFuture`/`BoxStream` aliases and pick up rdkafka stats metrics (instead of logging) 

## Why
- Dry-run logs were flooding output with logs
- Fixed latency made dry-run timing too uniform for a realistic comparison
- Make commit offset match for better comparison 