### PR TITLE
feat(sentry): Replace the flat trace sample rate with a traces sampler

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import re
+from typing import Any
 
 import sentry_sdk
 import structlog
@@ -160,6 +162,33 @@ def before_send(event: Event, hint: Hint) -> Event | None:
     return event
 
 
+_HEALTH_CHECK_PATH = re.compile(r"^/health(_envoy)?/?$")
+
+
+def traces_sampler(sampling_context: dict[str, Any]) -> float:
+    """
+    Decide the sample rate for a root span. This replaces the server-side
+    dynamic sampling rules for the snuba project.
+
+    A request that carries a sampling decision from the caller keeps that
+    decision, so traces stay complete. Only traces that start in snuba get
+    a fresh decision.
+    """
+    parent_sampled = sampling_context.get("parent_sampled")
+    if parent_sampled is not None:
+        return 1.0 if parent_sampled else 0.0
+
+    environment = sentry_sdk.get_client().options.get("environment") or ""
+    if any(marker in environment for marker in settings.SENTRY_ALWAYS_SAMPLED_ENVIRONMENTS):
+        return 1.0
+
+    path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO", "")
+    if _HEALTH_CHECK_PATH.match(path):
+        return settings.SENTRY_HEALTH_CHECK_TRACE_SAMPLE_RATE
+
+    return settings.SENTRY_TRACE_SAMPLE_RATE
+
+
 def setup_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
@@ -179,7 +208,7 @@ def setup_sentry() -> None:
         # the value for release is also computed in rust-snuba, please keep the
         # logic in sync
         release=os.getenv("SNUBA_RELEASE"),
-        traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
+        traces_sampler=traces_sampler,
         profiles_sample_rate=settings.SNUBA_PROFILES_SAMPLE_RATE,
         # Stream spans as they finish. Disables the legacy tracing API
         # (start_span/start_transaction/update_current_span/scope.span).

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -216,7 +216,13 @@ RECORD_COGS = False
 
 # Sentry Options
 SENTRY_DSN: str | None = None
-SENTRY_TRACE_SAMPLE_RATE = 0
+# Sample rate for traces that start in snuba (no incoming sampling decision).
+# Requests that carry a sampling decision from the caller inherit it.
+SENTRY_TRACE_SAMPLE_RATE = 0.0
+# Sample rate for traces started by health check requests.
+SENTRY_HEALTH_CHECK_TRACE_SAMPLE_RATE = 0.0
+# Environments whose traces are always sampled, matched as substrings.
+SENTRY_ALWAYS_SAMPLED_ENVIRONMENTS = ("debug", "dev", "local", "qa", "test")
 
 # Snuba Admin Options
 SLACK_API_TOKEN = os.environ.get("SLACK_API_TOKEN")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,3 +1,8 @@
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import sentry_sdk
 from arroyo.processing.strategies.run_task_with_multiprocessing import (
     ChildProcessTerminated,
 )
@@ -6,7 +11,8 @@ from redis.exceptions import RedisClusterException
 from redis.exceptions import TimeoutError as RedisTimeoutError
 from sentry_sdk.types import Event, Hint
 
-from snuba.environment import before_send
+from snuba import settings
+from snuba.environment import before_send, traces_sampler
 from snuba.query.allocation_policies import AllocationPolicyViolations
 from snuba.web.rpc.common.exceptions import RPCAllocationPolicyException
 
@@ -144,3 +150,73 @@ def test_before_send_terminates_on_cyclic_cause_chain() -> None:
     except ValueError:
         err.__context__ = err
         assert before_send(event, _hint_for(err)) is event
+
+
+@pytest.fixture
+def sentry_environment(monkeypatch: pytest.MonkeyPatch) -> Callable[[str | None], None]:
+    def _set(environment: str | None) -> None:
+        monkeypatch.setattr(sentry_sdk.get_client(), "options", {"environment": environment})
+
+    _set(None)
+    return _set
+
+
+@pytest.fixture
+def sample_rates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "SENTRY_TRACE_SAMPLE_RATE", 0.5)
+    monkeypatch.setattr(settings, "SENTRY_HEALTH_CHECK_TRACE_SAMPLE_RATE", 0.01)
+
+
+def _request(path: str, parent_sampled: bool | None = None) -> dict[str, Any]:
+    return {
+        "transaction_context": {"name": "generic WSGI request"},
+        "parent_sampled": parent_sampled,
+        "wsgi_environ": {"PATH_INFO": path},
+    }
+
+
+@pytest.mark.usefixtures("sentry_environment", "sample_rates")
+def test_traces_sampler_inherits_parent_decision() -> None:
+    assert traces_sampler(_request("/health", parent_sampled=True)) == 1.0
+    assert traces_sampler(_request("/query", parent_sampled=False)) == 0.0
+
+
+@pytest.mark.usefixtures("sentry_environment", "sample_rates")
+def test_traces_sampler_uses_base_rate_for_root_requests() -> None:
+    assert traces_sampler(_request("/query")) == 0.5
+    assert traces_sampler(_request("/rpc/EndpointTraceItemTable/v1")) == 0.5
+
+
+@pytest.mark.usefixtures("sentry_environment", "sample_rates")
+def test_traces_sampler_uses_health_check_rate() -> None:
+    assert traces_sampler(_request("/health")) == 0.01
+    assert traces_sampler(_request("/health/")) == 0.01
+    assert traces_sampler(_request("/health_envoy")) == 0.01
+    assert traces_sampler(_request("/healthy")) == 0.5
+
+
+@pytest.mark.usefixtures("sample_rates")
+def test_traces_sampler_uses_base_rate_without_wsgi_environ(
+    sentry_environment: Callable[[str | None], None],
+) -> None:
+    sentry_environment("us")
+    assert traces_sampler({"transaction_context": {"name": "[cli init] api"}}) == 0.5
+
+
+@pytest.mark.usefixtures("sample_rates")
+@pytest.mark.parametrize("environment", ["dev", "local-simon", "test", "qa-eu", "debug"])
+def test_traces_sampler_samples_everything_in_development_environments(
+    sentry_environment: Callable[[str | None], None], environment: str
+) -> None:
+    sentry_environment(environment)
+    assert traces_sampler(_request("/health")) == 1.0
+    assert traces_sampler(_request("/query")) == 1.0
+
+
+@pytest.mark.usefixtures("sample_rates")
+@pytest.mark.parametrize("environment", ["us", "de", "s4s2", "production"])
+def test_traces_sampler_keeps_rates_in_production_environments(
+    sentry_environment: Callable[[str | None], None], environment: str
+) -> None:
+    sentry_environment(environment)
+    assert traces_sampler(_request("/query")) == 0.5


### PR DESCRIPTION
Move the snuba project's dynamic sampling rules into the SDK. The client now makes the same decisions, so the project can turn off server-side dynamic sampling.
- A request that carries a sampling decision from the caller keeps it, so traces stay complete. Nearly all snuba traffic falls in this bucket.
- Traces that start in snuba use `SENTRY_TRACE_SAMPLE_RATE`, the same setting as before.
- Health checks are sampled at 0%
- Environments that contain debug, dev, local, qa, or test are sampled in full.