### PR TITLE
fix(migrations): Wait for ON CLUSTER DDL instead of failing at 5 min

### DIFF
--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -48,11 +48,6 @@ metrics = MetricsWrapper(environment.metrics, "clickhouse.connect")
 DEFAULT_SEND_RECEIVE_TIMEOUT_SECONDS = 60 * 60  # 1h fallback when profile timeout is None
 DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
 _CLICKHOUSE_CONNECT_TRANSPORT_SETTINGS = {"X-ClickHouse-Format": "Native"}
-# Re-sent per request so they beat clickhouse-connect's 120s progress cap.
-_HTTP_PROGRESS_SETTINGS = (
-    "send_progress_in_http_headers",
-    "http_headers_progress_interval_ms",
-)
 
 clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 clickhouse_connect_common.set_setting("use_protocol_version", True)
@@ -473,28 +468,22 @@ class ClickhouseConnectPool(ClickhousePool):
                 old.close()
         return client
 
-    def _merge_http_progress(self, settings: Mapping[str, Any] | None) -> dict[str, Any]:
-        """Re-send HTTP progress on the request so it beats the driver's 120s cap.
-
-        Constructor settings land in ``client.params``, but
-        ``HttpSyncBackend.request`` then overwrites
-        ``http_headers_progress_interval_ms`` with
-        ``min(120s, (send_receive_timeout - 5)s)``. Per-request settings win last.
-        """
-        merged: dict[str, Any] = dict(settings) if settings else {}
-        for key in _HTTP_PROGRESS_SETTINGS:
-            value = self.client_settings.get(key)
-            if value is not None and key not in merged:
-                merged[key] = value
-        return merged
-
     def _build_query_settings(
         self,
         settings: Mapping[str, Any] | None,
         query_id: str | None,
         capture_trace: bool,
     ) -> dict[str, Any] | None:
-        query_settings = self._merge_http_progress(settings)
+        # Re-send progress on the request. Constructor values land in
+        # client.params, then clickhouse-connect overwrites the interval with
+        # min(120s, (timeout-5)s). Per-request settings win last.
+        query_settings: dict[str, Any] = dict(settings) if settings else {}
+        for key in (
+            "send_progress_in_http_headers",
+            "http_headers_progress_interval_ms",
+        ):
+            if key not in query_settings and key in self.client_settings:
+                query_settings[key] = self.client_settings[key]
         if query_id is not None:
             query_settings["query_id"] = query_id
         if capture_trace:
@@ -601,7 +590,9 @@ class ClickhouseConnectPool(ClickhousePool):
             query_id = uuid.uuid4().hex
 
         json_settings = _jsoncompact_settings(
-            self._merge_http_progress(settings), query_id, capture_trace
+            self._build_query_settings(settings, query_id, capture_trace),
+            query_id,
+            capture_trace,
         )
         query = _apply_client_query_limit(client, _strip_trailing_semicolons(query))
 
@@ -644,7 +635,9 @@ class ClickhouseConnectPool(ClickhousePool):
             # Same client-side id rule as _execute_jsoncompact for query_log.
             resolved_query_id = query_id or (uuid.uuid4().hex if capture_trace else None)
             json_settings = _jsoncompact_settings(
-                self._merge_http_progress(settings), resolved_query_id, capture_trace
+                self._build_query_settings(settings, resolved_query_id, capture_trace),
+                resolved_query_id,
+                capture_trace,
             )
             sql = _strip_trailing_semicolons(query)
 

--- a/snuba/clickhouse/connect.py
+++ b/snuba/clickhouse/connect.py
@@ -48,6 +48,11 @@ metrics = MetricsWrapper(environment.metrics, "clickhouse.connect")
 DEFAULT_SEND_RECEIVE_TIMEOUT_SECONDS = 60 * 60  # 1h fallback when profile timeout is None
 DEFAULT_CLICKHOUSE_HTTP_PORT = 8123
 _CLICKHOUSE_CONNECT_TRANSPORT_SETTINGS = {"X-ClickHouse-Format": "Native"}
+# Re-sent per request so they beat clickhouse-connect's 120s progress cap.
+_HTTP_PROGRESS_SETTINGS = (
+    "send_progress_in_http_headers",
+    "http_headers_progress_interval_ms",
+)
 
 clickhouse_connect_common.set_setting("invalid_setting_action", "drop")
 clickhouse_connect_common.set_setting("use_protocol_version", True)
@@ -468,13 +473,28 @@ class ClickhouseConnectPool(ClickhousePool):
                 old.close()
         return client
 
