### PR TITLE
ref(cli): make attach-partitions output legible for long runs

### DIFF
--- a/snuba/cli/attach_partitions.py
+++ b/snuba/cli/attach_partitions.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 
 import click
@@ -18,6 +19,8 @@ from snuba.clusters.cluster import (
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.environment import setup_logging, setup_sentry
+
+logger = logging.getLogger("snuba.attach_partitions")
 
 
 @click.command()
@@ -127,9 +130,9 @@ def attach_partitions(
     source = f"{database}.{source_table}"
     destination = f"{database}.{destination_table}"
     mode = "EXECUTE" if execute else "DRY RUN"
-    click.echo(f"[{mode}] Attaching partitions from {source} to {destination}")
+    logger.info("[%s] Attaching partitions from %s to %s", mode, source, destination)
     if not execute:
-        click.echo("[DRY RUN] No partitions will be attached. Pass --execute to attach.")
+        logger.info("[DRY RUN] No partitions will be attached. Pass --execute to attach.")
 
     partition_ids: Sequence[str]
     try:
@@ -149,7 +152,9 @@ def attach_partitions(
                     destination_table,
                     partition_id,
                 )
-                click.echo(f"Attached partition {partition_id} from {source} to {destination}")
+                logger.info(
+                    "Attached partition %s from %s to %s", partition_id, source, destination
+                )
         else:
             partition_ids = attach_partitions_from_table(
                 connection,
@@ -158,8 +163,11 @@ def attach_partitions(
                 destination_table,
                 health_check_query=health_check_query,
                 dry_run=not execute,
-                on_partition_attached=lambda attached_partition_id: click.echo(
-                    f"Attached partition {attached_partition_id} from {source} to {destination}"
+                on_partition_attached=lambda attached_partition_id: logger.info(
+                    "Attached partition %s from %s to %s",
+                    attached_partition_id,
+                    source,
+                    destination,
                 ),
             )
     except PartitionBoundaryError as error:
@@ -167,9 +175,16 @@ def attach_partitions(
 
     if not execute:
         for partition_id in partition_ids:
-            click.echo(f"Would attach partition {partition_id} from {source} to {destination}")
+            logger.info(
+                "Would attach partition %s from %s to %s", partition_id, source, destination
+            )
 
     action = "Attached" if execute else "Would attach"
-    click.echo(
-        f"[{mode}] {action} {len(partition_ids)} partition(s) from {source} to {destination}"
+    logger.info(
+        "[%s] %s %d partition(s) from %s to %s",
+        mode,
+        action,
+        len(partition_ids),
+        source,
+        destination,
     )

--- a/snuba/cli/attach_partitions.py
+++ b/snuba/cli/attach_partitions.py
@@ -124,6 +124,13 @@ def attach_partitions(
     else:
         connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
 
+    source = f"{database}.{source_table}"
+    destination = f"{database}.{destination_table}"
+    mode = "EXECUTE" if execute else "DRY RUN"
+    click.echo(f"[{mode}] Attaching partitions from {source} to {destination}")
+    if not execute:
+        click.echo("[DRY RUN] No partitions will be attached. Pass --execute to attach.")
+
     partition_ids: Sequence[str]
     try:
         if partition_id is not None:
@@ -142,7 +149,7 @@ def attach_partitions(
                     destination_table,
                     partition_id,
                 )
-                click.echo(f"Attached partition {partition_id}")
+                click.echo(f"Attached partition {partition_id} from {source} to {destination}")
         else:
             partition_ids = attach_partitions_from_table(
                 connection,
@@ -152,7 +159,7 @@ def attach_partitions(
                 health_check_query=health_check_query,
                 dry_run=not execute,
                 on_partition_attached=lambda attached_partition_id: click.echo(
-                    f"Attached partition {attached_partition_id}"
+                    f"Attached partition {attached_partition_id} from {source} to {destination}"
                 ),
             )
     except PartitionBoundaryError as error:
@@ -160,7 +167,9 @@ def attach_partitions(
 
     if not execute:
         for partition_id in partition_ids:
-            click.echo(f"Would attach partition {partition_id}")
+            click.echo(f"Would attach partition {partition_id} from {source} to {destination}")
 
     action = "Attached" if execute else "Would attach"
-    click.echo(f"{action} {len(partition_ids)} partition(s)")
+    click.echo(
+        f"[{mode}] {action} {len(partition_ids)} partition(s) from {source} to {destination}"
+    )


### PR DESCRIPTION
`attach-partitions` walks partitions one at a time and can run for a long
time, but its progress output was hard to act on. Two commits fix that.

### State the mode and tables

The output never said whether a run was a dry run, so the only signal was
the wording of each line, and `Would attach partition 90-20240212` named
neither the source nor the destination. Reading a scrollback, you could not
tell a rehearsal from a real attach, or which tables were involved.

The mode and table pair are now announced before any work, and every
partition line is qualified with both tables.

### Add timestamps

Progress went through `click.echo`, so no line carried a timestamp. On a long
run there was no way to tell how long an individual `ATTACH` took, or when a
run stalled.

The output now goes through a module logger, matching the convention in the
rest of `snuba.cli`. `LOG_FORMAT` is `"%(asctime)s %(message)s"`, so lines are
timestamped:

```
2026-09-03 12:48:40,815 [EXECUTE] Attaching partitions from d.src to d.dst
2026-09-03 12:48:40,815 Attached partition 90-20260608 from d.src to d.dst
2026-09-03 12:48:40,815 [EXECUTE] Attached 1 partition(s) from d.src to d.dst
```

### Behaviour changes to be aware of

Moving to `logging` has two consequences beyond formatting:

- **Output moves from stdout to stderr**, since `logging.basicConfig` installs
  a `StreamHandler` on stderr. This would break any pipeline parsing this
  command's stdout. I am not aware of one, but say the word and I will attach a
  stdout handler instead.
- **`--log-level` now gates these lines**, so `--log-level WARNING` silences
  progress output.

Also worth a look: a `--partition-id` run now logs twice per partition, because
`attach_partition_from_table` already emits its own "Attaching partition" line.
Previously the two went to different streams so the overlap was invisible. Happy
to drop the CLI line or demote the library one to `debug`.

### Testing

`tests/clickhouse/test_partition_management.py` passes (43 tests); `mypy` and the
pre-commit `ruff` hooks are clean. No test asserted on this CLI's output before
or after.