### PR TITLE
build(deps): Bump brace-expansion to patched 1.1.18 and 5.0.9

### DIFF
--- a/snuba/admin/yarn.lock
+++ b/snuba/admin/yarn.lock
@@ -1846,17 +1846,17 @@ bootstrap@^5.2.3:
   integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
 
 brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
-  integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
Bumps the two vulnerable `brace-expansion` copies in `snuba/admin/yarn.lock` to patched releases, resolving [CVE-2026-13149](https://nvd.nist.gov/vuln/detail/CVE-2026-13149) / [GHSA-3jxr-9vmj-r5cp](https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-3jxr-9vmj-r5cp) — a high-severity DoS where `expand()` runs in exponential time on consecutive non-expanding `{}` groups. A ~90 byte all-ASCII input blocks the calling thread for minutes.

This closes both open Dependabot alerts for the package: [187](https://github.com/getsentry/snuba/security/dependabot/187) (the 1.x chain) and [186](https://github.com/getsentry/snuba/security/dependabot/186) (the 5.x chain).

### No `resolutions` override needed

Both copies are dev-only transitives:

| chain | declared range | was | now |
|---|---|---|---|
| jest 29 → `glob@7` → `minimatch@3` | `brace-expansion@^1.1.7` | 1.1.11 | **1.1.18** |
| `@sentry/esbuild-plugin` → `glob@13` → `minimatch@10` | `brace-expansion@^5.0.2` | 5.0.4 | **5.0.9** |

The patched releases are already semver compatible with the ranges `minimatch` declares — the lockfile was just pinned to stale resolutions. Dropping the two `brace-expansion` entries and reinstalling lets yarn pick the fixed versions inside the existing ranges, so the diff is 6 lines of `yarn.lock` with no `package.json` change and no override.

### Why not bump jest

I explored this since it was the obvious alternative. jest 30 moves `@jest/reporters`, `jest-config` and `jest-runtime` from `glob@^7.1.3` to `glob@^13.0.6`, which uses `minimatch@10` → `brace-expansion@^5`. That would eliminate the `brace-expansion` 1.x chain entirely and collapse the tree to a single major — a genuine cleanup, and probably worth doing.

But it is a major bump with breaking changes (jsdom version, snapshot format, `ts-jest` peer compat) affecting all 8 admin suites, and it shouldn't ride along with a security fix. Happy to do it as a follow-up PR if reviewers want the tree consolidated.

### Verification

- Integrity hashes and shasums cross-checked directly against `registry.npmjs.org`. My local install resolved through Sentry's `sfw.security.sentry.io` mirror, so I normalized the `resolved` URLs back to `registry.yarnpkg.com` to match the rest of the lockfile — worth a glance during review.
- Clean `node_modules` + `yarn install --frozen-lockfile` succeeds; both on-disk copies are 1.1.18 and 5.0.9.
- Advisory PoC (30 non-expanding groups) drops from ~2 minutes to 0.57ms and 0.45ms on the two copies.
- `yarn test` (8 suites, 36 tests) and `yarn build` both pass.

Refs GHSA-3jxr-9vmj-r5cp