### PR TITLE
fix(migrations): Send HTTP progress during long ON CLUSTER DDL

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -63,6 +63,11 @@ class ClickhouseClientSettings(Enum):
             "alter_sync": 2,  # Wait for ON CLUSTER DDL on all replicas
             "database_atomic_wait_for_drop_and_detach_synchronously": 1,
             "distributed_ddl_task_timeout": 300,  # 5 minute ON CLUSTER DDL timeout
+            # Quiet ON CLUSTER DDL (DROP MV waiting on a hot-table lock) writes
+            # no bytes until it finishes. Pin a 15s header so http_send_timeout
+            # / idle do not IncompleteRead the HTTP body.
+            "send_progress_in_http_headers": 1,
+            "http_headers_progress_interval_ms": 15000,
         },
         # 5 minute timeout to allow ON CLUSTER DDL operations to complete
         # across all replicas. This is needed because alter_sync=2 blocks

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -547,6 +547,15 @@ def test_replace_profile_uses_bounded_timeouts() -> None:
     assert replace.timeout == snuba_settings.REPLACER_QUERY_TIMEOUT + 60
 
 
+def test_migrate_profile_sends_http_progress() -> None:
+    # Quiet ON CLUSTER DDL can sit on a lock with no HTTP bytes until it
+    # finishes. Progress headers keep http_send_timeout / idle from cutting
+    # the chunked body (IncompleteRead).
+    migrate = ClickhouseClientSettings.MIGRATE.value
+    assert migrate.settings["send_progress_in_http_headers"] == 1
+    assert migrate.settings["http_headers_progress_interval_ms"] == 15000
+
+
 def test_clickhouse_reader_wraps_connect_pool() -> None:
     # The single driver-agnostic ClickhouseReader wraps the abstract pool, so it
     # works with the connect pool.


### PR DESCRIPTION
MIGRATE DDL can sit on a lock (DROP of an MV on a hot table) without writing HTTP bytes. ClickHouse then hits `http_send_timeout` / idle and the client sees `IncompleteRead` even though the statement is still running.

The MIGRATE profile now sends progress headers every 15s, same as REPLACE. SYNC and `distributed_ddl_task_timeout` are unchanged; this only keeps the HTTP stream alive until ClickHouse actually finishes.

Refs SNUBA-C3Y
