### PR TITLE
chore(gocd): use GitHub App credentials

### DIFF
--- a/.github/workflows/validate-pipelines.yml
+++ b/.github/workflows/validate-pipelines.yml
@@ -50,6 +50,7 @@ jobs:
                 id_token_include_email: true
             - uses: getsentry/action-gocd-jsonnet@2a32414fa9e58a46d1afea9cbfa7b77a928678e2 # v1.1.1
               with:
+                go-version: "1.25"
                 jb-install: true
                 jsonnet-dir: gocd/templates
                 generated-dir: gocd/generated-pipelines

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-checks-githubactions-checkruns \
+checks-githubactions-checkruns2 \
   --timeout-mins 60 \
   getsentry/snuba \
   ${GO_REVISION_SNUBA_REPO} \

--- a/gocd/templates/pipelines/snuba-py.libsonnet
+++ b/gocd/templates/pipelines/snuba-py.libsonnet
@@ -160,7 +160,7 @@ local deploy_canary_stage(region) =
 function(region) {
   environment_variables: {
     SENTRY_REGION: region,
-    // Required for checkruns.
+    // Required for checkruns2.
     GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
     GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
     GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',

--- a/gocd/templates/pipelines/snuba-py.libsonnet
+++ b/gocd/templates/pipelines/snuba-py.libsonnet
@@ -161,7 +161,8 @@ function(region) {
   environment_variables: {
     SENTRY_REGION: region,
     // Required for checkruns.
-    GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+    GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
+    GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
     GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
   },
   lock_behavior: 'unlockWhenFinished',

--- a/gocd/templates/pipelines/snuba-rs.libsonnet
+++ b/gocd/templates/pipelines/snuba-rs.libsonnet
@@ -136,7 +136,7 @@ local deploy_canary_stage(region) =
 function(region) {
   environment_variables: {
     SENTRY_REGION: region,
-    // Required for checkruns.
+    // Required for checkruns2.
     GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
     GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
     GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',

--- a/gocd/templates/pipelines/snuba-rs.libsonnet
+++ b/gocd/templates/pipelines/snuba-rs.libsonnet
@@ -137,7 +137,8 @@ function(region) {
   environment_variables: {
     SENTRY_REGION: region,
     // Required for checkruns.
-    GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+    GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
+    GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
     GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
   },
   lock_behavior: 'unlockWhenFinished',


### PR DESCRIPTION
Replace GoCD GitHub token references with GitHub App credentials.

- Pass GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY to GoCD jobs.
- Preserve legacy runtime compatibility where the existing helper supports it.