### PR TITLE
ref(manual-jobs): bound the manual jobs Redis keys

### DIFF
--- a/snuba/manual_jobs/redis.py
+++ b/snuba/manual_jobs/redis.py
@@ -8,14 +8,11 @@ from snuba.utils.serializable_exception import SerializableException
 
 _redis_client = get_redis_client(RedisClientKey.MANUAL_JOBS)
 
-# One run of a job may hold the lock for this long
 MANUAL_JOB_LOCK_TTL_SECONDS = 24 * 60 * 60
 
-# How long the record of a job run stays in Redis -
-# past 90 days the rows a job touched have aged out anyway.
+# Past 90 days the rows a job touches have aged out anyway
 MANUAL_JOB_STATE_TTL_SECONDS = 90 * 24 * 60 * 60
 
-# Longest log the runner keeps for one job
 MANUAL_JOB_LOG_MAX_LINES = 500
 
 

--- a/snuba/manual_jobs/redis.py
+++ b/snuba/manual_jobs/redis.py
@@ -8,6 +8,39 @@ from snuba.utils.serializable_exception import SerializableException
 
 _redis_client = get_redis_client(RedisClientKey.MANUAL_JOBS)
 
+# One run of a job may hold the lock for this long. This also sets the longest
+# run the rest of this module has to plan for.
+MANUAL_JOB_LOCK_TTL_SECONDS = 24 * 60 * 60
+
+# How long the record of a job run stays in Redis. All four state keys
+# (start time, execution status, log, job type) share this one window.
+#
+# The record is a human-facing history, not operational state. `run_job` refuses
+# to start a manifest job whose status key exists, and the admin UI replaces the
+# Run button with View Logs for the same reason. So when the record goes, a job
+# that already ran reports NOT_STARTED and looks re-runnable to the next engineer.
+# The window has to cover a realistic re-run window, not be as short as possible.
+#
+# 90 days is the longest standard retention Snuba allows for the ClickHouse data
+# that the destructive jobs act on (deletes, scrubs, mutations). The live policy in
+# `snuba/state/retention.py` caps standard retention at 90 days. Long-term
+# downsampled storage runs longer, but the row-touching jobs write only to tier-1
+# tables
+# (`errors_local`, `eap_spans_2_local`). Past 90 days the rows a job touched have
+# aged out anyway, so "did we already run this?" no longer has a target. The value
+# is its own constant on purpose: a region that shortens its data retention should
+# not silently shorten its operator history. The window is also far longer than one
+# run, which MANUAL_JOB_LOCK_TTL_SECONDS plans for at 24 hours.
+MANUAL_JOB_STATE_TTL_SECONDS = 90 * 24 * 60 * 60
+
+# Longest log the runner keeps for one job. The admin UI and the
+# `snuba jobs view-logs` CLI render the whole list in one response, and
+# `view_job_logs` refuses to show more lines than this. The cap counts lines, not
+# bytes, and a job that logs full SQL statements can still build a list of a few
+# megabytes. The list keeps the newest lines: on a failure the runner appends the
+# error and the traceback last, so the tail is the part an operator needs.
+MANUAL_JOB_LOG_MAX_LINES = 500
+
 
 def _build_job_lock_key(job_id: str) -> str:
     return f"snuba:manual_jobs:{job_id}:lock"
@@ -31,12 +64,23 @@ def _build_job_type_key(job_id: str) -> str:
 
 def _acquire_job_lock(job_id: str) -> bool:
     return bool(
-        _redis_client.set(name=_build_job_lock_key(job_id), value=1, nx=True, ex=(24 * 60 * 60))
+        _redis_client.set(
+            name=_build_job_lock_key(job_id), value=1, nx=True, ex=MANUAL_JOB_LOCK_TTL_SECONDS
+        )
     )
 
 
 def _push_job_log_line(job_id: str, line: str) -> bool:
