### PR TITLE
feat(replacer): add org bypass for max-groups FINAL

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -390,6 +390,14 @@
       "default": 256,
       "description": "Maximum number of group ids excluded from a query before it falls back to FINAL instead of an exclusion set."
     },
+    "max_groups_final_bypass_org_ids": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "default": [],
+      "description": "Organization ids for which the post-replacement consistency processor skips the max-groups fallback to FINAL. Affected queries may return stale or replaced rows until ClickHouse merges complete."
+    },
     "skip_seen_offsets": {
       "type": "boolean",
       "default": false,

--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -1,6 +1,7 @@
 from collections.abc import MutableMapping
 from dataclasses import replace
 from datetime import datetime
+from typing import cast
 
 from snuba import environment, settings
 from snuba.clickhouse.query import Query
@@ -20,6 +21,8 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 metrics = MetricsWrapper(environment.metrics, "processors.replaced_groups")
 FINAL_METRIC = "final"
 CONSISTENCY_DENYLIST_METRIC = "post_replacement_consistency_projects_denied"
+MAX_GROUPS_FINAL_DISABLED_METRIC = "max_groups_final_disabled"
+MAX_GROUPS_FINAL_BYPASS_ORG_IDS_OPTION = "max_groups_final_bypass_org_ids"
 
 
 class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
@@ -104,12 +107,20 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
                 len(flags.group_ids_to_exclude) > 2 * max_group_ids_exclude
                 or len(groups_to_exclude) > max_group_ids_exclude
             ):
