### PR TITLE
feat(allocation_policies): pardon rejections when the cluster is idle

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -266,16 +266,6 @@
       "default": false,
       "description": "When true, the storage routing strategy fetches ClickHouse cluster load info to inform routing decisions. Also the kill switch for idle allocation-policy pardons."
     },
-    "storage_routing.idle_cluster_load_threshold": {
-      "type": "number",
-      "default": 0,
-      "description": "Pardon allocation-policy rejections when cluster_load is strictly below this value (and concurrent queries are below storage_routing.idle_concurrent_queries_threshold). 0 means never idle."
-    },
-    "storage_routing.idle_concurrent_queries_threshold": {
-      "type": "integer",
-      "default": 0,
-      "description": "Pardon allocation-policy rejections when concurrent_queries is strictly below this value (and cluster load is below storage_routing.idle_cluster_load_threshold). 0 means never idle."
-    },
     "retention_days": {
       "type": "object",
       "properties": {

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -264,7 +264,17 @@
     "storage_routing.enable_get_cluster_loadinfo": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the storage routing strategy fetches ClickHouse cluster load info to inform routing decisions."
+      "description": "When true, the storage routing strategy fetches ClickHouse cluster load info to inform routing decisions. Also the kill switch for idle allocation-policy pardons."
+    },
+    "storage_routing.idle_cluster_load_threshold": {
+      "type": "number",
+      "default": 0,
+      "description": "Pardon allocation-policy rejections when cluster_load is strictly below this value (and concurrent queries are below storage_routing.idle_concurrent_queries_threshold). 0 means never idle."
+    },
+    "storage_routing.idle_concurrent_queries_threshold": {
+      "type": "integer",
+      "default": 0,
+      "description": "Pardon allocation-policy rejections when concurrent_queries is strictly below this value (and cluster load is below storage_routing.idle_cluster_load_threshold). 0 means never idle."
     },
     "retention_days": {
       "type": "object",

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -92,17 +92,18 @@ class QuotaAllowance:
 
     def decision(
         self,
-        *,
-        policy_max_threads: int,
-        idle_pardon: bool,
+        policy: AllocationPolicy,
+        load_info: LoadInfo | None,
     ) -> QuotaAllowanceDecision:
         if not self.can_run:
-            if idle_pardon:
-                return QuotaAllowanceDecision.PARDONED
-            return QuotaAllowanceDecision.REJECTED
-        max_threads = min(self.max_threads, policy_max_threads)
-        if max_threads < policy_max_threads:
+            idle_pardon = policy.is_pardonable and load_info is not None and load_info.is_idle()
+            return (
+                QuotaAllowanceDecision.PARDONED if idle_pardon else QuotaAllowanceDecision.REJECTED
+            )
+
+        if self.max_threads < policy.max_threads:
             return QuotaAllowanceDecision.THROTTLED
+
         return QuotaAllowanceDecision.ALLOWED
 
     def __eq__(self, other: Any) -> bool:
@@ -489,10 +490,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                 return _default_passthough_policy(
                     self._resource_identifier.value
                 ).get_quota_allowance(tenant_ids, query_id, load_info)
-            idle_pardon = self.is_pardonable and load_info is not None and load_info.is_idle()
-            decision = allowance.decision(
-                policy_max_threads=self.max_threads, idle_pardon=idle_pardon
-            )
+            decision = allowance.decision(self, load_info)
             referrer = str(tenant_ids.get("referrer", "no_referrer"))
             if decision == QuotaAllowanceDecision.PARDONED:
                 self.metrics.increment("db_request_pardoned", tags={"referrer": referrer})
@@ -517,13 +515,12 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                     suggestion=allowance.suggestion,
                 )
             elif decision == QuotaAllowanceDecision.PARDONED:
-                assert load_info is not None
                 allowance = QuotaAllowance(
                     can_run=True,
-                    max_threads=MAX_THRESHOLD,
+                    max_threads=self.max_threads,
                     explanation={
                         **allowance.explanation,
-                        "idle_pardon": load_info.to_dict(),
+                        "idle_pardon": load_info.to_dict() if load_info is not None else {},
                     },
                     is_throttled=allowance.is_throttled,
                     throttle_threshold=allowance.throttle_threshold,

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -96,7 +96,8 @@ class QuotaAllowance:
         load_info: LoadInfo | None,
     ) -> QuotaAllowanceDecision:
         if not self.can_run:
-            idle_pardon = policy.is_pardonable and load_info is not None and load_info.is_idle()
+            is_idle_load = getattr(load_info, "is_idle", lambda: False)
+            idle_pardon = policy.is_pardonable and is_idle_load()
             return (
                 QuotaAllowanceDecision.PARDONED if idle_pardon else QuotaAllowanceDecision.REJECTED
             )
@@ -455,6 +456,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
         ) as span:
             for t, tid in tenant_ids.items():
                 span.set_attribute(f"tenant_ids.{t}", str(tid))
+
             try:
                 allowance = self._get_quota_allowance(tenant_ids, query_id)
             except InvalidTenantsForAllocationPolicy as e:
@@ -490,6 +492,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                 return _default_passthough_policy(
                     self._resource_identifier.value
                 ).get_quota_allowance(tenant_ids, query_id, load_info)
+
             decision = allowance.decision(self, load_info)
             referrer = str(tenant_ids.get("referrer", "no_referrer"))
             if decision == QuotaAllowanceDecision.PARDONED:
@@ -502,6 +505,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                     tags={"referrer": referrer, "max_threads": str(allowance.max_threads)},
                 )
                 span.set_attribute("db_request_throttled", True)
