### PR TITLE
feat(admin): Allow system queries on allowlisted hosts

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -767,7 +767,7 @@
         "type": "string"
       },
       "default": [],
-      "description": "Hostnames (or host:port) that snuba-admin Copy Tables may CREATE on even when the host is not a member of the source cluster. Used to bootstrap tables on newly provisioned nodes before they are added to Snuba cluster config. Empty (the default) allows no extra targets. Compared case-insensitively; a hostname with no port matches any port."
+      "description": "Hostnames (or host:port) that snuba-admin may connect to even when the host is not a member of the storage's cluster: Copy Tables CREATE targets and manual host entry in System Queries. Used to bootstrap and inspect newly provisioned nodes before they are added to Snuba cluster config. Empty (the default) allows no extra hosts. Compared case-insensitively; a hostname with no port matches any port."
     },
     "executor_queue_size_factor": {
       "type": "integer",

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Sequence
+from typing import cast
 
-from sql_metadata import Parser, QueryType
+from sql_metadata import Parser, QueryType  # type: ignore[import-untyped]
 
 from snuba import settings
 from snuba.clickhouse.pool import ClickhousePool
@@ -17,7 +18,16 @@ from snuba.clusters.cluster import (
 from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.state.sentry_options import get_option
 from snuba.utils.serializable_exception import SerializableException
+
+# Hosts an operator has provisioned but not yet added to Snuba cluster config.
+# Admin tools that let a human type a host (copy-tables CREATE targets, manual
+# host entry in system queries) accept these in place of a cluster-membership
+# check. The option is shared by those tools on purpose: it is the single list
+# of hosts an operator vouches for, and both paths send the same ClickHouse
+# credentials to whatever answers, so widening one widens the other anyway.
+ADMIN_ALLOWED_HOSTS_OPTION = "admin.copy_tables_allowed_target_hosts"
 
 
 class InvalidNodeError(SerializableException):
@@ -36,6 +46,34 @@ def _node_connect_port(node: ClickhouseNode, cluster: ClickhouseCluster) -> int:
     if node.host_name == cluster.get_query_node().host_name:
         return cluster.get_port()
     return node.port if node.port is not None else DEFAULT_CLICKHOUSE_HTTP_PORT
+
+
+def split_host_port(raw: str) -> tuple[str, int | None]:
+    value = raw.strip()
+    if ":" in value:
+        host, port_s = value.rsplit(":", 1)
+        if port_s.isdigit():
+            return host, int(port_s)
+    return value, None
+
+
+def parse_host(raw: str) -> tuple[str, int]:
+    """Split ``host`` or ``host:port``; default port is 8123."""
+    host, port = split_host_port(raw)
+    return host, port if port is not None else DEFAULT_CLICKHOUSE_HTTP_PORT
+
+
+def host_is_allowlisted(host: str, port: int) -> bool:
+    """Whether ``host``/``port`` is on ``ADMIN_ALLOWED_HOSTS_OPTION``.
+
+    Hostname-only entries match any port; host:port entries must match both.
+    """
+    host_key = host.lower()
+    for entry in cast("list[str]", get_option(ADMIN_ALLOWED_HOSTS_OPTION, [])):
+        entry_host, entry_port = split_host_port(str(entry))
+        if entry_host.lower() == host_key and (entry_port is None or entry_port == port):
+            return True
+    return False
 
 
 def is_valid_node(
@@ -148,7 +186,10 @@ def _build_validated_pool(
     # through here. The regression test
     # test_no_direct_clickhouse_pool_construction_in_admin enforces this.
     #
-    # validate_node=False is copy-tables CREATE on an allowlisted bootstrap host.
+    # validate_node=False is reserved for hosts an operator explicitly
+    # allowlisted via ADMIN_ALLOWED_HOSTS_OPTION (copy-tables CREATE targets and
+    # manual host entry in system queries). Callers must check the allowlist
+    # themselves before passing it.
     if validate_node:
         _validate_node(
             clickhouse_host, clickhouse_port, cluster, storage_name, known_nodes=known_nodes
@@ -340,6 +381,7 @@ def get_ro_clusterless_node_connection(
     clickhouse_port: int,
     storage_name: str,
     client_settings: ClickhouseClientSettings,
+    validate_node: bool = True,
 ) -> ClickhousePool:
     # Compare by name: same reload-safe rule as get_ro_node_connection.
     allowed = {
@@ -363,6 +405,7 @@ def get_ro_clusterless_node_connection(
         settings.CLICKHOUSE_READONLY_USER,
         settings.CLICKHOUSE_READONLY_PASSWORD,
         client_settings,
+        validate_node=validate_node,
     )
     return connection
 

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Callable, Sequence
 from typing import cast
 
-from sql_metadata import Parser, QueryType  # type: ignore[import-untyped]
+from sql_metadata import Parser, QueryType
 
 from snuba import settings
 from snuba.clickhouse.pool import ClickhousePool

--- a/snuba/admin/clickhouse/copy_tables.py
+++ b/snuba/admin/clickhouse/copy_tables.py
@@ -1,14 +1,17 @@
 import re
 from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
-from typing import TypedDict, cast
+from typing import TypedDict
 
 from snuba.admin.clickhouse.common import (
+    ADMIN_ALLOWED_HOSTS_OPTION,
     InvalidNodeError,
     _get_storage,
     _node_connect_port,
     get_clusterless_node_connection,
+    host_is_allowlisted,
     is_valid_node,
+    parse_host,
 )
 from snuba.clickhouse.escaping import escape_string
 from snuba.clickhouse.pool import ClickhousePool
@@ -17,7 +20,6 @@ from snuba.clusters.cluster import (
     ClickhouseClientSettings,
     ClickhouseCluster,
 )
-from snuba.state.sentry_options import get_option
 from snuba.utils.serializable_exception import SerializableException
 
 
@@ -29,8 +31,6 @@ class InvalidClusterName(SerializableException):
 # clusterAllReplicas() on connections holding full cluster credentials.
 CLUSTER_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
 
-COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION = "admin.copy_tables_allowed_target_hosts"
-
 
 def validate_cluster_name(cluster_name: str) -> str:
     if not CLUSTER_NAME_RE.match(cluster_name):
@@ -38,31 +38,6 @@ def validate_cluster_name(cluster_name: str) -> str:
             "cluster name must be 1-128 characters of letters, digits, underscores or dashes"
         )
     return cluster_name
-
-
-def _split_host_port(raw: str) -> tuple[str, int | None]:
-    value = raw.strip()
-    if ":" in value:
-        host, port_s = value.rsplit(":", 1)
-        if port_s.isdigit():
-            return host, int(port_s)
-    return value, None
-
-
-def parse_target_host(raw: str) -> tuple[str, int]:
-    """Split ``host`` or ``host:port``; default port is 8123."""
-    host, port = _split_host_port(raw)
-    return host, port if port is not None else DEFAULT_CLICKHOUSE_HTTP_PORT
-
-
-def target_host_is_allowlisted(host: str, port: int) -> bool:
-    """Hostname-only entries match any port; host:port must match both."""
-    host_key = host.lower()
-    for entry in cast("list[str]", get_option(COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION, [])):
-        entry_host, entry_port = _split_host_port(str(entry))
-        if entry_host.lower() == host_key and (entry_port is None or entry_port == port):
-            return True
-    return False
 
 
 def _is_cluster_node(host: str, port: int, cluster: ClickhouseCluster, storage_name: str) -> bool:
@@ -81,13 +56,10 @@ def assert_target_host_allowed(
     cluster: ClickhouseCluster,
     storage_name: str,
 ) -> None:
-    if target_host_is_allowlisted(host, port) or _is_cluster_node(
-        host, port, cluster, storage_name
-    ):
+    if host_is_allowlisted(host, port) or _is_cluster_node(host, port, cluster, storage_name):
         return
     raise ValueError(
-        f"{host}:{port} is not a known cluster node and is not in "
-        f"{COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION}"
+        f"{host}:{port} is not a known cluster node and is not in {ADMIN_ALLOWED_HOSTS_OPTION}"
     )
 
 
@@ -231,7 +203,7 @@ def copy_tables(
     database_name = cluster.get_database()
     parsed_target: tuple[str, int] | None = None
     if target_host:
-        parsed_target = parse_target_host(target_host)
+        parsed_target = parse_host(target_host)
         assert_target_host_allowed(parsed_target[0], parsed_target[1], cluster, storage_name)
     source_connection = get_clusterless_node_connection(
         source_host,
@@ -276,7 +248,7 @@ def copy_tables(
 
     if parsed_target:
         host, port = parsed_target
-        if target_host_is_allowlisted(host, port):
+        if host_is_allowlisted(host, port):
             target_connection = get_clusterless_node_connection(
                 host,
                 port,

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -9,6 +9,7 @@ from snuba.admin.clickhouse.common import (
     get_ro_clusterless_node_connection,
     get_ro_node_connection,
     get_sudo_node_connection,
+    host_is_allowlisted,
 )
 from snuba.admin.user import AdminUser
 from snuba.clickhouse.error_codes import ErrorCodes
@@ -35,6 +36,22 @@ def _client_settings_for_storage(storage_name: str) -> ClickhouseClientSettings:
     return ClickhouseClientSettings.QUERY
 
 
+def _validate_clusterless_node(clickhouse_host: str, clickhouse_port: int) -> bool:
+    """Whether a manually entered host must be a member of the storage's cluster.
+
+    Hosts listed in ``admin.copy_tables_allowed_target_hosts`` are ones an
+    operator has provisioned but not yet added to Snuba's cluster config, so
+    topology discovery cannot see them; the allowlist is the vouching mechanism
+    in their place. Everything else still has to pass the membership check, so
+    an arbitrary host never receives ClickHouse credentials.
+
+    Skipping validation also means the port is used as typed rather than being
+    rewritten to the cluster's Envoy/HTTP port, which is what we want for a node
+    that is not behind the cluster's proxy yet.
+    """
+    return not host_is_allowlisted(clickhouse_host, clickhouse_port)
+
+
 def _run_sql_query_on_host(
     clickhouse_host: str,
     clickhouse_port: int,
@@ -53,13 +70,22 @@ def _run_sql_query_on_host(
         # cluster credentials; read-only clusterless queries use the global
         # readonly user so anonymous/low-privilege admin users cannot connect
         # to ClickHouse with admin credentials via this path.
+        validate_node = _validate_clusterless_node(clickhouse_host, clickhouse_port)
         clusterless_connection = (
             get_clusterless_node_connection(
-                clickhouse_host, clickhouse_port, storage_name, settings
+                clickhouse_host,
+                clickhouse_port,
+                storage_name,
+                settings,
+                validate_node=validate_node,
             )
             if sudo
             else get_ro_clusterless_node_connection(
-                clickhouse_host, clickhouse_port, storage_name, settings
+                clickhouse_host,
+                clickhouse_port,
+                storage_name,
+                settings,
+                validate_node=validate_node,
             )
         )
         if sudo and _is_command_statement(sql):
@@ -93,7 +119,13 @@ def _run_explain_on_host(
     """
     settings = _client_settings_for_storage(storage_name)
     connection = (
-        get_ro_clusterless_node_connection(clickhouse_host, clickhouse_port, storage_name, settings)
+        get_ro_clusterless_node_connection(
+            clickhouse_host,
+            clickhouse_port,
+            storage_name,
+            settings,
+            validate_node=_validate_clusterless_node(clickhouse_host, clickhouse_port),
+        )
         if clusterless_mode
         else get_ro_node_connection(clickhouse_host, clickhouse_port, storage_name, settings)
     )

--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -25,6 +25,7 @@ function QueryDisplay(props: {
   predefinedQueryOptions: Array<PredefinedQuery>;
 }) {
   const [nodeData, setNodeData] = useState<ClickhouseNodeData[]>([]);
+  const [manualHostInput, setManualHostInput] = useState<string>("");
   const [query, setQuery] = useState<QueryState>({
     storage: getParamFromStorage("storage"),
   });
@@ -75,12 +76,21 @@ function QueryDisplay(props: {
   }
 
   function selectHostIp(hostStringIP: string) {
+    // Manual entry accepts "host" or "host:port". The raw text is kept in its
+    // own state so a half-typed port ("host:9") is not clobbered by the split.
+    setManualHostInput(hostStringIP);
+
+    const trimmed = hostStringIP.trim();
+    const separator = trimmed.lastIndexOf(":");
+    const maybePort = separator === -1 ? "" : trimmed.slice(separator + 1);
+    // Without a port we default to ClickHouse HTTP, not the old native port.
+    const hasPort = /^\d+$/.test(maybePort);
+
     setQuery((prevQuery) => {
       return {
         ...prevQuery,
-        host: hostStringIP,
-        // Manual host entry defaults to ClickHouse HTTP, not the old native port.
-        port: 8123,
+        host: hasPort ? trimmed.slice(0, separator) : trimmed,
+        port: hasPort ? parseInt(maybePort, 10) : 8123,
       };
     });
   }
@@ -176,12 +186,16 @@ function QueryDisplay(props: {
               <input
                 style={inputStyle}
                 id="clusterless"
-                value={query.host || ""}
+                value={manualHostInput}
                 onChange={(evt) => selectHostIp(evt.target.value)}
                 name="host"
-                placeholder="enter host ip..."
+                placeholder="enter host or host:port..."
                 type="text"
               />
+              <p style={hostHelpTextStyle}>
+                Must be a known cluster node or listed in
+                admin.copy_tables_allowed_target_hosts. Defaults to port 8123.
+              </p>
             </div>) : (
               <div style={hostSelectStyle}>
                 <CustomSelect
@@ -260,7 +274,7 @@ const switchStyle = {
 
 const hostSelectStyle = {
   width: '20em',
-  height: '4em',
+  minHeight: '4em',
   margin: '8px 0px',
   display: 'flex',
   flexDirection: 'column' as const,
@@ -271,6 +285,12 @@ const hostSelectStyle = {
 const inputStyle = {
   fontSize: 16,
   minHeight: '2.25rem',
+}
+
+const hostHelpTextStyle = {
+  fontSize: '0.85em',
+  marginTop: 4,
+  marginBottom: 0,
 }
 
 const executeActionsStyle = {

--- a/tests/admin/clickhouse/test_copy_tables.py
+++ b/tests/admin/clickhouse/test_copy_tables.py
@@ -4,15 +4,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sentry_options.testing import override_options
 
-from snuba.admin.clickhouse.common import _get_storage, get_clusterless_node_connection
+from snuba.admin.clickhouse.common import (
+    ADMIN_ALLOWED_HOSTS_OPTION,
+    _get_storage,
+    get_clusterless_node_connection,
+    host_is_allowlisted,
+    parse_host,
+)
 from snuba.admin.clickhouse.copy_tables import (
-    COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION,
     InvalidClusterName,
     TableStatement,
     copy_tables,
     get_create_table_statements,
-    parse_target_host,
-    target_host_is_allowlisted,
     validate_cluster_name,
     verify_tables_on_replicas,
 )
@@ -335,31 +338,31 @@ def test_validate_cluster_name_rejects_quote_breaking_names(cluster_name: str) -
         ("  host.example.com  ", ("host.example.com", 8123)),
     ],
 )
-def test_parse_target_host_accepts(raw: str, expected: tuple[str, int]) -> None:
-    assert parse_target_host(raw) == expected
+def test_parse_host_accepts(raw: str, expected: tuple[str, int]) -> None:
+    assert parse_host(raw) == expected
 
 
-def test_target_host_is_allowlisted_hostname_matches_any_port() -> None:
+def test_host_is_allowlisted_hostname_matches_any_port() -> None:
     with override_options(
         SNUBA_OPTIONS_NAMESPACE,
-        {COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
+        {ADMIN_ALLOWED_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
     ):
-        assert target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123)
-        assert target_host_is_allowlisted("SNUBA-outcomes-query-arm-1-1", 9000)
-        assert not target_host_is_allowlisted("other-host", 8123)
+        assert host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123)
+        assert host_is_allowlisted("SNUBA-outcomes-query-arm-1-1", 9000)
+        assert not host_is_allowlisted("other-host", 8123)
 
 
-def test_target_host_is_allowlisted_host_port_must_match() -> None:
+def test_host_is_allowlisted_host_port_must_match() -> None:
     with override_options(
         SNUBA_OPTIONS_NAMESPACE,
-        {COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1:9000"]},
+        {ADMIN_ALLOWED_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1:9000"]},
     ):
-        assert target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 9000)
-        assert not target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123)
+        assert host_is_allowlisted("snuba-outcomes-query-arm-1-1", 9000)
+        assert not host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123)
 
 
-def test_target_host_is_allowlisted_empty_by_default() -> None:
-    assert target_host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123) is False
+def test_host_is_allowlisted_empty_by_default() -> None:
+    assert host_is_allowlisted("snuba-outcomes-query-arm-1-1", 8123) is False
 
 
 def _copy_tables_cluster_mock() -> MagicMock:
@@ -377,7 +380,7 @@ def test_copy_tables_target_host_requires_allowlist() -> None:
     """A host outside the source cluster is rejected unless allowlisted."""
     with patch("snuba.admin.clickhouse.copy_tables._get_storage") as mock_storage:
         mock_storage.return_value.get_cluster.return_value = _copy_tables_cluster_mock()
-        with pytest.raises(ValueError, match=COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION):
+        with pytest.raises(ValueError, match=ADMIN_ALLOWED_HOSTS_OPTION):
             copy_tables(
                 source_host="snuba-outcomes-query-1-2",
                 storage_name="outcomes_raw",
@@ -395,7 +398,7 @@ def test_copy_tables_target_host_skips_cluster_membership() -> None:
     with (
         override_options(
             SNUBA_OPTIONS_NAMESPACE,
-            {COPY_TABLES_ALLOWED_TARGET_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
+            {ADMIN_ALLOWED_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
         ),
         patch("snuba.admin.clickhouse.copy_tables._get_storage") as mock_storage,
         patch(

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -5,10 +5,15 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba import settings
 from snuba.admin.auth_roles import ROLES, Role
-from snuba.admin.clickhouse.common import InvalidCustomQuery, InvalidNodeError
+from snuba.admin.clickhouse.common import (
+    ADMIN_ALLOWED_HOSTS_OPTION,
+    InvalidCustomQuery,
+    InvalidNodeError,
+)
 from snuba.admin.clickhouse.system_queries import (
     UnauthorizedForSudo,
     is_valid_system_query,
@@ -18,6 +23,7 @@ from snuba.admin.clickhouse.system_queries import (
 from snuba.admin.user import AdminUser
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.state.sentry_options import SNUBA_OPTIONS_NAMESPACE
 
 
 @pytest.mark.parametrize(
@@ -346,8 +352,25 @@ def test_clusterless_rejects_unvalidated_host(
         )
 
 
-def test_clusterless_validate_node_false_skips_membership_check() -> None:
-    """Allowlisted copy-tables CREATE targets skip _validate_node."""
+@pytest.mark.parametrize(
+    "helper_name, client_settings",
+    [
+        pytest.param(
+            "get_clusterless_node_connection",
+            ClickhouseClientSettings.INTERNAL,
+            id="sudo clusterless helper",
+        ),
+        pytest.param(
+            "get_ro_clusterless_node_connection",
+            ClickhouseClientSettings.QUERY,
+            id="readonly clusterless helper",
+        ),
+    ],
+)
+def test_clusterless_validate_node_false_skips_membership_check(
+    helper_name: str, client_settings: ClickhouseClientSettings
+) -> None:
+    """Allowlisted hosts skip _validate_node and keep the port they were given."""
     from snuba.admin.clickhouse import common
 
     with (
@@ -359,11 +382,11 @@ def test_clusterless_validate_node_false_skips_membership_check() -> None:
         patch.object(common, "build_pool") as mock_pool,
     ):
         mock_pool.return_value = MagicMock()
-        common.get_clusterless_node_connection(
+        getattr(common, helper_name)(
             "snuba-outcomes-query-arm-1-1",
             8123,
             "errors",
-            ClickhouseClientSettings.INTERNAL,
+            client_settings,
             validate_node=False,
         )
 
@@ -372,6 +395,137 @@ def test_clusterless_validate_node_false_skips_membership_check() -> None:
         node = mock_pool.call_args.args[1]
         assert node.host_name == "snuba-outcomes-query-arm-1-1"
         assert node.port == 8123
+
+
+@pytest.mark.parametrize(
+    "sudo_mode, helper_name",
+    [
+        pytest.param(False, "get_ro_clusterless_node_connection", id="readonly"),
+        pytest.param(True, "get_clusterless_node_connection", id="sudo"),
+    ],
+)
+def test_clusterless_query_skips_validation_for_allowlisted_host(
+    sudo_mode: bool, helper_name: str
+) -> None:
+    """
+    Manual host entry against a host on ADMIN_ALLOWED_HOSTS_OPTION connects
+    without a cluster-membership check, so a node that has been provisioned but
+    not yet added to Snuba cluster config can be queried. The typed port is used
+    as-is rather than being rewritten to the cluster's port.
+    """
+    from snuba.admin.clickhouse import system_queries
+
+    with (
+        override_options(
+            SNUBA_OPTIONS_NAMESPACE,
+            {ADMIN_ALLOWED_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
+        ),
+        patch.object(system_queries, helper_name) as mock_helper,
+    ):
+        mock_helper.return_value.execute.return_value = MagicMock(results=[])
+
+        system_queries._run_sql_query_on_host(
+            "snuba-outcomes-query-arm-1-1",
+            8123,
+            "errors",
+            "SELECT * FROM system.clusters",
+            sudo_mode,
+            True,
+        )
+
+    assert mock_helper.call_args.kwargs["validate_node"] is False
+    assert mock_helper.call_args.args[:2] == ("snuba-outcomes-query-arm-1-1", 8123)
+
+
+@pytest.mark.parametrize(
+    "sudo_mode, helper_name",
+    [
+        pytest.param(False, "get_ro_clusterless_node_connection", id="readonly"),
+        pytest.param(True, "get_clusterless_node_connection", id="sudo"),
+    ],
+)
+def test_clusterless_query_validates_non_allowlisted_host(
+    sudo_mode: bool, helper_name: str
+) -> None:
+    """A host that is not allowlisted still has to be a member of the cluster."""
+    from snuba.admin.clickhouse import system_queries
+
+    with (
+        override_options(
+            SNUBA_OPTIONS_NAMESPACE,
+            {ADMIN_ALLOWED_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
+        ),
+        patch.object(system_queries, helper_name) as mock_helper,
+    ):
+        mock_helper.return_value.execute.return_value = MagicMock(results=[])
+
+        system_queries._run_sql_query_on_host(
+            "attacker.example.com",
+            9009,
+            "errors",
+            "SELECT * FROM system.clusters",
+            sudo_mode,
+            True,
+        )
+
+    assert mock_helper.call_args.kwargs["validate_node"] is True
+
+
+def test_clusterless_explain_skips_validation_for_allowlisted_host() -> None:
+    """
+    Query validation runs EXPLAIN on the target host, so it has to accept the
+    allowlisted host too — otherwise validation rejects the query before the
+    read ever reaches the node.
+    """
+    from snuba.admin.clickhouse import system_queries
+
+    with (
+        override_options(
+            SNUBA_OPTIONS_NAMESPACE,
+            {ADMIN_ALLOWED_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1:9000"]},
+        ),
+        patch.object(system_queries, "get_ro_clusterless_node_connection") as mock_helper,
+    ):
+        system_queries._run_explain_on_host(
+            "snuba-outcomes-query-arm-1-1",
+            9000,
+            "errors",
+            "EXPLAIN AST SELECT * FROM system.clusters",
+            True,
+        )
+
+    assert mock_helper.call_args.kwargs["validate_node"] is False
+
+
+def test_non_clusterless_ignores_allowlist() -> None:
+    """
+    The allowlist only relaxes manual host entry. Node-picker queries stay on
+    the membership-checked helpers.
+    """
+    from snuba.admin.clickhouse import system_queries
+
+    with (
+        override_options(
+            SNUBA_OPTIONS_NAMESPACE,
+            {ADMIN_ALLOWED_HOSTS_OPTION: ["snuba-outcomes-query-arm-1-1"]},
+        ),
+        patch.object(system_queries, "get_ro_node_connection") as mock_ro,
+        patch.object(system_queries, "get_ro_clusterless_node_connection") as mock_clusterless,
+    ):
+        mock_ro.return_value.execute.return_value = MagicMock(results=[])
+
+        system_queries._run_sql_query_on_host(
+            "snuba-outcomes-query-arm-1-1",
+            8123,
+            "errors",
+            "SELECT * FROM system.clusters",
+            False,
+            False,
+        )
+
+    assert mock_ro.called
+    assert not mock_clusterless.called
+    assert "validate_node" not in mock_ro.call_args.kwargs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follows #8411. System Queries' manual host entry can now target a host that is not a member of the storage's cluster, provided it is listed in `admin.copy_tables_allowed_target_hosts` — the same option copy-tables CREATE targets already use. That lets a node which has been provisioned but not yet added to Snuba cluster config be inspected.

The allowlist gates the EXPLAIN validation connection as well as the query connection: without that, `validate_query` rejects the query before the read ever reaches the node. Skipping validation also means the typed port is used verbatim instead of being rewritten to the cluster's Envoy/8123 port, which is what you want for a node that is not behind the cluster proxy yet.

Non-allowlisted hosts still go through `_validate_node`, and node-picker (non-clusterless) queries are untouched — the relaxation is limited to manual host entry.

### Changes

- `common.py`: host/port parsing and the allowlist lookup move out of `copy_tables.py` (`ADMIN_ALLOWED_HOSTS_OPTION`, `parse_host`, `host_is_allowlisted`) so both tools read one list. The option key value is unchanged, so no ops change is needed.
- `common.py`: `get_ro_clusterless_node_connection` gains `validate_node`; the sudo variant already had it from #8411.
- `system_queries.py`: `_validate_clusterless_node` gates `_run_sql_query_on_host` (sudo and read-only) and `_run_explain_on_host`.
- Frontend: manual entry parses `host:port` (defaults to 8123), keeping the raw text in its own state so a half-typed port is not clobbered, plus help text naming the option.

### Review notes

The `validate_node=False` path is the one to scrutinize. It is reached only after `host_is_allowlisted` returns true, and read-only clusterless queries still use the global readonly user, so a non-allowlisted host never receives credentials.

Open question: the option key still reads `admin.copy_tables_allowed_target_hosts` while now governing two tools. Only the schema description was updated here; renaming would need a coordinated options change.

### Tests

`tests/admin` passes (172 + 80). New coverage: allowlisted vs. non-allowlisted hosts for sudo and read-only, the EXPLAIN path, and that non-clusterless mode ignores the allowlist. Copy-tables tests updated for the moved helpers.