+    def _merge_http_progress(self, settings: Mapping[str, Any] | None) -> dict[str, Any]:
+        """Re-send HTTP progress on the request so it beats the driver's 120s cap.
+
+        Constructor settings land in ``client.params``, but
+        ``HttpSyncBackend.request`` then overwrites
+        ``http_headers_progress_interval_ms`` with
+        ``min(120s, (send_receive_timeout - 5)s)``. Per-request settings win last.
+        """
+        merged: dict[str, Any] = dict(settings) if settings else {}
+        for key in _HTTP_PROGRESS_SETTINGS:
+            value = self.client_settings.get(key)
+            if value is not None and key not in merged:
+                merged[key] = value
+        return merged
+
     def _build_query_settings(
         self,
         settings: Mapping[str, Any] | None,
         query_id: str | None,
         capture_trace: bool,
     ) -> dict[str, Any] | None:
-        query_settings: dict[str, Any] = dict(settings) if settings else {}
+        query_settings = self._merge_http_progress(settings)
         if query_id is not None:
             query_settings["query_id"] = query_id
         if capture_trace:
@@ -580,7 +600,9 @@ class ClickhouseConnectPool(ClickhousePool):
         if capture_trace and not query_id:
             query_id = uuid.uuid4().hex
 
-        json_settings = _jsoncompact_settings(settings, query_id, capture_trace)
+        json_settings = _jsoncompact_settings(
+            self._merge_http_progress(settings), query_id, capture_trace
+        )
         query = _apply_client_query_limit(client, _strip_trailing_semicolons(query))
 
         with _query_span(query, query_id):
@@ -621,7 +643,9 @@ class ClickhouseConnectPool(ClickhousePool):
             client = self._new_client()
             # Same client-side id rule as _execute_jsoncompact for query_log.
             resolved_query_id = query_id or (uuid.uuid4().hex if capture_trace else None)
-            json_settings = _jsoncompact_settings(settings, resolved_query_id, capture_trace)
+            json_settings = _jsoncompact_settings(
+                self._merge_http_progress(settings), resolved_query_id, capture_trace
+            )
             sql = _strip_trailing_semicolons(query)
 
             with _query_span(sql, resolved_query_id):

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -62,22 +62,17 @@ class ClickhouseClientSettings(Enum):
             "mutations_sync": 2,
             "alter_sync": 2,  # Wait for ON CLUSTER DDL on all replicas
             "database_atomic_wait_for_drop_and_detach_synchronously": 1,
-            # Negative = wait for every host. A positive value is a wait-to-fail
-            # clock: CH throws after N seconds and continues the DDL async
-            # (INC-2103 used 300s; quiet DROP then IncompleteRead, SNUBA-C3Y).
+            # Wait for every host. A positive value throws after N seconds and
+            # continues the DDL async (300s → IncompleteRead, SNUBA-C3Y).
             "distributed_ddl_task_timeout": -1,
-            # Quiet ON CLUSTER / lock wait sends no body. Don't close HTTP
-            # before we hear the real result. Server default is 30s.
+            # Quiet ON CLUSTER / lock wait sends no body. Server default is 30s.
             "http_send_timeout": 3600,
-            # Keep-alive for quiet DDL. Must also go out as per-request
-            # settings: clickhouse-connect overwrites constructor interval
-            # with min(120s, (timeout-5)s).
+            # clickhouse-connect caps constructor progress at 120s; 15s is
+            # re-sent per request so quiet DDL still writes bytes.
             "send_progress_in_http_headers": 1,
             "http_headers_progress_interval_ms": 15000,
         },
-        # seconds (urllib3 read). None → 1h fallback. Idle resets if progress
-        # headers arrive; http_send_timeout covers a quiet wait.
-        None,
+        None,  # seconds; None → 1h fallback
     )
     DELETE = ClickhouseClientSettingsType({"mutations_sync": 1}, None)
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -62,17 +62,22 @@ class ClickhouseClientSettings(Enum):
             "mutations_sync": 2,
             "alter_sync": 2,  # Wait for ON CLUSTER DDL on all replicas
             "database_atomic_wait_for_drop_and_detach_synchronously": 1,
-            "distributed_ddl_task_timeout": 300,  # 5 minute ON CLUSTER DDL timeout
-            # Quiet ON CLUSTER DDL (DROP MV waiting on a hot-table lock) writes
-            # no bytes until it finishes. Pin a 15s header so http_send_timeout
-            # / idle do not IncompleteRead the HTTP body.
+            # Negative = wait for every host. A positive value is a wait-to-fail
+            # clock: CH throws after N seconds and continues the DDL async
+            # (INC-2103 used 300s; quiet DROP then IncompleteRead, SNUBA-C3Y).
+            "distributed_ddl_task_timeout": -1,
+            # Quiet ON CLUSTER / lock wait sends no body. Don't close HTTP
+            # before we hear the real result. Server default is 30s.
+            "http_send_timeout": 3600,
+            # Keep-alive for quiet DDL. Must also go out as per-request
+            # settings: clickhouse-connect overwrites constructor interval
+            # with min(120s, (timeout-5)s).
             "send_progress_in_http_headers": 1,
             "http_headers_progress_interval_ms": 15000,
         },
