### PR TITLE
feat(query): Add disable_query_final killswitch

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -375,6 +375,11 @@
       "default": false,
       "description": "When true, queries missing mandatory condition columns raise an assertion; otherwise the omission is only logged."
     },
+    "disable_query_final": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, no query emits the ClickHouse FINAL keyword, regardless of replacement flags, SNQL final, or other processors."
+    },
     "skip_final_subscriptions_projects": {
       "type": "string",
       "default": "[]",

--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -29,6 +29,7 @@ from snuba.query.data_source.join import (
 from snuba.query.data_source.simple import Table
 from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.expressions import Expression, ExpressionVisitor
+from snuba.query.final import query_final_disabled
 from snuba.query.parsing import ParsingContext
 
 FormattableQuery = Query | CompositeQuery[Table]
@@ -67,7 +68,7 @@ class DataSourceFormatter(DataSourceVisitor[FormattedNode, Table]):
         Formats a simple table data source.
         """
 
-        final = " FINAL" if data_source.final else ""
+        final = " FINAL" if data_source.final and not query_final_disabled() else ""
         sample = f" SAMPLE {data_source.sampling_rate}" if data_source.sampling_rate else ""
         return StringNode(f"{data_source.table_name}{final}{sample}")
 

--- a/snuba/clickhouse/query_inspector.py
+++ b/snuba/clickhouse/query_inspector.py
@@ -10,6 +10,7 @@ from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.expressions import Column as ColumnExpr
 from snuba.query.expressions import Expression
 from snuba.query.expressions import FunctionCall as FunctionCallExpr
+from snuba.query.final import query_final_disabled
 
 
 def _get_date_range(query: ProcessableQuery[Table]) -> int | None:
@@ -76,7 +77,7 @@ class TablesCollector(DataSourceVisitor[None, Table], JoinVisitor[None, Table]):
     def _visit_simple_source(self, data_source: Table) -> None:
         self.__tables.add(data_source.table_name)
         self.__sample_rate = data_source.sampling_rate
-        if data_source.final:
+        if data_source.final and not query_final_disabled():
             self.__final = True
 
     def _visit_join(self, data_source: JoinClause[Table]) -> None:

--- a/snuba/query/final.py
+++ b/snuba/query/final.py
@@ -1,0 +1,8 @@
+from snuba.state.sentry_options import get_option
+
+DISABLE_QUERY_FINAL_OPTION = "disable_query_final"
+
+
+def query_final_disabled() -> bool:
+    """Return True when the global FINAL killswitch is on."""
+    return get_option(DISABLE_QUERY_FINAL_OPTION, False)

--- a/snuba/query/processors/physical/consistency_enforcer.py
+++ b/snuba/query/processors/physical/consistency_enforcer.py
@@ -1,6 +1,7 @@
 from dataclasses import replace
 
 from snuba.clickhouse.query import Query
+from snuba.query.final import query_final_disabled
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
 
@@ -15,4 +16,6 @@ class ConsistencyEnforcerProcessor(ClickhouseQueryProcessor):
     """
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
+        if query_final_disabled():
+            return
         query.set_from_clause(replace(query.get_from_clause(), final=True))

--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -11,6 +11,7 @@ from snuba.clickhouse.query_dsl.accessors import (
 )
 from snuba.query.conditions import not_in_condition
 from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.final import query_final_disabled
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings, SubscriptionQuerySettings
 from snuba.replacers.projects_query_flags import ProjectsQueryFlags
@@ -133,6 +134,10 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
                     )
                 )
 
+        if set_final and query_final_disabled():
+            metrics.increment(name="query_final_disabled")
+            set_final = False
+
         if (
             set_final
             and self.__replacer_state_name is not None
@@ -159,6 +164,9 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
         on the results of the query. This is very performance heavy and
         should be avoided whenever possible.
         """
+        if final and query_final_disabled():
+            metrics.increment(name="query_final_disabled")
+            final = False
         query.set_from_clause(replace(query.get_from_clause(), final=final))
 
     def _query_overlaps_replacements(

--- a/snuba/web/rpc/v1/endpoint_get_trace.py
+++ b/snuba/web/rpc/v1/endpoint_get_trace.py
@@ -39,6 +39,7 @@ from snuba.query.data_source.simple import Entity
 from snuba.query.dsl import Functions as f
 from snuba.query.dsl import and_cond, column, equals, literal, or_cond
 from snuba.query.expressions import FunctionCall
+from snuba.query.final import query_final_disabled
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request import Request as SnubaRequest
@@ -346,7 +347,7 @@ def _build_query(
         order_by=order_by,
         limit=limit,
     )
-    if random.random() < _get_apply_final_rollout_percentage():
+    if not query_final_disabled() and random.random() < _get_apply_final_rollout_percentage():
         query.set_final(True)
 
     span = traces.get_current_span()

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.clickhouse.columns import UUID, ColumnSet, String, UInt
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
@@ -643,6 +644,24 @@ def test_format_clickhouse_specific_query() -> None:
     )
 
     assert clickhouse_query.get_sql() == expected
+
+
+@override_options("snuba", {"disable_query_final": True})
+def test_format_omits_final_when_killswitch_enabled() -> None:
+    query = Query(
+        Table(
+            "my_table",
+            ColumnSet([]),
+            final=True,
+            sampling_rate=0.1,
+            storage_key=StorageKey("dontmatter"),
+        ),
+        selected_columns=[
+            SelectedExpression("column1", Column(None, None, "column1")),
+        ],
+    )
+
+    assert format_query(query).get_sql() == "SELECT column1 FROM my_table SAMPLE 0.1"
 
 
 def test_delete_query() -> None:

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -151,6 +151,28 @@ def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> No
 
 
 @pytest.mark.redis_db
+@override_options("snuba", {"disable_query_final": True})
+def test_disable_query_final_killswitch(query: ClickhouseQuery) -> None:
+    ProjectsQueryFlags.set_project_needs_final(
+        2,
+        ReplacerState.ERRORS,
+        ReplacementType.EXCLUDE_GROUPS,
+    )
+
+    query_settings = HTTPQuerySettings()
+    PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS.value).process_query(
+        query, query_settings
+    )
+
+    assert query.get_condition() == build_in("project_id", [2])
+    assert not query.get_from_clause().final
+    assert (
+        "do_not_merge_across_partitions_select_final"
+        not in query_settings.get_clickhouse_settings()
+    )
+
+
+@pytest.mark.redis_db
 def test_without_turbo_without_projects_needing_final(query: ClickhouseQuery) -> None:
     PostReplacementConsistencyEnforcer("project_id", None).process_query(query, HTTPQuerySettings())
 


### PR DESCRIPTION
Adds a `disable_query_final` Sentry option that strips ClickHouse `FINAL` from every query when enabled.

Replacement consistency, SNQL `final`, GetTrace, and CDC processors all honor it. The formatter is the last line of defense so a query cannot emit `FINAL` while the option is on.

Default is `false`. Flip the option to disable `FINAL` without a deploy. CDC tables (`groupedmessage`, `groupassignee`, `group_attributes`) also lose `FINAL` while it is on.
