### PR TITLE
feat(eap-items): add the eap_items_2 read switch

### DIFF
--- a/sentry-options/schemas/snuba/schema.json
+++ b/sentry-options/schemas/snuba/schema.json
@@ -251,6 +251,14 @@
       "default": false,
       "description": "When true, non-consistent EAP-items queries are routed to the read-only table replica."
     },
+    "eap_items_2_tiers": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "default": [],
+      "description": "Sampling tiers served from the eap_items_2 tables instead of eap_items_1. 1 is the unsampled base table; 8, 64 and 512 are the downsample tiers. Any tier not listed keeps reading eap_items_1, and the empty default keeps every read on eap_items_1. Tiers are listed individually because eap_items_2's downsample tiers are populated after its base table, so tier 1 has to be able to cut over on its own; setting [1, 8, 64, 512] before the downsample partitions are attached would silently serve near-empty results. Unrecognised values are ignored."
+    },
     "use_cross_item_path_for_single_item_queries": {
       "type": "boolean",
       "default": false,

--- a/snuba/datasets/entities/storage_selectors/eap_items.py
+++ b/snuba/datasets/entities/storage_selectors/eap_items.py
@@ -1,4 +1,7 @@
 from collections.abc import Sequence
+from typing import cast
+
+import sentry_sdk
 
 from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.storage import EntityStorageConnection
@@ -8,6 +11,38 @@ from snuba.downsampled_storage_tiers import Tier
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.state.sentry_options import get_option
+
+#: Sampling tiers served from the eap_items_2 tables rather than eap_items_1.
+#: Listed per tier because eap_items_2's downsample tiers are populated after
+#: its base table, so tier 1 has to be able to cut over on its own.
+EAP_ITEMS_2_TIERS_OPTION = "eap_items_2_tiers"
+
+_V1_PREFIX = "EAP_ITEMS"
+_V2_PREFIX = "EAP_ITEMS_2"
+
+
+def _storage_key_name(prefix: str, tier: Tier, readonly: bool) -> str:
+    suffix = "_RO" if readonly else ""
+    # TIER_NO_TIER (-1) means the caller never picked a tier, which is served
+    # by the unsampled base table just like TIER_1.
+    if tier in (Tier.TIER_1, Tier.TIER_NO_TIER):
+        return f"{prefix}{suffix}"
+    return f"{prefix}_DOWNSAMPLE_{tier.value}{suffix}"
+
+
+def _use_eap_items_2(tier: Tier) -> bool:
+    tiers = cast("list[int]", get_option(EAP_ITEMS_2_TIERS_OPTION, []))
+    # TIER_NO_TIER is not nameable in the option; it follows tier 1.
+    effective = Tier.TIER_1.value if tier == Tier.TIER_NO_TIER else tier.value
+    return effective in tiers
+
+
+def _registered_storage_key(name: str) -> StorageKey | None:
+    """The StorageKey called ``name``, or None if no such storage is registered."""
+    try:
+        return cast(StorageKey, getattr(StorageKey, name))
+    except AttributeError:
+        return None
 
 
 class EAPItemsStorageSelector(QueryStorageSelector):
@@ -25,11 +60,26 @@ class EAPItemsStorageSelector(QueryStorageSelector):
             get_option("enable_eap_readonly_table", False) and not query_settings.get_consistent()
         )
 
-        if tier == Tier.TIER_1 or tier == Tier.TIER_NO_TIER:
-            storage_key = StorageKey.EAP_ITEMS_RO if use_readonly_storage else StorageKey.EAP_ITEMS
-        else:
-            suffix = "_RO" if use_readonly_storage else ""
-            storage_key = getattr(StorageKey, f"EAP_ITEMS_DOWNSAMPLE_{tier.value}{suffix}")
+        storage_key: StorageKey | None = None
+        if _use_eap_items_2(tier):
+            name = _storage_key_name(_V2_PREFIX, tier, use_readonly_storage)
+            storage_key = _registered_storage_key(name)
+            if storage_key is None:
+                # The option named a tier whose eap_items_2 storage is not
+                # registered in this deployment. Fall back to eap_items_1
+                # rather than 500 mid-cutover: stale-but-correct data beats an
+                # outage, and the message surfaces the misconfiguration.
+                # RoutingStrategySelector handles a bad routing config the
+                # same way.
+                sentry_sdk.capture_message(
+                    f"{EAP_ITEMS_2_TIERS_OPTION} selected {name}, which is not a registered "
+                    f"storage; falling back to eap_items_1"
+                )
+
+        if storage_key is None:
+            storage_key = getattr(
+                StorageKey, _storage_key_name(_V1_PREFIX, tier, use_readonly_storage)
+            )
 
         return EntityStorageConnection(
             storage=get_storage(storage_key),

--- a/tests/datasets/entities/storage_selectors/test_eap_items.py
+++ b/tests/datasets/entities/storage_selectors/test_eap_items.py
@@ -79,3 +79,96 @@ def test_selects_downsample_ro_when_enabled() -> None:
         unimportant_query, query_settings, EAP_ITEMS_STORAGE_CONNECTIONS
     )
     assert selected_storage.storage == get_storage(StorageKey.EAP_ITEMS_DOWNSAMPLE_512_RO)
