### PR TITLE
feat(eap-items): create the eap_items_2 read-only distributed tables

### DIFF
--- a/snuba/snuba_migrations/events_analytics_platform/0071_create_eap_items_2_dist_ro.py
+++ b/snuba/snuba_migrations/events_analytics_platform/0071_create_eap_items_2_dist_ro.py
@@ -1,0 +1,105 @@
+"""Create the read-only distributed tables for eap_items_2.
+
+Step 3 of moving eap_items onto a ReplacingMergeTree keyed on `version`:
+0069 created the eap_items_2 tables, 0070 wired up their downsample
+materialized views, and this adds the `_dist_ro` counterparts so the
+read-only routing path has somewhere to point once reads cut over.
+
+`enable_eap_readonly_table` routes non-consistent EAP reads to the
+`events_analytics_platform_ro` storage set, so without these tables a v2
+read cutover would break for every deployment where that option is on.
+
+Mirrors 0056_eap_items_dist_ro, including its choice of template: the new
+tables are created `AS <the v2 distributed table>`, not `AS <the v2 local
+table>`. Distributed tables are created ON CLUSTER over the query nodes,
+which do not host the local tables -- those live on the storage cluster --
+so templating off a local table fails there with "Table ... does not
+exist". 0069 hit exactly that.
+
+These tables carry no data of their own; they are Distributed views onto
+the eap_items_2 local tables.
+"""
+
+from collections.abc import Sequence
+
+from snuba.clusters.cluster import get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set = StorageSetKey.EVENTS_ANALYTICS_PLATFORM_RO
+
+# Matches 0024_items / 0056_eap_items_dist_ro / 0069. A different sharding
+# key here would scatter a trace differently than the tables these read.
+SHARDING_KEY = "cityHash64(reinterpretAsUInt128(trace_id))"
+
+# (new dist_ro table, template dist table, local table it reads)
+DIST_RO_TABLES: list[tuple[str, str, str]] = [
+    (
+        "eap_items_2_dist_ro",
+        "eap_items_2_dist",
+        "eap_items_2_local",
+    ),
+    (
+        "eap_items_2_downsample_8_dist_ro",
+        "eap_items_2_downsample_8_dist",
+        "eap_items_2_downsample_8_local",
+    ),
+    (
+        "eap_items_2_downsample_64_dist_ro",
+        "eap_items_2_downsample_64_dist",
+        "eap_items_2_downsample_64_local",
+    ),
+    (
+        "eap_items_2_downsample_512_dist_ro",
+        "eap_items_2_downsample_512_dist",
+        "eap_items_2_downsample_512_local",
+    ),
+]
+
+
+def _on_cluster_clause() -> str:
+    cluster = get_cluster(storage_set)
+    if cluster.is_single_node():
+        return ""
+    name = cluster.get_clickhouse_distributed_cluster_name()
+    return f" ON CLUSTER `{name}`" if name else ""
+
+
+def _create_dist_ro_sql(new_table: str, template_table: str, local_table: str) -> str:
+    cluster = get_cluster(storage_set)
+    cluster_name = cluster.get_clickhouse_cluster_name()
+    database = cluster.get_database()
+    return (
+        f"CREATE TABLE IF NOT EXISTS {new_table}{_on_cluster_clause()} "
+        f"AS {template_table} "
+        f"ENGINE = Distributed(`{cluster_name}`, {database}, {local_table}, {SHARDING_KEY})"
+    )
+
+
+def _drop_dist_ro_sql(table: str) -> str:
+    return f"DROP TABLE IF EXISTS {table}{_on_cluster_clause()}"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.RunSql(
+                storage_set=storage_set,
+                statement=_create_dist_ro_sql(new_table, template_table, local_table),
+                target=OperationTarget.DISTRIBUTED,
+            )
+            for new_table, template_table, local_table in DIST_RO_TABLES
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.RunSql(
+                storage_set=storage_set,
+                statement=_drop_dist_ro_sql(new_table),
+                target=OperationTarget.DISTRIBUTED,
+            )
+            for new_table, *_ in DIST_RO_TABLES
+        ]


### PR DESCRIPTION
Based on #8443. Creates the read-only distributed tables for `eap_items_2`.

```sql
CREATE TABLE IF NOT EXISTS eap_items_2_dist_ro AS eap_items_2_dist
  ENGINE = Distributed(`<cluster>`, <db>, eap_items_2_local, cityHash64(reinterpretAsUInt128(trace_id)))
```

plus the same for the three downsample tiers, on the `events_analytics_platform_ro` storage set.

### Why

`enable_eap_readonly_table` routes non-consistent EAP reads to the `_ro` storage set, and it is enabled in production. Without these tables a v2 read cutover would break for every deployment where that option is on.

We deliberately skipped `_dist_ro` throughout the `version`-column work (0064-0067) because `version` is internal bookkeeping nothing queries. That reasoning does not extend here: these tables are the read path itself.

### Templating

Created `AS eap_items_2_dist`, i.e. off the *distributed* counterpart, not off the local table. Distributed tables are created `ON CLUSTER` over the query nodes, which do not host local tables — those live on the storage cluster — so `AS <local table>` fails there with `Code: 60 ... does not exist`. #8438 hit exactly that and was fixed the same way. 0056_eap_items_dist_ro templates off dist tables for the same reason.

### Testing

- `tests/migrations/test_runner.py::test_no_schema_differences`
- `tests/migrations/test_runner.py::test_run_and_reverse_all`
- `tests/migrations/test_runner.py::test_reverse_idempotency_all`

One thing CI verifies that I could not locally: these run on the RO storage set, so they depend on `eap_items_2_dist` being visible from whatever cluster that set resolves to. 0056 templates off `eap_items_1_dist` from the same storage set and works in production, so this should hold, but `test_distributed_migrations` is the real check.
