### PR TITLE
ref(rust-consumers): validate_schema option

### DIFF
--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -364,9 +364,6 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
 struct SchemaValidator {
     schema: Option<Arc<Schema>>,
     enforce_schema: bool,
-    /// Whether to validate at all. Resolved once from the `validate_schema`
-    /// option when the strategies are built (see
-    /// [`crate::options::validate_schema_enabled`]), never per message.
     validate_schema: bool,
 }
 

--- a/rust_snuba/src/factory_v2.rs
+++ b/rust_snuba/src/factory_v2.rs
@@ -99,6 +99,9 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
         let eap_items_emit_received_at = processor_name == "EAPItemsProcessor"
             && crate::processors::eap_items::emit_received_at();
 
+        let validate_schema_enabled =
+            crate::options::validate_schema_enabled(&self.storage_config.name);
+
         // RowBinary storages: the processor swap (JSON → RowBinary sibling) and
         // the column list the RowBinary writer needs, both used below.
         let (process_fn_override, insert_columns): (
@@ -258,6 +261,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                     func,
                     &self.logical_topic_name,
                     self.enforce_schema,
+                    validate_schema_enabled,
                     &self.processing_concurrency,
                     config::ProcessorConfig {
                         env_config: self.env_config.clone(),
@@ -277,6 +281,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                     func,
                     &self.logical_topic_name,
                     self.enforce_schema,
+                    validate_schema_enabled,
                     &self.processing_concurrency,
                     config::ProcessorConfig {
                         env_config: self.env_config.clone(),
@@ -293,7 +298,17 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                 panic!("Consumer with replacements cannot be run in hybrid-mode");
             }
             _ => {
-                let schema = get_schema(&self.logical_topic_name, self.enforce_schema);
+                // Same rule `make_rust_processor` applies on the Rust path:
+                // `enforce_schema` implies validation, so the option can only
+                // turn it off for consumers not running with --enforce-schema.
+                let validate_schema = validate_schema_enabled || self.enforce_schema;
+
+                // Skip loading the schema when we won't validate against it.
+                let schema = if validate_schema {
+                    get_schema(&self.logical_topic_name, self.enforce_schema)
+                } else {
+                    None
+                };
 
                 Box::new(RunTaskInThreads::new(
                     PythonTransformStep::new(
@@ -306,6 +321,7 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
                     SchemaValidator {
                         schema,
                         enforce_schema: self.enforce_schema,
+                        validate_schema,
                     },
                     &self.processing_concurrency,
                     Some("validate_schema"),
@@ -348,6 +364,10 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactoryV2 {
 struct SchemaValidator {
     schema: Option<Arc<Schema>>,
     enforce_schema: bool,
+    /// Whether to validate at all. Resolved once from the `validate_schema`
+    /// option when the strategies are built (see
+    /// [`crate::options::validate_schema_enabled`]), never per message.
+    validate_schema: bool,
 }
 
 impl SchemaValidator {
@@ -355,7 +375,9 @@ impl SchemaValidator {
         self,
         message: Message<KafkaPayload>,
     ) -> Result<Message<KafkaPayload>, RunTaskError<anyhow::Error>> {
-        validate_schema(&message, &self.schema, self.enforce_schema)?;
+        if self.validate_schema {
+            validate_schema(&message, &self.schema, self.enforce_schema)?;
+        }
         Ok(message)
     }
 }

--- a/rust_snuba/src/options.rs
+++ b/rust_snuba/src/options.rs
@@ -38,6 +38,28 @@ pub fn get_load_balancing_config(storage_name: &str) -> LoadBalancingConfig {
     }
 }
 
+/// Whether the consumer writing to `storage_name` should validate each message
+/// against its kafka schema.
+///
+/// `validate_schema` is a dict in the `snuba` sentry-options namespace mapping
+/// storage name to a boolean; storages with no entry default to true
+/// (validation on). It is read *once*, when the consumer's strategies are
+/// built, and then carried as a plain bool through the processing strategies —
+/// schema validation sits on the per-message hot path, so it must not pay an
+/// options lookup per message. Flipping it therefore requires a consumer
+/// restart (or a rebalance, which rebuilds the strategies).
+///
+/// This only ever turns validation *off*, and never for a consumer running
+/// with --enforce-schema: that flag implies validation, and the strategies
+/// (see `make_rust_processor`) OR it back in.
+pub fn validate_schema_enabled(storage_name: &str) -> bool {
+    options("snuba")
+        .ok()
+        .and_then(|o| o.get("validate_schema").ok())
+        .and_then(|v| v.get(storage_name).and_then(|b| b.as_bool()))
+        .unwrap_or(true)
+}
+
 /// ClickHouse's compiled-in default for `max_insert_block_size`. We refuse to
 /// apply any override below this to avoid silently shrinking blocks below what
 /// the server would already produce on its own.
@@ -218,6 +240,27 @@ mod tests {
         let config = get_load_balancing_config("lb_overrides_test");
         assert_eq!(config.load_balancing, "first_or_random");
         assert_eq!(config.first_offset, Some("1".to_string()));
+    }
+
+    #[test]
+    fn test_validate_schema_defaults_to_enabled() {
+        init_options();
+        assert!(validate_schema_enabled("validate_schema_unset_test"));
+    }
+
+    #[test]
+    fn test_validate_schema_can_be_disabled_per_storage() {
+        init_options();
+        let _guard = override_options(&[(
+            "snuba",
+            "validate_schema",
+            json!({ "validate_schema_off_test": false }),
+        )])
+        .unwrap();
+
+        assert!(!validate_schema_enabled("validate_schema_off_test"));
+        // Storages with no entry keep validating.
+        assert!(validate_schema_enabled("validate_schema_other_storage"));
     }
 
     #[test]

--- a/rust_snuba/src/options.rs
+++ b/rust_snuba/src/options.rs
@@ -38,20 +38,10 @@ pub fn get_load_balancing_config(storage_name: &str) -> LoadBalancingConfig {
     }
 }
 
-/// Whether the consumer writing to `storage_name` should validate each message
-/// against its kafka schema.
-///
-/// `validate_schema` is a dict in the `snuba` sentry-options namespace mapping
-/// storage name to a boolean; storages with no entry default to true
-/// (validation on). It is read *once*, when the consumer's strategies are
-/// built, and then carried as a plain bool through the processing strategies —
-/// schema validation sits on the per-message hot path, so it must not pay an
-/// options lookup per message. Flipping it therefore requires a consumer
-/// restart (or a rebalance, which rebuilds the strategies).
-///
-/// This only ever turns validation *off*, and never for a consumer running
-/// with --enforce-schema: that flag implies validation, and the strategies
-/// (see `make_rust_processor`) OR it back in.
+/// Whether the consumer writing to `storage_name` should validate messages
+/// against its kafka schema. Defaults to true, and read once when the
+/// consumer's strategies are built, so changing it requires a restart.
+/// --enforce-schema cli arg overrides option when true
 pub fn validate_schema_enabled(storage_name: &str) -> bool {
     options("snuba")
         .ok()

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -35,10 +35,7 @@ pub fn make_rust_processor(
     processor_config: ProcessorConfig,
     stop_at_timestamp: Option<i64>,
 ) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
-    // `enforce_schema` implies validation: a consumer running with
-    // --enforce-schema always validates, so the `validate_schema` option can
-    // only turn validation off where the schema is not being enforced.
-    // Resolved here, once, and carried as a bool — never per message.
+    // `enforce_schema` implies validation, so the option can only turn it off.
     let validate_schema = validate_schema || enforce_schema;
 
     // Skip loading the schema when we won't validate against it.
@@ -123,10 +120,7 @@ pub fn make_rust_processor_with_replacements(
     processor_config: ProcessorConfig,
     stop_at_timestamp: Option<i64>,
 ) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
-    // `enforce_schema` implies validation: a consumer running with
-    // --enforce-schema always validates, so the `validate_schema` option can
-    // only turn validation off where the schema is not being enforced.
-    // Resolved here, once, and carried as a bool — never per message.
+    // `enforce_schema` implies validation, so the option can only turn it off.
     let validate_schema = validate_schema || enforce_schema;
 
     // Skip loading the schema when we won't validate against it.
@@ -230,9 +224,6 @@ pub fn get_schema(schema_name: &str, enforce_schema: bool) -> Option<Arc<Schema>
 struct MessageProcessor<TResult: Clone, TNext: Clone> {
     schema: Option<Arc<Schema>>,
     enforce_schema: bool,
-    /// Whether to validate each payload against `schema`. Resolved once from
-    /// the `validate_schema` option when the strategy is built (see
-    /// [`crate::options::validate_schema_enabled`]), never per message.
     validate_schema: bool,
     // Convert payload to either InsertBatch (or either insert or replacement for the errors dataset)
     func:

--- a/rust_snuba/src/strategies/processor.rs
+++ b/rust_snuba/src/strategies/processor.rs
@@ -24,16 +24,29 @@ use crate::types::{
 };
 use tokio::time::Instant;
 
+#[allow(clippy::too_many_arguments)]
 pub fn make_rust_processor(
     next_step: impl ProcessingStrategy<BytesInsertBatch<RowData>> + 'static,
     func: ProcessingFunction,
     schema_name: &str,
     enforce_schema: bool,
+    validate_schema: bool,
     concurrency: &ConcurrencyConfig,
     processor_config: ProcessorConfig,
     stop_at_timestamp: Option<i64>,
 ) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
-    let schema = get_schema(schema_name, enforce_schema);
+    // `enforce_schema` implies validation: a consumer running with
+    // --enforce-schema always validates, so the `validate_schema` option can
+    // only turn validation off where the schema is not being enforced.
+    // Resolved here, once, and carried as a bool — never per message.
+    let validate_schema = validate_schema || enforce_schema;
+
+    // Skip loading the schema when we won't validate against it.
+    let schema = if validate_schema {
+        get_schema(schema_name, enforce_schema)
+    } else {
+        None
+    };
 
     fn result_to_next_msg(
         transformed: InsertBatch,
@@ -84,6 +97,7 @@ pub fn make_rust_processor(
     let task_runner = MessageProcessor {
         schema,
         enforce_schema,
+        validate_schema,
         func,
         result_to_next_msg,
         processor_config,
@@ -98,16 +112,29 @@ pub fn make_rust_processor(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn make_rust_processor_with_replacements(
     next_step: impl ProcessingStrategy<InsertOrReplacement<BytesInsertBatch<RowData>>> + 'static,
     func: ProcessingFunctionWithReplacements,
     schema_name: &str,
     enforce_schema: bool,
+    validate_schema: bool,
     concurrency: &ConcurrencyConfig,
     processor_config: ProcessorConfig,
     stop_at_timestamp: Option<i64>,
 ) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
-    let schema = get_schema(schema_name, enforce_schema);
+    // `enforce_schema` implies validation: a consumer running with
+    // --enforce-schema always validates, so the `validate_schema` option can
+    // only turn validation off where the schema is not being enforced.
+    // Resolved here, once, and carried as a bool — never per message.
+    let validate_schema = validate_schema || enforce_schema;
+
+    // Skip loading the schema when we won't validate against it.
+    let schema = if validate_schema {
+        get_schema(schema_name, enforce_schema)
+    } else {
+        None
+    };
 
     fn result_to_next_msg(
         transformed: InsertOrReplacement<InsertBatch>,
@@ -168,6 +195,7 @@ pub fn make_rust_processor_with_replacements(
     let task_runner = MessageProcessor {
         schema,
         enforce_schema,
+        validate_schema,
         func,
         result_to_next_msg,
         processor_config,
@@ -202,6 +230,10 @@ pub fn get_schema(schema_name: &str, enforce_schema: bool) -> Option<Arc<Schema>
 struct MessageProcessor<TResult: Clone, TNext: Clone> {
     schema: Option<Arc<Schema>>,
     enforce_schema: bool,
+    /// Whether to validate each payload against `schema`. Resolved once from
+    /// the `validate_schema` option when the strategy is built (see
+    /// [`crate::options::validate_schema_enabled`]), never per message.
+    validate_schema: bool,
     // Convert payload to either InsertBatch (or either insert or replacement for the errors dataset)
     func:
         fn(KafkaPayload, KafkaMessageMetadata, config: &ProcessorConfig) -> anyhow::Result<TResult>,
@@ -220,7 +252,9 @@ impl<TResult: Clone, TNext: Clone> MessageProcessor<TResult, TNext> {
         message: Message<KafkaPayload>,
     ) -> Result<Message<TNext>, RunTaskError<anyhow::Error>> {
         let start_time = Instant::now();
-        validate_schema(&message, &self.schema, self.enforce_schema)?;
+        if self.validate_schema {
+            validate_schema(&message, &self.schema, self.enforce_schema)?;
+        }
 
         let msg = match message.inner_message {
             InnerMessage::BrokerMessage(msg) => msg,
@@ -456,6 +490,7 @@ mod tests {
             noop_processor,
             "outcomes",
             true,
+            true,
             &concurrency,
             ProcessorConfig::default(),
             None,
@@ -497,6 +532,7 @@ mod tests {
             failing_processor,
             "outcomes",
             false,
+            true,
             &concurrency,
             ProcessorConfig::default(),
             None,
@@ -538,6 +574,7 @@ mod tests {
             noop_processor,
             "outcomes",
             true,
+            true,
             &concurrency,
             ProcessorConfig::default(),
             None,
@@ -550,6 +587,51 @@ mod tests {
         let err = strategy
             .join(None)
             .expect_err("schema validation failure should surface as InvalidMessage");
+
+        match err {
+            StrategyError::InvalidMessage(invalid) => {
+                assert_eq!(invalid.partition, partition);
+                assert_eq!(invalid.offset, offset);
+                assert_eq!(invalid.reason, InvalidMessageReason::Invalid);
+            }
+            other => panic!("unexpected strategy error: {other:?}"),
+        }
+    }
+
+    /// `enforce_schema` wins over the `validate_schema` option: a consumer
+    /// running with --enforce-schema keeps validating (and DLQing) even when
+    /// the option asks to skip validation.
+    #[test]
+    fn enforce_schema_validates_even_when_option_disables_validation() {
+        fn noop_processor(
+            _payload: KafkaPayload,
+            _metadata: KafkaMessageMetadata,
+            _config: &ProcessorConfig,
+        ) -> anyhow::Result<InsertBatch> {
+            Ok(InsertBatch::default())
+        }
+
+        let partition = Partition::new(Topic::new("test"), 0);
+        let offset = 29;
+        let concurrency = ConcurrencyConfig::new(1);
+        let mut strategy = make_rust_processor(
+            Noop,
+            noop_processor,
+            "outcomes",
+            true,
+            false,
+            &concurrency,
+            ProcessorConfig::default(),
+            None,
+        );
+
+        let payload = KafkaPayload::new(None, None, Some(b"{}".to_vec()));
+        let message = Message::new_broker_message(payload, partition, offset, Utc::now());
+
+        strategy.submit(message).unwrap();
+        let err = strategy
+            .join(None)
+            .expect_err("enforce_schema must validate regardless of the option");
 
         match err {
             StrategyError::InvalidMessage(invalid) => {
@@ -607,6 +689,7 @@ mod tests {
             noop_processor,
             "outcomes",
             false,
+            true,
             &concurrency,
             ProcessorConfig::default(),
             None,

--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -123,6 +123,14 @@
       "default": {},
       "description": "Dict mapping storage name to a grace period in minutes; eap-items messages from before the current partition older than this are routed to the DLQ. Storages with no entry have no grace-period dropping. Migrated from per-storage runtime config eap_items_dlq_grace_period_min:<storage>."
     },
+    "validate_schema": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "default": {},
+      "description": "Dict mapping storage name to whether that storage's consumer validates every message against its kafka schema before processing it. Storages with no entry default to true (validation on); false skips validation for that storage. Consumers running with --enforce-schema always validate and ignore a false here. Read once when the consumer builds its processing strategies, so a change requires a consumer restart (or a rebalance) to take effect."
+    },
     "eap_items_emit_received_at": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
Adds a `validate_schema` option to the `snuba` sentry-options namespace so schema validation can be turned off per storage. Leaves the `--enforce-schema` as is, and makes that take prescedence if it's `true`

The option is a dict mapping storage name to a bool:

```json
{ "eap_items": false }
```

- Storages with no entry default to `true`, so this is a no-op until a storage is explicitly listed.
- `false` skips validation and skips loading the schema entirely.
- `--enforce-schema` wins: those consumers always validate and DLQ, regardless of the option.

The option is read once when the consumer builds its processing strategies, then carried as a plain bool — never looked up per message, which is the cost this is meant to remove. So changing it requires a consumer restart or a rebalance. Both the Rust processor paths and the hybrid Python-transform path are covered.

Tests cover the default-on behavior, per-storage opt-out, and that `--enforce-schema` still validates when the option says `false`.
