### PR TITLE
perf(events): Reattach bytes-scanned policy on errors

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -272,6 +272,15 @@ schema:
     - retention_days
     - date
   not_deleted_mandatory_condition: deleted
+allocation_policies:
+  - name: BytesScannedRejectingPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - project_id
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -269,6 +269,15 @@ schema:
   local_table_name: errors_local
   dist_table_name: errors_dist_ro
   not_deleted_mandatory_condition: deleted
+allocation_policies:
+  - name: BytesScannedRejectingPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - project_id
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -535,18 +535,18 @@ def test_db_query_success() -> None:
             "throttled_by": {},
         },
         "details": {
-            "PassthroughPolicy": {
+            "BytesScannedRejectingPolicy": {
                 "can_run": True,
                 "max_threads": 10,
                 "max_bytes_to_read": 0,
                 "explanation": {
-                    "storage_key": "default.no_storage_key",
+                    "storage_key": "errors_ro",
                 },
                 "is_throttled": False,
-                "throttle_threshold": MAX_THRESHOLD,
-                "rejection_threshold": MAX_THRESHOLD,
-                "quota_used": 0,
-                "quota_unit": NO_UNITS,
+                "throttle_threshold": 1706666666666,
+                "rejection_threshold": 2560000000000,
+                "quota_used": 1560000000000,
+                "quota_unit": "bytes",
                 "suggestion": NO_SUGGESTION,
             },
         },


### PR DESCRIPTION
`errors` and `errors_ro` queries currently ignore `BytesScannedRejectingPolicy` automator overrides because #8260 left those storages on `PassthroughPolicy`. This puts the rejecting policy back on both storages so a follow-up option can cap one org.

The policy is attached unenforced (`is_enforced: 0`). Other orgs keep running unconstrained until an option flips enforcement and sets a per-org cap. Concurrent, referrer-guard, and window policies stay off so this does not restore the old global limits.
