### PR TITLE
chore(deps): bump arroyo for batch flush-reason metric

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -3911,8 +3911,8 @@ dependencies = [
 
 [[package]]
 name = "sentry_arroyo"
-version = "2.42.0"
-source = "git+https://github.com/getsentry/arroyo?branch=rbroughan%2Fpull-based-arroyo-part-2#7c5b1d7f453000cd1a8ebe4f5425a1df6e12701c"
+version = "2.43.0"
+source = "git+https://github.com/getsentry/arroyo?branch=rbroughan%2Fpull-based-arroyo-part-2#ad99a41a4a59f62a0b176871a46cab2e4402c0c6"
 dependencies = [
  "async-stream",
  "chrono",

--- a/snuba/lw_deletions/batching.py
+++ b/snuba/lw_deletions/batching.py
@@ -58,6 +58,14 @@ class ReduceRowsBuffer(Generic[TPayload, TResult]):
             or self._buffered_messages >= MAX_BUFFERED_MESSAGES
         )
 
+    @property
+    def readiness_reason(self) -> str:
+        if self._buffer_size >= self.max_batch_size:
+            return "size"
+        if time.time() >= self._buffer_until:
+            return "time"
+        return "message_count"
+
     def append(self, message: BaseValue[TPayload]) -> None:
         """
         Instead of increasing the buffer size based on the number

--- a/uv.lock
+++ b/uv.lock
@@ -1062,13 +1062,13 @@ source = { editable = "rust_snuba" }
 
 [[package]]
 name = "sentry-arroyo"
-version = "2.39.2"
+version = "2.43.1"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "confluent-kafka" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.39.2-py3-none-any.whl", hash = "sha256:a751392036aaab9d293fe5fa789f5a546f6673f5a1ff822090b428657653b7e5" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.43.1-py3-none-any.whl", hash = "sha256:6195bbdca5a2149e2af524821549305c51988f5c3c6e3d69237a62c431b5bda0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Bump arroyo (Rust + Python) to pick up the batch flush-reason metric.

## How
- `rust_snuba/Cargo.lock`: `sentry_arroyo` → `ad99a41a` (`rbroughan/pull-based-arroyo-part-2`)
- `uv.lock`: `sentry-arroyo` `2.39.2` → `2.43.1`
- Implement `readiness_reason` for `ReduceRowsBuffer`

## Why
- Tells use whether a batch flush was triggered by size, time, or force 
- So we can validate the byte-based batch sizing rollout is actually doing what we expect

## Links
- [EAP-694](https://linear.app/getsentry/issue/EAP-694/revisit-byte-based-max-batch-size-calculation)