-                tags["cause"] = "max_groups"
-                metrics.increment(
-                    name=FINAL_METRIC,
-                    tags=tags,
+                disabled_organization_ids = cast(
+                    "list[int]",
+                    get_option(MAX_GROUPS_FINAL_BYPASS_ORG_IDS_OPTION, []),
                 )
-                set_final = True
+                if query_settings.organization_id in disabled_organization_ids:
+                    tags["organization_id"] = str(query_settings.organization_id)
+                    metrics.increment(name=MAX_GROUPS_FINAL_DISABLED_METRIC, tags=tags)
+                else:
+                    tags["cause"] = "max_groups"
+                    metrics.increment(
+                        name=FINAL_METRIC,
+                        tags=tags,
+                    )
+                    set_final = True
             elif groups_to_exclude:
                 query.add_condition_to_ast(
                     not_in_condition(

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -16,6 +16,7 @@ class QuerySettings(ABC):
     """
 
     referrer: str
+    organization_id: int | None
 
     @abstractmethod
     def get_turbo(self) -> bool:
@@ -91,6 +92,7 @@ class HTTPQuerySettings(QuerySettings):
         asynchronous: bool = False,
         apply_default_subscriptable_mapping: bool = True,
         skip_transform_order_by: bool = False,
+        organization_id: int | None = None,
     ) -> None:
         super().__init__()
         self.__tier = Tier.TIER_NO_TIER
@@ -103,6 +105,7 @@ class HTTPQuerySettings(QuerySettings):
         self.__resource_quota: ResourceQuota | None = None
         self.__clickhouse_settings: MutableMapping[str, Any] = {}
         self.referrer = referrer
+        self.organization_id = organization_id
         self.__asynchronous = asynchronous
         self.__apply_default_subscriptable_mapping = apply_default_subscriptable_mapping
         self.__skip_transform_order_by = skip_transform_order_by
@@ -183,12 +186,14 @@ class SubscriptionQuerySettings(QuerySettings):
         feature: str = "subscription",
         app_id: str = "default",
         referrer: str = "subscription",
+        organization_id: int | None = None,
     ) -> None:
         self.__consistent = consistent
         self.__team = team
         self.__feature = feature
         self.__app_id = app_id
         self.referrer = referrer
+        self.organization_id = organization_id
         self.__clickhouse_settings: MutableMapping[str, Any] = {}
 
     def get_turbo(self) -> bool:

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -200,8 +200,12 @@ def _get_settings_object(
     request_parts: RequestParts,
     referrer: str,
 ) -> HTTPQuerySettings | SubscriptionQuerySettings:
+    organization_id = request_parts.attribution_info["tenant_ids"].get("organization_id")
+    if not isinstance(organization_id, int):
+        organization_id = None
+
     if settings_class == HTTPQuerySettings:
-        query_settings: MutableMapping[str, bool | str] = {
+        query_settings: MutableMapping[str, bool | int | str | None] = {
             **request_parts.query_settings,
             "consistent": _consistent_override(
                 request_parts.query_settings.get("consistent", False), referrer
@@ -209,11 +213,13 @@ def _get_settings_object(
         }
         # TODO: referrer probably doesn't need to be passed in, it should be from the body
         query_settings["referrer"] = referrer
-        # the parameters accept either `str` or `bool` but we pass in `str | bool`
+        query_settings["organization_id"] = organization_id
+        # The schema validates these values before they are unpacked into the constructor.
         return settings_class(**query_settings)  # type: ignore[arg-type]
     if settings_class == SubscriptionQuerySettings:
         return settings_class(
             consistent=_consistent_override(True, referrer),
+            organization_id=organization_id,
         )
     return None  # type: ignore[return-value]
 

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -234,6 +234,74 @@ def test_too_many_groups_to_exclude(query: ClickhouseQuery) -> None:
 
 
 @pytest.mark.redis_db
+@override_options(
+    "snuba",
+    {
+        "max_group_ids_exclude": 2,
+        "max_groups_final_bypass_org_ids": [1],
+    },
+)
+def test_too_many_groups_final_disabled_for_organization(query: ClickhouseQuery) -> None:
+    ProjectsQueryFlags.set_project_exclude_groups(
+        2,
+        [100, 101, 102],
+        ReplacerState.ERRORS,
+        ReplacementType.EXCLUDE_GROUPS,
+    )
+
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+        query, HTTPQuerySettings(organization_id=1)
+    )
+
+    assert query.get_condition() == build_in("project_id", [2])
+    assert not query.get_from_clause().final
+
+
+@pytest.mark.redis_db
+@override_options(
+    "snuba",
+    {
+        "max_group_ids_exclude": 2,
+        "max_groups_final_bypass_org_ids": [1],
+    },
+)
+def test_too_many_groups_final_not_disabled_for_other_organization(
+    query: ClickhouseQuery,
+) -> None:
+    ProjectsQueryFlags.set_project_exclude_groups(
+        2,
+        [100, 101, 102],
+        ReplacerState.ERRORS,
+        ReplacementType.EXCLUDE_GROUPS,
+    )
+
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+        query, HTTPQuerySettings(organization_id=2)
+    )
+
+    assert query.get_from_clause().final
+
+
+@pytest.mark.redis_db
+@override_options(
+    "snuba",
+    {"max_groups_final_bypass_org_ids": [1]},
+)
+def test_final_flag_not_disabled_for_organization(query: ClickhouseQuery) -> None:
+    ProjectsQueryFlags.set_project_needs_final(
+        2,
+        ReplacerState.ERRORS,
+        ReplacementType.EXCLUDE_GROUPS,
+    )
+
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+        query, HTTPQuerySettings(organization_id=1)
+    )
+
+    assert query.get_from_clause().final
+
+
+@pytest.mark.redis_db
 @override_options("snuba", {"max_group_ids_exclude": 2})
 def test_query_overlaps_replacements_processor(
     query: ClickhouseQuery,

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -95,6 +95,7 @@ def test_build_request(body: dict[str, Any], condition: Expression) -> None:
     )
 
     assert request.referrer == "my_request"
+    assert request.query_settings.organization_id == 1
     assert dict(request.original_body) == body
     status, differences = request.query.equals(expected_query)
     assert status, f"Query mismatch: {differences}"


### PR DESCRIPTION
## Summary
We're receiving some automated queries from one or two customers that have so many group IDs that they always get FINAL bucketing. This degrades ClickHouse performance and we would prefer to sacrifice their consistency for other tenants' benefit.

- add the `max_groups_final_bypass_org_ids` Sentry option
- propagate organization attribution to query settings so the replacement consistency processor can apply the bypass
- skip only the `max_groups` fallback to `FINAL` for configured organizations and emit a bypass metric
- preserve `final_flag` behavior for those organizations

Configured organizations favor query performance over post-replacement consistency when the exclusion set exceeds `max_group_ids_exclude`. Those queries may temporarily return stale or replaced rows until ClickHouse merges complete.

## Tests

- `pytest -q tests/datasets/storages/processors/test_replaced_groups.py tests/request/test_build_request.py tests/request/test_schema.py`
- pre-commit formatting, lint, mypy, and repository checks