### PR TITLE
feat(eap-items): add the eap_items_2 storages

### DIFF
--- a/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/entities/eap_items.yaml
@@ -107,6 +107,85 @@ storages:
   - storage: eap_item_co_occurring_attrs_ro
     is_writable: false
 
+  # eap_items_2: the ReplacingMergeTree(version) tables. Nothing selects these
+  # until the eap_items_2_tiers option lists a tier.
+  - storage: eap_items_2
+    is_writable: false
+    translation_mappers:
+      subscriptables:
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_string
+            to_col_table: null
+            to_col_name: attributes_string
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_float
+            to_col_table: null
+            to_col_name: attributes_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_string
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_float
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+  - storage: eap_items_2_ro
+    is_writable: false
+    translation_mappers:
+      subscriptables:
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_string
+            to_col_table: null
+            to_col_name: attributes_string
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: attributes_float
+            to_col_table: null
+            to_col_name: attributes_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_string
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+        - mapper: SubscriptableHashBucketMapper
+          args:
+            from_column_table: null
+            from_column_name: _hash_map_float
+            to_col_table: null
+            to_col_name: _hash_map_float
+            num_attribute_buckets: 40
+  - storage: eap_items_2_downsample_8
+    is_writable: false
+  - storage: eap_items_2_downsample_64
+    is_writable: false
+  - storage: eap_items_2_downsample_512
+    is_writable: false
+  - storage: eap_items_2_downsample_8_ro
+    is_writable: false
+  - storage: eap_items_2_downsample_64_ro
+    is_writable: false
+  - storage: eap_items_2_downsample_512_ro
+    is_writable: false
+
 storage_selector:
   selector: EAPItemsStorageSelector
 

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2.yaml
@@ -1,0 +1,177 @@
+version: v1
+kind: writable_storage
+name: eap_items_2
+
+storage:
+  key: eap_items_2
+  set_key: events_analytics_platform
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+      { name: indexed_name, type: String },
+      { name: downsampled_retention_days, type: UInt, args: { size: 16 } },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_local
+  dist_table_name: eap_items_2_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+deletion_settings:
+  is_enabled: 1
+  max_rows_to_delete: 2000000
+  bulk_delete_only: true
+  partition_column: timestamp
+  tables:
+    - eap_items_2_local
+    - eap_items_2_downsample_8_local
+    - eap_items_2_downsample_64_local
+    - eap_items_2_downsample_512_local
+  allowed_columns:
+    - project_id
+    - organization_id
+    - trace_id
+    - item_type
+  allowed_attributes_by_item_type:
+    occurrence:
+      - group_id
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id
+
+stream_loader:
+  processor: EAPItemsProcessor
+  default_topic: snuba-items
+  commit_log_topic: snuba-items-commit-log
+  subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
+  subscription_scheduled_topic: scheduled-subscriptions-eap-items
+  subscription_result_topic: subscription-results-eap-items
+  subscription_delay_seconds: 60
+  dlq_topic: snuba-dead-letter-items

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_512.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_512.yaml
@@ -1,0 +1,147 @@
+version: v1
+kind: readable_storage
+name: eap_items_2_downsample_512
+
+storage:
+  key: eap_items_2_downsample_512
+  set_key: events_analytics_platform
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: indexed_name, type: String },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_downsample_512_local
+  dist_table_name: eap_items_2_downsample_512_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_512_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_512_ro.yaml
@@ -1,0 +1,147 @@
+version: v1
+kind: readable_storage
+name: eap_items_2_downsample_512_ro
+
+storage:
+  key: eap_items_2_downsample_512_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: indexed_name, type: String },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_downsample_512_local
+  dist_table_name: eap_items_2_downsample_512_dist_ro
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_64.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_64.yaml
@@ -1,0 +1,147 @@
+version: v1
+kind: readable_storage
+name: eap_items_2_downsample_64
+
+storage:
+  key: eap_items_2_downsample_64
+  set_key: events_analytics_platform
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: indexed_name, type: String },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_downsample_64_local
+  dist_table_name: eap_items_2_downsample_64_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_64_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_64_ro.yaml
@@ -1,0 +1,147 @@
+version: v1
+kind: readable_storage
+name: eap_items_2_downsample_64_ro
+
+storage:
+  key: eap_items_2_downsample_64_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: indexed_name, type: String },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_downsample_64_local
+  dist_table_name: eap_items_2_downsample_64_dist_ro
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_8.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_8.yaml
@@ -1,0 +1,149 @@
+version: v1
+kind: readable_storage
+name: eap_items_2_downsample_8
+
+storage:
+  key: eap_items_2_downsample_8
+  set_key: events_analytics_platform
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: indexed_name, type: String },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_downsample_8_local
+  dist_table_name: eap_items_2_downsample_8_dist
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_8_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_downsample_8_ro.yaml
@@ -1,0 +1,147 @@
+version: v1
+kind: readable_storage
+name: eap_items_2_downsample_8_ro
+
+storage:
+  key: eap_items_2_downsample_8_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+
+      { name: indexed_name, type: String },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_downsample_8_local
+  dist_table_name: eap_items_2_downsample_8_dist_ro
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id

