### PR TITLE
build(docker): Exclude gha-creds files from image context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,4 @@ snuba/admin/dist/bundle.js*
 */node_modules
 rust_snuba/target/
 /.devenv
+**/gha-creds-*.json


### PR DESCRIPTION
google-github-actions/auth writes `gha-creds-*.json` into the workspace. The Dockerfile copies the full tree (`COPY . ./`), so this ignore keeps those credential files out of the image build context even if they are present during CI.