+
             if not self.is_enforced:
                 allowance = QuotaAllowance(
                     can_run=True,
@@ -530,6 +534,7 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                     suggestion=allowance.suggestion,
                     max_bytes_to_read=0,
                 )
+
             # make sure we always know which storage key we rejected a query from
             allowance.explanation["storage_key"] = self._resource_identifier.value
             for k, v in allowance.to_dict().items():

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import json
 import os
 from abc import ABC, abstractmethod
-from dataclasses import asdict, dataclass, field, replace
-from enum import Enum
+from dataclasses import asdict, dataclass, field
+from enum import Enum, IntEnum
 from typing import TYPE_CHECKING, Any, cast
 
 from redis.exceptions import TimeoutError as RedisTimeoutError
@@ -26,6 +26,8 @@ from snuba.utils.serializable_exception import JsonSerializable, SerializableExc
 from snuba.web import QueryResult
 
 if TYPE_CHECKING:
+    # Importing load_retriever at runtime pulls in snuba.web.rpc, which
+    # eventually imports db_query → AllocationPolicy (cycle).
     from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
 
 IS_ENFORCED = "is_enforced"
@@ -57,6 +59,13 @@ class AllocationPolicyConfig(Configuration):
     pass
 
 
+class QuotaAllowanceDecision(IntEnum):
+    REJECTED = 0
+    PARDONED = 1
+    ALLOWED = 2
+    THROTTLED = 3
+
+
 @dataclass(frozen=True)
 class QuotaAllowance:
     can_run: bool
@@ -80,6 +89,21 @@ class QuotaAllowance:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+    def decision(
+        self,
+        *,
+        policy_max_threads: int,
+        idle_pardon: bool,
+    ) -> QuotaAllowanceDecision:
+        if not self.can_run:
+            if idle_pardon:
+                return QuotaAllowanceDecision.PARDONED
+            return QuotaAllowanceDecision.REJECTED
+        max_threads = min(self.max_threads, policy_max_threads)
+        if max_threads < policy_max_threads:
+            return QuotaAllowanceDecision.THROTTLED
+        return QuotaAllowanceDecision.ALLOWED
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, QuotaAllowance):
@@ -452,9 +476,9 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                     1,
                     tags={"method": "get_quota_allowance", "reason": type(e).__name__},
                 )
-                return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(
-                    tenant_ids, query_id, load_info
-                )
+                return _default_passthough_policy(
+                    self._resource_identifier.value
+                ).get_quota_allowance(tenant_ids, query_id, load_info)
             except Exception:
                 self.metrics.increment("fail_open", 1, tags={"method": "get_quota_allowance"})
                 logger.exception(
@@ -462,35 +486,22 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                 )
                 if settings.RAISE_ON_ALLOCATION_POLICY_FAILURES:
                     raise
-                return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(
-                    tenant_ids, query_id, load_info
-                )
-            idle_pardon = (
-                not allowance.can_run
-                and self.is_pardonable
-                and load_info is not None
-                and load_info.is_idle()
+                return _default_passthough_policy(
+                    self._resource_identifier.value
+                ).get_quota_allowance(tenant_ids, query_id, load_info)
+            idle_pardon = self.is_pardonable and load_info is not None and load_info.is_idle()
+            decision = allowance.decision(
+                policy_max_threads=self.max_threads, idle_pardon=idle_pardon
             )
-            if not allowance.can_run:
-                if idle_pardon:
-                    self.metrics.increment(
-                        "db_request_pardoned",
-                        tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
-                    )
-                else:
-                    self.metrics.increment(
-                        "db_request_rejected",
-                        tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
-                    )
-            elif allowance.max_threads < self.max_threads:
-                # NOTE: The elif is very intentional here. Don't count the throttling
-                # if the request was rejected.
+            referrer = str(tenant_ids.get("referrer", "no_referrer"))
+            if decision == QuotaAllowanceDecision.PARDONED:
+                self.metrics.increment("db_request_pardoned", tags={"referrer": referrer})
+            elif decision == QuotaAllowanceDecision.REJECTED:
+                self.metrics.increment("db_request_rejected", tags={"referrer": referrer})
+            elif decision == QuotaAllowanceDecision.THROTTLED:
                 self.metrics.increment(
                     "db_request_throttled",
-                    tags={
-                        "referrer": str(tenant_ids.get("referrer", "no_referrer")),
-                        "max_threads": str(allowance.max_threads),
-                    },
+                    tags={"referrer": referrer, "max_threads": str(allowance.max_threads)},
                 )
                 span.set_attribute("db_request_throttled", True)
             if not self.is_enforced:
@@ -505,15 +516,23 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                     quota_unit=allowance.quota_unit,
                     suggestion=allowance.suggestion,
                 )
-            elif idle_pardon:
+            elif decision == QuotaAllowanceDecision.PARDONED:
                 assert load_info is not None
