### PR TITLE
chore: pin `action-build-and-push-images` to latest master

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.repository_owner == 'getsentry'
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: getsentry/action-build-and-push-images@8a785ee066b116b5fbcad72237f4ea68471954ad
+    - uses: getsentry/action-build-and-push-images@d91c0db327059826ded066cdda9d03ee2e467904
       with:
         image_name: 'snuba'
         platforms: linux/${{ matrix.platform }}
@@ -50,7 +50,7 @@ jobs:
     if: ${{ github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: getsentry/action-build-and-push-images@8a785ee066b116b5fbcad72237f4ea68471954ad
+      - uses: getsentry/action-build-and-push-images@d91c0db327059826ded066cdda9d03ee2e467904
         with:
           image_name: 'snuba'
           platforms: linux/amd64
@@ -81,7 +81,7 @@ jobs:
     if: github.repository_owner == 'getsentry'
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: getsentry/action-build-and-push-images@8a785ee066b116b5fbcad72237f4ea68471954ad
+    - uses: getsentry/action-build-and-push-images@d91c0db327059826ded066cdda9d03ee2e467904
       with:
         image_name: 'snuba'
         platforms: linux/${{ matrix.platform }}


### PR DESCRIPTION
Points to the [latest master](https://github.com/getsentry/action-build-and-push-images/commit/d91c0db327059826ded066cdda9d03ee2e467904) rather than a test branch