### PR TITLE
feat(consumers): Honor clickhouse-concurrency without async-inserts

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -106,6 +106,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
 @click.option(
     "--clickhouse-concurrency",
     type=int,
+    default=2,
     help=(
         "Number of concurrent clickhouse batches at one time. Defaults to 2. "
         "Independent of --async-inserts: raising it increases concurrent "

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -106,7 +106,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
 @click.option(
     "--clickhouse-concurrency",
     type=int,
-    help="Number of concurrent clickhouse batches at one time.",
+    help=(
+        "Number of concurrent clickhouse batches at one time. Defaults to 2. "
+        "Independent of --async-inserts: raising it increases concurrent "
+        "in-flight writes (and inserts/sec) on ClickHouse, so size memory and "
+        "batch buffers accordingly."
+    ),
 )
 @click.option(
     "--use-rust-processor/--use-python-processor",
@@ -316,12 +321,6 @@ def rust_consumer(
             dry_run or 0,
         )
         sys.exit(exitcode)
-
-    if not async_inserts:
-        # we don't want to allow increasing this if
-        # we aren't using async inserts since that will increase
-        # the number of inserts/sec on clickhouse
-        clickhouse_concurrency = 2
 
     exitcode = rust_snuba.consumer(  # type: ignore[attr-defined]
         consumer_group,

--- a/tests/cli/test_rust_consumer.py
+++ b/tests/cli/test_rust_consumer.py
@@ -61,3 +61,59 @@ def test_rust_consumer_passes_skip_write(resolve_config: Mock, *_mocks: Sequence
     assert result.exit_code == 0, result.output
     mock_rust.consumer.assert_called_once()
     assert mock_rust.consumer.call_args.args[-1] is True
+
+
+@patch("snuba.cli.rust_consumer.asdict", return_value={})
+@patch("snuba.cli.rust_consumer.resolve_consumer_config")
+def test_rust_consumer_clickhouse_concurrency_without_async_inserts(
+    resolve_config: Mock, *_mocks: Sequence[Mock]
+) -> None:
+    """--clickhouse-concurrency is honored even without --async-inserts."""
+    resolve_config.return_value = Mock()
+    mock_rust = Mock()
+    mock_rust.consumer.return_value = 0
+
+    runner = CliRunner()
+    with patch.dict(sys.modules, {"rust_snuba": mock_rust}):
+        result = runner.invoke(
+            rust_consumer,
+            [
+                "--storage",
+                "eap_items",
+                "--consumer-group",
+                "snuba-eap-items-consumers",
+                "--clickhouse-concurrency",
+                "4",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_rust.consumer.assert_called_once()
+    assert mock_rust.consumer.call_args.args[5] == 4
+
+
+@patch("snuba.cli.rust_consumer.asdict", return_value={})
+@patch("snuba.cli.rust_consumer.resolve_consumer_config")
+def test_rust_consumer_clickhouse_concurrency_defaults_to_two(
+    resolve_config: Mock, *_mocks: Sequence[Mock]
+) -> None:
+    """Without --clickhouse-concurrency the writer keeps its historical default of 2."""
+    resolve_config.return_value = Mock()
+    mock_rust = Mock()
+    mock_rust.consumer.return_value = 0
+
+    runner = CliRunner()
+    with patch.dict(sys.modules, {"rust_snuba": mock_rust}):
+        result = runner.invoke(
+            rust_consumer,
+            [
+                "--storage",
+                "eap_items",
+                "--consumer-group",
+                "snuba-eap-items-consumers",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_rust.consumer.assert_called_once()
+    assert mock_rust.consumer.call_args.args[5] == 2


### PR DESCRIPTION
The rust consumer no longer forces `--clickhouse-concurrency` back to 2 when `--async-inserts` is off. The flag now controls the ClickHouse writer concurrency directly, still defaulting to 2 when unset.

Previously the CLI silently discarded a raised value unless async inserts were enabled, so the only way to give the ClickHouse step more capacity was to also change insert behavior. The two concerns are independent: async inserts change how ClickHouse buffers writes server-side, while clickhouse concurrency is just how many batches the consumer has in flight. The pull-consumer path already passed the value through ungated; this makes the push path consistent.

Reviewers should note this is a behavior change for anyone who was passing a higher value with sync inserts: it now takes effect. Raising it increases concurrent in-flight inserts (inserts/sec) on ClickHouse, and the number of batch-sized buffers in memory grows accordingly — ops sizing of `max_batch_size` against pod memory assumes a specific in-flight count and must be revisited alongside any increase.
