### PR TITLE
ref(image): use scoped gha-snuba-push SA for GAR push

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -62,7 +62,7 @@ jobs:
           google_ar: true
           google_ar_image_name: us-docker.pkg.dev/sentryio/snuba-mr/image
           google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
-          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com
+          google_service_account: gha-snuba-push@sac-prod-sa.iam.gserviceaccount.com
 
   # Debug image — with busybox for troubleshooting
   build-debug-multiplatform:


### PR DESCRIPTION
Use the per-repo `gha-snuba-push` service account for the production image push instead of the shared `gha-gcr-push`.

Requires the corresponding IAM changes to be applied first (see SEC-1875).

Refs SEC-1875