-                allowance = replace(
-                    allowance,
+                allowance = QuotaAllowance(
                     can_run=True,
                     max_threads=MAX_THRESHOLD,
+                    explanation={
+                        **allowance.explanation,
+                        "idle_pardon": load_info.to_dict(),
+                    },
+                    is_throttled=allowance.is_throttled,
+                    throttle_threshold=allowance.throttle_threshold,
+                    rejection_threshold=allowance.rejection_threshold,
+                    quota_used=allowance.quota_used,
+                    quota_unit=allowance.quota_unit,
+                    suggestion=allowance.suggestion,
                     max_bytes_to_read=0,
                 )
-                allowance.explanation["idle_pardon"] = load_info.to_dict()
             # make sure we always know which storage key we rejected a query from
             allowance.explanation["storage_key"] = self._resource_identifier.value
             for k, v in allowance.to_dict().items():

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import os
 from abc import ABC, abstractmethod
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from enum import Enum
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from sentry_sdk import traces
@@ -24,6 +24,9 @@ from snuba.utils.registered_class import import_submodules_in_directory
 from snuba.utils.sentry import SENTRY_OP
 from snuba.utils.serializable_exception import JsonSerializable, SerializableException
 from snuba.web import QueryResult
+
+if TYPE_CHECKING:
+    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
 
 IS_ENFORCED = "is_enforced"
 MAX_THREADS = "max_threads"
@@ -376,6 +379,10 @@ class AllocationPolicy(ConfigurableComponent, ABC):
         return bool(self.get_config_value(IS_ENFORCED))
 
     @property
+    def is_pardonable(self) -> bool:
+        return True
+
+    @property
     def max_threads(self) -> int:
         """Maximum number of threads run a single query on ClickHouse with."""
         return int(self.get_config_value(MAX_THREADS))
@@ -412,7 +419,10 @@ class AllocationPolicy(ConfigurableComponent, ABC):
         return cast(list[Configuration], self._default_config_definitions)
 
     def get_quota_allowance(
-        self, tenant_ids: dict[str, str | int], query_id: str
+        self,
+        tenant_ids: dict[str, str | int],
+        query_id: str,
+        load_info: LoadInfo | None = None,
     ) -> QuotaAllowance:
         with traces.start_span(
             name=self.__class__.__name__,
@@ -442,7 +452,9 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                     1,
                     tags={"method": "get_quota_allowance", "reason": type(e).__name__},
                 )
-                return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids, query_id)
+                return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(
+                    tenant_ids, query_id, load_info
+                )
             except Exception:
                 self.metrics.increment("fail_open", 1, tags={"method": "get_quota_allowance"})
                 logger.exception(
@@ -450,12 +462,26 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                 )
                 if settings.RAISE_ON_ALLOCATION_POLICY_FAILURES:
                     raise
-                return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids, query_id)
-            if not allowance.can_run:
-                self.metrics.increment(
-                    "db_request_rejected",
-                    tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
+                return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(
+                    tenant_ids, query_id, load_info
                 )
+            idle_pardon = (
+                not allowance.can_run
+                and self.is_pardonable
+                and load_info is not None
+                and load_info.is_idle()
+            )
+            if not allowance.can_run:
+                if idle_pardon:
+                    self.metrics.increment(
+                        "db_request_pardoned",
+                        tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
+                    )
+                else:
+                    self.metrics.increment(
+                        "db_request_rejected",
+                        tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
+                    )
             elif allowance.max_threads < self.max_threads:
                 # NOTE: The elif is very intentional here. Don't count the throttling
                 # if the request was rejected.
@@ -479,6 +505,15 @@ class AllocationPolicy(ConfigurableComponent, ABC):
                     quota_unit=allowance.quota_unit,
                     suggestion=allowance.suggestion,
                 )
+            elif idle_pardon:
+                assert load_info is not None
+                allowance = replace(
+                    allowance,
+                    can_run=True,
+                    max_threads=MAX_THRESHOLD,
+                    max_bytes_to_read=0,
+                )
+                allowance.explanation["idle_pardon"] = load_info.to_dict()
             # make sure we always know which storage key we rejected a query from
             allowance.explanation["storage_key"] = self._resource_identifier.value
             for k, v in allowance.to_dict().items():

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -27,6 +27,7 @@ from snuba.clickhouse.query import Query
 from snuba.clickhouse.query_dsl.accessors import get_time_range_estimate
 from snuba.clickhouse.query_profiler import generate_profile
 from snuba.configs.configuration import ResourceIdentifier
+from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.downsampled_storage_tiers import Tier
 from snuba.query import ProcessableQuery
@@ -76,6 +77,7 @@ from snuba.utils.serializable_exception import (
     SerializableExceptionDict,
 )
 from snuba.web import QueryException, QueryResult, constants
+from snuba.web.rpc.storage_routing.load_retriever import get_cluster_loadinfo
 
 metrics = MetricsWrapper(environment.metrics, "db_query")
 