-    return bool(_redis_client.rpush(_build_job_log_key(job_id), line))
+    key = _build_job_log_key(job_id)
+    # All three commands act on one key, so this pipeline stays on one slot in a
+    # Redis cluster. The expiry is refreshed on every line, so the retention window
+    # of a long job starts at its last log line and not at its first.
+    with _redis_client.pipeline(transaction=False) as pipeline:
+        pipeline.rpush(key, line)
+        pipeline.ltrim(key, -MANUAL_JOB_LOG_MAX_LINES, -1)
+        pipeline.expire(key, MANUAL_JOB_STATE_TTL_SECONDS)
+        results = pipeline.execute()
+    return bool(results[0])
 
 
 def _release_job_lock(job_id: str) -> None:
@@ -44,17 +88,31 @@ def _release_job_lock(job_id: str) -> None:
 
 
 def _record_start_time(job_id: str) -> None:
-    _redis_client.set(name=_build_start_time_key(job_id), value=datetime.utcnow().isoformat())
+    _redis_client.set(
+        name=_build_start_time_key(job_id),
+        value=datetime.utcnow().isoformat(),
+        ex=MANUAL_JOB_STATE_TTL_SECONDS,
+    )
 
 
 def _set_job_status(job_id: str, status: JobStatus) -> JobStatus:
-    if not _redis_client.set(name=_build_job_status_key(job_id), value=status.value):
+    if not _redis_client.set(
+        name=_build_job_status_key(job_id), value=status.value, ex=MANUAL_JOB_STATE_TTL_SECONDS
+    ):
         raise SerializableException(f"Failed to set job status {status} on {job_id}")
+    # Keep the job type alive at least as long as the status. `get_job_status`
+    # reads the job type when the status says an async job is still running, and
+    # `_get_job_type` does not handle a missing key. No job in the tree is async
+    # today, so this refresh is a guard and not a fix for a live failure. The call
+    # is a no-op on the first status write, which runs before the type key exists.
+    _redis_client.expire(_build_job_type_key(job_id), MANUAL_JOB_STATE_TTL_SECONDS)
     return status
 
 
 def _set_job_type(job_id: str, job_type: str) -> None:
-    _redis_client.set(name=_build_job_type_key(job_id), value=job_type)
+    _redis_client.set(
+        name=_build_job_type_key(job_id), value=job_type, ex=MANUAL_JOB_STATE_TTL_SECONDS
+    )
 
 
 def _get_job_type(job_id: str) -> str:

--- a/snuba/manual_jobs/redis.py
+++ b/snuba/manual_jobs/redis.py
@@ -8,37 +8,14 @@ from snuba.utils.serializable_exception import SerializableException
 
 _redis_client = get_redis_client(RedisClientKey.MANUAL_JOBS)
 
-# One run of a job may hold the lock for this long. This also sets the longest
-# run the rest of this module has to plan for.
+# One run of a job may hold the lock for this long
 MANUAL_JOB_LOCK_TTL_SECONDS = 24 * 60 * 60
 
-# How long the record of a job run stays in Redis. All four state keys
-# (start time, execution status, log, job type) share this one window.
-#
-# The record is a human-facing history, not operational state. `run_job` refuses
-# to start a manifest job whose status key exists, and the admin UI replaces the
-# Run button with View Logs for the same reason. So when the record goes, a job
-# that already ran reports NOT_STARTED and looks re-runnable to the next engineer.
-# The window has to cover a realistic re-run window, not be as short as possible.
-#
-# 90 days is the longest standard retention Snuba allows for the ClickHouse data
-# that the destructive jobs act on (deletes, scrubs, mutations). The live policy in
-# `snuba/state/retention.py` caps standard retention at 90 days. Long-term
-# downsampled storage runs longer, but the row-touching jobs write only to tier-1
-# tables
-# (`errors_local`, `eap_spans_2_local`). Past 90 days the rows a job touched have
-# aged out anyway, so "did we already run this?" no longer has a target. The value
-# is its own constant on purpose: a region that shortens its data retention should
-# not silently shorten its operator history. The window is also far longer than one
-# run, which MANUAL_JOB_LOCK_TTL_SECONDS plans for at 24 hours.
+# How long the record of a job run stays in Redis -
+# past 90 days the rows a job touched have aged out anyway.
 MANUAL_JOB_STATE_TTL_SECONDS = 90 * 24 * 60 * 60
 
