### PR TITLE
feat(outcomes): Add `callback_error` discard reason

### DIFF
--- a/rust_snuba/src/processors/outcomes.rs
+++ b/rust_snuba/src/processors/outcomes.rs
@@ -21,6 +21,8 @@ const CLIENT_DISCARD_REASONS: &[&str] = &[
     "buffer_overflow",
     // a SDK internal cache (eg: offline event cache) overflowed
     "cache_overflow",
+    // an event was dropped because a user-provided callback (eg: `before_send`, `traces_sampler`) threw an error
+    "callback_error",
     // an event was dropped by an event processor; may also be used for ignored exceptions / errors
     "event_processor",
     // an event was dropped by an SDK ignore config (e.g. an `ignore_spans` deny list)


### PR DESCRIPTION
This adds a new `callback_error` discard reason for when events are dropped because a user-provided callback (like `beforeSend`, `tracesSampler`, etc.) throws an error. Without this a user wouldn't be able to distinguish between an event being filtered because their callback worked as intended or because it threw.

ref https://linear.app/getsentry/project/wrap-all-sdk-user-callbacks-in-a-try-catch-6bfdbe9f7268/overview