@@ -878,15 +880,21 @@ def _apply_allocation_policies_quota(
     rejection_quota_and_policy = None
     throttle_quota_and_policy = None
     min_threads_across_policies = MAX_THRESHOLD
+    load_info = get_cluster_loadinfo(
+        get_storage(
+            StorageKey(allocation_policies[0].resource_identifier.value)
+        ).get_storage_set_key()
+    )
     with traces.start_span(
         name="_apply_allocation_policies_quota",
         attributes={SENTRY_OP: "allocation_policy"},
     ) as span:
         for allocation_policy in allocation_policies:
-            allowance = allocation_policy.get_quota_allowance(attribution_info.tenant_ids, query_id)
+            allowance = allocation_policy.get_quota_allowance(
+                attribution_info.tenant_ids, query_id, load_info
+            )
             can_run &= allowance.can_run
             quota_allowances[allocation_policy.class_name()] = allowance
-            # QuotaAllowance isn't a valid attribute value; serialize it.
             span.set_attribute(
                 "quota_allowance",
                 json.dumps(

--- a/snuba/web/rpc/storage_routing/load_retriever.py
+++ b/snuba/web/rpc/storage_routing/load_retriever.py
@@ -10,6 +10,7 @@ from snuba import environment
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.redis import RedisClientKey, get_redis_client
+from snuba.state.sentry_options import get_option
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(
@@ -38,6 +39,17 @@ class LoadInfo:
             cluster_load=load_info_dict["cluster_load"],
             concurrent_queries=int(load_info_dict["concurrent_queries"]),
         )
+
+    def is_idle(self) -> bool:
+        if self.cluster_load == -1.0 or self.concurrent_queries == -1:
+            return False
+        idle_load = self.cluster_load < get_option(
+            "storage_routing.idle_cluster_load_threshold", 0.0
+        )
+        idle_conc_queries = self.concurrent_queries < get_option(
+            "storage_routing.idle_concurrent_queries_threshold", 0
+        )
+        return idle_load and idle_conc_queries
 
 
 def cache(
@@ -78,8 +90,16 @@ def cache(
     return decorator
 
 
-@cache(ttl_secs=60)
 def get_cluster_loadinfo(
+    storage_set_key: StorageSetKey = StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
+) -> LoadInfo | None:
+    if not get_option("storage_routing.enable_get_cluster_loadinfo", False):
+        return None
+    return _get_cluster_loadinfo(storage_set_key)
+
+
+@cache(ttl_secs=60)
+def _get_cluster_loadinfo(
     storage_set_key: StorageSetKey = StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
 ) -> LoadInfo:
     try:

--- a/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
+++ b/snuba/web/rpc/storage_routing/routing_strategies/storage_routing.py
@@ -462,6 +462,7 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                 recommendations[allocation_policy_name] = allocation_policy.get_quota_allowance(
                     routing_context.tenant_ids,
                     routing_context.query_id,
+                    routing_context.cluster_load_info,
                 )
                 # QuotaAllowance isn't a valid attribute value; serialize it.
                 span.set_attribute(
@@ -482,6 +483,7 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
             try:
                 routing_context.timer.mark(_START_ESTIMATION_MARK)
 
+                routing_context.cluster_load_info = get_cluster_loadinfo()
                 routing_context.allocation_policies_recommendations = (
                     self._get_recommendations_from_allocation_policies(routing_context)
                 )
@@ -498,12 +500,6 @@ class BaseRoutingStrategy(ConfigurableComponent, ABC):
                     clickhouse_settings=combined_allocation_policies_recommendations["settings"],
                     can_run=combined_allocation_policies_recommendations["can_run"],
                     is_throttled=combined_allocation_policies_recommendations["is_throttled"],
-                )
-
-                routing_context.cluster_load_info = (
-                    get_cluster_loadinfo()
-                    if get_option("storage_routing.enable_get_cluster_loadinfo", False)
-                    else None
                 )
 
                 self._update_routing_decision(routing_decision)

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -464,7 +464,7 @@ def test_is_pardonable_overrides_can_run_when_idle() -> None:
         assert reject_policy.get_quota_allowance(tenant_ids, "deadbeef").can_run is False
         pardoned = reject_policy.get_quota_allowance(tenant_ids, "deadbeef", idle)
     assert pardoned.can_run is True
-    assert pardoned.max_threads == MAX_THRESHOLD
+    assert pardoned.max_threads == reject_policy.max_threads
     assert pardoned.max_bytes_to_read == 0
     assert pardoned.explanation["idle_pardon"] == {
         "cluster_load": 1.0,

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from unittest import TestCase, mock
 
 import pytest
-from sentry_options.testing import override_options
 
 from snuba.configs.configuration import Configuration, InvalidConfig
 from snuba.datasets.storages.storage_key import StorageKey
@@ -31,6 +30,7 @@ from snuba.query.allocation_policies.concurrent_rate_limit import (
 from snuba.query.allocation_policies.cross_org import CrossOrgQueryAllocationPolicy
 from snuba.query.allocation_policies.per_referrer import ReferrerGuardRailPolicy
 from snuba.utils.metrics.backends.testing import get_recorded_metric_calls
+from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
 from tests.configs.component_config import (
     delete_component_config,
     set_component_config,
@@ -451,8 +451,6 @@ def test_is_not_enforced() -> None:
 
 @pytest.mark.redis_db
 def test_is_pardonable_overrides_can_run_when_idle() -> None:
-    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
-
     reject_policy = RejectingEverythingAllocationPolicy(
         StorageKey("some_storage"),
         is_enforced=1,
@@ -462,22 +460,16 @@ def test_is_pardonable_overrides_can_run_when_idle() -> None:
         "referrer": "some_referrer",
     }
     idle = LoadInfo(cluster_load=1.0, concurrent_queries=1)
-    with override_options(
-        "snuba",
-        {
-            "storage_routing.idle_cluster_load_threshold": 10.0,
-            "storage_routing.idle_concurrent_queries_threshold": 5,
-        },
-    ):
+    with mock.patch.object(LoadInfo, "is_idle", return_value=True):
         assert reject_policy.get_quota_allowance(tenant_ids, "deadbeef").can_run is False
         pardoned = reject_policy.get_quota_allowance(tenant_ids, "deadbeef", idle)
-        assert pardoned.can_run is True
-        assert pardoned.max_threads == MAX_THRESHOLD
-        assert pardoned.max_bytes_to_read == 0
-        assert pardoned.explanation["idle_pardon"] == {
-            "cluster_load": 1.0,
-            "concurrent_queries": 1,
-        }
+    assert pardoned.can_run is True
+    assert pardoned.max_threads == MAX_THRESHOLD
+    assert pardoned.max_bytes_to_read == 0
+    assert pardoned.explanation["idle_pardon"] == {
+        "cluster_load": 1.0,
+        "concurrent_queries": 1,
+    }
 
     pardoned_metrics = get_recorded_metric_calls(
         "increment", "allocation_policy.db_request_pardoned"

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import TestCase, mock
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.configs.configuration import Configuration, InvalidConfig
 from snuba.datasets.storages.storage_key import StorageKey
@@ -446,6 +447,48 @@ def test_is_not_enforced() -> None:
     assert throttled_metrics[0].tags["policy_class"] == "ThrottleEverythingAllocationPolicy"
     assert throttled_metrics[0].tags["is_enforced"] == "True"
     assert throttled_metrics[1].tags["is_enforced"] == "False"
+
+
+@pytest.mark.redis_db
+def test_is_pardonable_overrides_can_run_when_idle() -> None:
+    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
+
+    reject_policy = RejectingEverythingAllocationPolicy(
+        StorageKey("some_storage"),
+        is_enforced=1,
+    )
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    idle = LoadInfo(cluster_load=1.0, concurrent_queries=1)
+    with override_options(
+        "snuba",
+        {
+            "storage_routing.idle_cluster_load_threshold": 10.0,
+            "storage_routing.idle_concurrent_queries_threshold": 5,
+        },
+    ):
+        assert reject_policy.get_quota_allowance(tenant_ids, "deadbeef").can_run is False
+        pardoned = reject_policy.get_quota_allowance(tenant_ids, "deadbeef", idle)
+        assert pardoned.can_run is True
+        assert pardoned.max_threads == MAX_THRESHOLD
+        assert pardoned.max_bytes_to_read == 0
+        assert pardoned.explanation["idle_pardon"] == {
+            "cluster_load": 1.0,
+            "concurrent_queries": 1,
+        }
+
+    pardoned_metrics = get_recorded_metric_calls(
+        "increment", "allocation_policy.db_request_pardoned"
+    )
+    assert pardoned_metrics is not None
+    assert len(pardoned_metrics) == 1
+    rejected_metrics = get_recorded_metric_calls(
+        "increment", "allocation_policy.db_request_rejected"
+    )
+    assert rejected_metrics is not None
+    assert len(rejected_metrics) == 1
 
 
 class TestComponentNameBackwardsCompatibility:

--- a/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
+++ b/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
@@ -1,22 +1,34 @@
+from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
+from sentry_options import OptionValue
 from sentry_options.testing import override_options
 
 from snuba.web.rpc.storage_routing.load_retriever import get_cluster_loadinfo
 
-ENABLE_LOADINFO = {"storage_routing.enable_get_cluster_loadinfo": True}
+ENABLE_LOADINFO: dict[str, OptionValue] = {"storage_routing.enable_get_cluster_loadinfo": True}
 
 
+@pytest.fixture(autouse=True)
+def enable_get_cluster_loadinfo() -> Generator[None]:
+    with override_options("snuba", ENABLE_LOADINFO):
+        yield
+
+
+@pytest.mark.redis_db
+@pytest.mark.clickhouse_db
 def test_get_cluster_loadinfo_disabled() -> None:
-    assert get_cluster_loadinfo() is None
+    with override_options("snuba", {"storage_routing.enable_get_cluster_loadinfo": False}):
+        assert get_cluster_loadinfo() is None
+    with override_options("snuba", ENABLE_LOADINFO):
+        assert get_cluster_loadinfo() is not None
 
 
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_get_cluster_load() -> None:
-    with override_options("snuba", ENABLE_LOADINFO):
-        load_info = get_cluster_loadinfo()
+    load_info = get_cluster_loadinfo()
     assert load_info is not None
     assert load_info.cluster_load != -1.0
     assert load_info.concurrent_queries != -1
@@ -25,7 +37,7 @@ def test_get_cluster_load() -> None:
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_get_cluster_load_from_cache() -> None:
-    with override_options("snuba", ENABLE_LOADINFO), patch("time.time") as mock_time:
+    with patch("time.time") as mock_time:
         mock_time.return_value = 0
         load_info = get_cluster_loadinfo()
         assert load_info is not None
@@ -41,10 +53,7 @@ def test_get_cluster_load_from_cache() -> None:
 def test_get_cluster_loadinfo_if_cache_fails() -> None:
     mock_redis = Mock()
     mock_redis.side_effect = Exception("Test error")
-    with (
-        override_options("snuba", ENABLE_LOADINFO),
-        patch("snuba.redis.get_redis_client") as mock_redis_client,
-    ):
+    with patch("snuba.redis.get_redis_client") as mock_redis_client:
         mock_redis_client.return_value = mock_redis
         load_info = get_cluster_loadinfo()
         assert load_info is not None
@@ -55,10 +64,7 @@ def test_get_cluster_loadinfo_if_cache_fails() -> None:
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_get_cluster_load_error_handling() -> None:
-    with (
-        override_options("snuba", ENABLE_LOADINFO),
-        patch("snuba.clickhouse.connect.ClickhouseConnectPool.execute") as mock_execute,
-    ):
+    with patch("snuba.clickhouse.connect.ClickhouseConnectPool.execute") as mock_execute:
         mock_execute.side_effect = Exception("Test error")
         load_info = get_cluster_loadinfo()
         assert load_info is not None

--- a/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
+++ b/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
@@ -1,14 +1,22 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from sentry_options.testing import override_options
 
 from snuba.web.rpc.storage_routing.load_retriever import get_cluster_loadinfo
+
+ENABLE_LOADINFO = {"storage_routing.enable_get_cluster_loadinfo": True}
+
+
+def test_get_cluster_loadinfo_disabled() -> None:
+    assert get_cluster_loadinfo() is None
 
 
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_get_cluster_load() -> None:
-    load_info = get_cluster_loadinfo()
+    with override_options("snuba", ENABLE_LOADINFO):
+        load_info = get_cluster_loadinfo()
     assert load_info is not None
     assert load_info.cluster_load != -1.0
     assert load_info.concurrent_queries != -1
@@ -17,12 +25,14 @@ def test_get_cluster_load() -> None:
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_get_cluster_load_from_cache() -> None:
-    with patch("time.time") as mock_time:
+    with override_options("snuba", ENABLE_LOADINFO), patch("time.time") as mock_time:
         mock_time.return_value = 0
         load_info = get_cluster_loadinfo()
+        assert load_info is not None
 
         mock_time.return_value = 59
         second_load_info = get_cluster_loadinfo()
+        assert second_load_info is not None
         assert load_info.to_dict() == second_load_info.to_dict()
 
 
@@ -31,7 +41,10 @@ def test_get_cluster_load_from_cache() -> None:
 def test_get_cluster_loadinfo_if_cache_fails() -> None:
     mock_redis = Mock()
     mock_redis.side_effect = Exception("Test error")
-    with patch("snuba.redis.get_redis_client") as mock_redis_client:
+    with (
+        override_options("snuba", ENABLE_LOADINFO),
+        patch("snuba.redis.get_redis_client") as mock_redis_client,
+    ):
         mock_redis_client.return_value = mock_redis
         load_info = get_cluster_loadinfo()
         assert load_info is not None
@@ -42,7 +55,10 @@ def test_get_cluster_loadinfo_if_cache_fails() -> None:
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_get_cluster_load_error_handling() -> None:
-    with patch("snuba.clickhouse.connect.ClickhouseConnectPool.execute") as mock_execute:
+    with (
+        override_options("snuba", ENABLE_LOADINFO),
+        patch("snuba.clickhouse.connect.ClickhouseConnectPool.execute") as mock_execute,
+    ):
         mock_execute.side_effect = Exception("Test error")
         load_info = get_cluster_loadinfo()
         assert load_info is not None

--- a/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
+++ b/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
@@ -21,7 +21,7 @@ def enable_get_cluster_loadinfo() -> Generator[None]:
 def test_get_cluster_loadinfo_disabled() -> None:
     with override_options("snuba", {"storage_routing.enable_get_cluster_loadinfo": False}):
         assert get_cluster_loadinfo() is None
-    with override_options("snuba", ENABLE_LOADINFO):
+    with override_options("snuba", {"storage_routing.enable_get_cluster_loadinfo": True}):
         assert get_cluster_loadinfo() is not None
 
 

--- a/tests/web/rpc/v1/test_storage_routing.py
+++ b/tests/web/rpc/v1/test_storage_routing.py
@@ -601,7 +601,7 @@ def test_routing_strategy_idle_pardon_allows_rejected_query() -> None:
             )
         )
         assert decision.can_run is True
-        assert decision.clickhouse_settings["max_threads"] == MAX_THRESHOLD
+        assert decision.clickhouse_settings["max_threads"] == 10
         pardoned = decision.routing_context.allocation_policies_recommendations[
             "IdlePardonRejectionPolicy"
         ]

--- a/tests/web/rpc/v1/test_storage_routing.py
+++ b/tests/web/rpc/v1/test_storage_routing.py
@@ -546,6 +546,76 @@ def test_routing_strategy_with_rejecting_allocation_policy() -> None:
 
 
 @pytest.mark.redis_db
+def test_routing_strategy_idle_pardon_allows_rejected_query() -> None:
+    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
+
+    class IdlePardonRejectionPolicy(AllocationPolicy):
+        def _additional_config_definitions(self) -> list[Configuration]:
+            return []
+
+        def _get_quota_allowance(
+            self, tenant_ids: dict[str, str | int], query_id: str
+        ) -> QuotaAllowance:
+            return QuotaAllowance(
+                can_run=False,
+                max_threads=0,
+                explanation={"reason": "policy rejects all queries"},
+                is_throttled=False,
+                throttle_threshold=MAX_THRESHOLD,
+                rejection_threshold=MAX_THRESHOLD,
+                quota_used=0,
+                quota_unit=NO_UNITS,
+                suggestion=NO_SUGGESTION,
+            )
+
+        def _update_quota_balance(
+            self,
+            tenant_ids: dict[str, str | int],
+            query_id: str,
+            result_or_error: QueryResultOrError,
+        ) -> None:
+            return
+
+    with (
+        mock.patch.object(
+            BaseRoutingStrategy,
+            "get_allocation_policies",
+            return_value=[
+                IdlePardonRejectionPolicy(ResourceIdentifier(StorageKey("doesntmatter")))
+            ],
+        ),
+        override_options(
+            "snuba",
+            {
+                "storage_routing.enable_get_cluster_loadinfo": True,
+                "storage_routing.idle_cluster_load_threshold": 10.0,
+                "storage_routing.idle_concurrent_queries_threshold": 5,
+            },
+        ),
+        mock.patch(
+            "snuba.web.rpc.storage_routing.routing_strategies.storage_routing.get_cluster_loadinfo",
+            return_value=LoadInfo(cluster_load=1.0, concurrent_queries=1),
+        ),
+    ):
+        decision = OutcomesBasedRoutingStrategy().get_routing_decision(
+            RoutingContext(
+                in_msg=_get_in_msg(),
+                timer=Timer("test"),
+                query_id="abc",
+            )
+        )
+        assert decision.can_run is True
+        assert decision.clickhouse_settings["max_threads"] == MAX_THRESHOLD
+        pardoned = decision.routing_context.allocation_policies_recommendations[
+            "IdlePardonRejectionPolicy"
+        ]
+        assert pardoned.explanation["idle_pardon"] == {
+            "cluster_load": 1.0,
+            "concurrent_queries": 1,
+        }
+
+
+@pytest.mark.redis_db
 def test_routing_strategy_with_throttling_allocation_policy() -> None:
     POLICY_THREADS = 4
 

--- a/tests/web/rpc/v1/test_storage_routing.py
+++ b/tests/web/rpc/v1/test_storage_routing.py
@@ -27,6 +27,7 @@ from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryResult
 from snuba.web.rpc.common.exceptions import RPCAllocationPolicyException
 from snuba.web.rpc.storage_routing.common import extract_message_meta
+from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
 from snuba.web.rpc.storage_routing.routing_strategies.outcomes_based import (
     OutcomesBasedRoutingStrategy,
 )
@@ -547,8 +548,6 @@ def test_routing_strategy_with_rejecting_allocation_policy() -> None:
 
 @pytest.mark.redis_db
 def test_routing_strategy_idle_pardon_allows_rejected_query() -> None:
-    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
-
     class IdlePardonRejectionPolicy(AllocationPolicy):
         def _additional_config_definitions(self) -> list[Configuration]:
             return []
@@ -586,16 +585,13 @@ def test_routing_strategy_idle_pardon_allows_rejected_query() -> None:
         ),
         override_options(
             "snuba",
-            {
-                "storage_routing.enable_get_cluster_loadinfo": True,
-                "storage_routing.idle_cluster_load_threshold": 10.0,
-                "storage_routing.idle_concurrent_queries_threshold": 5,
-            },
+            {"storage_routing.enable_get_cluster_loadinfo": True},
         ),
         mock.patch(
             "snuba.web.rpc.storage_routing.routing_strategies.storage_routing.get_cluster_loadinfo",
             return_value=LoadInfo(cluster_load=1.0, concurrent_queries=1),
         ),
+        mock.patch.object(LoadInfo, "is_idle", return_value=True),
     ):
         decision = OutcomesBasedRoutingStrategy().get_routing_decision(
             RoutingContext(

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -1360,3 +1360,105 @@ def test_policy_sets_max_bytes_to_read() -> None:
             },
         },
     }
+
+
+class _RejectAllPolicy(AllocationPolicy):
+    def _additional_config_definitions(self) -> list[Configuration]:
+        return []
+
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
+        return QuotaAllowance(
+            can_run=False,
+            max_threads=0,
+            explanation={"reason": "reject"},
+            is_throttled=False,
+            throttle_threshold=MAX_THRESHOLD,
+            rejection_threshold=MAX_THRESHOLD,
+            quota_used=0,
+            quota_unit=NO_UNITS,
+            suggestion=NO_SUGGESTION,
+        )
+
+    def _update_quota_balance(
+        self,
+        tenant_ids: dict[str, str | int],
+        query_id: str,
+        result_or_error: QueryResultOrError,
+    ) -> None:
+        return
+
+
+def test_idle_pardon_allows_rejected_query() -> None:
+    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
+
+    attribution_info = mock.Mock()
+    attribution_info.tenant_ids = {"referrer": "test_referrer", "organization_id": 1}
+    stats: MutableMapping[str, Any] = {}
+    with (
+        override_options(
+            "snuba",
+            {
+                "storage_routing.enable_get_cluster_loadinfo": True,
+                "storage_routing.idle_cluster_load_threshold": 10.0,
+                "storage_routing.idle_concurrent_queries_threshold": 5,
+            },
+        ),
+        mock.patch(
+            "snuba.web.rpc.storage_routing.load_retriever.get_cluster_loadinfo",
+            return_value=LoadInfo(cluster_load=1.0, concurrent_queries=1),
+        ),
+    ):
+        query_settings = HTTPQuerySettings()
+        _apply_allocation_policies_quota(
+            query_settings=query_settings,
+            attribution_info=attribution_info,
+            formatted_query=mock.Mock(),
+            stats=stats,
+            allocation_policies=[_RejectAllPolicy(ResourceIdentifier(StorageKey("errors_ro")))],
+            query_id="pardon_query",
+        )
+    assert stats["quota_allowance"]["summary"]["is_rejected"] is False
+    details = stats["quota_allowance"]["details"]["_RejectAllPolicy"]
+    assert details["can_run"] is True
+    assert details["max_threads"] == MAX_THRESHOLD
+    assert details["explanation"]["idle_pardon"] == {
+        "cluster_load": 1.0,
+        "concurrent_queries": 1,
+    }
+    quota = query_settings.get_resource_quota()
+    assert quota is not None
+    assert quota.max_threads == MAX_THRESHOLD
+
+
+def test_idle_pardon_still_rejects_when_not_idle() -> None:
+    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
+
+    attribution_info = mock.Mock()
+    attribution_info.tenant_ids = {"referrer": "test_referrer", "organization_id": 1}
+    stats: MutableMapping[str, Any] = {}
+    with (
+        override_options(
+            "snuba",
+            {
+                "storage_routing.enable_get_cluster_loadinfo": True,
+                "storage_routing.idle_cluster_load_threshold": 10.0,
+                "storage_routing.idle_concurrent_queries_threshold": 5,
+            },
+        ),
+        mock.patch(
+            "snuba.web.rpc.storage_routing.load_retriever.get_cluster_loadinfo",
+            return_value=LoadInfo(cluster_load=50.0, concurrent_queries=1),
+        ),
+        pytest.raises(AllocationPolicyViolations),
+    ):
+        _apply_allocation_policies_quota(
+            query_settings=HTTPQuerySettings(),
+            attribution_info=attribution_info,
+            formatted_query=mock.Mock(),
+            stats=stats,
+            allocation_policies=[_RejectAllPolicy(ResourceIdentifier(StorageKey("errors_ro")))],
+            query_id="no_pardon_query",
+        )
+    assert stats["quota_allowance"]["summary"]["is_rejected"] is True

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -41,6 +41,7 @@ from snuba.web.db_query import (
     db_query,
     execute_query,
 )
+from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
 from tests.query.allocation_policies.attachment import (
     match_block,
     override_allocation_policy,
@@ -1391,24 +1392,20 @@ class _RejectAllPolicy(AllocationPolicy):
 
 
 def test_idle_pardon_allows_rejected_query() -> None:
-    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
-
     attribution_info = mock.Mock()
     attribution_info.tenant_ids = {"referrer": "test_referrer", "organization_id": 1}
     stats: MutableMapping[str, Any] = {}
+    idle = LoadInfo(cluster_load=1.0, concurrent_queries=1)
     with (
         override_options(
             "snuba",
-            {
-                "storage_routing.enable_get_cluster_loadinfo": True,
-                "storage_routing.idle_cluster_load_threshold": 10.0,
-                "storage_routing.idle_concurrent_queries_threshold": 5,
-            },
+            {"storage_routing.enable_get_cluster_loadinfo": True},
         ),
         mock.patch(
-            "snuba.web.rpc.storage_routing.load_retriever.get_cluster_loadinfo",
-            return_value=LoadInfo(cluster_load=1.0, concurrent_queries=1),
+            "snuba.web.db_query.get_cluster_loadinfo",
+            return_value=idle,
         ),
+        mock.patch.object(LoadInfo, "is_idle", return_value=True),
     ):
         query_settings = HTTPQuerySettings()
         _apply_allocation_policies_quota(
@@ -1433,24 +1430,20 @@ def test_idle_pardon_allows_rejected_query() -> None:
 
 
 def test_idle_pardon_still_rejects_when_not_idle() -> None:
-    from snuba.web.rpc.storage_routing.load_retriever import LoadInfo
-
     attribution_info = mock.Mock()
     attribution_info.tenant_ids = {"referrer": "test_referrer", "organization_id": 1}
     stats: MutableMapping[str, Any] = {}
+    busy = LoadInfo(cluster_load=50.0, concurrent_queries=1)
     with (
         override_options(
             "snuba",
-            {
-                "storage_routing.enable_get_cluster_loadinfo": True,
-                "storage_routing.idle_cluster_load_threshold": 10.0,
-                "storage_routing.idle_concurrent_queries_threshold": 5,
-            },
+            {"storage_routing.enable_get_cluster_loadinfo": True},
         ),
         mock.patch(
-            "snuba.web.rpc.storage_routing.load_retriever.get_cluster_loadinfo",
-            return_value=LoadInfo(cluster_load=50.0, concurrent_queries=1),
+            "snuba.web.db_query.get_cluster_loadinfo",
+            return_value=busy,
         ),
+        mock.patch.object(LoadInfo, "is_idle", return_value=False),
         pytest.raises(AllocationPolicyViolations),
     ):
         _apply_allocation_policies_quota(

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -1419,14 +1419,14 @@ def test_idle_pardon_allows_rejected_query() -> None:
     assert stats["quota_allowance"]["summary"]["is_rejected"] is False
     details = stats["quota_allowance"]["details"]["_RejectAllPolicy"]
     assert details["can_run"] is True
-    assert details["max_threads"] == MAX_THRESHOLD
+    assert details["max_threads"] == 10
     assert details["explanation"]["idle_pardon"] == {
         "cluster_load": 1.0,
         "concurrent_queries": 1,
     }
     quota = query_settings.get_resource_quota()
     assert quota is not None
-    assert quota.max_threads == MAX_THRESHOLD
+    assert quota.max_threads == 10
 
 
 def test_idle_pardon_still_rejects_when_not_idle() -> None:


### PR DESCRIPTION
Linear: [EAP-692](https://linear.app/getsentry/issue/EAP-692/disable-allocation-policy-enforcement-when-cluster-load-is-low)

## Summary
When the cluster is idle, pardon allocation-policy rejections (`can_run=False`) so the query still runs. Policies stay attached; we still record what they would have done.

Idle = `cluster_load < T_load` **and** `concurrent_queries < T_conc`. Missing/stale loadinfo (`-1`) is not idle.

Off by default:
- `storage_routing.enable_get_cluster_loadinfo` (existing kill switch, still false)
- `storage_routing.idle_cluster_load_threshold` default `0`
- `storage_routing.idle_concurrent_queries_threshold` default `0`

A pardoned rejector gets `can_run=True`, `max_threads=MAX_THRESHOLD`, `max_bytes_to_read=0`. Caps from policies that already allowed are unchanged.

Applies to classic `db_query` (query’s storage set) and RPC routing (still EAP default `get_cluster_loadinfo()`).

## Notes
- `is_pardonable` is currently always `True` (not an automator knob yet).
- Classic first-reject `break` is unchanged: if the first rejector is pardoned, later policies still run.
- Observability: `allocation_policy.db_request_pardoned` + `explanation["idle_pardon"]` with loadinfo.

## Testing
- `tests/query/allocation_policies/test_allocation_policy_base.py`
- `tests/web/test_db_query.py`
- `tests/web/rpc/v1/test_storage_routing.py`
- `tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py`