### PR TITLE
feat(eap-items): add version column to eap_items_1_downsample_64_local

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0066_add_version_column_downsample_64.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0066_add_version_column_downsample_64.py
@@ -1,0 +1,66 @@
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM
+local_table_name = "eap_items_1_downsample_64_local"
+
+new_column_name = "version"
+
+# Mirrors the `version` column added to eap_items_1 in migration 0064, so this
+# downsample tier's schema lines up with its target ReplacingMergeTree before
+# existing parts are attached onto it.
+#
+# ADD COLUMN does not rewrite existing parts, so rows written before this
+# migration have no `version` on disk and this DEFAULT is what gets evaluated
+# when they are read or merged. It therefore has to be deterministic: under
+# ReplacingMergeTree(version) a now64() default would hand those legacy rows a
+# version of "whenever the merge happened", which is always newer than a real
+# write, letting a stale row silently beat a genuine update. `0` is the sentinel
+# for "written before versioning existed" and deterministically loses to
+# everything else.
+new_column: Column[Modifiers] = Column(
+    new_column_name,
+    UInt(
+        64,
+        modifiers=Modifiers(
+            default="0",
+            codecs=["ZSTD(1)"],
+        ),
+    ),
+)
+
+# Only the *_local table gets the column, unlike 0064 which also touched
+# eap_items_1_dist. `version` is internal bookkeeping for the
+# ReplacingMergeTree cutover: it is absent from the storage YAML so we never
+# query it, and the downsample tiers are fed by materialized views that write
+# straight to *_local, so the distributed table is never an insert target
+# either. A Distributed table that declares a subset of its local table's
+# columns reads normally; only a query naming `version` through the dist table
+# would fail, and nothing does that. The same reasoning covers *_dist_ro.
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> list[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set,
+                table_name=local_table_name,
+                column=new_column,
+                target=OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> list[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set,
+                table_name=local_table_name,
+                column_name=new_column_name,
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
### Stack

1. ~#8424 — `version` on `eap_items_1` (merged)~
2. #8428 — `version` on `eap_items_1_downsample_8_local`
3. #8426 — `version` on `eap_items_1_downsample_64_local`
4. #8427 — `version` on `eap_items_1_downsample_512_local`
5. #8430 — downsample MVs carry `version`
6. #8438 — create the `eap_items_2` tables (draft)

Merge in order; each targets the one above it.

---

Adds the `version` column to the `downsample_64` tier.

```sql
ALTER TABLE eap_items_1_downsample_64_local ADD COLUMN IF NOT EXISTS version UInt64 DEFAULT 0 CODEC (ZSTD(1));
```

### Why

Part of getting the `eap_items` schemas aligned with the target `ReplacingMergeTree` (keyed on `version`) so that existing parts can be attached onto the new tables. This mirrors the column added to `eap_items_1` in migration 0064.

Schema-only — no engine change, so no dedup behaviour changes yet.

### Why `DEFAULT 0`

`ADD COLUMN` does not rewrite existing parts, so rows written before this migration have no `version` on disk and the default is evaluated at read/merge time. That makes a non-deterministic default actively dangerous here: under `ReplacingMergeTree(version)` a `now64()` default gives legacy rows a version of "whenever the merge ran", which always beats a genuine write. Verified on ClickHouse — a real update was silently discarded in favour of the stale row against a `DEFAULT now64()` destination, and won as expected against a `DEFAULT 0` one.

`0` is the sentinel for "written before versioning existed" and deterministically loses to every real write, matching the `received_at` precedent in `snuba/manual_jobs/create_eap_received_at_version_test.py`.

### Why local only

Unlike 0064, this does not touch `eap_items_1_downsample_64_dist` (or `_dist_ro`):

- We never query `version` — it is internal bookkeeping for the cutover and is absent from the storage YAML, so the query layer cannot generate SQL naming it.
- The downsample tiers are fed by materialized views that write straight to `*_local` (`swap_downsample_materialized_views` uses `destination_table_name={prefix}_local`, `target=OperationTarget.LOCAL`), so the distributed table is never an insert target.

A Distributed table declaring a subset of its local table's columns behaves normally — verified that reads and `SELECT *` through the narrower dist table work, and that an insert routed through it still lets the local default fire. Only an explicit `SELECT version` through the dist table errors, and nothing does that.

### Follow-up

Handled in #8430: the downsample MVs did not originally carry `version` through from the source, so rows they insert would read `0` rather than the source row's version.

### Testing

- `tests/migrations/test_runner.py::test_no_schema_differences`
- `tests/migrations/test_runner.py::test_run_and_reverse_all`