-        # 5 minute timeout to allow ON CLUSTER DDL operations to complete
-        # across all replicas. This is needed because alter_sync=2 blocks
-        # until all replicas confirm completion.
-        300000,
+        # seconds (urllib3 read). None → 1h fallback. Idle resets if progress
+        # headers arrive; http_send_timeout covers a quiet wait.
+        None,
     )
     DELETE = ClickhouseClientSettingsType({"mutations_sync": 1}, None)
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -414,6 +414,7 @@ def test_command_does_not_query() -> None:
 
     client.command.assert_called_once()
     client.query.assert_not_called()
+    assert client.command.call_args.kwargs["settings"] is None
     assert result.results == []
     assert result.meta == []
 
@@ -548,22 +549,17 @@ def test_replace_profile_uses_bounded_timeouts() -> None:
 
 
 def test_migrate_profile_waits_for_clickhouse() -> None:
-    # Wait for ON CLUSTER hosts instead of throwing at 5 min (and continuing
-    # async). Quiet DDL still needs HTTP keep-alive so the body is not
-    # IncompleteRead (SNUBA-C3Y). Client timeout is seconds, not leftover ms.
+    # Wait for ON CLUSTER hosts; keep HTTP alive on quiet DDL (SNUBA-C3Y).
     migrate = ClickhouseClientSettings.MIGRATE.value
     assert migrate.settings["distributed_ddl_task_timeout"] == -1
     assert migrate.settings["http_send_timeout"] == 3600
     assert migrate.settings["send_progress_in_http_headers"] == 1
     assert migrate.settings["http_headers_progress_interval_ms"] == 15000
-    assert migrate.settings["alter_sync"] == 2
     assert migrate.timeout is None
 
 
 def test_command_reposts_http_progress_interval() -> None:
     # clickhouse-connect overwrites constructor interval with min(120s, ...).
-    # command() must pass the profile interval as per-request settings so 15s
-    # actually hits the wire.
     client = mock.Mock()
     pool = _make_pool(
         client,
@@ -573,41 +569,16 @@ def test_command_reposts_http_progress_interval() -> None:
         },
     )
     pool.command("DROP TABLE t")
-    _, kwargs = client.command.call_args
-    assert kwargs["settings"]["send_progress_in_http_headers"] == 1
-    assert kwargs["settings"]["http_headers_progress_interval_ms"] == 15000
+    assert client.command.call_args.kwargs["settings"] == {
+        "send_progress_in_http_headers": 1,
+        "http_headers_progress_interval_ms": 15000,
+    }
 
-
-def test_command_preserves_caller_http_progress_interval() -> None:
-    client = mock.Mock()
-    pool = _make_pool(
-        client,
-        client_settings={"http_headers_progress_interval_ms": 15000},
-    )
     pool.command("DROP TABLE t", settings={"http_headers_progress_interval_ms": 5000})
-    _, kwargs = client.command.call_args
-    assert kwargs["settings"]["http_headers_progress_interval_ms"] == 5000
-
-
-def test_command_omits_progress_when_profile_has_none() -> None:
-    client = mock.Mock()
-    pool = _make_pool(client)
-    pool.command("SYSTEM FLUSH LOGS")
-    _, kwargs = client.command.call_args
-    assert kwargs["settings"] is None
-
-
-def test_execute_reposts_http_progress_interval() -> None:
-    # REPLACE (and other long execute() profiles) hit the same 120s cap.
-    client = mock.Mock()
-    client.query.return_value = FakeQueryResult([], summary={})
-    pool = _make_pool(
-        client,
-        client_settings={"http_headers_progress_interval_ms": 15000},
-    )
-    pool.execute("SELECT 1")
-    _, kwargs = client.query.call_args
-    assert kwargs["settings"]["http_headers_progress_interval_ms"] == 15000
+    assert client.command.call_args.kwargs["settings"] == {
+        "send_progress_in_http_headers": 1,
+        "http_headers_progress_interval_ms": 5000,
+    }
 
 
 def test_clickhouse_reader_wraps_connect_pool() -> None:

--- a/tests/clickhouse/test_connect.py
+++ b/tests/clickhouse/test_connect.py
@@ -421,15 +421,15 @@ def test_command_does_not_query() -> None:
 def test_timeouts_are_passed_through() -> None:
     import clickhouse_connect
 