-# Longest log the runner keeps for one job. The admin UI and the
-# `snuba jobs view-logs` CLI render the whole list in one response, and
-# `view_job_logs` refuses to show more lines than this. The cap counts lines, not
-# bytes, and a job that logs full SQL statements can still build a list of a few
-# megabytes. The list keeps the newest lines: on a failure the runner appends the
-# error and the traceback last, so the tail is the part an operator needs.
+# Longest log the runner keeps for one job
 MANUAL_JOB_LOG_MAX_LINES = 500
 
 
@@ -72,9 +49,6 @@ def _acquire_job_lock(job_id: str) -> bool:
 
 def _push_job_log_line(job_id: str, line: str) -> bool:
     key = _build_job_log_key(job_id)
-    # All three commands act on one key, so this pipeline stays on one slot in a
-    # Redis cluster. The expiry is refreshed on every line, so the retention window
-    # of a long job starts at its last log line and not at its first.
     with _redis_client.pipeline(transaction=False) as pipeline:
         pipeline.rpush(key, line)
         pipeline.ltrim(key, -MANUAL_JOB_LOG_MAX_LINES, -1)
@@ -100,11 +74,7 @@ def _set_job_status(job_id: str, status: JobStatus) -> JobStatus:
         name=_build_job_status_key(job_id), value=status.value, ex=MANUAL_JOB_STATE_TTL_SECONDS
     ):
         raise SerializableException(f"Failed to set job status {status} on {job_id}")
-    # Keep the job type alive at least as long as the status. `get_job_status`
-    # reads the job type when the status says an async job is still running, and
-    # `_get_job_type` does not handle a missing key. No job in the tree is async
-    # today, so this refresh is a guard and not a fix for a live failure. The call
-    # is a no-op on the first status write, which runs before the type key exists.
+    # Keep the job type alive at least as long as the status
     _redis_client.expire(_build_job_type_key(job_id), MANUAL_JOB_STATE_TTL_SECONDS)
     return status
 

