### PR TITLE
feat(replacer): add global consistency enforcer bypass

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -385,6 +385,11 @@
       "default": "[]",
       "description": "Bracketed comma-separated list of project ids that are forced to FINAL after a replacement."
     },
+    "bypass_post_replacement_consistency_enforcer": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, the post-replacement consistency processor does not add FINAL or group-id exclusions to queries. Results may include stale or replaced rows until ClickHouse merges complete."
+    },
     "max_group_ids_exclude": {
       "type": "integer",
       "default": 256,

--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -21,6 +21,7 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 metrics = MetricsWrapper(environment.metrics, "processors.replaced_groups")
 FINAL_METRIC = "final"
 CONSISTENCY_DENYLIST_METRIC = "post_replacement_consistency_projects_denied"
+CONSISTENCY_ENFORCER_BYPASSED_METRIC = "consistency_enforcer_bypassed"
 MAX_GROUPS_FINAL_DISABLED_METRIC = "max_groups_final_disabled"
 MAX_GROUPS_FINAL_BYPASS_ORG_IDS_OPTION = "max_groups_final_bypass_org_ids"
 
@@ -45,6 +46,13 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
         )
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
+        if get_option("bypass_post_replacement_consistency_enforcer", False):
+            metrics.increment(
+                name=CONSISTENCY_ENFORCER_BYPASSED_METRIC,
+                tags={"referrer": query_settings.referrer},
+            )
+            return
+
         if query_settings.get_turbo():
             return
 

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -131,6 +131,43 @@ def test_with_turbo(query: ClickhouseQuery) -> None:
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"bypass_post_replacement_consistency_enforcer": True})
+def test_global_bypass_skips_final(query: ClickhouseQuery) -> None:
+    ProjectsQueryFlags.set_project_needs_final(
+        2,
+        ReplacerState.ERRORS,
+        ReplacementType.EXCLUDE_GROUPS,
+    )
+    query_settings = HTTPQuerySettings()
+
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+        query, query_settings
+    )
+
+    assert query.get_condition() == build_in("project_id", [2])
+    assert not query.get_from_clause().final
+    assert query_settings.get_clickhouse_settings() == {}
+
+
+@pytest.mark.redis_db
+@override_options("snuba", {"bypass_post_replacement_consistency_enforcer": True})
+def test_global_bypass_skips_group_exclusions(query: ClickhouseQuery) -> None:
+    ProjectsQueryFlags.set_project_exclude_groups(
+        2,
+        [100, 101, 102],
+        ReplacerState.ERRORS,
+        ReplacementType.EXCLUDE_GROUPS,
+    )
+
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+        query, HTTPQuerySettings()
+    )
+
+    assert query.get_condition() == build_in("project_id", [2])
+    assert not query.get_from_clause().final
+
+
+@pytest.mark.redis_db
 def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> None:
     ProjectsQueryFlags.set_project_needs_final(
         2,


### PR DESCRIPTION
## Summary

- add the default-false `bypass_post_replacement_consistency_enforcer` Sentry option
- return before project handling or replacement-state Redis reads when the option is enabled
- skip both `FINAL` and replacement `group_id NOT IN (...)` query mutations globally
- emit `snuba.processors.replaced_groups.consistency_enforcer_bypassed` tagged by referrer

Enabling this option favors query availability and performance over post-replacement consistency. Queries may temporarily return stale or replaced rows until ClickHouse merges complete.

## Tests

- `pytest -q tests/datasets/storages/processors/test_replaced_groups.py`
- pre-commit formatting, lint, mypy, and repository checks