-    # The per-profile timeout is honored as-is (no capping), the same way the
-    # native driver uses it. A large timeout (e.g. from MIGRATE) is preserved.
+    # The per-profile timeout is honored as-is (no capping). A large timeout
+    # (e.g. OPTIMIZE's 4h) is preserved.
     pool = ClickhouseConnectPool(
         host="host",
         user="test",
         password="test",
         database="test",
         connect_timeout=60,
-        send_receive_timeout=300000,
+        send_receive_timeout=14400,
     )
 
     with (
@@ -439,7 +439,7 @@ def test_timeouts_are_passed_through() -> None:
         pool._new_client()
 
     _, kwargs = get_client.call_args
-    assert kwargs["send_receive_timeout"] == 300000
+    assert kwargs["send_receive_timeout"] == 14400
     assert kwargs["connect_timeout"] == 60
     assert kwargs["compress"] == "lz4"
     assert kwargs["query_retries"] == 2
@@ -547,13 +547,67 @@ def test_replace_profile_uses_bounded_timeouts() -> None:
     assert replace.timeout == snuba_settings.REPLACER_QUERY_TIMEOUT + 60
 
 
-def test_migrate_profile_sends_http_progress() -> None:
-    # Quiet ON CLUSTER DDL can sit on a lock with no HTTP bytes until it
-    # finishes. Progress headers keep http_send_timeout / idle from cutting
-    # the chunked body (IncompleteRead).
+def test_migrate_profile_waits_for_clickhouse() -> None:
+    # Wait for ON CLUSTER hosts instead of throwing at 5 min (and continuing
+    # async). Quiet DDL still needs HTTP keep-alive so the body is not
+    # IncompleteRead (SNUBA-C3Y). Client timeout is seconds, not leftover ms.
     migrate = ClickhouseClientSettings.MIGRATE.value
+    assert migrate.settings["distributed_ddl_task_timeout"] == -1
+    assert migrate.settings["http_send_timeout"] == 3600
     assert migrate.settings["send_progress_in_http_headers"] == 1
     assert migrate.settings["http_headers_progress_interval_ms"] == 15000
+    assert migrate.settings["alter_sync"] == 2
+    assert migrate.timeout is None
+
+
+def test_command_reposts_http_progress_interval() -> None:
+    # clickhouse-connect overwrites constructor interval with min(120s, ...).
+    # command() must pass the profile interval as per-request settings so 15s
+    # actually hits the wire.
+    client = mock.Mock()
+    pool = _make_pool(
+        client,
+        client_settings={
+            "send_progress_in_http_headers": 1,
+            "http_headers_progress_interval_ms": 15000,
+        },
+    )
+    pool.command("DROP TABLE t")
+    _, kwargs = client.command.call_args
+    assert kwargs["settings"]["send_progress_in_http_headers"] == 1
+    assert kwargs["settings"]["http_headers_progress_interval_ms"] == 15000
+
+
+def test_command_preserves_caller_http_progress_interval() -> None:
+    client = mock.Mock()
+    pool = _make_pool(
+        client,
+        client_settings={"http_headers_progress_interval_ms": 15000},
+    )
+    pool.command("DROP TABLE t", settings={"http_headers_progress_interval_ms": 5000})
+    _, kwargs = client.command.call_args
+    assert kwargs["settings"]["http_headers_progress_interval_ms"] == 5000
+
+
+def test_command_omits_progress_when_profile_has_none() -> None:
+    client = mock.Mock()
+    pool = _make_pool(client)
+    pool.command("SYSTEM FLUSH LOGS")
+    _, kwargs = client.command.call_args
+    assert kwargs["settings"] is None
+
+
+def test_execute_reposts_http_progress_interval() -> None:
+    # REPLACE (and other long execute() profiles) hit the same 120s cap.
+    client = mock.Mock()
+    client.query.return_value = FakeQueryResult([], summary={})
+    pool = _make_pool(
+        client,
+        client_settings={"http_headers_progress_interval_ms": 15000},
+    )
+    pool.execute("SELECT 1")
+    _, kwargs = client.query.call_args
+    assert kwargs["settings"]["http_headers_progress_interval_ms"] == 15000
 
 
 def test_clickhouse_reader_wraps_connect_pool() -> None:


### PR DESCRIPTION
ON CLUSTER migrations now wait for ClickHouse to finish instead of throwing at 5 minutes (and continuing the DDL in the background). Quiet DROP/ALTER no longer dies as `IncompleteRead` after that wait.

`distributed_ddl_task_timeout` is `-1` (wait for every host; real errors still return immediately). `http_send_timeout` is 1h so a lock wait with no body does not close HTTP. The 15s progress interval from #8413 is re-sent on each `command()`/`execute()` because clickhouse-connect overwrites constructor settings with a 120s cap. The client timeout is `None` (1h urllib3 fallback) — the old `300000` was leftover milliseconds, not 5 minutes.

Tradeoff: a replica that never acks hangs the migrate job instead of failing at 5 min while ClickHouse keeps going. That matches waiting for processing.

Refs SNUBA-C3Y