--- a/snuba/manual_jobs/runner.py
+++ b/snuba/manual_jobs/runner.py
@@ -11,6 +11,7 @@ from snuba.manual_jobs.job_loader import _JobLoader
 from snuba.manual_jobs.job_logging import get_job_logger
 from snuba.manual_jobs.job_status import JobStatus
 from snuba.manual_jobs.redis import (
+    MANUAL_JOB_LOG_MAX_LINES,
     _acquire_job_lock,
     _build_job_log_key,
     _build_job_status_key,
@@ -143,7 +144,7 @@ def view_job_logs(job_id: str) -> Sequence[str]:
     job_logs_length = _redis_client.llen(name=_build_job_log_key(job_id))
     if job_logs_length == 0:
         return []
-    assert job_logs_length < 500, "Job logs are too long to display"
+    assert job_logs_length <= MANUAL_JOB_LOG_MAX_LINES, "Job logs are too long to display"
     job_logs = _redis_client.lrange(
         name=_build_job_log_key(job_id), start=0, end=job_logs_length - 1
     )

--- a/tests/manual_jobs/test_job_key_expiry.py
+++ b/tests/manual_jobs/test_job_key_expiry.py
@@ -19,8 +19,7 @@ job_spec = JobSpec(job_id=JOB_ID, job_type="ToyJob")
 
 @pytest.mark.redis_db
 def test_job_state_keys_expire() -> None:
-    """Every key a job run leaves behind must expire. Without this the four keys
-    per job id stay in Redis forever on a long-lived cluster."""
+    """Every key a job run leaves behind must expire"""
     run_job(job_spec)
 
     for build_key in (

--- a/tests/manual_jobs/test_job_key_expiry.py
+++ b/tests/manual_jobs/test_job_key_expiry.py
@@ -1,0 +1,70 @@
+import pytest
+
+from snuba.manual_jobs import JobSpec
+from snuba.manual_jobs.redis import (
+    MANUAL_JOB_LOG_MAX_LINES,
+    MANUAL_JOB_STATE_TTL_SECONDS,
+    _build_job_log_key,
+    _build_job_status_key,
+    _build_job_type_key,
+    _build_start_time_key,
+    _push_job_log_line,
+    _redis_client,
+)
+from snuba.manual_jobs.runner import run_job, view_job_logs
+
+JOB_ID = "abc1234"
+job_spec = JobSpec(job_id=JOB_ID, job_type="ToyJob")
+
+
+@pytest.mark.redis_db
+def test_job_state_keys_expire() -> None:
+    """Every key a job run leaves behind must expire. Without this the four keys
+    per job id stay in Redis forever on a long-lived cluster."""
+    run_job(job_spec)
+
+    for build_key in (
+        _build_start_time_key,
+        _build_job_status_key,
+        _build_job_log_key,
+        _build_job_type_key,
+    ):
+        key = build_key(JOB_ID)
+        assert _redis_client.exists(key) == 1, f"{key} was not written"
+        ttl = _redis_client.ttl(key)
+        assert ttl > 0, f"{key} has no expiry"
+        # Check the value, not only that some expiry is set, so that a wrong
+        # unit does not pass.
+        assert MANUAL_JOB_STATE_TTL_SECONDS - 60 < ttl <= MANUAL_JOB_STATE_TTL_SECONDS, (
+            f"{key} has an unexpected expiry {ttl}"
+        )
+
+
+@pytest.mark.redis_db
+def test_job_log_expiry_is_refreshed_on_each_line() -> None:
+    """A job that runs longer than the retention window must not lose its own log
+    while it is still writing to it, so every line resets the expiry."""
+    log_key = _build_job_log_key(JOB_ID)
+    _push_job_log_line(JOB_ID, "first line")
+    _redis_client.expire(log_key, 60)
+    assert _redis_client.ttl(log_key) <= 60
+
+    _push_job_log_line(JOB_ID, "second line")
+    assert _redis_client.ttl(log_key) > 60
+
+
+@pytest.mark.redis_db
+def test_job_log_is_capped_to_the_newest_lines() -> None:
+    """The log list is capped so that a chatty job cannot grow it without bound.
+    The newest lines are kept, because a failing run appends its error and
+    traceback last."""
+    for i in range(MANUAL_JOB_LOG_MAX_LINES + 50):
+        _push_job_log_line(JOB_ID, f"line {i}")
+
+    assert _redis_client.llen(_build_job_log_key(JOB_ID)) == MANUAL_JOB_LOG_MAX_LINES
+
+    # A capped log is still short enough for the admin UI and the CLI to display.
+    logs = view_job_logs(JOB_ID)
+    assert len(logs) == MANUAL_JOB_LOG_MAX_LINES
+    assert logs[0] == "line 50"
+    assert logs[-1] == f"line {MANUAL_JOB_LOG_MAX_LINES + 49}"


### PR DESCRIPTION
Manual jobs leave four keys behind: `start_time, execution_status, log, job_type`. Most especially the log key grows one entry per log line (no cap). `lock` is already bounded at 24hr, so we're using the same pattern here, w/ a different TTL.

Notes:
- Retention window is 90 days - chose this because if a record is dropped, a job that already ran will report `NOT_STARTED` and the UI will make it look like the job is re-runnable. So we want a TTL that gives re-runs plenty of time to happen and avoid this issue. Also 90 days is the standard retention cap via `snuba/state/retention.py`. After that point the rows the job acts on have aged out anyways
- Capping log lines at 500 since `view_job_logs` already refuses to render more than 500 lines anyways
- TTL windows start at end of runs, so we won't age out even massively long runs (although reealistically that ain't happening with a 90 day ttl let's be real)

Refs INFRENG-480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