--- a/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_ro.yaml
+++ b/snuba/datasets/configuration/events_analytics_platform/storages/eap_items_2_ro.yaml
@@ -1,0 +1,147 @@
+version: v1
+kind: readable_storage
+name: eap_items_2_ro
+
+storage:
+  key: eap_items_2_ro
+  set_key: events_analytics_platform_ro
+
+readiness_state: complete
+
+schema:
+  columns:
+    [
+      { name: organization_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: item_type, type: UInt, args: { size: 8 } },
+      { name: timestamp, type: DateTime },
+      { name: trace_id, type: UUID },
+      { name: conversation_id, type: UUID },
+      { name: session_id, type: UUID },
+      { name: ai_conversation_id, type: String },
+      { name: item_id, type: UInt, args: { size: 128 } },
+      { name: sampling_weight, type: UInt, args: { size: 64 } },
+      { name: sampling_factor, type: Float, args: { size: 64 } },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+      { name: indexed_name, type: String },
+      { name: downsampled_retention_days, type: UInt, args: { size: 16 } },
+
+      { name: attributes_bool, type: Map, args: { key: { type: String }, value: { type: Bool } } },
+      { name: attributes_int, type: Map, args: { key: { type: String }, value: { type: Int, args: { size: 64 } } } },
+
+      { name: attributes_string_0, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_1, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_2, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_3, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_4, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_5, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_6, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_7, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_8, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_9, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_10, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_11, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_12, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_13, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_14, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_15, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_16, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_17, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_18, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_19, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_20, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_21, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_22, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_23, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_24, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_25, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_26, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_27, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_28, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_29, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_30, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_31, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_32, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_33, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_34, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_35, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_36, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_37, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_38, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_string_39, type: Map, args: { key: { type: String }, value: { type: String } } },
+      { name: attributes_float_0, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_1, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_2, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_3, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_4, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_5, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_6, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_7, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_8, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_9, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_10, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_11, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_12, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_13, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_14, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_15, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_16, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_17, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_18, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_19, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_20, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_21, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_22, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_23, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_24, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_25, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_26, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_27, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_28, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_29, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_30, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_31, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_32, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_33, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_34, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_35, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_36, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_37, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_38, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+      { name: attributes_float_39, type: Map, args: { key: { type: String }, value: { type: Float, args: { size: 64 } } } },
+
+      { name: attributes_array_string, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: String } } } } },
+      { name: attributes_array_int, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Int, args: { size: 64 } } } } } },
+      { name: attributes_array_float, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Float, args: { size: 64 } } } } } },
+      { name: attributes_array_bool, type: Map, args: { key: { type: String }, value: { type: Array, args: { inner_type: { type: Bool } } } } },
+    ]
+  local_table_name: eap_items_2_local
+  dist_table_name: eap_items_2_dist_ro
+  partition_format: [retention_days, date]
+
+query_processors:
+  - processor: UniqInSelectAndHavingProcessor
+  - processor: UUIDColumnProcessor
+    args:
+      columns: [trace_id, conversation_id, session_id]
+  - processor: HexIntColumnProcessor
+    args:
+      columns: [item_id]
+      size: 32
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        [trace_id]
+  - processor: TupleUnaliaser
+  - processor: ClickhouseSettingsOverride
+    args:
+      overwrite_existing: false
+      settings:
+        max_execution_time: 25
+        timeout_before_checking_execution_speed: 0
+        distributed_product_mode: global
+
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+    args:
+      field_name: organization_id


