### PR TITLE
feat(eap): collect more cluster load signals for storage routing

### DIFF
--- a/snuba/web/rpc/storage_routing/load_retriever.py
+++ b/snuba/web/rpc/storage_routing/load_retriever.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 from collections.abc import Callable
+from dataclasses import dataclass, fields
 from functools import wraps
 from typing import Any
 
@@ -18,25 +19,26 @@ metrics = MetricsWrapper(
 )
 
 
+@dataclass
 class LoadInfo:
-    cluster_load: float
-    concurrent_queries: int
+    cluster_load: float = -1.0
+    concurrent_queries: float = -1.0
+    cgroup_user_time_normalized: float = -1.0
+    block_in_flight_ops: float = -1.0
+    memory_tracking: float = -1.0
+    part_mutation: float = -1.0
 
-    def __init__(self, cluster_load: float, concurrent_queries: int) -> None:
-        self.cluster_load = cluster_load
-        self.concurrent_queries = concurrent_queries
-
-    def to_dict(self) -> dict[str, float | int]:
-        return {
-            "cluster_load": self.cluster_load,
-            "concurrent_queries": self.concurrent_queries,
-        }
+    def to_dict(self) -> dict[str, float]:
+        return {f.name: getattr(self, f.name) for f in fields(self)}
 
     @classmethod
-    def from_dict(cls, load_info_dict: dict[str, float | int]) -> "LoadInfo":
+    def from_dict(cls, load_info_dict: dict[str, float | int | None]) -> "LoadInfo":
         return cls(
-            cluster_load=load_info_dict["cluster_load"],
-            concurrent_queries=int(load_info_dict["concurrent_queries"]),
+            **{
+                f.name: float(v)
+                for f in fields(cls)
+                if (v := load_info_dict.get(f.name)) is not None
+            }
         )
 
 
