### PR TITLE
fix(schema.json): policies can accept any number of arbitrary properties

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -376,6 +376,9 @@
                     },
                     "optional": true
                   }
+                },
+                "additionalProperties": {
+                    "type": "number"
                 }
               }
             }


### PR DESCRIPTION
Allocation policy items in sentry-options currently fail schema validation when they include constructor overrides beyond the few named fields.

Allow additional numeric properties on each policy object so per-policy default_config_overrides can be set without listing every config key in the schema.

Follow-up to #8393. 
Linear: [EAP-726](https://linear.app/getsentry/issue/EAP-726).

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.