### PR TITLE
ref(admin): Make region URLs list more dynamic

### DIFF
--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -1,4 +1,4 @@
-import { AllowedTools, Settings } from "SnubaAdmin/types";
+import { AdminRegion, AllowedTools, Settings } from "SnubaAdmin/types";
 
 import {
   ClickhouseNodeData,
@@ -71,7 +71,7 @@ interface Client {
   getAllMigrationGroups: () => Promise<MigrationGroupResult[]>;
   runMigration: (req: RunMigrationRequest) => Promise<RunMigrationResult>;
   getAllowedTools: () => Promise<AllowedTools>;
-  getAdminRegions: () => Promise<string[]>;
+  getAdminRegions: () => Promise<AdminRegion[]>;
   listJobSpecs: () => Promise<JobSpecMap>;
   runJob(job_id: string): Promise<String>;
   listJobTypes: () => Promise<string[]>;

--- a/snuba/admin/static/types.tsx
+++ b/snuba/admin/static/types.tsx
@@ -2,6 +2,12 @@ type AllowedTools = {
   tools: string[];
 };
 
+type AdminRegion = {
+  name: string;
+  url: string;
+  is_main: boolean;
+};
+
 type Settings = {
   dsn: string;
   tracesSampleRate: number;
@@ -12,4 +18,4 @@ type Settings = {
   userEmail: string;
 };
 
-export { AllowedTools, Settings };
+export { AdminRegion, AllowedTools, Settings };

--- a/snuba/admin/static/welcome/index.tsx
+++ b/snuba/admin/static/welcome/index.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import Client from "SnubaAdmin/api_client";
+import { AdminRegion } from "SnubaAdmin/types";
 
 function Welcome(props: { api: Client }) {
-  const [adminRegions, setAdminRegions] = useState<string[]>([]);
+  const [adminRegions, setAdminRegions] = useState<AdminRegion[]>([]);
 
   useEffect(() => {
     props.api.getAdminRegions().then((res) => {
@@ -13,21 +14,13 @@ function Welcome(props: { api: Client }) {
   function urls() {
     return (
       <div>
-        <p>Available regions:</p>
         <p>MEREDITH IS #1</p>
+        <p>Available regions:</p>
         <ul>
-          <li>
-            <a href="https://snuba-admin.getsentry.net/" target="_blank">
-              SaaS
-            </a>
-          </li>
           {adminRegions.map((region) => (
-            <li>
-              <a
-                href={"https://snuba-admin." + region + ".getsentry.net/"}
-                target="_blank"
-              >
-                {region}
+            <li key={region.name}>
+              <a href={region.url} target="_blank">
+                {region.is_main ? `SaaS (${region.name})` : region.name}
               </a>
             </li>
           ))}

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -1060,7 +1060,18 @@ def get_allowed_projects() -> Response:
 
 @application.route("/admin_regions", methods=["GET"])
 def get_admin_regions() -> Response:
-    return make_response(jsonify(settings.ADMIN_REGIONS), 200)
+    regions = []
+    for region in settings.ADMIN_REGIONS:
+        is_main = region == settings.ADMIN_MAIN_REGION
+        subdomain = "" if is_main else f".{region}"
+        regions.append(
+            {
+                "name": region,
+                "url": f"https://snuba-admin{subdomain}.getsentry.net/",
+                "is_main": is_main,
+            }
+        )
+    return make_response(jsonify(regions), 200)
 
 
 @application.route("/job-specs", methods=["GET"])

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -56,8 +56,10 @@ ADMIN_ALLOWED_PROD_PROJECTS: Sequence[int] = []
 ADMIN_ALLOWED_ORG_IDS: Sequence[int] = []
 ADMIN_ROLES_REDIS_TTL = 600
 
+ADMIN_MAIN_REGION: str = os.environ.get("ADMIN_MAIN_REGION", "us")
 # All available regions where region is:
-# https://snuba-admin.<region>.getsentry.net/
+# - https://snuba-admin.<region>.getsentry.net/ generally
+# - https://snuba-admin.getsentry.net/ for ADMIN_MAIN_REGION
 ADMIN_REGIONS: Sequence[str] = []
 
 ######################

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -68,6 +68,25 @@ def get_node_for_table(admin_api: FlaskClient, storage_name: str) -> tuple[str, 
 
 
 @pytest.mark.redis_db
+def test_admin_regions(admin_api: FlaskClient) -> None:
+    with (
+        mock.patch("snuba.settings.ADMIN_REGIONS", ["us", "de"]),
+        mock.patch("snuba.settings.ADMIN_MAIN_REGION", "us"),
+    ):
+        response = admin_api.get("/admin_regions")
+
+    assert response.status_code == 200
+    assert json.loads(response.data) == [
+        {"name": "us", "url": "https://snuba-admin.getsentry.net/", "is_main": True},
+        {
+            "name": "de",
+            "url": "https://snuba-admin.de.getsentry.net/",
+            "is_main": False,
+        },
+    ]
+
+
+@pytest.mark.redis_db
 @pytest.mark.events_db
 def test_system_query(admin_api: FlaskClient) -> None:
     _, host, port = get_node_for_table(admin_api, "errors")


### PR DESCRIPTION
Allows for configuring the main region and the main URL is no longer hard-coded, but instead dynamically generated.

Tested locally with no issues.