### PR TITLE
ref(resolvers): remove unused resolver declarations

### DIFF
--- a/snuba/web/rpc/v1/resolvers/__init__.py
+++ b/snuba/web/rpc/v1/resolvers/__init__.py
@@ -1,18 +1,8 @@
 import os
 
-from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import (
-    GetTraceRequest,
-    GetTraceResponse,
-)
 from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeriesRequest,
     TimeSeriesResponse,
-)
-from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
-    TraceItemAttributeNamesRequest,
-    TraceItemAttributeNamesResponse,
-    TraceItemAttributeValuesRequest,
-    TraceItemAttributeValuesResponse,
 )
 from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
     TraceItemStatsRequest,
@@ -39,40 +29,10 @@ class ResolverTimeSeries(TraceItemDataResolver[TimeSeriesRequest, TimeSeriesResp
         return "TimeSeries"
 
 
-class ResolverAttributeNames(
-    TraceItemDataResolver[TraceItemAttributeNamesRequest, TraceItemAttributeNamesResponse]
-):
-    @classmethod
-    def endpoint_name(cls) -> str:
-        return "AttributeNames"
-
-
-class ResolverAttributeValues(
-    TraceItemDataResolver[TraceItemAttributeValuesRequest, TraceItemAttributeValuesResponse]
-):
-    @classmethod
-    def endpoint_name(cls) -> str:
-        return "AttributeValues"
-
-
-class ResolverGetTrace(
-    TraceItemDataResolver[
-        GetTraceRequest,
-        GetTraceResponse,
-    ]
-):
-    @classmethod
-    def endpoint_name(cls) -> str:
-        return "GetTrace"
-
-
 class ResolverTraceItemStats(TraceItemDataResolver[TraceItemStatsRequest, TraceItemStatsResponse]):
     @classmethod
     def endpoint_name(cls) -> str:
         return "TraceItemStats"
-
-
-# TODO: Traces, subscriptions
 
 
 _TO_IMPORT = {}


### PR DESCRIPTION
## Stack
1. **→ #this** `ref(resolvers): remove unused resolver declarations`
2. `ref(resolvers): inline the trace item stats resolver`
3. `ref(resolvers): inline the time series resolver`
4. `ref(resolvers): inline the trace item table resolver`
5. `ref(resolvers): remove the TraceItemDataResolver abstraction`

## What

Deletes the `ResolverAttributeNames`, `ResolverAttributeValues`, and `ResolverGetTrace` marker classes from `snuba/web/rpc/v1/resolvers/__init__.py`, plus the now-unused proto imports and a stale `# TODO: Traces, subscriptions` comment.

None of these had a concrete subclass left — the endpoints they belonged to were converted away from resolvers earlier (`76d1fed8f`, `37dc351c3`) or never used one. This is registry cleanup ahead of removing the resolver abstraction entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)