### PR TITLE
feat(replacer): Honor disable_query_final on INSERT SELECT

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -378,7 +378,7 @@
     "disable_query_final": {
       "type": "boolean",
       "default": false,
-      "description": "When true, no query emits the ClickHouse FINAL keyword, regardless of replacement flags, SNQL final, or other processors."
+      "description": "When true, no query emits the ClickHouse FINAL keyword, including replacement INSERT ... SELECT, replacement consistency, SNQL final, GetTrace, and CDC processors."
     },
     "skip_final_subscriptions_projects": {
       "type": "string",

--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -37,6 +37,7 @@ from snuba.processor import (
     ReplacementType,
     _hashify,
 )
+from snuba.query.final import query_final_disabled
 from snuba.replacers.projects_query_flags import ProjectsQueryFlags
 from snuba.replacers.replacements_and_expiry import (
     get_config_auto_replacements_bypass_projects,
@@ -58,6 +59,14 @@ In theory this will be needed only during the events to errors migration.
 
 logger = logging.getLogger(__name__)
 metrics = MetricsWrapper(environment.metrics, "errors.replacer")
+
+
+def _final_clause() -> str:
+    """ClickHouse FINAL on replacement SELECTs, omitted when the killswitch is on."""
+    if query_final_disabled():
+        metrics.increment("query_final_disabled")
+        return ""
+    return " FINAL"
 
 
 @dataclass(frozen=True)
@@ -357,7 +366,7 @@ class ReplaceGroupReplacement(Replacement):
         return f"""\
             INSERT INTO {table_name} ({all_columns})
             SELECT {select_columns}
-            FROM {table_name} FINAL
+            FROM {table_name}{_final_clause()}
             {self._where_clause}
         """
 
@@ -425,7 +434,7 @@ class DeleteGroupsReplacement(Replacement):
         return f"""\
             INSERT INTO {table_name} ({required_columns})
             SELECT {select_columns}
-            FROM {table_name} FINAL
+            FROM {table_name}{_final_clause()}
             {self._where_clause}
         """
 
@@ -481,7 +490,7 @@ class TombstoneEventsReplacement(Replacement):
         return f"""\
             INSERT INTO {table_name} ({required_columns})
             SELECT {select_columns}
-            FROM {table_name} FINAL
+            FROM {table_name}{_final_clause()}
             {self._where_clause}
         """
 
@@ -644,7 +653,7 @@ class MergeReplacement(Replacement):
         return f"""\
             INSERT INTO {table_name} ({all_columns})
             SELECT {select_columns}
-            FROM {table_name} FINAL
+            FROM {table_name}{_final_clause()}
             {self._where_clause}
         """
 
@@ -736,7 +745,7 @@ class UnmergeGroupsReplacement(Replacement):
         return f"""\
             INSERT INTO {table_name} ({all_columns})
             SELECT {select_columns}
-            FROM {table_name} FINAL
+            FROM {table_name}{_final_clause()}
             {self._where_clause}
         """
 
@@ -832,7 +841,7 @@ class DeleteTagReplacement(Replacement):
         return f"""\
             INSERT INTO {table_name} ({all_columns})
             SELECT {select_columns}
-            FROM {table_name} FINAL
+            FROM {table_name}{_final_clause()}
             {self._where_clause}
         """
 

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -846,6 +846,51 @@ class TestReplacerProcess(BaseTest):
             group_ids=[1, 2, 3]
         )
 
+    @pytest.mark.parametrize(
+        "replacement_type, extra",
+        [
+            (ReplacementType.END_DELETE_GROUPS, {"group_ids": [1, 2, 3]}),
+            (
+                ReplacementType.TOMBSTONE_EVENTS,
+                {"event_ids": ["00e24a150d7f4ee4b142b61b4d893b6d"]},
+            ),
+            (
+                ReplacementType.REPLACE_GROUP,
+                {"event_ids": ["00e24a150d7f4ee4b142b61b4d893b6d"], "new_group_id": 2},
+            ),
+            (ReplacementType.END_MERGE, {"new_group_id": 2, "previous_group_ids": [1, 2]}),
+            (
+                ReplacementType.END_UNMERGE,
+                {"previous_group_id": 1, "new_group_id": 2, "hashes": ["a" * 32]},
+            ),
+            (ReplacementType.END_DELETE_TAG, {"tag": "sentry:user"}),
+        ],
+    )
+    def test_disable_query_final_omits_final(
+        self, replacement_type: ReplacementType, extra: dict[str, Any]
+    ) -> None:
+        timestamp = datetime.now()
+        message = (
+            2,
+            replacement_type,
+            {
+                "project_id": self.project_id,
+                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                **extra,
+            },
+        )
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
+        assert isinstance(replacement, errors_replacer.Replacement)
+
+        with override_options("snuba", {"disable_query_final": True}):
+            query = replacement.get_insert_query("foo")
+
+        assert query is not None
+        assert " FINAL" not in query
+        assert re.search(r"FROM foo\s+WHERE", query) is not None
+
     def test_project_bypass(self) -> None:
         timestamp = datetime.now()
         message = (


### PR DESCRIPTION
The `disable_query_final` killswitch already strips ClickHouse `FINAL` from the query pipeline. Replacement `INSERT ... SELECT` still hardcoded `FINAL`, so flipping the option left the errors replacer hitting the same cluster with expensive merges.

Those replacements now omit `FINAL` when the option is on. They still write; they just read without `FINAL`, so the written rows can be wrong until ClickHouse merges catch up.

`OPTIMIZE ... FINAL`, migration-status lookups, and admin raw SQL are unchanged.