@@ -78,6 +80,9 @@ def cache(
     return decorator
 
 
+_LOAD_FIELDS = tuple(f.name for f in fields(LoadInfo))
+
+
 @cache(ttl_secs=60)
 def get_cluster_loadinfo(
     storage_set_key: StorageSetKey = StorageSetKey.EVENTS_ANALYTICS_PLATFORM,
@@ -88,70 +93,79 @@ def get_cluster_loadinfo(
 
         if cluster.is_single_node():
             cluster_load_query = """
-    SELECT
-        toFloat32(value)/ (SELECT
-                    max(toInt32(replaceAll(metric, 'OSNiceTimeCPU', ''))) + 1 as num_cpus
-                FROM system.asynchronous_metrics
-                WHERE metric LIKE '%OSNiceTimeCPU%') * 100 as normalized_load
-    FROM system.asynchronous_metrics
-    WHERE metric = 'LoadAverage1'
-            """
-            concurrent_queries_query = """
             SELECT
-                count()
-            FROM system.processes
+                toFloat32(max(if(metric = 'LoadAverage1', value, NULL)))
+                    / (SELECT
+                            max(toInt32(replaceAll(metric, 'OSNiceTimeCPU', ''))) + 1 as num_cpus
+                        FROM system.asynchronous_metrics
+                        WHERE metric LIKE '%OSNiceTimeCPU%') * 100 as cluster_load,
+                (SELECT max(if(metric = 'Query', value, NULL)) FROM system.metrics
+                    WHERE metric = 'Query') as concurrent_queries,
+                max(if(metric = 'CGroupUserTimeNormalized', value, NULL)) as cgroup_user_time_normalized,
+                max(if(metric = 'BlockInFlightOps', value, NULL)) as block_in_flight_ops,
+                (SELECT max(if(metric = 'MemoryTracking', value, NULL)) FROM system.metrics
+                    WHERE metric = 'MemoryTracking') as memory_tracking,
+                (SELECT max(if(metric = 'PartMutation', value, NULL)) FROM system.metrics
+                    WHERE metric = 'PartMutation') as part_mutation
+            FROM system.asynchronous_metrics
+            WHERE metric IN ('LoadAverage1', 'CGroupUserTimeNormalized', 'BlockInFlightOps')
             """
         else:
+            replicas = f"clusterAllReplicas('{cluster.get_clickhouse_cluster_name()}'"
             cluster_load_query = f"""
-    SELECT
-        max(load_average.value / cpu_counts.num_cpus * 100) AS max_normalized_load
-    FROM (
-        SELECT
-            hostName() AS host,
-            value,
-            metric
-        FROM clusterAllReplicas('{cluster.get_clickhouse_cluster_name()}', 'system', asynchronous_metrics)
-        WHERE metric = 'LoadAverage1'
-    ) AS load_average
-    JOIN (
-        SELECT
-            hostName() AS host,
-            max(toInt32(replaceAll(metric, 'OSNiceTimeCPU', ''))) + 1 AS num_cpus
-        FROM clusterAllReplicas('{cluster.get_clickhouse_cluster_name()}', 'system', asynchronous_metrics)
-        WHERE metric LIKE 'OSNiceTimeCPU%'
-        GROUP BY host
-    ) AS cpu_counts
-    ON load_average.host = cpu_counts.host
-        """
-            concurrent_queries_query = f"""
-            SELECT sum(count) AS concurrent_queries
+            SELECT
+                load.cluster_load,
+                metrics.concurrent_queries,
+                load.cgroup_user_time_normalized,
+                load.block_in_flight_ops,
+                metrics.memory_tracking,
+                metrics.part_mutation
             FROM (
-                SELECT count() AS count
-                FROM clusterAllReplicas('{cluster.get_clickhouse_cluster_name()}', 'system', 'processes')
-            )
+                SELECT
+                    max(if(load_average.metric = 'LoadAverage1',
+                           load_average.value / cpu_counts.num_cpus * 100, NULL)) AS cluster_load,
+                    max(if(load_average.metric = 'CGroupUserTimeNormalized',
+                           load_average.value, NULL)) AS cgroup_user_time_normalized,
+                    max(if(load_average.metric = 'BlockInFlightOps',
+                           load_average.value, NULL)) AS block_in_flight_ops
+                FROM (
+                    SELECT hostName() AS host, value, metric
+                    FROM {replicas}, 'system', asynchronous_metrics)
+                    WHERE metric IN ('LoadAverage1', 'CGroupUserTimeNormalized', 'BlockInFlightOps')
+                ) AS load_average
+                JOIN (
+                    SELECT
+                        hostName() AS host,
+                        max(toInt32(replaceAll(metric, 'OSNiceTimeCPU', ''))) + 1 AS num_cpus
+                    FROM {replicas}, 'system', asynchronous_metrics)
+                    WHERE metric LIKE 'OSNiceTimeCPU%'
+                    GROUP BY host
+                ) AS cpu_counts
+                ON load_average.host = cpu_counts.host
+            ) AS load
+            CROSS JOIN (
+                SELECT
+                    max(if(metric = 'Query', value, NULL)) AS concurrent_queries,
+                    max(if(metric = 'MemoryTracking', value, NULL)) AS memory_tracking,
+                    max(if(metric = 'PartMutation', value, NULL)) AS part_mutation
+                FROM {replicas}, 'system', 'metrics')
+                WHERE metric IN ('Query', 'MemoryTracking', 'PartMutation')
+            ) AS metrics
             """
 
-        cluster_load = float(
+        row = (
             cluster.get_query_connection(ClickhouseClientSettings.INTERNAL)
             .execute(cluster_load_query)
-            .results[0][0]
+            .results[0]
         )
-        concurrent_queries = int(
-            cluster.get_query_connection(ClickhouseClientSettings.INTERNAL)
-            .execute(concurrent_queries_query)
-            .results[0][0]
-        )
-        load_info = LoadInfo(cluster_load=cluster_load, concurrent_queries=concurrent_queries)
+        load_info = LoadInfo.from_dict(dict(zip(_LOAD_FIELDS, row, strict=True)))
 
-        metrics.gauge("cluster_load", load_info.cluster_load, tags={"cluster_name": cluster_name})
-        metrics.gauge(
-            "concurrent_queries",
-            load_info.concurrent_queries,
-            tags={"cluster_name": cluster_name},
-        )
+        tags = {"cluster_name": cluster_name}
+        for name, value in load_info.to_dict().items():
+            metrics.gauge(name, value, tags=tags)
         return load_info
 
     except Exception as e:
         metrics.increment("get_cluster_loadinfo_failure", tags={"cluster_name": cluster_name})
         sentry_sdk.capture_exception(e)
-        return LoadInfo(cluster_load=-1.0, concurrent_queries=-1)
+        return LoadInfo()

--- a/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
+++ b/tests/web/rpc/v1/routing_strategies/test_cluster_loadinfo.py
@@ -2,16 +2,48 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from snuba.web.rpc.storage_routing.load_retriever import get_cluster_loadinfo
+from snuba.web.rpc.storage_routing.load_retriever import LoadInfo, get_cluster_loadinfo
+
+# Always present on CH. CGroupUserTimeNormalized / BlockInFlightOps are
+# host-dependent and may be -1 without failing the probe.
+_REQUIRED_FIELDS = (
+    "cluster_load",
+    "concurrent_queries",
+    "memory_tracking",
+    "part_mutation",
+)
+_ALL_FIELDS = _REQUIRED_FIELDS + (
+    "cgroup_user_time_normalized",
+    "block_in_flight_ops",
+)
+
+
+def _assert_probe_ok(load_info: LoadInfo) -> None:
+    assert load_info is not None
+    for field in _REQUIRED_FIELDS:
+        assert getattr(load_info, field) != -1, field
+
+
+def _assert_probe_failed(load_info: LoadInfo) -> None:
+    assert load_info is not None
+    for field in _ALL_FIELDS:
+        assert getattr(load_info, field) == -1, field
+
+
+def test_from_dict_old_cache_shape() -> None:
+    load_info = LoadInfo.from_dict({"cluster_load": 1.5, "concurrent_queries": 3})
+    assert load_info.cluster_load == 1.5
+    assert load_info.concurrent_queries == 3.0
+    assert load_info.cgroup_user_time_normalized == -1
+    assert load_info.block_in_flight_ops == -1
+    assert load_info.memory_tracking == -1
+    assert load_info.part_mutation == -1
 
 
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_get_cluster_load() -> None:
-    load_info = get_cluster_loadinfo()
-    assert load_info is not None
-    assert load_info.cluster_load != -1.0
-    assert load_info.concurrent_queries != -1
+    _assert_probe_ok(get_cluster_loadinfo())
 
 
 @pytest.mark.redis_db
@@ -33,10 +65,7 @@ def test_get_cluster_loadinfo_if_cache_fails() -> None:
     mock_redis.side_effect = Exception("Test error")
     with patch("snuba.redis.get_redis_client") as mock_redis_client:
         mock_redis_client.return_value = mock_redis
-        load_info = get_cluster_loadinfo()
-        assert load_info is not None
-        assert load_info.cluster_load != -1.0
-        assert load_info.concurrent_queries != -1
+        _assert_probe_ok(get_cluster_loadinfo())
 
 
 @pytest.mark.redis_db
@@ -44,7 +73,4 @@ def test_get_cluster_loadinfo_if_cache_fails() -> None:
 def test_get_cluster_load_error_handling() -> None:
     with patch("snuba.clickhouse.connect.ClickhouseConnectPool.execute") as mock_execute:
         mock_execute.side_effect = Exception("Test error")
-        load_info = get_cluster_loadinfo()
-        assert load_info is not None
-        assert load_info.cluster_load == -1.0
-        assert load_info.concurrent_queries == -1
+        _assert_probe_failed(get_cluster_loadinfo())


### PR DESCRIPTION
`get_cluster_loadinfo` now returns a wider `LoadInfo` bag so we can graph hottest-replica load and pick thresholds for a later routing / dynamic-sampling strategy. This PR is probe + gauges only; nothing branches on the new fields yet.

**Signals** (all `float`, default `-1.0`):

- `cluster_load` — max 1m load / CPU, as before
- `concurrent_queries` — max `system.metrics.Query` (was `count()` on `system.processes`)
- `cgroup_user_time_normalized`
- `block_in_flight_ops`
- `memory_tracking`
- `part_mutation`

Replica aggregations are **max** (the hot node). Missing CH metrics and old Redis blobs become `-1.0`; treat that as not-loaded. Probe failure still increments `get_cluster_loadinfo_failure` and does not gauge.

One INTERNAL query per cache miss. Single-node vs `clusterAllReplicas` SQL is unchanged.

Follow-up: look at the gauges, set thresholds, then a strategy that actually reads these.