### PR TITLE
feat(admin): Allow copy-tables CREATE on any target host

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -761,6 +761,14 @@
       "default": 4,
       "description": "max_threads ClickHouse setting used by the admin querylog query; clamped to a hard maximum of 4."
     },
+    "admin.copy_tables_allowed_target_hosts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "Hostnames (or host:port) that snuba-admin Copy Tables may CREATE on even when the host is not a member of the source cluster. Used to bootstrap tables on newly provisioned nodes before they are added to Snuba cluster config. Empty (the default) allows no extra targets. Compared case-insensitively; a hostname with no port matches any port."
+    },
     "executor_queue_size_factor": {
       "type": "integer",
       "default": 10,

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -140,19 +140,31 @@ def _build_validated_pool(
     password: str,
     client_settings: ClickhouseClientSettings,
     known_nodes: Sequence[ClickhouseNode] | None = None,
+    validate_node: bool = True,
 ) -> ClickhousePool:
     # Single chokepoint for admin ClickhousePool acquisition. A pool ships the
     # user/password to the node (HTTP auth header), so an unvalidated host means
     # credentials reach whatever listener answers. All admin helpers must go
     # through here. The regression test
     # test_no_direct_clickhouse_pool_construction_in_admin enforces this.
-    _validate_node(clickhouse_host, clickhouse_port, cluster, storage_name, known_nodes=known_nodes)
-    # Query-endpoint traffic uses the cluster Envoy listen port. Replica
-    # (by-host) traffic uses 8123 on that node.
-    query_node = cluster.get_query_node()
-    envoy_port = cluster.get_port()
-    is_query_endpoint = clickhouse_host == query_node.host_name and clickhouse_port == envoy_port
-    connect_port = envoy_port if is_query_endpoint else DEFAULT_CLICKHOUSE_HTTP_PORT
+    #
+    # `validate_node=False` is only for copy-tables CREATE against a host that
+    # is not (yet) in the source cluster topology. That path is sudo-gated at
+    # the view layer. Every other helper must leave the default on.
+    if validate_node:
+        _validate_node(
+            clickhouse_host, clickhouse_port, cluster, storage_name, known_nodes=known_nodes
+        )
+        # Query-endpoint traffic uses the cluster Envoy listen port. Replica
+        # (by-host) traffic uses 8123 on that node.
+        query_node = cluster.get_query_node()
+        envoy_port = cluster.get_port()
+        is_query_endpoint = (
+            clickhouse_host == query_node.host_name and clickhouse_port == envoy_port
+        )
+        connect_port = envoy_port if is_query_endpoint else DEFAULT_CLICKHOUSE_HTTP_PORT
+    else:
+        connect_port = clickhouse_port
     return build_pool(
         client_settings,
         ClickhouseNode(clickhouse_host, connect_port),
@@ -322,6 +334,36 @@ def get_clusterless_node_connection(
         client_settings,
     )
     return connection
+
+
+def get_unvalidated_node_connection(
+    clickhouse_host: str,
+    clickhouse_port: int,
+    storage_name: str,
+    client_settings: ClickhouseClientSettings,
+) -> ClickhousePool:
+    """Connect using this storage's credentials without cluster membership checks.
+
+    Copy-tables uses this for the CREATE target so schemas can be applied on a
+    host that is not a member of the source cluster (for example a new ARM
+    cluster). The host is not checked against topology; credentials still come
+    from the source storage's cluster. Callers must already be sudo-gated.
+    """
+    storage = _get_storage(storage_name)
+    cluster = storage.get_cluster()
+    database = cluster.get_database()
+    (clickhouse_user, clickhouse_password) = cluster.get_credentials()
+    return _build_validated_pool(
+        clickhouse_host,
+        clickhouse_port,
+        storage_name,
+        cluster,
+        database,
+        clickhouse_user,
+        clickhouse_password,
+        client_settings,
+        validate_node=False,
+    )
 
 
 def get_ro_clusterless_node_connection(

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Sequence
 
-from sql_metadata import Parser, QueryType  # type: ignore[import-untyped]
+from sql_metadata import Parser, QueryType
 
 from snuba import settings
 from snuba.clickhouse.pool import ClickhousePool

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -148,10 +148,7 @@ def _build_validated_pool(
     # through here. The regression test
     # test_no_direct_clickhouse_pool_construction_in_admin enforces this.
     #
-    # `validate_node=False` is only for copy-tables CREATE against a host on
-    # admin.copy_tables_allowed_target_hosts that is not in the source cluster
-    # topology. That path is also sudo-gated at the view layer. Every other
-    # helper must leave the default on.
+    # validate_node=False is copy-tables CREATE on an allowlisted bootstrap host.
     if validate_node:
         _validate_node(
             clickhouse_host, clickhouse_port, cluster, storage_name, known_nodes=known_nodes
@@ -318,41 +315,12 @@ def get_clusterless_node_connection(
     clickhouse_port: int,
     storage_name: str,
     client_settings: ClickhouseClientSettings,
+    validate_node: bool = True,
 ) -> ClickhousePool:
     storage = _get_storage(storage_name)
     cluster = storage.get_cluster()
     database = cluster.get_database()
 
-    (clickhouse_user, clickhouse_password) = cluster.get_credentials()
-    connection = _build_validated_pool(
-        clickhouse_host,
-        clickhouse_port,
-        storage_name,
-        cluster,
-        database,
-        clickhouse_user,
-        clickhouse_password,
-        client_settings,
-    )
-    return connection
-
-
-def get_unvalidated_node_connection(
-    clickhouse_host: str,
-    clickhouse_port: int,
-    storage_name: str,
-    client_settings: ClickhouseClientSettings,
-) -> ClickhousePool:
-    """Connect using this storage's credentials without cluster membership checks.
-
-    Copy-tables uses this for the CREATE target when the host is on
-    ``admin.copy_tables_allowed_target_hosts`` but not (yet) in the source
-    cluster topology. Credentials still come from the source storage's cluster.
-    Callers must already be sudo-gated and must have checked the allowlist.
-    """
-    storage = _get_storage(storage_name)
-    cluster = storage.get_cluster()
-    database = cluster.get_database()
     (clickhouse_user, clickhouse_password) = cluster.get_credentials()
     return _build_validated_pool(
         clickhouse_host,
@@ -363,7 +331,7 @@ def get_unvalidated_node_connection(
         clickhouse_user,
         clickhouse_password,
         client_settings,
-        validate_node=False,
+        validate_node=validate_node,
     )
 
 

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -148,9 +148,10 @@ def _build_validated_pool(
     # through here. The regression test
     # test_no_direct_clickhouse_pool_construction_in_admin enforces this.
     #
-    # `validate_node=False` is only for copy-tables CREATE against a host that
-    # is not (yet) in the source cluster topology. That path is sudo-gated at
-    # the view layer. Every other helper must leave the default on.
+    # `validate_node=False` is only for copy-tables CREATE against a host on
+    # admin.copy_tables_allowed_target_hosts that is not in the source cluster
+    # topology. That path is also sudo-gated at the view layer. Every other
+    # helper must leave the default on.
     if validate_node:
         _validate_node(
             clickhouse_host, clickhouse_port, cluster, storage_name, known_nodes=known_nodes
@@ -344,10 +345,10 @@ def get_unvalidated_node_connection(
 ) -> ClickhousePool:
     """Connect using this storage's credentials without cluster membership checks.
 
-    Copy-tables uses this for the CREATE target so schemas can be applied on a
-    host that is not a member of the source cluster (for example a new ARM
-    cluster). The host is not checked against topology; credentials still come
-    from the source storage's cluster. Callers must already be sudo-gated.
+    Copy-tables uses this for the CREATE target when the host is on
+    ``admin.copy_tables_allowed_target_hosts`` but not (yet) in the source
+    cluster topology. Credentials still come from the source storage's cluster.
+    Callers must already be sudo-gated and must have checked the allowlist.
     """
     storage = _get_storage(storage_name)
     cluster = storage.get_cluster()

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -7,6 +7,7 @@ from snuba.admin.clickhouse.common import (
     _get_storage,
     _node_connect_port,
     get_clusterless_node_connection,
+    get_unvalidated_node_connection,
 )
 from snuba.clickhouse.escaping import escape_string
 from snuba.clickhouse.pool import ClickhousePool
@@ -35,6 +36,32 @@ def validate_cluster_name(cluster_name: str) -> str:
     return cluster_name
 
 
+def parse_target_host(raw: str) -> tuple[str, int]:
+    """Parse a free-form copy-tables target as ``host`` or ``host:port``.
+
+    Does not check cluster membership. Rejects URLs, whitespace, and path
+    separators so the value can be used as an HTTP host.
+    """
+    value = raw.strip()
+    if not value:
+        raise ValueError("target host must not be empty")
+    if any(ch.isspace() for ch in value) or "/" in value or "\\" in value:
+        raise ValueError("target host must be a hostname or host:port")
+    if "://" in value:
+        raise ValueError("target host must be a hostname or host:port, not a URL")
+
+    if ":" in value:
+        host, port_s = value.rsplit(":", 1)
+        if port_s.isdigit():
+            port = int(port_s)
+            if not 1 <= port <= 65535:
+                raise ValueError("target host port is out of range")
+            if not host:
+                raise ValueError("target host must not be empty")
+            return host, port
+    return value, DEFAULT_CLICKHOUSE_HTTP_PORT
+
+
 def _http_port_for_host(host: str, cluster: ClickhouseCluster) -> int:
     if host == cluster.get_query_node().host_name:
         return cluster.get_port()
@@ -53,6 +80,7 @@ class TableStatement:
 
 class CopyTablesResponse(TypedDict, total=False):
     source_host: str
+    target_host: str
     tables: str
     cluster_name: str
     dry_run: bool
@@ -172,6 +200,9 @@ def copy_tables(
     storage = _get_storage(storage_name)
     cluster = storage.get_cluster()
     database_name = cluster.get_database()
+    parsed_target: tuple[str, int] | None = None
+    if target_host:
+        parsed_target = parse_target_host(target_host)
     source_connection = get_clusterless_node_connection(
         source_host,
         _http_port_for_host(source_host, cluster),
@@ -207,14 +238,19 @@ def copy_tables(
         "cluster_name": cluster_name or "no cluster",
         "dry_run": dry_run,
     }
+    if parsed_target:
+        resp["target_host"] = parsed_target[0]
 
     if dry_run:
         return resp
 
-    if target_host:
-        target_connection = get_clusterless_node_connection(
-            target_host,
-            _http_port_for_host(target_host, cluster),
+    if parsed_target:
+        # CREATE target is not required to be in the source cluster. Source
+        # reads stay membership-checked; this connection uses source-cluster
+        # credentials against the typed-in host.
+        target_connection = get_unvalidated_node_connection(
+            parsed_target[0],
+            parsed_target[1],
             storage_name,
             client_settings=settings,
         )

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -8,7 +8,6 @@ from snuba.admin.clickhouse.common import (
     _get_storage,
     _node_connect_port,
     get_clusterless_node_connection,
-    get_unvalidated_node_connection,
     is_valid_node,
 )
 from snuba.clickhouse.escaping import escape_string
@@ -41,38 +40,39 @@ def validate_cluster_name(cluster_name: str) -> str:
     return cluster_name
 
 
-def parse_target_host(raw: str) -> tuple[str, int]:
-    """Split ``host`` or ``host:port``; default port is 8123."""
+def _split_host_port(raw: str) -> tuple[str, int | None]:
     value = raw.strip()
     if ":" in value:
         host, port_s = value.rsplit(":", 1)
         if port_s.isdigit():
             return host, int(port_s)
-    return value, DEFAULT_CLICKHOUSE_HTTP_PORT
+    return value, None
+
+
+def parse_target_host(raw: str) -> tuple[str, int]:
+    """Split ``host`` or ``host:port``; default port is 8123."""
+    host, port = _split_host_port(raw)
+    return host, port if port is not None else DEFAULT_CLICKHOUSE_HTTP_PORT
 
 
 def target_host_is_allowlisted(host: str, port: int) -> bool:
-    """Return whether host/port is on admin.copy_tables_allowed_target_hosts.
-
-    A hostname-only entry matches any port. A host:port entry must match both.
-    """
-    allowed = cast("list[str]", get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, []))
-    if not isinstance(allowed, list):
-        return False
+    """Hostname-only entries match any port; host:port must match both."""
     host_key = host.lower()
-    for raw in allowed:
-        if not isinstance(raw, str):
-            continue
-        entry = raw.strip()
-        if not entry:
-            continue
-        if ":" in entry:
-            entry_host, port_s = entry.rsplit(":", 1)
-            if port_s.isdigit() and entry_host.lower() == host_key and int(port_s) == port:
-                return True
-        elif entry.lower() == host_key:
+    for entry in cast("list[str]", get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, [])):
+        entry_host, entry_port = _split_host_port(str(entry))
+        if entry_host.lower() == host_key and (entry_port is None or entry_port == port):
             return True
     return False
+
+
+def _is_cluster_node(host: str, port: int, cluster: ClickhouseCluster, storage_name: str) -> bool:
+    try:
+        if is_valid_node(host, port, cluster, storage_name):
+            return True
+        topology_port = _http_port_for_host(host, cluster)
+        return topology_port != port and is_valid_node(host, topology_port, cluster, storage_name)
+    except InvalidNodeError:
+        return False
 
 
 def assert_target_host_allowed(
@@ -81,19 +81,10 @@ def assert_target_host_allowed(
     cluster: ClickhouseCluster,
     storage_name: str,
 ) -> None:
-    """Reject a CREATE target that is neither allowlisted nor a cluster node."""
-    if target_host_is_allowlisted(host, port):
+    if target_host_is_allowlisted(host, port) or _is_cluster_node(
+        host, port, cluster, storage_name
+    ):
         return
-    try:
-        if is_valid_node(host, port, cluster, storage_name):
-            return
-        # Typed port defaults to 8123; query nodes often listen on the cluster
-        # Envoy port instead. Match the connect path, which uses _http_port_for_host.
-        topology_port = _http_port_for_host(host, cluster)
-        if topology_port != port and is_valid_node(host, topology_port, cluster, storage_name):
-            return
-    except InvalidNodeError:
-        pass
     raise ValueError(
         f"{host}:{port} is not a known cluster node and is not in "
         f"{COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION}"
@@ -286,13 +277,12 @@ def copy_tables(
     if parsed_target:
         host, port = parsed_target
         if target_host_is_allowlisted(host, port):
-            # Bootstrap host: not in Snuba cluster config yet, but explicitly
-            # allowlisted. Source reads stay membership-checked.
-            target_connection = get_unvalidated_node_connection(
+            target_connection = get_clusterless_node_connection(
                 host,
                 port,
                 storage_name,
                 client_settings=settings,
+                validate_node=False,
             )
         else:
             target_connection = get_clusterless_node_connection(

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -42,28 +42,12 @@ def validate_cluster_name(cluster_name: str) -> str:
 
 
 def parse_target_host(raw: str) -> tuple[str, int]:
-    """Parse a free-form copy-tables target as ``host`` or ``host:port``.
-
-    Does not check cluster membership. Rejects URLs, whitespace, and path
-    separators so the value can be used as an HTTP host.
-    """
+    """Split ``host`` or ``host:port``; default port is 8123."""
     value = raw.strip()
-    if not value:
-        raise ValueError("target host must not be empty")
-    if any(ch.isspace() for ch in value) or "/" in value or "\\" in value:
-        raise ValueError("target host must be a hostname or host:port")
-    if "://" in value:
-        raise ValueError("target host must be a hostname or host:port, not a URL")
-
     if ":" in value:
         host, port_s = value.rsplit(":", 1)
         if port_s.isdigit():
-            port = int(port_s)
-            if not 1 <= port <= 65535:
-                raise ValueError("target host port is out of range")
-            if not host:
-                raise ValueError("target host must not be empty")
-            return host, port
+            return host, int(port_s)
     return value, DEFAULT_CLICKHOUSE_HTTP_PORT
 
 

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -72,7 +72,7 @@ def target_host_is_allowlisted(host: str, port: int) -> bool:
 
     A hostname-only entry matches any port. A host:port entry must match both.
     """
-    allowed = get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, cast(list[str], []))
+    allowed = cast("list[str]", get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, []))
     if not isinstance(allowed, list):
         return False
     host_key = host.lower()

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -4,10 +4,12 @@ from dataclasses import dataclass
 from typing import TypedDict
 
 from snuba.admin.clickhouse.common import (
+    InvalidNodeError,
     _get_storage,
     _node_connect_port,
     get_clusterless_node_connection,
     get_unvalidated_node_connection,
+    is_valid_node,
 )
 from snuba.clickhouse.escaping import escape_string
 from snuba.clickhouse.pool import ClickhousePool
@@ -16,6 +18,7 @@ from snuba.clusters.cluster import (
     ClickhouseClientSettings,
     ClickhouseCluster,
 )
+from snuba.state.sentry_options import get_option
 from snuba.utils.serializable_exception import SerializableException
 
 
@@ -26,6 +29,8 @@ class InvalidClusterName(SerializableException):
 # Caller-supplied cluster names are interpolated into executed DDL and into
 # clusterAllReplicas() on connections holding full cluster credentials.
 CLUSTER_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+
+COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION = "admin.copy_tables_allowed_target_hosts"
 
 
 def validate_cluster_name(cluster_name: str) -> str:
@@ -60,6 +65,50 @@ def parse_target_host(raw: str) -> tuple[str, int]:
                 raise ValueError("target host must not be empty")
             return host, port
     return value, DEFAULT_CLICKHOUSE_HTTP_PORT
+
+
+def target_host_is_allowlisted(host: str, port: int) -> bool:
+    """Return whether host/port is on admin.copy_tables_allowed_target_hosts.
+
+    A hostname-only entry matches any port. A host:port entry must match both.
+    """
+    allowed = get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, [])
+    if not isinstance(allowed, list):
+        return False
+    host_key = host.lower()
+    for raw in allowed:
+        if not isinstance(raw, str):
+            continue
+        entry = raw.strip()
+        if not entry:
+            continue
+        if ":" in entry:
+            entry_host, port_s = entry.rsplit(":", 1)
+            if port_s.isdigit() and entry_host.lower() == host_key and int(port_s) == port:
+                return True
+        elif entry.lower() == host_key:
+            return True
+    return False
+
+
+def assert_target_host_allowed(
+    host: str,
+    port: int,
+    cluster: ClickhouseCluster,
+    storage_name: str,
+) -> None:
+    """Reject a CREATE target that is neither allowlisted nor a cluster node."""
+    if target_host_is_allowlisted(host, port):
+        return
+    try:
+        if is_valid_node(host, port, cluster, storage_name):
+            return
+    except InvalidNodeError:
+        pass
+    raise ValueError(
+        f"{host}:{port} is not a known cluster node and is not in "
+        f"{COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION}"
+    )
 
 
 def _http_port_for_host(host: str, cluster: ClickhouseCluster) -> int:
@@ -203,6 +252,7 @@ def copy_tables(
     parsed_target: tuple[str, int] | None = None
     if target_host:
         parsed_target = parse_target_host(target_host)
+        assert_target_host_allowed(parsed_target[0], parsed_target[1], cluster, storage_name)
     source_connection = get_clusterless_node_connection(
         source_host,
         _http_port_for_host(source_host, cluster),
@@ -245,15 +295,23 @@ def copy_tables(
         return resp
 
     if parsed_target:
-        # CREATE target is not required to be in the source cluster. Source
-        # reads stay membership-checked; this connection uses source-cluster
-        # credentials against the typed-in host.
-        target_connection = get_unvalidated_node_connection(
-            parsed_target[0],
-            parsed_target[1],
-            storage_name,
-            client_settings=settings,
-        )
+        host, port = parsed_target
+        if target_host_is_allowlisted(host, port):
+            # Bootstrap host: not in Snuba cluster config yet, but explicitly
+            # allowlisted. Source reads stay membership-checked.
+            target_connection = get_unvalidated_node_connection(
+                host,
+                port,
+                storage_name,
+                client_settings=settings,
+            )
+        else:
+            target_connection = get_clusterless_node_connection(
+                host,
+                _http_port_for_host(host, cluster),
+                storage_name,
+                client_settings=settings,
+            )
     else:
         target_connection = source_connection
 

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from snuba.admin.clickhouse.common import (
     InvalidNodeError,
@@ -72,7 +72,7 @@ def target_host_is_allowlisted(host: str, port: int) -> bool:
 
     A hostname-only entry matches any port. A host:port entry must match both.
     """
-    allowed = get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, [])
+    allowed = get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, cast(list[str], []))
     if not isinstance(allowed, list):
         return False
     host_key = host.lower()
@@ -102,6 +102,11 @@ def assert_target_host_allowed(
         return
     try:
         if is_valid_node(host, port, cluster, storage_name):
+            return
+        # Typed port defaults to 8123; query nodes often listen on the cluster
+        # Envoy port instead. Match the connect path, which uses _http_port_for_host.
+        topology_port = _http_port_for_host(host, cluster)
+        if topology_port != port and is_valid_node(host, topology_port, cluster, storage_name):
             return
     except InvalidNodeError:
         pass

--- a/snuba/admin/static/copy_tables/index.tsx
+++ b/snuba/admin/static/copy_tables/index.tsx
@@ -120,7 +120,8 @@ function CopyTables(props: {
             <h3>Target host (optional):</h3>
             <p style={targetHelpTextStyle}>
               If specified, CREATE statements run on this host instead of the source host.
-              It does not need to belong to the source cluster. Defaults to port 8123; you can pass host:port.
+              The host must be a known cluster node or listed in admin.copy_tables_allowed_target_hosts.
+              Defaults to port 8123; you can pass host:port.
             </p>
             <div style={{ marginTop: 10 }}>
               <input

--- a/snuba/admin/static/copy_tables/index.tsx
+++ b/snuba/admin/static/copy_tables/index.tsx
@@ -119,13 +119,14 @@ function CopyTables(props: {
           <div style={sectionContainerStyle}>
             <h3>Target host (optional):</h3>
             <p style={targetHelpTextStyle}>
-              If specified, CREATE statements will be run on this host instead of the source host.
+              If specified, CREATE statements run on this host instead of the source host.
+              It does not need to belong to the source cluster. Defaults to port 8123; you can pass host:port.
             </p>
             <div style={{ marginTop: 10 }}>
               <input
                 type="text"
                 style={textInputStyle}
-                placeholder="e.g. my-clickhouse-node.example.com"
+                placeholder="e.g. snuba-outcomes-query-arm-1-1"
                 value={targetHostInput}
                 onChange={(e) => setTargetHostInput(e.target.value)}
               />
@@ -181,6 +182,9 @@ function CopyTables(props: {
           <h4>
             {copyTableResult.dry_run ? "DRY RUN" : <>Executed <code>CREATE TABLE</code></>}
             {" "}with <strong>Source Host:</strong> <code>{copyTableResult.source_host}</code>
+            {copyTableResult.target_host && (
+              <> and <strong>Target Host:</strong> <code>{copyTableResult.target_host}</code></>
+            )}
             {copyTableResult.cluster_name && (
               <> and <strong>Cluster Name:</strong> <code>{copyTableResult.cluster_name}</code></>
             )}

--- a/snuba/admin/static/copy_tables/types.tsx
+++ b/snuba/admin/static/copy_tables/types.tsx
@@ -33,6 +33,7 @@ type CopyTableRequest = {
 
 type CopyTableResult = {
   source_host: string
+  target_host?: string
   tables: string
   dry_run: boolean
   cluster_name: string

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -442,3 +442,32 @@ def test_copy_tables_target_host_skips_cluster_membership() -> None:
     assert result["target_host"] == "snuba-outcomes-query-arm-1-1"
     target_conn.command.assert_called_once_with("CREATE TABLE t")
     source_conn.command.assert_not_called()
+
+
+def test_copy_tables_query_node_target_accepted_without_typed_port() -> None:
+    """A query-node hostname with default port 8123 still matches the Envoy port."""
+    cluster = _copy_tables_cluster_mock()
+    cluster.get_port.return_value = 9000
+    cluster.get_query_node.return_value.host_name = "query.example"
+
+    with (
+        patch("snuba.admin.clickhouse.copy_tables._get_storage") as mock_storage,
+        patch(
+            "snuba.admin.clickhouse.copy_tables.get_clusterless_node_connection",
+            return_value=MagicMock(),
+        ),
+        patch("snuba.admin.clickhouse.copy_tables.get_tables", return_value=["t"]),
+        patch(
+            "snuba.admin.clickhouse.copy_tables.get_create_table_statements",
+            return_value=[TableStatement("t", "CREATE TABLE t", True)],
+        ),
+    ):
+        mock_storage.return_value.get_cluster.return_value = cluster
+        result = copy_tables(
+            source_host="query.example",
+            storage_name="outcomes_raw",
+            dry_run=True,
+            target_host="query.example",
+        )
+
+    assert result["target_host"] == "query.example"

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -2,20 +2,24 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.admin.clickhouse.common import _get_storage, get_clusterless_node_connection
 from snuba.admin.clickhouse.copy_tables import (
+    COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION,
     InvalidClusterName,
     TableStatement,
     copy_tables,
     get_create_table_statements,
     parse_target_host,
+    target_host_is_allowlisted,
     validate_cluster_name,
     verify_tables_on_replicas,
 )
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.migrations import table_engines
 from snuba.migrations.groups import MigrationGroup
+from snuba.state.sentry_options import SNUBA_OPTIONS_NAMESPACE
 
 OUTCOMES_DAILY_TABLE_NO_CLUSTER = """
 CREATE TABLE IF NOT EXISTS {db}.outcomes_daily_local_v2
@@ -344,13 +348,64 @@ def test_parse_target_host_rejects(raw: str) -> None:
         parse_target_host(raw)
 
 
+def test_target_host_is_allowlisted_hostname_matches_any_port() -> None:
+    with override_options(
+        SNUBA_OPTIONS_NAMESPACE,
+        {COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
+    ):
+        assert target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123)
+        assert target_host_is_allowlisted("SNUBA-outcomes-query-arm-1-1", 9000)
+        assert not target_host_is_allowlisted("other-host", 8123)
+
+
+def test_target_host_is_allowlisted_host_port_must_match() -> None:
+    with override_options(
+        SNUBA_OPTIONS_NAMESPACE,
+        {COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1:9000"]},
+    ):
+        assert target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 9000)
+        assert not target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123)
+
+
+def test_target_host_is_allowlisted_empty_by_default() -> None:
+    assert target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123) is False
+
+
+def _copy_tables_cluster_mock() -> MagicMock:
+    cluster = MagicMock()
+    cluster.get_database.return_value = "default"
+    cluster.is_single_node.return_value = True
+    cluster.get_query_node.return_value.host_name = "snuba-outcomes-query-1-2"
+    cluster.get_port.return_value = 8123
+    cluster.get_local_nodes.return_value = []
+    cluster.get_distributed_nodes.return_value = []
+    return cluster
+
+
+def test_copy_tables_target_host_requires_allowlist() -> None:
+    """A host outside the source cluster is rejected unless allowlisted."""
+    with patch("snuba.admin.clickhouse.copy_tables._get_storage") as mock_storage:
+        mock_storage.return_value.get_cluster.return_value = _copy_tables_cluster_mock()
+        with pytest.raises(ValueError, match=COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION):
+            copy_tables(
+                source_host="snuba-outcomes-query-1-2",
+                storage_name="outcomes_raw",
+                dry_run=True,
+                target_host="snuba-outcomes-query-arm-1-1",
+            )
+
+
 def test_copy_tables_target_host_skips_cluster_membership() -> None:
-    """CREATE runs on the typed-in host even when it is not in the source cluster."""
+    """CREATE runs on an allowlisted host even when it is not in the source cluster."""
     source_conn = MagicMock()
     target_conn = MagicMock()
     table_statement = TableStatement("t", "CREATE TABLE t", True)
 
     with (
+        override_options(
+            SNUBA_OPTIONS_NAMESPACE,
+            {COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
+        ),
         patch("snuba.admin.clickhouse.copy_tables._get_storage") as mock_storage,
         patch(
             "snuba.admin.clickhouse.copy_tables.get_clusterless_node_connection",
@@ -370,14 +425,7 @@ def test_copy_tables_target_host_skips_cluster_membership() -> None:
             return_value=({}, 1),
         ),
     ):
-        cluster = MagicMock()
-        cluster.get_database.return_value = "default"
-        cluster.is_single_node.return_value = True
-        cluster.get_query_node.return_value.host_name = "snuba-outcomes-query-1-2"
-        cluster.get_port.return_value = 8123
-        cluster.get_local_nodes.return_value = []
-        cluster.get_distributed_nodes.return_value = []
-        mock_storage.return_value.get_cluster.return_value = cluster
+        mock_storage.return_value.get_cluster.return_value = _copy_tables_cluster_mock()
 
         result = copy_tables(
             source_host="snuba-outcomes-query-1-2",

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -339,15 +339,6 @@ def test_parse_target_host_accepts(raw: str, expected: tuple[str, int]) -> None:
     assert parse_target_host(raw) == expected
 
 
-@pytest.mark.parametrize(
-    "raw",
-    ["", "   ", "http://evil.example", "host/path", "host port", "host:99999", ":8123"],
-)
-def test_parse_target_host_rejects(raw: str) -> None:
-    with pytest.raises(ValueError):
-        parse_target_host(raw)
-
-
 def test_target_host_is_allowlisted_hostname_matches_any_port() -> None:
     with override_options(
         SNUBA_OPTIONS_NAMESPACE,

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -1,12 +1,15 @@
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from snuba.admin.clickhouse.common import _get_storage, get_clusterless_node_connection
 from snuba.admin.clickhouse.copy_tables import (
     InvalidClusterName,
+    TableStatement,
     copy_tables,
     get_create_table_statements,
+    parse_target_host,
     validate_cluster_name,
     verify_tables_on_replicas,
 )
@@ -318,3 +321,76 @@ def test_validate_cluster_name_accepts_identifier_shape(cluster_name: str) -> No
 def test_validate_cluster_name_rejects_quote_breaking_names(cluster_name: str) -> None:
     with pytest.raises(InvalidClusterName):
         validate_cluster_name(cluster_name)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("snuba-outcomes-query-arm-1-1", ("snuba-outcomes-query-arm-1-1", 8123)),
+        ("snuba-outcomes-query-arm-1-1:9000", ("snuba-outcomes-query-arm-1-1", 9000)),
+        ("  host.example.com  ", ("host.example.com", 8123)),
+    ],
+)
+def test_parse_target_host_accepts(raw: str, expected: tuple[str, int]) -> None:
+    assert parse_target_host(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", "http://evil.example", "host/path", "host port", "host:99999", ":8123"],
+)
+def test_parse_target_host_rejects(raw: str) -> None:
+    with pytest.raises(ValueError):
+        parse_target_host(raw)
+
+
+def test_copy_tables_target_host_skips_cluster_membership() -> None:
+    """CREATE runs on the typed-in host even when it is not in the source cluster."""
+    source_conn = MagicMock()
+    target_conn = MagicMock()
+    table_statement = TableStatement("t", "CREATE TABLE t", True)
+
+    with (
+        patch("snuba.admin.clickhouse.copy_tables._get_storage") as mock_storage,
+        patch(
+            "snuba.admin.clickhouse.copy_tables.get_clusterless_node_connection",
+            return_value=source_conn,
+        ),
+        patch(
+            "snuba.admin.clickhouse.copy_tables.get_unvalidated_node_connection",
+            return_value=target_conn,
+        ) as mock_unvalidated,
+        patch("snuba.admin.clickhouse.copy_tables.get_tables", return_value=["t"]),
+        patch(
+            "snuba.admin.clickhouse.copy_tables.get_create_table_statements",
+            return_value=[table_statement],
+        ),
+        patch(
+            "snuba.admin.clickhouse.copy_tables.verify_tables_on_replicas",
+            return_value=({}, 1),
+        ),
+    ):
+        cluster = MagicMock()
+        cluster.get_database.return_value = "default"
+        cluster.is_single_node.return_value = True
+        cluster.get_query_node.return_value.host_name = "snuba-outcomes-query-1-2"
+        cluster.get_port.return_value = 8123
+        cluster.get_local_nodes.return_value = []
+        cluster.get_distributed_nodes.return_value = []
+        mock_storage.return_value.get_cluster.return_value = cluster
+
+        result = copy_tables(
+            source_host="snuba-outcomes-query-1-2",
+            storage_name="outcomes_raw",
+            dry_run=False,
+            target_host="snuba-outcomes-query-arm-1-1",
+            skip_on_cluster=True,
+        )
+
+    mock_unvalidated.assert_called_once()
+    assert mock_unvalidated.call_args.args[0] == "snuba-outcomes-query-arm-1-1"
+    assert mock_unvalidated.call_args.args[1] == 8123
+    assert mock_unvalidated.call_args.args[2] == "outcomes_raw"
+    assert result["target_host"] == "snuba-outcomes-query-arm-1-1"
+    target_conn.command.assert_called_once_with("CREATE TABLE t")
+    source_conn.command.assert_not_called()

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -400,12 +400,8 @@ def test_copy_tables_target_host_skips_cluster_membership() -> None:
         patch("snuba.admin.clickhouse.copy_tables._get_storage") as mock_storage,
         patch(
             "snuba.admin.clickhouse.copy_tables.get_clusterless_node_connection",
-            return_value=source_conn,
-        ),
-        patch(
-            "snuba.admin.clickhouse.copy_tables.get_unvalidated_node_connection",
-            return_value=target_conn,
-        ) as mock_unvalidated,
+            side_effect=[source_conn, target_conn],
+        ) as mock_connect,
         patch("snuba.admin.clickhouse.copy_tables.get_tables", return_value=["t"]),
         patch(
             "snuba.admin.clickhouse.copy_tables.get_create_table_statements",
@@ -426,10 +422,11 @@ def test_copy_tables_target_host_skips_cluster_membership() -> None:
             skip_on_cluster=True,
         )
 
-    mock_unvalidated.assert_called_once()
-    assert mock_unvalidated.call_args.args[0] == "snuba-outcomes-query-arm-1-1"
-    assert mock_unvalidated.call_args.args[1] == 8123
-    assert mock_unvalidated.call_args.args[2] == "outcomes_raw"
+    assert mock_connect.call_count == 2
+    target_call = mock_connect.call_args_list[1]
+    assert target_call.args[0] == "snuba-outcomes-query-arm-1-1"
+    assert target_call.args[1] == 8123
+    assert target_call.kwargs["validate_node"] is False
     assert result["target_host"] == "snuba-outcomes-query-arm-1-1"
     target_conn.command.assert_called_once_with("CREATE TABLE t")
     source_conn.command.assert_not_called()

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -346,12 +346,8 @@ def test_clusterless_rejects_unvalidated_host(
         )
 
 
-def test_unvalidated_node_connection_skips_membership_check() -> None:
-    """
-    Copy-tables CREATE targets may not be in the source cluster yet.
-    get_unvalidated_node_connection must still acquire a pool without
-    calling _validate_node.
-    """
+def test_clusterless_validate_node_false_skips_membership_check() -> None:
+    """Allowlisted copy-tables CREATE targets skip _validate_node."""
     from snuba.admin.clickhouse import common
 
     with (
@@ -363,11 +359,12 @@ def test_unvalidated_node_connection_skips_membership_check() -> None:
         patch.object(common, "build_pool") as mock_pool,
     ):
         mock_pool.return_value = MagicMock()
-        common.get_unvalidated_node_connection(
+        common.get_clusterless_node_connection(
             "snuba-outcomes-query-arm-1-1",
             8123,
             "errors",
             ClickhouseClientSettings.INTERNAL,
+            validate_node=False,
         )
 
         mock_validate.assert_not_called()

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -346,6 +346,37 @@ def test_clusterless_rejects_unvalidated_host(
         )
 
 
+def test_unvalidated_node_connection_skips_membership_check() -> None:
+    """
+    Copy-tables CREATE targets may not be in the source cluster yet.
+    get_unvalidated_node_connection must still acquire a pool without
+    calling _validate_node.
+    """
+    from snuba.admin.clickhouse import common
+
+    with (
+        patch.object(
+            common,
+            "_validate_node",
+            side_effect=InvalidNodeError("host not in cluster"),
+        ) as mock_validate,
+        patch.object(common, "build_pool") as mock_pool,
+    ):
+        mock_pool.return_value = MagicMock()
+        common.get_unvalidated_node_connection(
+            "snuba-outcomes-query-arm-1-1",
+            8123,
+            "errors",
+            ClickhouseClientSettings.INTERNAL,
+        )
+
+        mock_validate.assert_not_called()
+        assert mock_pool.called
+        node = mock_pool.call_args.args[1]
+        assert node.host_name == "snuba-outcomes-query-arm-1-1"
+        assert node.port == 8123
+
+
 @pytest.mark.parametrize(
     "helper_name",
     [


### PR DESCRIPTION
Copy Tables can now run CREATE on a typed-in target host that is not in the source cluster. Source reads stay membership-checked; the CREATE connection is still sudo-gated and still uses the source storage's ClickHouse credentials.

This restores the original target-host workflow (stand up schemas on a new cluster) that node-validation had blocked. Review the `validate_node=False` path in `_build_validated_pool` — it is only used by copy-tables CREATE.
