### PR TITLE
fix(admin): Allow listing migrations without every storage set configured

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -29,9 +29,13 @@ _REGISTERED_STORAGE_SET_KEYS: dict[str, str] = {}
 
 class _StorageSetKey(type):
     def __getattr__(self, attr: str) -> StorageSetKey:
-        if attr not in _HARDCODED_STORAGE_SET_KEYS and attr not in _REGISTERED_STORAGE_SET_KEYS:
+        if attr.startswith("_"):
             raise AttributeError(attr)
 
+        # Cluster config registers the storage sets this process can reach.
+        # Historical migrations still name storage sets that may be absent from
+        # that config (snuba-admin listing groups is the usual case). Keep the
+        # identifier constructible; get_cluster() still fails if it is unmapped.
         return StorageSetKey(attr.lower())
 
     def __iter__(self) -> Iterator[StorageSetKey]:

--- a/tests/clusters/test_storage_sets.py
+++ b/tests/clusters/test_storage_sets.py
@@ -1,5 +1,46 @@
-from snuba.clusters.storage_sets import StorageSetKey, is_valid_storage_set_combination
+import sys
+from typing import Any
+
+import pytest
+
+from snuba.clusters.storage_sets import (
+    _HARDCODED_STORAGE_SET_KEYS,
+    _REGISTERED_STORAGE_SET_KEYS,
+    StorageSetKey,
+    is_valid_storage_set_combination,
+)
+from snuba.migrations.group_loader import GenericMetricsLoader
 
 
 def test_storage_set_combination() -> None:
     assert is_valid_storage_set_combination(StorageSetKey.EVENTS, StorageSetKey.PROFILES) is False
+
+
+def test_unregistered_storage_set_key_is_constructible() -> None:
+    assert "GENERIC_METRICS_DISTRIBUTIONS" not in _HARDCODED_STORAGE_SET_KEYS
+    popped = _REGISTERED_STORAGE_SET_KEYS.pop("GENERIC_METRICS_DISTRIBUTIONS", None)
+    try:
+        key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+        assert key.value == "generic_metrics_distributions"
+        assert key not in set(StorageSetKey)
+    finally:
+        if popped is not None:
+            _REGISTERED_STORAGE_SET_KEYS["GENERIC_METRICS_DISTRIBUTIONS"] = popped
+
+
+def test_private_storage_set_key_attr_raises() -> None:
+    with pytest.raises(AttributeError):
+        StorageSetKey._not_a_storage_set  # noqa: B018
+
+
+def test_historical_migration_imports_without_cluster_registration() -> None:
+    module = "snuba.snuba_migrations.generic_metrics.0007_distributions_aggregate_table"
+    popped = _REGISTERED_STORAGE_SET_KEYS.pop("GENERIC_METRICS_DISTRIBUTIONS", None)
+    sys.modules.pop(module, None)
+    try:
+        migration: Any = GenericMetricsLoader().load_migration("0007_distributions_aggregate_table")
+        assert migration.storage_set_key.value == "generic_metrics_distributions"
+    finally:
+        sys.modules.pop(module, None)
+        if popped is not None:
+            _REGISTERED_STORAGE_SET_KEYS["GENERIC_METRICS_DISTRIBUTIONS"] = popped


### PR DESCRIPTION
`GET /migrations/groups` imported every historical migration to build the list. Those modules reference `StorageSetKey` names that only existed if this process's cluster config had registered them, so a missing `generic_metrics_distributions` mapping 500'd the whole page.

`StorageSetKey.FOO` is now always constructible. `get_cluster()` still raises if that set isn't mapped, so you cannot run DDL against a cluster that isn't there.

Fixes SNUBA-CKE