+
+
+def _select(tier: Tier, consistent: bool = False) -> StorageKey:
+    query_settings = HTTPQuerySettings(consistent=consistent)
+    query_settings.set_sampling_tier(tier)
+    return (
+        EAPItemsStorageSelector()
+        .select_storage(
+            Query(from_clause=EAP_ITEMS_ENTITY), query_settings, EAP_ITEMS_STORAGE_CONNECTIONS
+        )
+        .storage.get_storage_key()
+    )
+
+
+ALL_TIERS = [Tier.TIER_NO_TIER, Tier.TIER_1, Tier.TIER_8, Tier.TIER_64, Tier.TIER_512]
+
+
+@pytest.mark.redis_db
+@pytest.mark.parametrize("tier", ALL_TIERS)
+def test_eap_items_2_tiers_defaults_to_v1(tier: Tier) -> None:
+    """With the option unset, nothing reaches the eap_items_2 storages."""
+    assert "_2" not in _select(tier).value
+
+
+@pytest.mark.redis_db
+@override_options("snuba", {"eap_items_2_tiers": [1]})
+def test_eap_items_2_tier_1_only_moves_the_base_table() -> None:
+    """The downsample tiers must stay on v1 while only tier 1 is listed.
+
+    eap_items_2's downsample partitions are attached after its base table, so
+    moving them early would silently serve near-empty results.
+    """
+    assert _select(Tier.TIER_1) == StorageKey.EAP_ITEMS_2
+    assert _select(Tier.TIER_NO_TIER) == StorageKey.EAP_ITEMS_2
+    assert _select(Tier.TIER_8) == StorageKey.EAP_ITEMS_DOWNSAMPLE_8
+    assert _select(Tier.TIER_64) == StorageKey.EAP_ITEMS_DOWNSAMPLE_64
+    assert _select(Tier.TIER_512) == StorageKey.EAP_ITEMS_DOWNSAMPLE_512
+
+
+@pytest.mark.redis_db
+@override_options("snuba", {"eap_items_2_tiers": [1, 8, 64, 512]})
+def test_eap_items_2_all_tiers() -> None:
+    assert _select(Tier.TIER_1) == StorageKey.EAP_ITEMS_2
+    assert _select(Tier.TIER_NO_TIER) == StorageKey.EAP_ITEMS_2
+    assert _select(Tier.TIER_8) == StorageKey.EAP_ITEMS_2_DOWNSAMPLE_8
+    assert _select(Tier.TIER_64) == StorageKey.EAP_ITEMS_2_DOWNSAMPLE_64
+    assert _select(Tier.TIER_512) == StorageKey.EAP_ITEMS_2_DOWNSAMPLE_512
+
+
+@pytest.mark.redis_db
+@override_options(
+    "snuba", {"eap_items_2_tiers": [1, 8, 64, 512], "enable_eap_readonly_table": True}
+)
+def test_eap_items_2_combines_with_readonly() -> None:
+    assert _select(Tier.TIER_1) == StorageKey.EAP_ITEMS_2_RO
+    assert _select(Tier.TIER_NO_TIER) == StorageKey.EAP_ITEMS_2_RO
+    assert _select(Tier.TIER_8) == StorageKey.EAP_ITEMS_2_DOWNSAMPLE_8_RO
+    assert _select(Tier.TIER_512) == StorageKey.EAP_ITEMS_2_DOWNSAMPLE_512_RO
+
+
+@pytest.mark.redis_db
+@override_options("snuba", {"eap_items_2_tiers": [1], "enable_eap_readonly_table": True})
+def test_eap_items_2_consistent_query_uses_writable_v2() -> None:
+    """A consistent query opts out of the read-only replica, not out of v2."""
+    assert _select(Tier.TIER_1, consistent=True) == StorageKey.EAP_ITEMS_2
+
+
+@pytest.mark.redis_db
+@override_options("snuba", {"eap_items_2_tiers": [99]})
+def test_eap_items_2_ignores_unrecognised_tiers() -> None:
+    assert _select(Tier.TIER_1) == StorageKey.EAP_ITEMS
+    assert _select(Tier.TIER_8) == StorageKey.EAP_ITEMS_DOWNSAMPLE_8
+
+
+@pytest.mark.redis_db
+@override_options("snuba", {"eap_items_2_tiers": [1]})
+def test_eap_items_2_falls_back_to_v1_when_storage_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tier whose v2 storage is not registered must not 500 the query."""
+    import snuba.datasets.entities.storage_selectors.eap_items as selector_module
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        selector_module,
+        "_registered_storage_key",
+        lambda name: None if name.startswith("EAP_ITEMS_2") else StorageKey(name.lower()),
+    )
+    monkeypatch.setattr(selector_module.sentry_sdk, "capture_message", captured.append)
+
+    assert _select(Tier.TIER_1) == StorageKey.EAP_ITEMS
+    assert len(captured) == 1
+    assert "EAP_ITEMS_2" in captured[0]


### PR DESCRIPTION
Based on #8448. Adds the `eap_items_2_tiers` option and teaches `EAPItemsStorageSelector` to honour it.

**Defaults to `[]`, so every read stays on `eap_items_1` and this is a no-op until a deployment sets it.**

```json
"eap_items_2_tiers": {
  "type": "array",
  "items": { "type": "integer" },
  "default": [],
  "description": "Sampling tiers served from the eap_items_2 tables instead of eap_items_1. ..."
}
```

### Why per-tier and not a boolean

`eap_items_2`'s downsample partitions are attached *after* its base table — step 6 of the move plan, versus step 3 for the read switch, and the downsample tables carry 13 months of retention. A single `use_eap_items_2` boolean would move tiers 8/64/512 at the same instant as tier 1 and silently serve near-empty results for the length of that attach.

Rollout is `[]` → `[1]` → `[1, 8, 64, 512]`; rollback is removing a tier. Option values are per deployment, so a region can cut over on its own — which was the original question this whole line of work started from.

### Behaviour

Verified across every combination:

```
opt=[]           ro=False  NO_TIER=eap_items    TIER_1=eap_items    TIER_8=eap_items_downsample_8    TIER_512=eap_items_downsample_512
opt=[]           ro=True   NO_TIER=eap_items_ro TIER_1=eap_items_ro TIER_8=eap_items_downsample_8_ro TIER_512=eap_items_downsample_512_ro
opt=[1]          ro=False  NO_TIER=eap_items_2  TIER_1=eap_items_2  TIER_8=eap_items_downsample_8    TIER_512=eap_items_downsample_512
opt=[1]          ro=True   NO_TIER=eap_items_2_ro TIER_1=eap_items_2_ro TIER_8=eap_items_downsample_8_ro TIER_512=eap_items_downsample_512_ro
opt=[1,8,64,512] ro=False  NO_TIER=eap_items_2  TIER_1=eap_items_2  TIER_8=eap_items_2_downsample_8  TIER_512=eap_items_2_downsample_512
opt=[1,8,64,512] ro=True   NO_TIER=eap_items_2_ro TIER_1=eap_items_2_ro TIER_8=eap_items_2_downsample_8_ro TIER_512=eap_items_2_downsample_512_ro

consistent=True, opt=[1], ro=True -> eap_items_2   (consistent opts out of the replica, not out of v2)
unknown tier, opt=[99]            -> eap_items     (ignored)
```

`Tier.TIER_NO_TIER` is `-1` and cannot be named in the array, so it follows tier 1, as it already does today.

### Fallback rather than raise

If the option names a tier whose v2 storage is not registered in a deployment, the selector `capture_message`s and falls back to `eap_items_1` rather than letting `AttributeError` escape and 500 the query. Stale-but-correct data beats an outage mid-cutover, and the message surfaces the misconfiguration. `RoutingStrategySelector.get_storage_routing_config` handles a bad routing config the same way.

The lookup is behind `_registered_storage_key()` so this path is directly testable. I mutation-checked that test — removing the fallback makes it fail, so it is not vacuous.

### Testing

`tests/datasets/entities/storage_selectors/test_eap_items.py`, 16 tests: default-empty across all five tiers, `[1]` moving only the base table, all-tiers, each crossed with `enable_eap_readonly_table`, consistent queries, unrecognised tier values, and the missing-storage fallback.

Wider run: `tests/datasets/entities/`, `tests/datasets/storages/`, `tests/datasets/configuration/`, `tests/datasets/test_factory.py`, `tests/migrations/` — 564 passed.

(There are 23 pre-existing failures in `tests/datasets/test_errors_processor.py` and `test_errors_replacer.py` on this branch's base; I confirmed they reproduce on a clean checkout and are unrelated.)

### Rollout, mapped to the move plan

Stop inserts and attach the base partitions (steps 1-2) → set `eap_items_2_tiers: [1]` in one region (step 3) → verify unsampled UI (step 4) → redeploy consumers to `--storage=eap_items_2` (step 5) → attach the downsample partitions (step 6) → set `[1, 8, 64, 512]`.

### Does not follow the switch

Deletes (`endpoint_delete_trace_items.py:161,173` hardcodes `StorageKey.EAP_ITEMS` and the literal `eap_items_1_local`; also `delete_query.py:120,125`, `lw_deletions/{strategy,formatters}.py`, `bulk_delete_query.py:65`), the literal `FROM eap_items_1_dist` in `trace_item_attribute_values.py:108`, co-occurring attrs (raw `Storage(...)`, bypasses the selector), and allocation-policy accounting (stays on the `eap_items` resource identifier, which is probably desirable). Each needs its own follow-up.
