### PR TITLE
feat(events): Enable ReferrerGuardRailPolicy on errors

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -281,6 +281,12 @@ allocation_policies:
         - referrer
       default_config_overrides:
         is_enforced: 0
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -278,6 +278,12 @@ allocation_policies:
         - referrer
       default_config_overrides:
         is_enforced: 0
+  - name: ReferrerGuardRailPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -568,9 +568,6 @@ def test_db_query_success() -> None:
                 "max_threads": 10,
                 "max_bytes_to_read": 0,
                 "explanation": {
-                    "reason": "within limit",
-                    "policy": "referrer_guard_rail_policy",
-                    "referrer": "test_db_query_success",
                     "storage_key": "errors_ro",
                 },
                 "is_throttled": False,

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -563,6 +563,23 @@ def test_db_query_success() -> None:
                 "quota_unit": "bytes",
                 "suggestion": "no_suggestion",
             },
+            "ReferrerGuardRailPolicy": {
+                "can_run": True,
+                "max_threads": 10,
+                "max_bytes_to_read": 0,
+                "explanation": {
+                    "reason": "within limit",
+                    "policy": "referrer_guard_rail_policy",
+                    "referrer": "test_db_query_success",
+                    "storage_key": "errors_ro",
+                },
+                "is_throttled": False,
+                "throttle_threshold": 66,
+                "rejection_threshold": 100,
+                "quota_used": 1,
+                "quota_unit": "concurrent_queries",
+                "suggestion": "no_suggestion",
+            },
         },
     }
 


### PR DESCRIPTION
Add `ReferrerGuardRailPolicy` to the `errors` and `errors_ro` storages so referrer concurrency is observed in quota-allowance stats.

The policy is active (`is_active` defaults to 1) but not enforced (`is_enforced: 0`), so it records usage without rejecting or throttling queries.
