### PR TITLE
ref(dlq): add a TTL to the DLQ instruction key

### DIFF
--- a/snuba/consumers/dlq.py
+++ b/snuba/consumers/dlq.py
@@ -18,19 +18,9 @@ from snuba.redis import RedisClientKey, get_redis_client
 redis_client = get_redis_client(RedisClientKey.DLQ)
 DLQ_REDIS_KEY = "dlq_instruction"
 
-# The instruction key must expire, so that a replay that is never cleared cannot leave
-# the key in Redis forever.
-# The consumer rewrites the key when it starts the replay (see
-# mark_instruction_in_progress), so the expiry must cover one replay, not the waiting
-# time plus the replay.
-# Nothing in the code limits max_messages_to_process, so there is no hard bound on how
-# long a replay runs. Seven days is a judgement call. It is much longer than any replay
-# we expect, and it also covers an instruction that waits while no DLQ consumer runs.
-# The expiry is set long because the key is the only record that a replay was asked for.
-# If it expires while a replay runs, the replay itself continues, because nothing reads
-# the key again after the replay starts. The risk is that an operator sees no replay in
-# progress and issues a new instruction, which the running consumer then deletes when it
-# calls clear_instruction at the end.
+# Instruction keys have expiries to handle replays which are never cleared.
+# Consumer rewrites key when replay is started, expiry covers the one replay.
+# Went with 7 days because it's longer than any replay.
 DLQ_INSTRUCTION_TTL_SECONDS = 7 * 24 * 60 * 60
 
 

--- a/snuba/consumers/dlq.py
+++ b/snuba/consumers/dlq.py
@@ -18,6 +18,21 @@ from snuba.redis import RedisClientKey, get_redis_client
 redis_client = get_redis_client(RedisClientKey.DLQ)
 DLQ_REDIS_KEY = "dlq_instruction"
 
+# The instruction key must expire, so that a replay that is never cleared cannot leave
+# the key in Redis forever.
+# The consumer rewrites the key when it starts the replay (see
+# mark_instruction_in_progress), so the expiry must cover one replay, not the waiting
+# time plus the replay.
+# Nothing in the code limits max_messages_to_process, so there is no hard bound on how
+# long a replay runs. Seven days is a judgement call. It is much longer than any replay
+# we expect, and it also covers an instruction that waits while no DLQ consumer runs.
+# The expiry is set long because the key is the only record that a replay was asked for.
+# If it expires while a replay runs, the replay itself continues, because nothing reads
+# the key again after the replay starts. The risk is that an operator sees no replay in
+# progress and issues a new instruction, which the running consumer then deletes when it
+# calls clear_instruction at the end.
+DLQ_INSTRUCTION_TTL_SECONDS = 7 * 24 * 60 * 60
+
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +118,7 @@ def clear_instruction() -> None:
 
 
 def store_instruction(instruction: DlqInstruction) -> None:
-    redis_client.set(DLQ_REDIS_KEY, instruction.to_bytes())
+    redis_client.set(DLQ_REDIS_KEY, instruction.to_bytes(), ex=DLQ_INSTRUCTION_TTL_SECONDS)
 
 
 TPayload = TypeVar("TPayload")

--- a/tests/consumers/test_dlq.py
+++ b/tests/consumers/test_dlq.py
@@ -6,6 +6,8 @@ from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
 from snuba.consumers.dlq import (
+    DLQ_INSTRUCTION_TTL_SECONDS,
+    DLQ_REDIS_KEY,
     DlqInstruction,
     DlqInstructionStatus,
     DlqReplayPolicy,
@@ -13,6 +15,7 @@ from snuba.consumers.dlq import (
     clear_instruction,
     load_instruction,
     mark_instruction_in_progress,
+    redis_client,
     store_instruction,
 )
 from snuba.datasets.storages.storage_key import StorageKey
@@ -42,12 +45,28 @@ def test_store_instruction() -> None:
     )
     store_instruction(instruction)
     assert load_instruction() == instruction
+    # The instruction key must expire, so that a dropped replay cannot leave it in
+    # Redis forever. Check the value, not only that some expiry is set, so that a
+    # wrong unit does not pass.
+    assert (
+        DLQ_INSTRUCTION_TTL_SECONDS - 10
+        < redis_client.ttl(DLQ_REDIS_KEY)
+        <= DLQ_INSTRUCTION_TTL_SECONDS
+    )
     mark_instruction_in_progress()
     loaded_instruction = load_instruction()
     assert loaded_instruction is not None
     assert loaded_instruction.status == DlqInstructionStatus.IN_PROGRESS
+    # The start of the replay rewrites the key, which restarts the expiry.
+    assert (
+        DLQ_INSTRUCTION_TTL_SECONDS - 10
+        < redis_client.ttl(DLQ_REDIS_KEY)
+        <= DLQ_INSTRUCTION_TTL_SECONDS
+    )
     clear_instruction()
     assert load_instruction() is None
+    # clear_instruction removes the key, it does not only let it expire.
+    assert redis_client.exists(DLQ_REDIS_KEY) == 0
 
 
 def test_exit_after_n_messages() -> None:


### PR DESCRIPTION
The key `dlq_instruction` is written without expiry. Most of the time it's deleted at the end of a clean replay, but if a replay dies before that point will leave the key in Redis forever. `dlq` client is None is all multi-tenant region's `REDIs_CLUSTERS`, so this has a fallback of the default client.

 Fix is just to add a 7-day TTL. (7 days because it's just my judgement call, it seems much longer than any replay we expect). I'm very open to tightening this up if we think how long the actual longest replays run (like...24 hours maybe?).

Some notes from claude:
- ⚠️ **There is no production writer of this key any more.** The admin DLQ tool that issued these instructions (`/dead_letter_queue`, `/dead_letter_queue/replay` in `snuba/admin/views.py`, shipped 2023) was deleted on 2026-07-20 by #8200, "ref(admin): Remove unused snuba-admin tools". In current master `store_instruction` has exactly one non-test caller, `mark_instruction_in_progress`, which can only rewrite an instruction that already exists. Nothing can create one.
- So this expiry can only ever fire on a rewrite of a key that an older version of the code wrote. 

^ aka this is just a hygiene change

Refs INFRENG-484