### PR DESCRIPTION
Based on 8447. Adds the eight storage configs for the `eap_items_2` tables and lists them on the `eap_items` entity.

**Inert.** `EAPItemsStorageSelector` does not reference any of them, so no query can reach these storages. The switch is #8449.

| file | kind | storage set | local | dist |
|---|---|---|---|---|
| `eap_items_2.yaml` | writable | `..._platform` | `eap_items_2_local` | `eap_items_2_dist` |
| `eap_items_2_ro.yaml` | readable | `..._platform_ro` | `eap_items_2_local` | `eap_items_2_dist_ro` |
| `eap_items_2_downsample_{8,64,512}.yaml` | readable | `..._platform` | `..._local` | `..._dist` |
| `eap_items_2_downsample_{8,64,512}_ro.yaml` | readable | `..._platform_ro` | `..._local` | `..._dist_ro` |

### On the column lists

Each file is a mechanical copy of its v1 counterpart with only the storage `name`, `key` and table names rewritten — generated by script, not by hand. The diff against each source file is 8 changed lines (4 pairs), or 16 for the writable one which also carries `deletion_settings.tables`:

```
eap_items.yaml                    -> eap_items_2.yaml                   changed lines: 16
eap_items_ro.yaml                 -> eap_items_2_ro.yaml                changed lines: 8
eap_items_downsample_8.yaml       -> eap_items_2_downsample_8.yaml      changed lines: 8
...
```

That keeps the ~100-column blocks provably identical to v1, which is what we want: `eap_items_2_local` was created `AS eap_items_1_local`, so the physical schemas match by construction.

### `eap_items_2` is writable in its YAML but not on the entity

`kind: writable_storage` is what makes `--storage=eap_items_2` a valid consumer target for the write cutover. But the entity entry is `is_writable: false`, because `Entity.get_writable_storage()` returns the *first* writable connection (`entity.py:106-114`, with a comment noting an entity cannot yet have more than one), so declaring a second would be ambiguous. Consumers never consult entities anyway — they go through `get_writable_storage(StorageKey(...))`, and `eap_items_dlq_replay` is precedent for a writable storage that appears in zero entity YAMLs.

`eap_items_2` and `eap_items_2_ro` carry copies of v1's `translation_mappers`; the downsample entries are bare, mirroring their v1 counterparts. In practice the selector always reuses `storage_connections[0].translation_mappers` regardless of which storage it returns, and v2's schema is identical to v1's, so this is correct either way.

### Verification

All eight register with the right storage sets and table names:

```
eap_items_2                     set=events_analytics_platform       local=eap_items_2_local
eap_items_2_ro                  set=events_analytics_platform_ro    local=eap_items_2_local
eap_items_2_downsample_8        set=events_analytics_platform       local=eap_items_2_downsample_8_local
eap_items_2_downsample_8_ro     set=events_analytics_platform_ro    local=eap_items_2_downsample_8_local
... (64, 512)

writable storage keys: ['eap_items', 'eap_items_2', 'eap_items_dlq_replay']
```

No changes needed to `storage_key.py` (keys self-register from the YAML glob), `groups.py`, or `storage_sets.py`, since we reuse the two existing storage sets.

### Testing

`tests/datasets/entities/`, `tests/datasets/storages/`, `tests/datasets/configuration/`, `tests/datasets/test_factory.py`, `tests/migrations/` — 564 passed. `test_no_schema_differences` is the meaningful one: it iterates every storage and asserts the YAML columns match the real ClickHouse local table.
