### PR TITLE
ref(attribute-values): return the most recent items

### DIFF
--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -93,32 +93,6 @@ def _build_conditions(request: TraceItemAttributeValuesRequest) -> Expression:
     return base_conditions_and(request.meta, *conditions)
 
 
-def _build_inner_order_by(
-    request: TraceItemAttributeValuesRequest,
-) -> list[OrderBy] | None:
-    """Order the inner query newest-first, but only when it's free.
-
-    ClickHouse reads in sort-key order when the ORDER BY is a prefix of the table's sort
-    key -- (organization_id, project_id, item_type, timestamp, ...) here -- so ordering by
-    that prefix costs nothing: the 10000-row sample is the most recent matching data
-    instead of whatever ClickHouse reads first (sort-key order, i.e. the oldest rows in the
-    range). ClickHouse infers a prefix from equality conditions, but `project_id IN (...)`
-    doesn't count even for a single project, so the columns are named explicitly.
-
-    That only holds when each leading column is pinned to one value. With several projects
-    (or an unset item type) they outrank timestamp, so the sample would be the newest rows
-    of the highest project/type rather than the newest overall -- and ordering by timestamp
-    alone would fall back to sorting the whole matching range. Neither is worth it, so
-    those requests get no ORDER BY and take whatever the sample scan returns.
-    """
-    if len(request.meta.project_ids) != 1 or not request.meta.trace_item_type:
-        return None
-    return [
-        OrderBy(direction=OrderByDirection.DESC, expression=column(col))
-        for col in ("organization_id", "project_id", "item_type", "timestamp")
-    ]
-
-
 def _build_query(
     request: TraceItemAttributeValuesRequest,
 ) -> CompositeQuery[LogicalDataSource]:
@@ -135,15 +109,13 @@ def _build_query(
         AND project_id = 1 AND organization_id=1 AND item_type=1
         AND less(timestamp, toDateTime(1741910400))
         AND greaterOrEquals(timestamp, toDateTime(1741651200))
-        -- only for a single project with a set item type; see _build_inner_order_by
         ORDER BY organization_id DESC, project_id DESC, item_type DESC, timestamp DESC
         LIMIT 10000
     ) ORDER BY attr_value LIMIT 1000
 
 
-    This query samples 10000 matching items and then deduplicates them, which gives a large
-    speedup at the cost of ordering and paginating all values. The sample is the 10000 most
-    recent items when the inner ORDER BY above applies, and an arbitrary 10000 otherwise.
+    This query samples the 10000 most recent matching items and then deduplicates them,
+    which gives a large speedup at the cost of ordering and paginating all values.
     """
     if request.limit > 10000:
         raise BadSnubaRPCRequestException("Limit can be at most 10000")
@@ -160,7 +132,12 @@ def _build_query(
         from_clause=entity,
         selected_columns=[SelectedExpression(name=attr_value.alias, expression=attr_value)],
         condition=_build_conditions(request),
-        order_by=_build_inner_order_by(request),
+        # Order newest-first. ClickHouse reads in sort-key order when the ORDER BY is a
+        # prefix of the table's sort key (optimize_read_in_order=1 is the default)
+        order_by=[
+            OrderBy(direction=OrderByDirection.DESC, expression=column(col))
+            for col in ("organization_id", "project_id", "item_type", "timestamp")
+        ],
         offset=0,
         limit=10000,
     )

--- a/snuba/web/rpc/v1/trace_item_attribute_values.py
+++ b/snuba/web/rpc/v1/trace_item_attribute_values.py
@@ -93,6 +93,32 @@ def _build_conditions(request: TraceItemAttributeValuesRequest) -> Expression:
     return base_conditions_and(request.meta, *conditions)
 
 
+def _build_inner_order_by(
+    request: TraceItemAttributeValuesRequest,
+) -> list[OrderBy] | None:
+    """Order the inner query newest-first, but only when it's free.
+
+    ClickHouse reads in sort-key order when the ORDER BY is a prefix of the table's sort
+    key -- (organization_id, project_id, item_type, timestamp, ...) here -- so ordering by
+    that prefix costs nothing: the 10000-row sample is the most recent matching data
+    instead of whatever ClickHouse reads first (sort-key order, i.e. the oldest rows in the
+    range). ClickHouse infers a prefix from equality conditions, but `project_id IN (...)`
+    doesn't count even for a single project, so the columns are named explicitly.
+
+    That only holds when each leading column is pinned to one value. With several projects
+    (or an unset item type) they outrank timestamp, so the sample would be the newest rows
+    of the highest project/type rather than the newest overall -- and ordering by timestamp
+    alone would fall back to sorting the whole matching range. Neither is worth it, so
+    those requests get no ORDER BY and take whatever the sample scan returns.
+    """
+    if len(request.meta.project_ids) != 1 or not request.meta.trace_item_type:
+        return None
+    return [
+        OrderBy(direction=OrderByDirection.DESC, expression=column(col))
+        for col in ("organization_id", "project_id", "item_type", "timestamp")
+    ]
+
+
 def _build_query(
     request: TraceItemAttributeValuesRequest,
 ) -> CompositeQuery[LogicalDataSource]:
@@ -109,13 +135,15 @@ def _build_query(
         AND project_id = 1 AND organization_id=1 AND item_type=1
         AND less(timestamp, toDateTime(1741910400))
         AND greaterOrEquals(timestamp, toDateTime(1741651200))
-        ORDER BY attr_value
+        -- only for a single project with a set item type; see _build_inner_order_by
+        ORDER BY organization_id DESC, project_id DESC, item_type DESC, timestamp DESC
         LIMIT 10000
     ) ORDER BY attr_value LIMIT 1000
 
 
-    This query will match the first 10000 occurrences of an attribute value and then deduplicate them,
-    this gives a large speedup to the query at the cost of ordering and paginating all values
+    This query samples 10000 matching items and then deduplicates them, which gives a large
+    speedup at the cost of ordering and paginating all values. The sample is the 10000 most
+    recent items when the inner ORDER BY above applies, and an arbitrary 10000 otherwise.
     """
     if request.limit > 10000:
         raise BadSnubaRPCRequestException("Limit can be at most 10000")
