### PR TITLE
fix(subscriptions): Attribute subscription queries to a real organization id

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -396,7 +396,7 @@
         "type": "integer"
       },
       "default": [],
-      "description": "Organization ids for which the post-replacement consistency processor skips the max-groups fallback to FINAL. Affected queries may return stale or replaced rows until ClickHouse merges complete."
+      "description": "Organization ids for which the post-replacement consistency processor skips the max-groups fallback to FINAL. Affected queries may return stale or replaced rows until ClickHouse merges complete. Only organization ids supplied by the request are matched, so queries with no organization attribution never bypass FINAL."
     },
     "skip_seen_offsets": {
       "type": "boolean",

--- a/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
@@ -132,6 +132,7 @@ subscription_processors:
   - processor: AddColumnCondition
     args:
       extra_condition_data_key: organization
+      fallback_data_key: organization_id
       extra_condition_column: org_id
 subscription_validators:
   - validator: AggregationValidator

--- a/snuba/datasets/configuration/metrics/entities/metrics_counters.yaml
+++ b/snuba/datasets/configuration/metrics/entities/metrics_counters.yaml
@@ -99,6 +99,7 @@ subscription_processors:
   - processor: AddColumnCondition
     args:
       extra_condition_data_key: organization
+      fallback_data_key: organization_id
       extra_condition_column: org_id
 
 subscription_validators:

--- a/snuba/datasets/configuration/metrics/entities/metrics_sets.yaml
+++ b/snuba/datasets/configuration/metrics/entities/metrics_sets.yaml
@@ -103,6 +103,7 @@ subscription_processors:
   - processor: AddColumnCondition
     args:
       extra_condition_data_key: organization
+      fallback_data_key: organization_id
       extra_condition_column: org_id
 
 subscription_validators:

--- a/snuba/datasets/entity_subscriptions/processors.py
+++ b/snuba/datasets/entity_subscriptions/processors.py
@@ -39,16 +39,28 @@ class EntitySubscriptionProcessor(metaclass=RegisteredClass):
 
 
 class AddColumnCondition(EntitySubscriptionProcessor):
-    def __init__(self, extra_condition_data_key: str, extra_condition_column: str):
+    def __init__(
+        self,
+        extra_condition_data_key: str,
+        extra_condition_column: str,
+        fallback_data_key: str | None = None,
+    ):
         self.extra_condition_data_key = extra_condition_data_key
         self.extra_condition_column = extra_condition_column
+        # Lets a renamed payload key be accepted alongside the configured one, so
+        # subscriptions stored under either key keep working.
+        self.fallback_data_key = fallback_data_key
+
+    def _get_value(self, metadata: Mapping[str, Any]) -> Any:
+        for key in (self.extra_condition_data_key, self.fallback_data_key):
+            if key is not None and key in metadata:
+                return metadata[key]
+        raise InvalidQueryException(
+            f"'{self.extra_condition_data_key}' not found in metadata: {metadata}"
+        )
 
     def to_dict(self, metadata: Mapping[str, Any]) -> Mapping[str, Any]:
-        if self.extra_condition_data_key not in metadata:
-            raise InvalidQueryException(
-                f"{self.extra_condition_data_key} not found in metadata: {metadata}"
-            )
-        return {self.extra_condition_data_key: metadata[self.extra_condition_data_key]}
+        return {self.extra_condition_data_key: self._get_value(metadata)}
 
     def process(
         self,
@@ -56,15 +68,10 @@ class AddColumnCondition(EntitySubscriptionProcessor):
         metadata: Mapping[str, Any],
         offset: int | None = None,
     ) -> None:
-        if self.extra_condition_data_key not in metadata:
-            raise InvalidQueryException(
-                f"'{self.extra_condition_data_key}' not found in metadata: {metadata}"
-            )
-
         condition_to_add: Expression = binary_condition(
             ConditionFunctions.EQ,
             Column(None, None, self.extra_condition_column),
-            Literal(None, metadata[self.extra_condition_data_key]),
+            Literal(None, self._get_value(metadata)),
         )
         condition = query.get_condition()
         if condition:

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -216,7 +216,7 @@ def _get_settings_object(
     # Only a real organization id from the request may drive per-organization query
     # behavior. The subscription placeholder is applied later, to attribution only.
     organization_id = request_parts.attribution_info["tenant_ids"].get("organization_id")
-    if not isinstance(organization_id, int) or isinstance(organization_id, bool):
+    if not isinstance(organization_id, int):
         organization_id = None
 
     if settings_class == HTTPQuerySettings:

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -40,9 +40,11 @@ from snuba.utils.sentry import SENTRY_OP, set_tag_and_attribute
 metrics = MetricsWrapper(environment.metrics, "snuba.validation")
 
 # Allocation policies require an organization tenant id, but subscription payloads
-# do not always carry one. Such queries are attributed to this placeholder org.
+# do not always carry one. Such queries are attributed to this placeholder, which
+# matches the querylog sentinel for an unknown organization and can never collide
+# with a real organization id.
 # TODO: Subscription queries should always have a real organization id.
-PLACEHOLDER_SUBSCRIPTION_ORGANIZATION_ID = 1
+PLACEHOLDER_SUBSCRIPTION_ORGANIZATION_ID = 0
 
 
 class Parser(Protocol):

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -39,11 +39,11 @@ from snuba.utils.sentry import SENTRY_OP, set_tag_and_attribute
 
 metrics = MetricsWrapper(environment.metrics, "snuba.validation")
 
-# Allocation policies require an organization tenant id, but subscription payloads
-# do not always carry one. Such queries are attributed to this placeholder, which
-# matches the querylog sentinel for an unknown organization and can never collide
-# with a real organization id.
-# TODO: Subscription queries should always have a real organization id.
+# Allocation policies require an organization tenant id, but subscriptions stored
+# before Sentry started sending one carry no organization until they are recreated.
+# Those queries are attributed to this placeholder, which matches the querylog
+# sentinel for an unknown organization and can never collide with a real one, so a
+# nonzero count here measures how many such subscriptions are left.
 PLACEHOLDER_SUBSCRIPTION_ORGANIZATION_ID = 0
 
 

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -39,6 +39,11 @@ from snuba.utils.sentry import SENTRY_OP, set_tag_and_attribute
 
 metrics = MetricsWrapper(environment.metrics, "snuba.validation")
 
+# Allocation policies require an organization tenant id, but subscription payloads
+# do not always carry one. Such queries are attributed to this placeholder org.
+# TODO: Subscription queries should always have a real organization id.
+PLACEHOLDER_SUBSCRIPTION_ORGANIZATION_ID = 1
+
 
 class Parser(Protocol):
     def __call__(
@@ -87,7 +92,10 @@ def _consistent_override(original_setting: bool, referrer: str) -> bool:
 
 
 def update_attribution_info(
-    request_parts: RequestParts, referrer: str, query_project_id: int | None
+    request_parts: RequestParts,
+    referrer: str,
+    query_project_id: int | None,
+    is_subscription: bool = False,
 ) -> dict[str, Any]:
     attribution_info = dict(request_parts.attribution_info)
 
@@ -100,6 +108,9 @@ def update_attribution_info(
 
     if "project_id" not in attribution_info["tenant_ids"] and query_project_id is not None:
         attribution_info["tenant_ids"]["project_id"] = query_project_id
+
+    if is_subscription and "organization_id" not in attribution_info["tenant_ids"]:
+        attribution_info["tenant_ids"]["organization_id"] = PLACEHOLDER_SUBSCRIPTION_ORGANIZATION_ID
 
     return attribution_info
 
@@ -200,8 +211,10 @@ def _get_settings_object(
     request_parts: RequestParts,
     referrer: str,
 ) -> HTTPQuerySettings | SubscriptionQuerySettings:
+    # Only a real organization id from the request may drive per-organization query
+    # behavior. The subscription placeholder is applied later, to attribution only.
     organization_id = request_parts.attribution_info["tenant_ids"].get("organization_id")
-    if not isinstance(organization_id, int):
+    if not isinstance(organization_id, int) or isinstance(organization_id, bool):
         organization_id = None
 
     if settings_class == HTTPQuerySettings:
@@ -232,9 +245,14 @@ def _get_project_id(query: Query | CompositeQuery[LogicalDataSource]) -> int | N
 
 
 def _get_attribution_info(
-    request_parts: RequestParts, referrer: str, query_project_id: int | None
+    request_parts: RequestParts,
+    referrer: str,
+    query_project_id: int | None,
+    is_subscription: bool = False,
 ) -> AttributionInfo:
-    return AttributionInfo(**update_attribution_info(request_parts, referrer, query_project_id))
+    return AttributionInfo(
+        **update_attribution_info(request_parts, referrer, query_project_id, is_subscription)
+    )
 
 
 def _build_request(
@@ -252,7 +270,12 @@ def _build_request(
     if query_project_id:
         set_tag_and_attribute("snuba_project_id", query_project_id)
 
-    attribution_info = _get_attribution_info(request_parts, referrer, query_project_id)
+    attribution_info = _get_attribution_info(
+        request_parts,
+        referrer,
+        query_project_id,
+        is_subscription=isinstance(settings, SubscriptionQuerySettings),
+    )
 
     return Request(
         id=uuid.uuid4(),

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -422,8 +422,13 @@ class SnQLSubscriptionData(_SubscriptionData[Request]):
 
         tenant_ids = {**self.tenant_ids}
         tenant_ids["referrer"] = referrer
-        # A missing organization id is backfilled with a placeholder during attribution,
-        # in build_request, so it never reaches per-organization query behavior.
+        # Entities with an `organization` subscription processor (the metrics entities)
+        # persist the real organization id in metadata, so prefer it over the placeholder
+        # that attribution applies when no organization is known.
+        if "organization_id" not in tenant_ids:
+            organization_id = self.metadata.get("organization")
+            if organization_id is not None:
+                tenant_ids["organization_id"] = int(organization_id)
 
         request = build_request(
             {

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -78,6 +78,17 @@ SUBSCRIPTION_DATA_PAYLOAD_KEYS = {
 
 REQUEST_TYPE_ALLOWLIST = [("TimeSeriesRequest", "v1")]
 
+# Subscription metadata key holding the organization id. This is the key the metrics
+# entities' subscription processors are configured with, so it is also what gets
+# persisted for them.
+ORGANIZATION_METADATA_KEY = "organization"
+
+
+def get_organization_id(metadata: Mapping[str, Any]) -> int | None:
+    """Return the organization id from subscription metadata, if it has one."""
+    organization_id = metadata.get(ORGANIZATION_METADATA_KEY)
+    return int(organization_id) if organization_id is not None else None
+
 
 class SubscriptionType(Enum):
     SNQL = "snql"
@@ -232,9 +243,9 @@ class RPCSubscriptionData(_SubscriptionData[TimeSeriesRequest]):
 
         request_class.meta.referrer = referrer
         request_class.meta.project_ids[:] = [self.project_id]
-        organization_id = self.metadata.get("organization")
+        organization_id = get_organization_id(self.metadata)
         if organization_id is not None:
-            request_class.meta.organization_id = int(organization_id)
+            request_class.meta.organization_id = organization_id
 
         request_class.granularity_secs = self.time_window_sec
 
@@ -298,7 +309,7 @@ class RPCSubscriptionData(_SubscriptionData[TimeSeriesRequest]):
 
         metadata = {}
         if item.time_series_request.meta:
-            metadata["organization"] = item.time_series_request.meta.organization_id
+            metadata[ORGANIZATION_METADATA_KEY] = item.time_series_request.meta.organization_id
 
         return RPCSubscriptionData(
             project_id=item.time_series_request.meta.project_ids[0],
@@ -422,13 +433,12 @@ class SnQLSubscriptionData(_SubscriptionData[Request]):
 
         tenant_ids = {**self.tenant_ids}
         tenant_ids["referrer"] = referrer
-        # Entities with an `organization` subscription processor (the metrics entities)
-        # persist the real organization id in metadata, so prefer it over the placeholder
-        # that attribution applies when no organization is known.
+        # Subscription metadata carries the real organization id, so prefer it over the
+        # placeholder that attribution applies when no organization is known.
         if "organization_id" not in tenant_ids:
-            organization_id = self.metadata.get("organization")
+            organization_id = get_organization_id(self.metadata)
             if organization_id is not None:
-                tenant_ids["organization_id"] = int(organization_id)
+                tenant_ids["organization_id"] = organization_id
 
         request = build_request(
             {
@@ -496,6 +506,13 @@ class SnQLSubscriptionData(_SubscriptionData[Request]):
         if subscription_processors:
             for processor in subscription_processors:
                 subscription_data_dict.update(processor.to_dict(self.metadata))
+
+        # Entities without an organization subscription processor would otherwise drop
+        # the organization, leaving their stored subscriptions unattributable.
+        organization_id = get_organization_id(self.metadata)
+        if organization_id is not None and ORGANIZATION_METADATA_KEY not in subscription_data_dict:
+            subscription_data_dict[ORGANIZATION_METADATA_KEY] = organization_id
+
         return subscription_data_dict
 
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -78,15 +78,21 @@ SUBSCRIPTION_DATA_PAYLOAD_KEYS = {
 
 REQUEST_TYPE_ALLOWLIST = [("TimeSeriesRequest", "v1")]
 
-# Subscription metadata key holding the organization id. This is the key the metrics
-# entities' subscription processors are configured with, so it is also what gets
-# persisted for them.
-ORGANIZATION_METADATA_KEY = "organization"
+# Subscription metadata key holding the organization id.
+ORGANIZATION_ID_METADATA_KEY = "organization_id"
+# The metrics entities' subscription processors are configured with this key, so it is
+# what gets persisted for them and what every subscription stored before the rename
+# carries. Those payloads live in Redis until their subscriptions are recreated, and
+# `AddColumnCondition` raises when its configured key is missing, so the processors keep
+# using it and we read both here.
+LEGACY_ORGANIZATION_METADATA_KEY = "organization"
 
 
 def get_organization_id(metadata: Mapping[str, Any]) -> int | None:
     """Return the organization id from subscription metadata, if it has one."""
-    organization_id = metadata.get(ORGANIZATION_METADATA_KEY)
+    organization_id = metadata.get(
+        ORGANIZATION_ID_METADATA_KEY, metadata.get(LEGACY_ORGANIZATION_METADATA_KEY)
+    )
     return int(organization_id) if organization_id is not None else None
 
 
@@ -309,7 +315,7 @@ class RPCSubscriptionData(_SubscriptionData[TimeSeriesRequest]):
 
         metadata = {}
         if item.time_series_request.meta:
-            metadata[ORGANIZATION_METADATA_KEY] = item.time_series_request.meta.organization_id
+            metadata[ORGANIZATION_ID_METADATA_KEY] = item.time_series_request.meta.organization_id
 
         return RPCSubscriptionData(
             project_id=item.time_series_request.meta.project_ids[0],
@@ -508,10 +514,14 @@ class SnQLSubscriptionData(_SubscriptionData[Request]):
                 subscription_data_dict.update(processor.to_dict(self.metadata))
 
         # Entities without an organization subscription processor would otherwise drop
-        # the organization, leaving their stored subscriptions unattributable.
+        # the organization, leaving their stored subscriptions unattributable. The
+        # processors persist the legacy key themselves, so only add ours when absent.
         organization_id = get_organization_id(self.metadata)
-        if organization_id is not None and ORGANIZATION_METADATA_KEY not in subscription_data_dict:
-            subscription_data_dict[ORGANIZATION_METADATA_KEY] = organization_id
+        if (
+            organization_id is not None
+            and LEGACY_ORGANIZATION_METADATA_KEY not in subscription_data_dict
+        ):
+            subscription_data_dict[ORGANIZATION_ID_METADATA_KEY] = organization_id
 
         return subscription_data_dict
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -422,9 +422,8 @@ class SnQLSubscriptionData(_SubscriptionData[Request]):
 
         tenant_ids = {**self.tenant_ids}
         tenant_ids["referrer"] = referrer
-        if "organization_id" not in tenant_ids:
-            # TODO: Subscriptions queries should have an org ID
-            tenant_ids["organization_id"] = 1
+        # A missing organization id is backfilled with a placeholder during attribution,
+        # in build_request, so it never reaches per-organization query behavior.
 
         request = build_request(
             {

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -18,6 +18,7 @@ from snuba.subscriptions.data import (
     Subscription,
     SubscriptionIdentifier,
     SubscriptionWithMetadata,
+    get_organization_id,
 )
 from snuba.subscriptions.data import SubscriptionScheduler as SubscriptionSchedulerBase
 from snuba.subscriptions.store import SubscriptionDataStore
@@ -273,8 +274,7 @@ def filter_subscriptions(
             for subscription in subscriptions:
                 # get the metadata and org_id from the Subscription
                 sub_data = subscription.data
-                sub_metadata = sub_data.metadata
-                org_id = sub_metadata["organization"]
+                org_id = get_organization_id(sub_data.metadata)
 
                 if org_id is not None:
                     # map the org_id to the slice ID

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -14,7 +14,11 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.physical.replaced_groups import (
     PostReplacementConsistencyEnforcer,
 )
-from snuba.query.query_settings import HTTPQuerySettings, SubscriptionQuerySettings
+from snuba.query.query_settings import (
+    HTTPQuerySettings,
+    QuerySettings,
+    SubscriptionQuerySettings,
+)
 from snuba.redis import RedisClientKey, get_redis_client
 from snuba.replacers.projects_query_flags import ProjectsQueryFlags
 from snuba.replacers.replacer_processor import ReplacerState
@@ -277,6 +281,41 @@ def test_too_many_groups_final_not_disabled_for_other_organization(
 
     PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
         query, HTTPQuerySettings(organization_id=2)
+    )
+
+    assert query.get_from_clause().final
+
+
+@pytest.mark.redis_db
+@override_options(
+    "snuba",
+    {
+        "max_group_ids_exclude": 2,
+        "max_groups_final_bypass_org_ids": [1],
+    },
+)
+@pytest.mark.parametrize(
+    "query_settings",
+    [
+        pytest.param(HTTPQuerySettings(), id="http"),
+        pytest.param(SubscriptionQuerySettings(), id="subscription"),
+    ],
+)
+def test_too_many_groups_final_not_disabled_without_organization(
+    query: ClickhouseQuery, query_settings: QuerySettings
+) -> None:
+    """Queries with no organization attribution must never match the bypass list, so
+    that the subscription placeholder org cannot silently disable FINAL for all of
+    them."""
+    ProjectsQueryFlags.set_project_exclude_groups(
+        2,
+        [100, 101, 102],
+        ReplacerState.ERRORS,
+        ReplacementType.EXCLUDE_GROUPS,
+    )
+
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+        query, query_settings
     )
 
     assert query.get_from_clause().final

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -247,7 +247,7 @@ def test_subscription_without_organization_id() -> None:
         "subscription",
     )
 
-    assert request.attribution_info.tenant_ids["organization_id"] == 1
+    assert request.attribution_info.tenant_ids["organization_id"] == 0
     assert request.query_settings.organization_id is None
 
 

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -20,7 +20,7 @@ from snuba.query.data_source.simple import Entity
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
-from snuba.query.query_settings import HTTPQuerySettings
+from snuba.query.query_settings import HTTPQuerySettings, SubscriptionQuerySettings
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
 from snuba.utils.metrics.timer import Timer
@@ -216,6 +216,80 @@ def test_client_cross_org_query_flag_is_stripped() -> None:
     )
     assert "cross_org_query" not in request.attribution_info.tenant_ids
     assert request.attribution_info.tenant_ids["organization_id"] == 1
+
+
+SUBSCRIPTION_QUERY = (
+    "MATCH (events) "
+    "SELECT count() AS count BY time "
+    "WHERE "
+    "project_id IN tuple(1) AND "
+    "timestamp >= toDateTime('2011-07-01T19:54:15') AND "
+    "timestamp < toDateTime('2018-07-06T19:54:15') "
+    "LIMIT 1000 "
+    "GRANULARITY 60"
+)
+
+
+@pytest.mark.redis_db
+def test_subscription_without_organization_id() -> None:
+    """A subscription with no organization tenant id still gets a placeholder org for
+    attribution, but must not inherit it as a real org for query behavior."""
+    dataset = get_dataset("events")
+    schema = RequestSchema.build(SubscriptionQuerySettings)
+
+    request = build_request(
+        {"query": SUBSCRIPTION_QUERY, "tenant_ids": {"referrer": "subscription"}},
+        parse_snql_query,
+        SubscriptionQuerySettings,
+        schema,
+        dataset,
+        Timer("test"),
+        "subscription",
+    )
+
+    assert request.attribution_info.tenant_ids["organization_id"] == 1
+    assert request.query_settings.organization_id is None
+
+
+@pytest.mark.redis_db
+def test_subscription_with_organization_id() -> None:
+    dataset = get_dataset("events")
+    schema = RequestSchema.build(SubscriptionQuerySettings)
+
+    request = build_request(
+        {
+            "query": SUBSCRIPTION_QUERY,
+            "tenant_ids": {"organization_id": 42, "referrer": "subscription"},
+        },
+        parse_snql_query,
+        SubscriptionQuerySettings,
+        schema,
+        dataset,
+        Timer("test"),
+        "subscription",
+    )
+
+    assert request.attribution_info.tenant_ids["organization_id"] == 42
+    assert request.query_settings.organization_id == 42
+
+
+@pytest.mark.redis_db
+def test_http_query_without_organization_id() -> None:
+    dataset = get_dataset("events")
+    schema = RequestSchema.build(HTTPQuerySettings)
+
+    request = build_request(
+        {"query": SUBSCRIPTION_QUERY, "tenant_ids": {"referrer": "my_request"}},
+        parse_snql_query,
+        HTTPQuerySettings,
+        schema,
+        dataset,
+        Timer("test"),
+        "my_request",
+    )
+
+    assert "organization_id" not in request.attribution_info.tenant_ids
+    assert request.query_settings.organization_id is None
 
 
 @pytest.mark.redis_db

--- a/tests/subscriptions/entity_subscriptions/test_entity_subscriptions.py
+++ b/tests/subscriptions/entity_subscriptions/test_entity_subscriptions.py
@@ -139,6 +139,27 @@ TESTS = [
         5,
         id="Metrics sets subscription",
     ),
+    pytest.param(
+        EntityKey.METRICS_SETS,
+        Query(
+            QueryEntity(
+                EntityKey.METRICS_SETS,
+                get_entity(EntityKey.METRICS_SETS).get_data_model(),
+            ),
+            selected_columns=[
+                SelectedExpression("time", Column("_snuba_timestamp", None, "timestamp")),
+            ],
+            condition=binary_condition(
+                "equals",
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 1),
+            ),
+        ),
+        {"organization_id": 1},
+        None,
+        5,
+        id="Metrics sets subscription with renamed organization key",
+    ),
 ]
 
 

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -104,7 +104,7 @@ def build_rpc_subscription_data(
 RPC_CASES = [
     pytest.param(
         build_rpc_subscription_data_from_proto,
-        {"organization": 1},
+        {"organization_id": 1},
         EntityKey.EAP_ITEMS,
         id="rpc",
     ),

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -1,5 +1,6 @@
 import base64
 from datetime import datetime
+from typing import Any
 
 import pytest
 from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
@@ -22,6 +23,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.factory import get_dataset
 from snuba.query.exceptions import InvalidQueryException
 from snuba.subscriptions.data import (
     RPCSubscriptionData,
@@ -269,3 +271,50 @@ def test_rpc_build_request_rebinds_project_and_org() -> None:
     )
     assert list(request.meta.project_ids) == [1]
     assert request.meta.organization_id == 1
+
+
+SNQL_SUBSCRIPTION_QUERY = (
+    "MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3] "
+    "WHERE org_id = 1 AND project_id IN tuple(1) AND metric_id = 7 "
+    "AND tags[3] IN tuple(13, 4) "
+)
+
+
+@pytest.mark.redis_db
+@pytest.mark.parametrize(
+    "metadata, tenant_ids, expected_organization_id",
+    [
+        pytest.param({"organization": 4567}, {}, 4567, id="organization from metadata"),
+        pytest.param(
+            {"organization": 4567},
+            {"organization_id": 89},
+            89,
+            id="explicit tenant id wins over metadata",
+        ),
+    ],
+)
+def test_snql_build_request_organization_id(
+    metadata: dict[str, Any],
+    tenant_ids: dict[str, Any],
+    expected_organization_id: int,
+) -> None:
+    """Entities that persist the organization in metadata should attribute their queries
+    to the real organization rather than the placeholder."""
+    subscription = SnQLSubscriptionData(
+        project_id=1,
+        query=SNQL_SUBSCRIPTION_QUERY,
+        time_window_sec=3600,
+        resolution_sec=60,
+        entity=get_entity(EntityKey.METRICS_COUNTERS),
+        metadata={"granularity": 3600, **metadata},
+        tenant_ids=tenant_ids,
+    )
+
+    request = subscription.build_request(
+        get_dataset("metrics"),
+        datetime.utcnow(),
+        None,
+        Timer("test"),
+    )
+
+    assert request.query_settings.organization_id == expected_organization_id


### PR DESCRIPTION
Follow-up to #8399, which made `max_groups_final_bypass_org_ids` skip the max-groups fallback to `FINAL` for listed organizations. That option matches on `query_settings.organization_id`, and subscription queries did not reliably carry a real one, so this makes the organization behind a query trustworthy before the option gets turned on.

**The placeholder no longer reaches query settings.** Subscription payloads do not always carry an organization tenant id, so `SnQLSubscriptionData.build_request` backfilled `organization_id: 1` into `tenant_ids` before query settings were built. Adding org 1 to the bypass list would then have disabled `FINAL` for *every* unattributed subscription query rather than for that one organization — and org 1 is plausibly a real org. The placeholder now lives in `update_attribution_info`, which runs after `_get_settings_object`, so allocation policies still see an organization tenant id while `query_settings.organization_id` stays `None` unless a real one is known.

**The placeholder is now 0**, matching the querylog sentinel for an unknown organization. It can never collide with a real organization id, so a nonzero count of `organization = 0` in querylog measures how many subscriptions still lack attribution.

**Subscriptions use the organization they already store.** The metrics entities persist it in subscription metadata via their `AddColumnCondition` processor, and `RPCSubscriptionData` already read it back. SnQL subscriptions now do the same, and entities without such a processor persist it too, so their stored subscriptions stay attributable. Reads go through one `get_organization_id` helper instead of indexing metadata directly — which also fixes a latent `KeyError` in the sliced-storage scheduler path for subscriptions stored without the key.

**`AddColumnCondition` accepts a fallback key.** getsentry/sentry#122733 sends this field as `organization_id`, while the metrics entities' processors are configured with the older `organization` and raise when their configured key is missing. Without a fallback, metrics subscriptions created after that change would throw `InvalidQueryException` on every scheduled execution. The configured key and the emitted `org_id` condition are unchanged; the processors simply also accept the new spelling.

Existing subscriptions keep their stored payloads until they are recreated, so attribution fills in over time rather than at deploy. Errors and transactions subscriptions stay unattributed until the Sentry PR ships, which is why the placeholder remains a fallback rather than becoming an error.

Merge before getsentry/sentry#122733: this must be deployed before Sentry starts sending `organization_id`, otherwise metrics subscriptions hit the missing-key path above.