@@ -132,6 +160,7 @@ def _build_query(
         from_clause=entity,
         selected_columns=[SelectedExpression(name=attr_value.alias, expression=attr_value)],
         condition=_build_conditions(request),
+        order_by=_build_inner_order_by(request),
         offset=0,
         limit=10000,
     )


### PR DESCRIPTION
Related to https://github.com/getsentry/snuba/pull/8390

We are going to be adding a `last_seen` to the `TraceItemAttributeValuesResponse` (among other things) but right now the inner query has no order by. 

We want to add to order by timestamp so that the 10000 we grab are the most recent, so that when we get the `last_seen` aka `max(timestamp)`, this actually represents the most recent data. 

However in order to get the benefit of `optimize_read_in_order` we need the ORDER BY be a prefix of the primary key. Since we use `project_ids IN ()` syntax, if we just have one project, order by timestamp doesn't optimize the query. So you'd need the full prefix `(organization_id, project_id, item_type, timestamp)` in the ORDER BY, and with multiple projects that might not make sense since you'd be getting data from one project

### examples 

**project_id = 1**

```EXPLAIN PIPELINE
SELECT
    attributes_string_38['sentry.description'],
    timestamp
FROM eap_items_1_local
WHERE (project_id = 1) AND (organization_id = 1) AND (item_type = 1)
ORDER BY timestamp DESC
LIMIT 10
SETTINGS optimize_read_in_order = 1

Query id: ec4ecaf9-9d49-46dd-aea7-6d566cc2dc62

    ┌─explain───────────────────────────────────────────────────────────────────────────────────┐
 1. │ (Expression)                                                                              │
 2. │ ExpressionTransform                                                                       │
 3. │   (Limit)                                                                                 │
 4. │   Limit                                                                                   │
 5. │     (Sorting)                                                                             │
 6. │     MergingSortedTransform 2 → 1                                                          │
 7. │       BufferChunks × 2                                                                    │
 8. │         (Expression)                                                                      │
 9. │         ExpressionTransform × 2                                                           │
10. │           (Expression)                                                                    │
11. │           ExpressionTransform × 2                                                         │
12. │             (ReadFromMergeTree)                                                           │
13. │             ReverseTransform                                                              │
14. │               MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InReverseOrder) 0 → 1     │
15. │                 ReverseTransform                                                          │
16. │                   MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InReverseOrder) 0 → 1 │
    └───────────────────────────────────────────────────────────────────────────────────────────┘

16 rows in set. Elapsed: 0.015 sec.
````

**project_id IN [1]**

```
EXPLAIN PIPELINE
SELECT
    attributes_string_38['sentry.description'],
    timestamp
FROM eap_items_1_local
WHERE (project_id IN [1]) AND (organization_id = 1) AND (item_type = 1)
ORDER BY timestamp DESC
LIMIT 10
SETTINGS optimize_read_in_order = 1

Query id: 89de6449-8eee-4381-b8a2-50dfe3a98628

    ┌─explain──────────────────────────────────────────────────────────────────────┐
 1. │ (Expression)                                                                 │
 2. │ ExpressionTransform                                                          │
 3. │   (Limit)                                                                    │
 4. │   Limit                                                                      │
 5. │     (Sorting)                                                                │
 6. │     MergingSortedTransform 2 → 1                                             │
 7. │       MergeSortingTransform × 2                                              │
 8. │         LimitsCheckingTransform × 2                                          │
 9. │           PartialSortingTransform × 2                                        │
10. │             (Expression)                                                     │
11. │             ExpressionTransform × 2                                          │
12. │               (Expression)                                                   │
  13. │               ExpressionTransform × 2                                        │
14. │                 (ReadFromMergeTree)                                          │
15. │                 MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1 │
    └──────────────────────────────────────────────────────────────────────────────┘

15 rows in set. Elapsed: 0.022 sec.
```